### PR TITLE
Anonymize fixture names in tests

### DIFF
--- a/plugins/web-ui/test/group-dm-label.test.ts
+++ b/plugins/web-ui/test/group-dm-label.test.ts
@@ -3,9 +3,9 @@ import assert from "node:assert/strict";
 import { groupDmLabel, groupDmText } from "../src/group-dm-label.ts";
 
 test("groupDmLabel parses Slack's raw mpdm channel names into people lists", () => {
-  assert.deepEqual(groupDmLabel("mpdm-alice--gm--katie--carol-1"), {
-    names: ["alice", "gm", "katie", "carol"],
-    text: "alice, gm, katie, carol",
+  assert.deepEqual(groupDmLabel("mpdm-alice--gm--jordan--carol-1"), {
+    names: ["alice", "gm", "jordan", "carol"],
+    text: "alice, gm, jordan, carol",
     count: 4,
   });
   assert.equal(groupDmText("#mpdm-eric--eve--katherine--lucas--sean-1"), "eric, eve, katherine, lucas, sean");

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1574,7 +1574,7 @@ test("a message answered on one turn is not re-imported as overheard on the next
     channel("did that work?", {
       liveActor: true,
       triggerTs: "200.002",
-      overheard: [{ ts: "200.001", role: "user", name: "Pete", text: "run it now on the first 20 emails" }],
+      overheard: [{ ts: "200.001", role: "user", name: "Avery", text: "run it now on the first 20 emails" }],
     }),
   );
   assert.equal(r2.status, "ok");
@@ -1608,7 +1608,7 @@ test("an unprompted thread-follow (no triggerTs) is stamped via entryTs and not 
     channel("ok done?", {
       liveActor: true,
       triggerTs: "300.002",
-      overheard: [{ ts: "300.001", role: "user", name: "Pete", text: followText }],
+      overheard: [{ ts: "300.001", role: "user", name: "Avery", text: followText }],
     }),
   );
   assert.equal(r2.status, "ok");
@@ -2907,7 +2907,7 @@ test("Door 2: an envelopeWrapped request on its own skips the overheard seed (re
     dm("did that work?", {
       conversation: { kind: "dm", threadRef: "dm:U1:door2-wrapped" },
       envelopeWrapped: true,
-      overheard: [{ ts: "900.000", role: "user", name: "Pete", text: "unrelated chatter" }],
+      overheard: [{ ts: "900.000", role: "user", name: "Avery", text: "unrelated chatter" }],
     }),
   );
   assert.equal(wrapped.status, "ok");
@@ -2921,7 +2921,7 @@ test("Door 2: an envelopeWrapped request on its own skips the overheard seed (re
   const plain = await app.turn(
     dm("did that work?", {
       conversation: { kind: "dm", threadRef: "dm:U1:door2-plain" },
-      overheard: [{ ts: "901.000", role: "user", name: "Pete", text: "unrelated chatter" }],
+      overheard: [{ ts: "901.000", role: "user", name: "Avery", text: "unrelated chatter" }],
     }),
   );
   assert.equal(plain.status, "ok");

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -221,7 +221,7 @@ function fakeToolContext(sink?: { lastExecOpts?: Parameters<ToolContext["execute
         verb: "share",
         type: "file",
         id: "F1",
-        target: { scope: "channel:C1", label: "#pete-katie" },
+        target: { scope: "channel:C1", label: "#avery-jordan" },
         permission: "read",
       };
     },

--- a/test/postgres-surface-cache.test.ts
+++ b/test/postgres-surface-cache.test.ts
@@ -178,13 +178,13 @@ test("pg surface-cache: mentions JSONB round-trips and survives a mention-less e
   const cache = createPostgresSurfaceCache(URL!);
   try {
     await cache.ingest([
-      { container: "Cm", ts: "9.0", text: "hi @katie", mentions: { U1: "katie", U2: "pete" }, createdAt: 1 },
+      { container: "Cm", ts: "9.0", text: "hi @jordan", mentions: { U1: "jordan", U2: "avery" }, createdAt: 1 },
     ]);
     let msgs = await cache.readMessages("Cm");
-    assert.deepEqual(msgs[0]!.mentions, { U1: "katie", U2: "pete" });
-    await cache.ingest([{ container: "Cm", ts: "9.0", text: "hi @katie edited", editedAt: 5, createdAt: 1 }]);
+    assert.deepEqual(msgs[0]!.mentions, { U1: "jordan", U2: "avery" });
+    await cache.ingest([{ container: "Cm", ts: "9.0", text: "hi @jordan edited", editedAt: 5, createdAt: 1 }]);
     msgs = await cache.readMessages("Cm");
-    assert.deepEqual(msgs[0]!.mentions, { U1: "katie", U2: "pete" }, "a mention-less edit keeps the prior mentions");
+    assert.deepEqual(msgs[0]!.mentions, { U1: "jordan", U2: "avery" }, "a mention-less edit keeps the prior mentions");
   } finally {
     await cache.close();
   }

--- a/test/replay.test.ts
+++ b/test/replay.test.ts
@@ -314,8 +314,8 @@ test("recordedMessageTimestamps collects ts from BOTH overheard imports and stam
 test("a message answered as a trigger is NOT re-imported as overheard next turn (the duplication fix)", () => {
   const history = [triggerEntry("100.002", "run it now on the first 20 emails")];
   const incoming: OverheardMessage[] = [
-    { ts: "100.002", role: "user", name: "Pete", text: "run it now on the first 20 emails" },
-    { ts: "100.005", role: "user", name: "Pete", text: "I don't see an approval prompt" },
+    { ts: "100.002", role: "user", name: "Avery", text: "run it now on the first 20 emails" },
+    { ts: "100.005", role: "user", name: "Avery", text: "I don't see an approval prompt" },
   ];
   const picked = selectOverheardToImport(incoming, recordedMessageTimestamps(history));
   assert.deepEqual(
@@ -386,12 +386,12 @@ test("renderOverheard adds a mentions attr when the payload carries resolved men
   const line = renderOverheard({
     overheard: true,
     ts: "2",
-    name: "Pete",
-    text: "cc @katie",
-    mentions: { U1: "katie", U2: "pete" },
+    name: "Avery",
+    text: "cc @jordan",
+    mentions: { U1: "jordan", U2: "avery" },
   });
-  assert.match(line, /mentions="U1=katie,U2=pete"/);
-  const bare = renderOverheard({ overheard: true, ts: "3", name: "Pete", text: "no mentions" });
+  assert.match(line, /mentions="U1=jordan,U2=avery"/);
+  const bare = renderOverheard({ overheard: true, ts: "3", name: "Avery", text: "no mentions" });
   assert.doesNotMatch(bare, /mentions=/);
 });
 

--- a/test/skills-http.test.ts
+++ b/test/skills-http.test.ts
@@ -97,7 +97,9 @@ test("GET /v1/skills marks a private-channel skill editable for a member and not
     );
     await publish(srv.skills, scopeId("channel", "C9"), "team-thing", "shared in the channel");
 
-    const forJordan = (await (await fetch(`${srv.base}/v1/skills?principalId=jordan`)).json()) as { skills: SkillView[] };
+    const forJordan = (await (await fetch(`${srv.base}/v1/skills?principalId=jordan`)).json()) as {
+      skills: SkillView[];
+    };
     const k = forJordan.skills.find((s) => s.name === "team-thing");
     assert.ok(k, "the channel skill is visible to a member");
     assert.equal(k!.scope, "channel");

--- a/test/skills-http.test.ts
+++ b/test/skills-http.test.ts
@@ -89,16 +89,16 @@ test("GET /v1/skills marks a private-channel skill editable for a member and not
   const srv = start();
   try {
     await srv.directory.replaceChannels(
-      [{ channelId: "C9", name: "pete-katie", isPrivate: true }],
+      [{ channelId: "C9", name: "avery-jordan", isPrivate: true }],
       [
-        { channelId: "C9", principalId: "pete" },
-        { channelId: "C9", principalId: "katie" },
+        { channelId: "C9", principalId: "avery" },
+        { channelId: "C9", principalId: "jordan" },
       ],
     );
     await publish(srv.skills, scopeId("channel", "C9"), "team-thing", "shared in the channel");
 
-    const forKatie = (await (await fetch(`${srv.base}/v1/skills?principalId=katie`)).json()) as { skills: SkillView[] };
-    const k = forKatie.skills.find((s) => s.name === "team-thing");
+    const forJordan = (await (await fetch(`${srv.base}/v1/skills?principalId=jordan`)).json()) as { skills: SkillView[] };
+    const k = forJordan.skills.find((s) => s.name === "team-thing");
     assert.ok(k, "the channel skill is visible to a member");
     assert.equal(k!.scope, "channel");
     assert.equal(k!.editable, true, "a member may edit it");
@@ -481,17 +481,17 @@ test("POST /v1/skills via a capability token from a private-channel scope homes 
   const srv = await startSecure();
   try {
     await srv.directory.replaceChannels(
-      [{ channelId: "C9", name: "pete-katie", isPrivate: true }],
+      [{ channelId: "C9", name: "avery-jordan", isPrivate: true }],
       [
-        { channelId: "C9", principalId: "pete" },
-        { channelId: "C9", principalId: "katie" },
+        { channelId: "C9", principalId: "avery" },
+        { channelId: "C9", principalId: "jordan" },
       ],
     );
     const res = await fetch(`${srv.base}/v1/skills`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "x-agent-capability": await srv.cap("pete", scopeId("channel", "C9")),
+        "x-agent-capability": await srv.cap("avery", scopeId("channel", "C9")),
       },
       body: JSON.stringify({ name: "team-thing", description: "d", body: "# b" }),
     });
@@ -499,8 +499,8 @@ test("POST /v1/skills via a capability token from a private-channel scope homes 
     const all = await srv.skills.list();
     const sk = all.find((s) => s.manifest.name === "team-thing");
     assert.ok(sk, "the skill was created");
-    assert.equal(sk!.scopeId, scopeId("channel", "C9"), "homed in the channel, not pete's personal scope");
-    assert.equal(sk!.createdBy, "pete", "provenance is the real author, never the scope");
+    assert.equal(sk!.scopeId, scopeId("channel", "C9"), "homed in the channel, not avery's personal scope");
+    assert.equal(sk!.createdBy, "avery", "provenance is the real author, never the scope");
     assert.equal(sk!.status, "published", "a membership-managed shared skill auto review+publishes");
   } finally {
     await srv.close();
@@ -570,17 +570,17 @@ test("PUT /v1/skills/:id via a capability token cannot edit another scope's skil
 
 async function seedChannelSkill(srv: Awaited<ReturnType<typeof startSecure>>) {
   await srv.directory.replaceChannels(
-    [{ channelId: "C9", name: "pete-katie", isPrivate: true }],
+    [{ channelId: "C9", name: "avery-jordan", isPrivate: true }],
     [
-      { channelId: "C9", principalId: "pete" },
-      { channelId: "C9", principalId: "katie" },
+      { channelId: "C9", principalId: "avery" },
+      { channelId: "C9", principalId: "jordan" },
     ],
   );
   const res = await fetch(`${srv.base}/v1/skills`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-agent-capability": await srv.cap("pete", scopeId("channel", "C9")),
+      "x-agent-capability": await srv.cap("avery", scopeId("channel", "C9")),
     },
     body: JSON.stringify({ name: "team-thing", description: "v1", body: "# v1" }),
   });
@@ -596,14 +596,14 @@ test("PUT /v1/skills/:id lets a DIFFERENT member of the home channel edit it, pr
       method: "PUT",
       headers: {
         "content-type": "application/json",
-        "x-agent-capability": await srv.cap("katie", scopeId("channel", "C9")),
+        "x-agent-capability": await srv.cap("jordan", scopeId("channel", "C9")),
       },
-      body: JSON.stringify({ body: "# v2 by katie" }),
+      body: JSON.stringify({ body: "# v2 by jordan" }),
     });
     assert.equal(res.status, 200);
     const after = await srv.skills.get(id);
-    assert.equal(after!.manifest.body, "# v2 by katie");
-    assert.equal(after!.createdBy, "pete", "edit by a member never rewrites provenance");
+    assert.equal(after!.manifest.body, "# v2 by jordan");
+    assert.equal(after!.createdBy, "avery", "edit by a member never rewrites provenance");
     assert.equal(after!.status, "published", "a membership-managed edit re-publishes — no org review needed");
   } finally {
     await srv.close();
@@ -616,11 +616,11 @@ test("PUT /v1/skills/:id from a member's own DM (not the channel) still edits �
     const id = await seedChannelSkill(srv);
     const res = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
-      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("katie") },
-      body: JSON.stringify({ description: "from katie's DM" }),
+      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("jordan") },
+      body: JSON.stringify({ description: "from jordan's DM" }),
     });
     assert.equal(res.status, 200);
-    assert.equal((await srv.skills.get(id))!.manifest.description, "from katie's DM");
+    assert.equal((await srv.skills.get(id))!.manifest.description, "from jordan's DM");
   } finally {
     await srv.close();
   }
@@ -654,7 +654,7 @@ test("DELETE /v1/skills/:id lets any member of the home channel archive it", asy
     const id = await seedChannelSkill(srv);
     const res = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "DELETE",
-      headers: { "x-agent-capability": await srv.cap("katie") },
+      headers: { "x-agent-capability": await srv.cap("jordan") },
     });
     assert.equal(res.status, 200);
     assert.equal((await srv.skills.get(id))?.status, "archived");
@@ -668,23 +668,23 @@ test("an author who LEAVES a private channel loses inline CRUD on its skill (mem
   try {
     const id = await seedChannelSkill(srv);
     await srv.directory.replaceChannels(
-      [{ channelId: "C9", name: "pete-katie", isPrivate: true }],
-      [{ channelId: "C9", principalId: "katie" }],
+      [{ channelId: "C9", name: "avery-jordan", isPrivate: true }],
+      [{ channelId: "C9", principalId: "jordan" }],
     );
     const edit = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
-      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("pete") },
+      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("avery") },
       body: JSON.stringify({ description: "ex-member edit" }),
     });
     assert.equal(edit.status, 404, "an ex-member author cannot edit a private-channel skill");
     const del = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "DELETE",
-      headers: { "x-agent-capability": await srv.cap("pete") },
+      headers: { "x-agent-capability": await srv.cap("avery") },
     });
     assert.equal(del.status, 403, "an ex-member author cannot delete it either");
     const k = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
-      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("katie") },
+      headers: { "content-type": "application/json", "x-agent-capability": await srv.cap("jordan") },
       body: JSON.stringify({ description: "still managed by the remaining member" }),
     });
     assert.equal(k.status, 200);
@@ -697,7 +697,7 @@ test("management tracks CURRENT directory membership, not a stale session — a 
   const srv = await startSecure();
   try {
     const id = await seedChannelSkill(srv);
-    const sess = await srv.sessions.getOrCreateByThread("C9:t1", "channel", scopeId("channel", "C9"), "pete-katie");
+    const sess = await srv.sessions.getOrCreateByThread("C9:t1", "channel", scopeId("channel", "C9"), "avery-jordan");
     await srv.sessions.addParticipant(sess.id, "dana");
     const edit = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
@@ -715,10 +715,10 @@ test("a shared-scope skill cannot be created/edited/deleted by an automated trig
   const srv = await startSecure();
   try {
     await srv.directory.replaceChannels(
-      [{ channelId: "C9", name: "pete-katie", isPrivate: true }],
-      [{ channelId: "C9", principalId: "pete" }],
+      [{ channelId: "C9", name: "avery-jordan", isPrivate: true }],
+      [{ channelId: "C9", principalId: "avery" }],
     );
-    const triggerTok = await srv.cap("pete", scopeId("channel", "C9"), false);
+    const triggerTok = await srv.cap("avery", scopeId("channel", "C9"), false);
     const create = await fetch(`${srv.base}/v1/skills`, {
       method: "POST",
       headers: { "content-type": "application/json", "x-agent-capability": triggerTok },
@@ -760,7 +760,7 @@ test("a PERSONAL-scope trigger (no liveActor) cannot edit or delete a skill home
   const srv = await startSecure();
   try {
     const id = await seedChannelSkill(srv);
-    const personalTrigger = await srv.cap("pete", scopeId("personal", "pete"), false);
+    const personalTrigger = await srv.cap("avery", scopeId("personal", "avery"), false);
     const edit = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
       headers: { "content-type": "application/json", "x-agent-capability": personalTrigger },
@@ -784,17 +784,17 @@ test("a LIVE member of a private channel may edit + delete its skill from their 
   const srv = await startSecure();
   try {
     const id = await seedChannelSkill(srv);
-    const liveKatie = await srv.cap("katie");
+    const liveJordan = await srv.cap("jordan");
     const edit = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "PUT",
-      headers: { "content-type": "application/json", "x-agent-capability": liveKatie },
+      headers: { "content-type": "application/json", "x-agent-capability": liveJordan },
       body: JSON.stringify({ description: "edited live by a member" }),
     });
     assert.equal(edit.status, 200, "a live member may edit the shared skill");
     assert.equal((await srv.skills.get(id))!.manifest.description, "edited live by a member");
     const del = await fetch(`${srv.base}/v1/skills/${id}`, {
       method: "DELETE",
-      headers: { "x-agent-capability": liveKatie },
+      headers: { "x-agent-capability": liveJordan },
     });
     assert.equal(del.status, 200, "and delete it");
     assert.equal((await srv.skills.get(id))?.status, "archived");

--- a/test/slack-mrkdwn.test.ts
+++ b/test/slack-mrkdwn.test.ts
@@ -136,12 +136,12 @@ test("slackSectionBlocks splits long replies below Slack's section limit", () =>
 });
 
 test("resolveMentionsInText: plain, labeled, unknown, multiple", () => {
-  const lookup = (id: string): string | undefined => ({ U1: "katie", U2: "pete" })[id];
-  assert.equal(resolveMentionsInText("hey <@U1>", lookup), "hey @katie");
-  assert.equal(resolveMentionsInText("hey <@U1|Katie Label>", lookup), "hey @Katie Label");
+  const lookup = (id: string): string | undefined => ({ U1: "jordan", U2: "avery" })[id];
+  assert.equal(resolveMentionsInText("hey <@U1>", lookup), "hey @jordan");
+  assert.equal(resolveMentionsInText("hey <@U1|Jordan Label>", lookup), "hey @Jordan Label");
   assert.equal(resolveMentionsInText("ping <@U9>", lookup), "ping @U9");
   assert.equal(resolveMentionsInText("ping <@U9|Nobody>", lookup), "ping @Nobody");
-  assert.equal(resolveMentionsInText("<@U1> and <@U2> and <@U3>", lookup), "@katie and @pete and @U3");
+  assert.equal(resolveMentionsInText("<@U1> and <@U2> and <@U3>", lookup), "@jordan and @avery and @U3");
   assert.equal(resolveMentionsInText("no mentions", lookup), "no mentions");
 });
 

--- a/test/surface-cache-ambient.test.ts
+++ b/test/surface-cache-ambient.test.ts
@@ -313,7 +313,7 @@ test("a message that @mentions ANOTHER person (not the bot) is judged normally, 
     const container = "C-other";
     await built.app.setChannelPolicy(container, "", "U-admin", undefined, undefined, true);
     await built.app.ingestSurfaceEvents(
-      [{ container, ts: "1.0", authorId: "U1", text: "@katie can you send those emails?", createdAt: 1 }],
+      [{ container, ts: "1.0", authorId: "U1", text: "@jordan can you send those emails?", createdAt: 1 }],
       "slack",
       { name: "bot", mentionId: "UBOT" },
     );

--- a/test/surface-cache-ingest-mapper.test.ts
+++ b/test/surface-cache-ingest-mapper.test.ts
@@ -7,7 +7,7 @@ test("toEvent passes through mentions, bot, mentionsSelf, and handled", () => {
     container: "C1",
     ts: "1.0",
     text: "@bot help",
-    mentions: { U1: "katie" },
+    mentions: { U1: "jordan" },
     bot: true,
     mentionsSelf: true,
     handled: true,
@@ -15,7 +15,7 @@ test("toEvent passes through mentions, bot, mentionsSelf, and handled", () => {
     kind: "channel",
   });
   assert.ok(e);
-  assert.deepEqual(e.mentions, { U1: "katie" });
+  assert.deepEqual(e.mentions, { U1: "jordan" });
   assert.equal(e.bot, true);
   assert.equal(e.mentionsSelf, true);
   assert.equal(e.handled, true, "the direct-path ownership flag reaches the mirror (not dropped at the route)");
@@ -37,13 +37,13 @@ test("toEvent omits the flags when absent or false, and keeps only string mentio
     bot: false,
     mentionsSelf: false,
     handled: false,
-    mentions: { U1: "katie", U2: 5 },
+    mentions: { U1: "jordan", U2: 5 },
   });
   assert.ok(e);
   assert.equal(e.bot, undefined);
   assert.equal(e.mentionsSelf, undefined);
   assert.equal(e.handled, undefined);
-  assert.deepEqual(e.mentions, { U1: "katie" }, "non-string mention values are dropped");
+  assert.deepEqual(e.mentions, { U1: "jordan" }, "non-string mention values are dropped");
 });
 
 test("toEvent rejects a payload with no container/ts", () => {

--- a/test/surface-cache.test.ts
+++ b/test/surface-cache.test.ts
@@ -280,12 +280,12 @@ test("ambient judge: the agent's own posts are never shown to the judge as new m
 
 test("mentions round-trip through ingest → readMessages (memory)", async () => {
   const cache = createMemorySurfaceCache();
-  await cache.ingest([{ container: "C1", ts: "100.9", text: "hi @katie", mentions: { U1: "katie" }, createdAt: 1 }]);
+  await cache.ingest([{ container: "C1", ts: "100.9", text: "hi @jordan", mentions: { U1: "jordan" }, createdAt: 1 }]);
   const msgs = await cache.readMessages("C1");
-  assert.deepEqual(msgs[0]!.mentions, { U1: "katie" }, "the mentions map survives the round-trip");
-  await cache.ingest([{ container: "C1", ts: "100.9", text: "hi @katie", editedAt: 5, createdAt: 1 }]);
+  assert.deepEqual(msgs[0]!.mentions, { U1: "jordan" }, "the mentions map survives the round-trip");
+  await cache.ingest([{ container: "C1", ts: "100.9", text: "hi @jordan", editedAt: 5, createdAt: 1 }]);
   const after = await cache.readMessages("C1");
-  assert.deepEqual(after[0]!.mentions, { U1: "katie" }, "a mention-less edit keeps the prior mentions");
+  assert.deepEqual(after[0]!.mentions, { U1: "jordan" }, "a mention-less edit keeps the prior mentions");
 });
 
 test("mentionsSelf round-trips through ingest → readMessages (memory)", async () => {

--- a/test/wake-envelope.test.ts
+++ b/test/wake-envelope.test.ts
@@ -57,7 +57,7 @@ test("addressed envelope: trigger rides the instruction block, not the overheard
     channel: "C1",
     at: AT,
     why: "ada addressed you directly; they expect a response.",
-    recentMessages: [{ ts: "1.0", authorName: "pete", text: "earlier chatter" }],
+    recentMessages: [{ ts: "1.0", authorName: "avery", text: "earlier chatter" }],
     addressedMessages: [{ ts: "2.0", authorName: "ada", authorId: "U1", text: "can you help?" }],
     instructions: "Act on it.",
   });


### PR DESCRIPTION
Test fixtures used two real first names as placeholder people. This replaces them with neutral stand-ins — `pete` → `avery`, `katie` → `jordan` — across 11 test files.

Strings only; no production code or behavior changes. All 334 tests in the affected files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787948677&installation_model_id=19911&pr_number=2&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F2&signature=43cd89c8d061f7318e95b6ae1833e1273aa1a7f5d080e34d64b97eac9189ed51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->