### PR TITLE
Fix two config gaps that break a from-scratch Fly deployment

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -200,6 +200,8 @@ export function sandboxCoreEnv(
     if (violation) throw new CliError(violation.message, { clause: violation.clause });
     env.FLY_SANDBOX_APP_NAME = sb.app;
     env.FLY_BASE_IMAGE = sb.image;
+    const backend = sb.backend ?? (config.target === "fly" ? "sprites" : undefined);
+    if (backend) env.SANDBOX_BACKEND = backend;
   }
   for (const [k, v] of Object.entries(sb.env ?? {})) env[`FLY_RESIDENT_ENV_${k}`] = v;
   for (const name of sb.secretEnv ?? []) {

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -251,6 +251,20 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
     generate: MINT_LOCALLY,
   },
   {
+    name: "PORTAL_IDENTITY_SECRET",
+    service: "web-ui",
+    required: true,
+    description: "Signing key shared with core for portal-bound user identity.",
+    generate: MINT_LOCALLY,
+  },
+  {
+    name: "PORTAL_IDENTITY_SECRET",
+    service: "admin",
+    required: true,
+    description: "Signing key shared with core for portal-bound user identity.",
+    generate: MINT_LOCALLY,
+  },
+  {
     name: "CORE_SIGNING_SECRET",
     service: "auth",
     required: true,

--- a/cli/test/secrets.test.ts
+++ b/cli/test/secrets.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { QmConfig } from "../src/config.ts";
+import { sandboxCoreEnv, type QmConfig } from "../src/config.ts";
 import {
   FLY_TEMPLATE_ENV_DEFAULTS,
   computedSecrets,
@@ -287,4 +287,48 @@ test("secretEnv merges onto an existing computed secret instead of duplicating i
 test("secretEnv for a service the config does not enable is ignored", () => {
   const config = makeConfig({ secretEnv: { portal: { EXTRA_TOKEN: "EXTRA_TOKEN" } } });
   assert.ok(!computedSecrets(config).some((s) => s.name === "EXTRA_TOKEN"));
+});
+
+test("PORTAL_IDENTITY_SECRET reaches every service that signs or verifies a portal identity", () => {
+  const config = makeConfig({ services: ["core", "web-ui", "admin", "portal"] });
+  const secret = secretByName(config, "PORTAL_IDENTITY_SECRET");
+  assert.deepEqual(
+    [...secretDestinations(secret).keys()].sort(),
+    ["admin", "core", "portal", "web-ui"],
+    "core verifies with PORTAL_IDENTITY_SECRET, so a surface left without it signs with a different key and every request it makes is rejected",
+  );
+});
+
+test("a fly deployment tells core which sandbox substrate to boot", () => {
+  const config = makeConfig({
+    target: "fly",
+    sandbox: {
+      app: "acme-sb",
+      image: "registry.fly.io/acme-sb@sha256:1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",
+    },
+  });
+  assert.equal(
+    sandboxCoreEnv(config).env.SANDBOX_BACKEND,
+    "sprites",
+    "core refuses to boot in production unless SANDBOX_BACKEND is set explicitly",
+  );
+});
+
+test("an explicit sandbox.backend wins, and non-fly targets keep their own default", () => {
+  const pinned = makeConfig({
+    target: "fly",
+    sandbox: {
+      app: "acme-sb",
+      backend: "sprites",
+      image: "registry.fly.io/acme-sb@sha256:2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b",
+    },
+  });
+  assert.equal(sandboxCoreEnv(pinned).env.SANDBOX_BACKEND, "sprites");
+  const docker = makeConfig({
+    sandbox: {
+      app: "acme-sb",
+      image: "registry.fly.io/acme-sb@sha256:3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c",
+    },
+  });
+  assert.equal(sandboxCoreEnv(docker).env.SANDBOX_BACKEND, undefined);
 });

--- a/deploy/core/fly.toml
+++ b/deploy/core/fly.toml
@@ -22,6 +22,7 @@ primary_region = "sjc"
   FLY_ORG = "personal"
   FLY_DEPLOY_BASE_IMAGE = "registry.fly.io/acme-sandboxes@sha256:1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"
   FLY_DEPLOY_APP_PREFIX = "qm-d"
+  SANDBOX_BACKEND = "sprites"
 [deploy]
   strategy = "bluegreen"
 


### PR DESCRIPTION
Two gaps in what the CLI hands the runtime. Each independently breaks a Fly deployment, and both were hit in sequence standing one up from scratch today.

## 1. Core never receives `SANDBOX_BACKEND` on Fly

Core refuses to start in production unless `SANDBOX_BACKEND` is set (`src/config.ts`), but only the AWS backend emitted it (`cli/src/backends/aws.ts`). A Fly deploy therefore crash-loops to its 10-restart cap:

```
Error: SANDBOX_BACKEND must be set explicitly in production — use sprites, aws, or local.
    at loadConfig (file:///app/src/config.ts:535:11)
```

Fixed in `sandboxCoreEnv`, which is the layer all three backends derive core env from (`fly.ts:181`, `docker.ts:483`, `aws.ts:240`), rather than in one backend:

- an explicit `sandbox.backend` now always reaches core, on every target
- a `fly` target with a `sandbox.app` defaults to `sprites` — the substrate `sandbox.app` already describes, matching the fallback AWS uses for the same case
- **docker is unchanged** — its sandboxes are local rather than sprites, so it still emits nothing unless `sandbox.backend` is explicit
- `env.core.SANDBOX_BACKEND` still wins, since `configuredEnv` is applied after `sandboxEnv`

## 2. `PORTAL_IDENTITY_SECRET` never reaches admin or web-ui

It was declared for `core` and `portal` only, but `admin` and `web-ui` also sign portal identities through the chassis. When it is absent the chassis silently substitutes a different key:

```js
// plugins/chassis/src/env.ts
export const PORTAL_IDENTITY_SECRET = process.env.PORTAL_IDENTITY_SECRET ?? CORE_SIGNING_SECRET;
```

Core verifies with `portalIdentitySecret ?? secret` and *does* have the real key, so every admin and web-ui request fails the identity check. The portal fails closed on that, which surfaces as **"Admin is temporarily unavailable"**, and web chat returns `401 sign in` — neither pointing at a key mismatch.

Verified against a live deployment: with the secret delivered, `GET /v1/admin/whoami` returns `{"isAdmin":true,"role":"org_admin",...}`; without it, the same request 401s.

`auth` is deliberately **not** included — it imports the chassis (so it logs the same fallback line) but never signs a portal identity.

## Tests

Three tests in `cli/test/secrets.test.ts`, each confirmed to fail without the corresponding source change:

- `PORTAL_IDENTITY_SECRET` reaches all four services in the trust boundary
- a `fly` deployment tells core which substrate to boot
- an explicit `sandbox.backend` wins, and non-fly targets keep their own default

`deploy/core/fly.toml` is regenerated from the derive function, so the byte-for-byte test passes.

`npm run typecheck` clean, oxlint clean, 474/475 CLI tests pass. The one failure — *"AWS secret rotation holds the deploy lease across the complete write set"* — **fails identically on `main` without this change** and is unrelated.

## Worth considering separately

The chassis fallback is what made #2 invisible: a signing/verifying key mismatch should refuse to boot in production rather than degrade to 401s at runtime. Changing that is a behavioural change with wider blast radius, so it is not in this PR.

Needs an adversarial review pass — I wrote it, so I am the wrong reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787949127&installation_model_id=19911&pr_number=4&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F4&signature=04e72b7238a5f58f076b2eeaf8c499cd0d96bdc0ffd3adf036eccc3d68b0e61c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->