### PR TITLE
docs: add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ isn't tied to any single vendor.
 
 ## Architecture
 
+```mermaid
+flowchart LR
+  DB[("Postgres<br/>sessions · memory · queue")]
+
+  subgraph CORE["Headless core"]
+    API["API · identity · policy · scheduler"]
+    LOOP["Agent loop<br/>(Pi, OpenCode, Claude Code)"]
+    API <--> LOOP
+  end
+
+  SBX["Per-scope sandbox<br/>files · tools · logged-in services"]
+
+  DB <--> API
+  LOOP <--> SBX
+```
+
 Every turn runs through a central core, which can use a variety of models and harnesses
 to generate the response. A Postgres persistence layer holds user data, session history,
 and other durable state. The agent has a small, fixed tool surface; one of those tools is


### PR DESCRIPTION
Spec diff: none.

## Summary

- Add a compact Mermaid diagram to the README Architecture section.
- Show Postgres, the headless core and agent loop, and the per-scope sandbox.
- Identify Pi, OpenCode, and Claude Code as agent-loop drivers.

## Why

The existing prose explains these boundaries, but the diagram makes the main software shape visible at a glance.

## Impact

Documentation only; runtime behavior is unchanged.

## Validation

- `git diff --check`
- Reviewed the final README diff against `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787952023&installation_model_id=19911&pr_number=7&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F7&signature=32d64021665bc3f45431de8351ad1c5985fd1fe84dfc20fd9aa34b014ebcae44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->