### PR TITLE
Fix CI: drop doc guards premised on the removed README quickstart

### DIFF
--- a/test/public-architecture-docs.test.ts
+++ b/test/public-architecture-docs.test.ts
@@ -16,21 +16,6 @@ const webPackage = JSON.parse(read("plugins/web-ui/package.json")) as {
   devDependencies: Record<string, string>;
 };
 
-test("the README quickstart mints real secrets but never forges a provider API key", () => {
-  const source = /env\.replace\(\/(.+?)\/gm,/.exec(readme)?.[1];
-  assert.ok(source, "the quickstart still mints secrets with a /.../gm replace");
-  const minted = [...read(".env.example").matchAll(new RegExp(source!, "gm"))].map((m) => m[1]);
-
-  assert.ok(minted.includes("CORE_SIGNING_SECRET"), "the real secrets are still minted for the user");
-  for (const name of minted) {
-    assert.doesNotMatch(
-      name!,
-      /_API_KEY$/,
-      `${name} is empty in .env.example, so the README one-liner fills it with random hex — the deployment then reports a provider it cannot authenticate`,
-    );
-  }
-});
-
 test(".env.example declares no model provider key, real or placeholder", () => {
   for (const line of read(".env.example").split("\n")) {
     assert.doesNotMatch(
@@ -40,7 +25,6 @@ test(".env.example declares no model provider key, real or placeholder", () => {
         `so a placeholder counts), and the deployment then advertises a provider whose key cannot authenticate`,
     );
   }
-  assert.match(readme, /ANTHROPIC_API_KEY.*OPENAI_API_KEY.*OPENROUTER_API_KEY/, "the README still names all three");
 });
 
 test(".env.example does not pin a base model that drifts from the shipped default", () => {


### PR DESCRIPTION
Main is red since the Remove-"Run it"-section merge: two tests in test/public-architecture-docs.test.ts assert on the deleted README quickstart (the secret-minting regex and the line naming all three provider API keys). This removes those assertions; the .env.example provider-key guard is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787953025&installation_model_id=19911&pr_number=9&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F9&signature=478238f16dfaee0de80d310dc79e73d74662b23ce191634c2005cf97beb8d4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->