### PR TITLE
Publish the deployment CLI to npm with provenance

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,34 @@
+name: Publish the QM CLI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  package:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version-file: .node-version
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+      - name: Install, typecheck, packed-artifact test
+        working-directory: cli
+        run: |
+          npm ci
+          npm run typecheck
+          npm run test:pack
+      - name: Publish
+        working-directory: cli
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,10 +18,11 @@ npm exec qm -- up --yes
 npm exec qm -- check --live
 ```
 
-This package is private and is never published to a registry. First-party image
-publication is a release operation outside this repository change. The checked-in
-image manifest is a sentinel that a deployment overrides with real digests. The
-packed-artifact test exercises the consumer path locally.
+This package is published to npm as `@yc-software/qm`, with npm provenance attesting the
+building workflow. First-party image publication is a separate release operation run by
+`.github/workflows/release-package.yml`. The checked-in image manifest is a sentinel that
+a deployment overrides with real digests. The packed-artifact test exercises the consumer
+path locally.
 
 The CLI deploys long-running QM services; it is not the runtime. Docker runs
 them locally, Fly runs them as Fly apps with Fly Machines for agent computers, and AWS

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,20 @@
 {
   "name": "@yc-software/qm",
   "version": "0.1.0",
-  "private": true,
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yc-software/qm.git",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/yc-software/qm/tree/main/cli#readme",
+  "bugs": "https://github.com/yc-software/qm/issues",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "qm": "dist/bin/qm.js"
   },

--- a/test/release-workflows.test.ts
+++ b/test/release-workflows.test.ts
@@ -44,17 +44,32 @@ test("the release signs private images without requiring anonymous registry acce
   assert.ok(workflow.indexOf("docker/build-push-action") < workflow.indexOf("Sign exact image"));
 });
 
-test("the CLI package cannot be published to a registry", () => {
+test("the CLI package publishes publicly with provenance", () => {
   const manifest = JSON.parse(readFileSync("cli/package.json", "utf8")) as {
     private?: boolean;
-    publishConfig?: unknown;
+    repository?: { url?: string; directory?: string };
+    publishConfig?: { access?: string; provenance?: boolean };
     scripts?: Record<string, string>;
   };
 
-  assert.equal(manifest.private, true);
-  assert.equal(manifest.publishConfig, undefined);
-  assert.equal(manifest.scripts?.prepublishOnly, undefined);
+  assert.equal(manifest.private, undefined);
+  assert.equal(manifest.publishConfig?.access, "public");
+  assert.equal(manifest.publishConfig?.provenance, true);
+  assert.equal(manifest.repository?.url, "git+https://github.com/yc-software/qm.git");
+  assert.equal(manifest.repository?.directory, "cli");
   assert.equal(manifest.scripts?.["verify:release"], undefined);
   assert.equal(existsSync("cli/scripts/verify-release-manifest.mjs"), false);
   assert.equal(existsSync("scripts/prepare-release-manifest.mjs"), false);
+});
+
+test("publishing the CLI is a separate, attested, main-only operation", () => {
+  const workflow = readFileSync(".github/workflows/publish-cli.yml", "utf8");
+
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:$/m);
+  assert.match(workflow, /if: github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /permissions:\s+contents: read\s+id-token: write/);
+  assert.match(workflow, /registry-url: https:\/\/registry\.npmjs\.org/);
+  assert.match(workflow, /npm publish --provenance --access public/);
+  assert.match(workflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/);
+  assert.doesNotMatch(workflow, /packages: write/);
 });

--- a/test/removed-features.test.ts
+++ b/test/removed-features.test.ts
@@ -157,7 +157,6 @@ test("active source and public documentation do not expose retired credential fe
     ["prepare", "-release-manifest"].join(""),
     ["verify", "-release-manifest"].join(""),
     ["prepublish", "Only"].join(""),
-    ["npm ", "publish"].join(""),
   ].map((value) => value.toLowerCase());
   const matches = paths.flatMap((path) => {
     const source = readFileSync(path, "utf8").toLowerCase();


### PR DESCRIPTION
`README.md:105` — the sole documented deploy path — is `npm exec --yes --package=@yc-software/qm@<exact-version> -- qm init …`. That 404s today: `cli/package.json` carried `private: true` and no workflow published it. `cli/README.md` said the command works at line 9 and "never published to a registry" at line 21.

That invariant came from the private fork, where publishing an org-scoped package to a public registry was meaningless rather than unsafe. The repository is public now, so publish it — keeping the verifiability the images already have:

- `publishConfig: {access: public, provenance: true}` plus the `repository` field provenance requires.
- New `.github/workflows/publish-cli.yml`: `workflow_dispatch`, gated on `main`, `id-token: write` and nothing else — notably no `packages: write`. Runs typecheck and the packed-artifact test as a pre-publish gate.
- `release-package.yml` and its cosign signing are untouched.

`test/release-workflows.test.ts` had the old invariant encoded; it now pins the new one, plus the publish workflow's shape so the permissions can't quietly widen.

## Verification

`prettier --check`, `typecheck`, `lint`, `lint:ox`, `test/release-workflows.test.ts` (5/5), and `cli` `test/package.test.ts` (2/2 — the real pack-install-operate path against a local registry) all pass.

No user-visible surface changed, so no screenshots.

## Before the first run

Add an `NPM_TOKEN` secret — a granular token with write scope on `@yc-software`. It is not set on this repo yet, so the workflow will fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787955875&installation_model_id=19911&pr_number=10&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F10&signature=e656a54c9e81fb6055a9a0eeaafba354afeb0c91287d982c65f9fb042ec9e649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->