### PR TITLE
Publish images under a repo-nested GHCR namespace

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -47,12 +47,12 @@ jobs:
           provenance: false
           push: true
           build-args: ${{ matrix.build-args }}
-          tags: ghcr.io/yc-software/qm-${{ matrix.name }}:${{ github.sha }}
+          tags: ghcr.io/yc-software/qm/${{ matrix.name }}:${{ github.sha }}
           cache-from: type=gha,scope=qm-${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=qm-${{ matrix.name }}
       - name: Sign exact image
         run: |
-          image='ghcr.io/yc-software/qm-${{ matrix.name }}@${{ steps.build.outputs.digest }}'
+          image='ghcr.io/yc-software/qm/${{ matrix.name }}@${{ steps.build.outputs.digest }}'
           cosign sign --yes "$image"
           cosign verify "$image" \
             --certificate-identity='https://github.com/${{ github.repository }}/.github/workflows/release-package.yml@refs/heads/main' \

--- a/test/release-workflows.test.ts
+++ b/test/release-workflows.test.ts
@@ -38,7 +38,7 @@ test("the release signs private images without requiring anonymous registry acce
   assert.match(workflow, /platforms: linux\/amd64\s+provenance: false/);
   assert.match(
     workflow,
-    /image='ghcr\.io\/yc-software\/qm-\$\{\{ matrix\.name \}\}@\$\{\{ steps\.build\.outputs\.digest \}\}'\s+cosign sign --yes "\$image"\s+cosign verify "\$image"/,
+    /image='ghcr\.io\/yc-software\/qm\/\$\{\{ matrix\.name \}\}@\$\{\{ steps\.build\.outputs\.digest \}\}'\s+cosign sign --yes "\$image"\s+cosign verify "\$image"/,
   );
   assert.ok(workflow.indexOf("docker/login-action") < workflow.indexOf("docker/build-push-action"));
   assert.ok(workflow.indexOf("docker/build-push-action") < workflow.indexOf("Sign exact image"));


### PR DESCRIPTION
Every image build on this repository currently fails:

```
failed to push ghcr.io/yc-software/qm-admin:f081c0b:
403 Forbidden
```

The six `qm-<name>` packages were created by the repository this one was exported from. GHCR ties a package's Actions-write access to its originating repository, so the rename left them owned elsewhere and this repository's `GITHUB_TOKEN` cannot push to them.

The obvious fix — relink each package to this repository and flip it public — is the wrong one. Making an existing package public exposes **every version it already holds**, and those were all built from the pre-export tree. Same shape of mistake as reusing a repository that still carries `refs/pull/*`.

So: publish to a fresh namespace, and leave the old packages private and untouched on the archived repository.

`ghcr.io/yc-software/qm/<name>` nests the six under the repository name. A package created by this workflow is owned by this repository from its first push, so no manual relinking is ever needed. `--certificate-identity` already interpolates `${{ github.repository }}`, so signing needs no change.

Only two lines actually referenced the GHCR path. The other ~120 `qm-*` hits in the tree are Fly app names, ECR repository names, and test fixtures — none of them registry paths.

## Verification

`test/release-workflows.test.ts` pins the image path; its regex is updated with the workflow. That file plus `test/removed-features.test.ts` pass (9/9), and prettier is clean.

Not yet exercised end to end — the first dispatch after merge will create the six packages. They land private by default and need a one-time visibility flip to public, per package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787956773&installation_model_id=19911&pr_number=12&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F12&signature=8441016dbfd191ff5469766d271c9a8eac5f8a98db04c62489745921720aa163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->