### PR TITLE
Stop shipping build-time caches and host identity in published images

### DIFF
--- a/deploy/auth/Dockerfile
+++ b/deploy/auth/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432
 WORKDIR /app
 
 COPY plugins/auth/package.json plugins/auth/package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && rm -rf /root/.npm /tmp/node-compile-cache
 
 COPY plugins/auth/src ./src
 COPY plugins/chassis/src /chassis/src

--- a/deploy/core/Dockerfile
+++ b/deploy/core/Dockerfile
@@ -5,7 +5,8 @@ RUN apk add --no-cache ca-certificates curl git git-daemon
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm audit --omit=dev --audit-level=moderate
+RUN npm ci --omit=dev && npm audit --omit=dev --audit-level=moderate \
+  && rm -rf /root/.npm /tmp/node-compile-cache
 
 COPY src ./src
 COPY cli/templates/slack-manifest.json ./cli/templates/slack-manifest.json

--- a/deploy/portal/Dockerfile
+++ b/deploy/portal/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432
 WORKDIR /app
 
 COPY plugins/portal/package.json plugins/portal/package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && rm -rf /root/.npm /tmp/node-compile-cache
 
 COPY plugins/portal/src ./src
 COPY plugins/chassis/src /chassis/src

--- a/deploy/web-ui/Dockerfile
+++ b/deploy/web-ui/Dockerfile
@@ -12,7 +12,8 @@ RUN npm run build
 FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 WORKDIR /app
 COPY plugins/web-ui/package.json plugins/web-ui/package-lock.json ./
-RUN npm ci --omit=dev && rm package-lock.json
+RUN npm ci --omit=dev && rm package-lock.json \
+  && rm -rf /root/.npm /tmp/node-compile-cache
 COPY plugins/web-ui/server ./server
 COPY plugins/chassis/src /chassis/src
 COPY --from=build /app/dist-web ./dist-web

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -5,7 +5,7 @@ RUN npm install -g --allow-scripts=@anthropic-ai/claude-code \
 
 FROM debian:12-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash coreutils findutils grep sed gawk \
@@ -29,7 +29,8 @@ RUN case "$TARGETARCH" in \
   && tar xzf /tmp/gh.tgz -C /tmp \
   && install "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /usr/local/bin/gh \
   && rm -rf /tmp/gh* \
-  && gh --version
+  && gh --version \
+  && rm -rf /root/.local/state/gh
 
 RUN claude --version \
   && codex --version
@@ -67,7 +68,12 @@ RUN if [ "$INSTALL_BROWSER_ENGINE" = "1" ]; then \
       /opt/browser-engine/venv/bin/pip install --no-cache-dir "browser-use==${BROWSER_USE_VERSION}"; \
       /opt/browser-engine/venv/bin/python -c "import browser_use; print('browser-use ok')"; \
       /usr/bin/chromium --version; \
+      : > /etc/machine-id; \
+      : > /var/lib/dbus/machine-id; \
     fi
+
+ENV ANONYMIZED_TELEMETRY=false
+ENV BROWSER_USE_CLOUD_SYNC=false
 
 WORKDIR /workspace
 


### PR DESCRIPTION
All six release images were built and scanned as filesystems — `docker export`, full-tree scan, per-layer whiteout analysis, metadata inspection — rather than audited by reading Dockerfiles.

**No organization data, credentials, or repository content leaks in any of the six.** Zero hits for `ycombinator`, `quartermaster`, `work-claw`, or the old AWS account, on any image. No `.git`, `.env`, SSH keys, or cloud configs. The web-ui client bundle — the only artifact that reaches browsers — has no source maps, no build-machine paths, and no inlined build env.

What the audit did find is build-environment residue that becomes public the moment these are pushed to a public registry.

## `/root/.npm` ships in core, portal, auth, web-ui

npm's cacache stores **every fetch URL verbatim as the cache key**, so npm's own log redaction never applies. The core image carried a live GitHub release-asset JWT and Azure SAS signature, from resolving `@earendil-works/pi-coding-agent` over a signed release URL:

```
"key":"make-fetch-happen:request-cache:https://release-assets.githubusercontent.com/...&sig=L8WnDk34...%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9...
```

Those specific tokens are worthless — 300-second JWT TTL, SAS expires an hour after build, and both grant read on an asset that is already public. **The mechanism is the problem**: any dependency resolved through an authenticated or signed URL gets published verbatim. Cached `reqHeaders` are empty, so header-based auth is unaffected; only URL-embedded secrets are exposed.

Removing the cache also takes core from **4.44 GB to 3.12 GB**.

## `sandbox-base` baked a fixed host identity

`/etc/machine-id` and `/var/lib/dbus/machine-id` both held `b2dc9eb4b2c34319bb4861e8c984bab3` — identical across separate `docker run` invocations. Generated by systemd's postinst, pulled in as a chromium dependency. Every container anyone runs from the published image would present the same 128-bit identity to systemd, D-Bus, and anything keyed on it. Debian's own cloud images ship these empty for exactly this reason. The `gh` device-id, a side effect of the version smoke test, had the same problem.

## browser-use telemetry was on by default

An agent sandbox that browses on users' behalf shipped with an unconfigured outbound data path to `eu.i.posthog.com` and `api.browser-use.com`, with exception autocapture enabled. Now off by default; operators can re-enable via env.

## `DEBIAN_FRONTEND` was an `ENV`

So it persisted into the runtime and silently suppressed prompts for anything the agent ran. It is a build-time concern — demoted to `ARG`.

## Verification

Rebuilt all six and re-inspected:

| check | result |
|---|---|
| `/root/.npm` in core/portal/auth/web-ui | gone |
| `/tmp/node-compile-cache` | gone |
| `/etc/machine-id`, `/var/lib/dbus/machine-id` | 0 bytes |
| `gh` device-id | gone |
| `ANONYMIZED_TELEMETRY` / `BROWSER_USE_CLOUD_SYNC` | `false` |
| `DEBIAN_FRONTEND` in runtime env | absent |
| core image size | 4.44 GB → 3.12 GB |

## Deliberately not in this PR

- **web-ui ships 307 MB of build-only dependencies** into its final stage — 112 top-level packages for a 6.3 MB bundle, none imported by the server, which uses only node builtins, `lru-cache`, and chassis. Bloat and vulnerability surface, not exposure: static serving is confined to `dist-web` behind a traversal guard. Fixing it means restructuring the multi-stage build, which deserves its own change.
- **`rm package-lock.json` in the web-ui Dockerfile does nothing** — the file is recoverable byte-identical from the underlying `COPY` layer. Left alone rather than change what ships inside a hardening PR.
- **SLSA provenance embeds the git remote and SHA.** Harmless here, and `release-package.yml` sets `provenance: false` so it never reaches GHCR — but that is one deleted line away from a private fork publishing its repo URL and commit SHA. Worth making durable separately.

## Caveats

Images were built on arm64 under emulation; CI builds native amd64 with GHA layer cache. Detection was literal-text regex and `strings`, not entropy analysis, so encoded or compressed secrets would not surface. Worth adding gitleaks or trufflehog to CI for standing coverage rather than point-in-time passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787958782&installation_model_id=19911&pr_number=14&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F14&signature=a8419234e58b0bb61cac183d9f6d8ebe067410167a4f005d513500ee82c4fd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->