### PR TITLE
Pin real image digests into the published CLI package

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -2,6 +2,10 @@ name: Publish the QM CLI
 
 on:
   workflow_dispatch:
+    inputs:
+      images_ref:
+        description: Commit SHA whose published images the package should pin
+        required: false
 
 permissions:
   contents: read
@@ -27,6 +31,36 @@ jobs:
           npm ci
           npm run typecheck
           npm run test:pack
+      - name: Pin published image digests
+        env:
+          IMAGES_REF: ${{ inputs.images_ref || github.sha }}
+        run: |
+          set -euo pipefail
+          out=$(jq -n '{sandboxBase: "", services: {}}')
+          for service in core web-ui admin portal auth sandbox-base; do
+            repo="yc-software/qm/$service"
+            token=$(curl -fsS "https://ghcr.io/token?scope=repository:$repo:pull&service=ghcr.io" | jq -r .token)
+            digest=$(curl -fsS -o /dev/null -D - -H "Authorization: Bearer $token" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json' \
+              "https://ghcr.io/v2/$repo/manifests/$IMAGES_REF" \
+              | tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }')
+            if [ -z "$digest" ]; then
+              echo "no published image for $repo at $IMAGES_REF" >&2
+              exit 1
+            fi
+            ref="ghcr.io/$repo@$digest"
+            if [ "$service" = sandbox-base ]; then
+              out=$(printf '%s' "$out" | jq --arg r "$ref" '.sandboxBase = $r')
+            else
+              out=$(printf '%s' "$out" | jq --arg k "$service" --arg r "$ref" '.services[$k] = $r')
+            fi
+          done
+          printf '%s\n' "$out" > cli/manifest.json
+          cat cli/manifest.json
+          jq -e '[.sandboxBase] + [.services[]]
+                 | length == 6
+                 and all(test("^ghcr\\.io/yc-software/qm/[a-z-]+@sha256:[0-9a-f]{64}$"))
+                 and all(test("@sha256:(.)\\1{63}$") | not)' cli/manifest.json > /dev/null
       - name: Publish
         working-directory: cli
         run: npm publish --provenance --access public

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/test/init.test.ts
+++ b/cli/test/init.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runInit } from "../src/commands/init.ts";
 import { CONFIG_FILENAME, loadConfigInDir } from "../src/config.ts";
+import { cliVersion } from "../src/manifest.ts";
 import { parseToolDescriptor, validateSandboxLayer } from "../src/sandbox-layer.ts";
 import { SERVICE_NAMES, VIRTUAL_SERVICE_NAMES } from "../src/services.ts";
 import { renderEnvExample } from "../src/secrets.ts";
@@ -427,7 +428,7 @@ test("init preflights package.json and completes an install-first package manife
     assert.equal(manifest.private, true);
     assert.equal(manifest.engines?.node, ">=24.0.0");
     assert.equal(manifest.scripts?.deploy, "qm up");
-    assert.equal(manifest.dependencies?.["@yc-software/qm"], "0.1.0");
+    assert.equal(manifest.dependencies?.["@yc-software/qm"], cliVersion());
     assert.equal(manifest.dependencies?.["qm-cli"], undefined);
     assert.equal(manifest.dependencies?.other, "1.0.0");
   } finally {
@@ -512,7 +513,7 @@ test("the scaffold is an npm-backed deployment repository with no CI coupling an
       scripts?: Record<string, string>;
     };
     assert.equal(packageJson.private, true);
-    assert.equal(packageJson.dependencies?.["@yc-software/qm"], "0.1.0");
+    assert.equal(packageJson.dependencies?.["@yc-software/qm"], cliVersion());
     assert.equal(packageJson.scripts?.check, "qm check");
     assert.ok(existsSync(join(dir, "deployment.md")));
     assert.ok(existsSync(join(dir, ".codex", "skills", "deploy-qm", "SKILL.md")));

--- a/cli/test/package.test.ts
+++ b/cli/test/package.test.ts
@@ -49,6 +49,7 @@ test(
       const awsDeployment = join(dir, "aws-deployment");
       const tarballBytes = readFileSync(tarball);
       const packageManifest = JSON.parse(readFileSync(join(cliDir, "package.json"), "utf8")) as Record<string, unknown>;
+      const version = packageManifest["version"] as string;
       registry = createServer((request, response) => {
         const origin = `http://${request.headers.host}`;
         if (request.url && decodeURIComponent(request.url) === "/@yc-software/qm") {
@@ -56,12 +57,12 @@ test(
           response.end(
             JSON.stringify({
               name: "@yc-software/qm",
-              "dist-tags": { latest: "0.1.0" },
+              "dist-tags": { latest: version },
               versions: {
-                "0.1.0": {
+                [version]: {
                   ...packageManifest,
                   dist: {
-                    tarball: `${origin}/@yc-software/qm/-/qm-0.1.0.tgz`,
+                    tarball: `${origin}/@yc-software/qm/-/qm-${version}.tgz`,
                     shasum: createHash("sha1").update(tarballBytes).digest("hex"),
                     integrity: `sha512-${createHash("sha512").update(tarballBytes).digest("base64")}`,
                   },
@@ -71,7 +72,7 @@ test(
           );
           return;
         }
-        if (request.url === "/@yc-software/qm/-/qm-0.1.0.tgz") {
+        if (request.url === `/@yc-software/qm/-/qm-${version}.tgz`) {
           response.setHeader("content-type", "application/octet-stream");
           response.end(tarballBytes);
           return;
@@ -93,7 +94,7 @@ test(
           [
             "exec",
             "--yes",
-            "--package=@yc-software/qm@0.1.0",
+            `--package=@yc-software/qm@${version}`,
             "--",
             "qm",
             "init",
@@ -134,7 +135,7 @@ test(
         };
         assert.equal(consumerPackage.private, true);
         assert.equal(consumerPackage.scripts?.deploy, "qm up");
-        assert.equal(consumerPackage.dependencies?.["@yc-software/qm"], "0.1.0");
+        assert.equal(consumerPackage.dependencies?.["@yc-software/qm"], version);
       }
       await new Promise<void>((resolve, reject) => registry!.close((error) => (error ? reject(error) : resolve())));
       registry = undefined;

--- a/test/release-workflows.test.ts
+++ b/test/release-workflows.test.ts
@@ -73,3 +73,27 @@ test("publishing the CLI is a separate, attested, main-only operation", () => {
   assert.match(workflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/);
   assert.doesNotMatch(workflow, /packages: write/);
 });
+
+test("the published package pins real image digests, never the checked-in sentinel", () => {
+  const workflow = readFileSync(".github/workflows/publish-cli.yml", "utf8");
+
+  assert.ok(
+    workflow.indexOf("Pin published image digests") < workflow.indexOf("npm publish"),
+    "digests are resolved before the package is published",
+  );
+  assert.match(workflow, /for service in core web-ui admin portal auth sandbox-base; do/);
+  assert.match(workflow, /printf '%s\\n' "\$out" > cli\/manifest\.json/);
+  assert.match(workflow, /no published image for \$repo at \$IMAGES_REF/);
+  assert.match(workflow, /\{63\}\$"\) \| not\)/);
+
+  const sentinel = JSON.parse(readFileSync("cli/manifest.json", "utf8")) as {
+    sandboxBase: string;
+    services: Record<string, string>;
+  };
+  const refs = [sentinel.sandboxBase, ...Object.values(sentinel.services)];
+  assert.equal(refs.length, 6);
+  assert.ok(
+    refs.every((ref) => ref.startsWith("registry.invalid/")),
+    "the checked-in manifest stays a sentinel so a source checkout never pulls a stale digest",
+  );
+});


### PR DESCRIPTION
A self-hoster reported that `@yc-software/qm@0.1.0` cannot pull any runtime image. It can't — the published package ships the sentinel manifest verbatim:

```json
"core": "registry.invalid/qm/qm-core@sha256:aaaaaaaa…"
```

`registry.invalid` is an RFC 2606 never-resolves TLD and the digest is 64 literal `a`s. Every service points there.

## Why nothing caught it

1. `cli/manifest.json` has always been a sentinel, and `cli/README.md` says so. That was harmless while the package was `private: true` — a source checkout deploys with `--build-from` or operator-published images, and `plan` / `sandbox build` only *render* the reference. Publishing it made the placeholder everyone's default.
2. The release step that once substituted real digests was retired with the private release scheme, and is pinned deleted by `test/removed-features.test.ts`. No code path could populate the file.
3. `immutableRef` (`cli/src/manifest.ts:54`) validates only the *shape* — `/@sha256:[a-f0-9]{64}$/`. Sixty-four `a`s is valid hex, so the sentinel passes as a legitimately digest-pinned reference and goes straight to `docker pull`. Only `fly.ts` guards for `registry.invalid`; docker and aws have no such check.

## The fix

Resolve the six digests from GHCR **at publish time** rather than committing them. `cli/manifest.json` stays a sentinel in the tree; the published tarball always carries what the registry actually served for the commit being released.

Keeping the checked-in sentinel is deliberate: committed digests go stale the moment images are rebuilt, and `cli/test/e2e/plan.e2e.test.ts` and `cli/test/sandbox-build.test.ts` assert the sentinel renders, which is the correct dev behaviour for a source checkout.

The step fails closed if an image is missing for the commit, and rejects both a surviving `registry.invalid` host and a degenerate all-one-character digest — so a sentinel cannot reach npm even if the resolver silently no-ops. Verified against three fixtures: sentinel rejected, real-registry-with-fake-digest rejected, real digests accepted.

`workflow_dispatch` takes an optional `images_ref` so a release can pin images from a commit other than `HEAD`; it defaults to `github.sha`.

## Not done, and why

I did not make `immutableRef` throw on sentinels, which was the obvious-looking fix. `plan` and `sandbox build` legitimately render the sentinel in a source checkout and their tests assert it — a throw at manifest load breaks the documented dev loop. Those are dry-run paths that never pull, so the guard belongs at publish time, which is where it now is.

## Also

`cli/test/package.test.ts` hardcoded `0.1.0` in six places and would have broken on any version bump. It now reads the version from the manifest. Version bumped to `0.1.1` — `0.1.0` is immutable on npm.

## Verification

`test/release-workflows.test.ts` (6/6, including a new test pinning the resolve step ahead of publish), `test/removed-features.test.ts` (5/5), `cli` `test/package.test.ts` (2/2 at 0.1.1 — real pack-install-operate against a local registry), prettier, both typechecks, eslint. The digest-verification jq was tested against sentinel, fake-digest, and real-digest fixtures directly.

Not exercised end to end: the resolve step itself runs for the first time on the next dispatch. It fails closed, so the failure mode is a failed publish rather than another broken package.

**After merge:** dispatch *Publish the QM CLI* with `images_ref` = `b27c78b11538a16a0f6ac2e65c77913996ab4954` (the commit whose images are live), and tell the reporter to use `qm up --build-from` until `0.1.1` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787961216&installation_model_id=19911&pr_number=15&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F15&signature=d0bc8c4fbf02c9dc14f5d24c4d7b97320b3ed5dd5e0aa6f3ce990f3761bfabce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->