### PR TITLE
Fix MicroVM image tag parsing to read the capitalized Tags response key

### DIFF
--- a/cli/src/commands/infra.ts
+++ b/cli/src/commands/infra.ts
@@ -298,8 +298,8 @@ function imageTags(awsBin: string, region: string, imageArn: string): Record<str
       "json",
       "--no-cli-pager",
     ]),
-  ) as { tags?: Record<string, string> };
-  return parsed.tags ?? {};
+  ) as { Tags?: Record<string, string> };
+  return parsed.Tags ?? {};
 }
 
 function assertImageIdentity(config: QmConfig, awsBin: string, image: ImageSummary): ImageSummary {

--- a/cli/test/infra-image.test.ts
+++ b/cli/test/infra-image.test.ts
@@ -103,7 +103,7 @@ else if (command === "s3api put-object") {
     console.log(JSON.stringify({items:[image()]}));
   }
 } else if (command === "lambda-microvms list-tags") {
-  console.log(JSON.stringify({tags:{ManagedBy:"qm-cli",Deployment:process.env.FAKE_DEPLOYMENT_TAG || "acme"}}));
+  console.log(JSON.stringify({Tags:{ManagedBy:"qm-cli",Deployment:process.env.FAKE_DEPLOYMENT_TAG || "acme"}}));
 } else if (command === "lambda-microvms create-microvm-image" || command === "lambda-microvms update-microvm-image") {
   state = state || {version:0,state:"CREATED"};
   if (process.env.FAKE_CONFLICT === "1" && !state.conflictUsed) {


### PR DESCRIPTION
## Bug

`qm infra build-image` always failed on AWS with `refusing to manage MicroVM image ... ownership tags do not match`, even for images the CLI had just created and correctly tagged `{"Tags": {"Deployment": "...", "ManagedBy": "qm-cli"}}`.

Root cause: `imageTags()` in `cli/src/commands/infra.ts` parsed the `aws lambda-microvms list-tags` response via `parsed.tags`, but the response key is `Tags` (capitalized). It therefore always returned `{}`, and `assertImageIdentity` rejected every image — the command could never succeed against real AWS.

## How it was found

Hit during a real AWS deployment; the failure reproduced on every run despite the tags being verifiably correct via `aws lambda-microvms list-tags`.

## Fix

- `imageTags()` now reads `Tags` (no lowercase fallback — the surrounding parsing is non-defensive, e.g. `parsed.taskDefinitionArns`).
- The test fake mirrored the same lowercase key, which is why the suite passed. It now emits the realistic `{"Tags": {...}}` payload, so the existing build/delete ownership tests exercise the real response shape and catch this regression (they fail against the old code).
- Swept the repo for other `list-tags` parsing: the ECS `list-tags-for-resource` handling is correct and untouched — that API genuinely returns lowercase `tags`.

## Testing

- `node --test cli/test/infra-image.test.ts`: 18 pass, 0 fail
- `npm run typecheck` (cli): clean
- `eslint` on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787962308&installation_model_id=19911&pr_number=16&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F16&signature=fe6a3db45820239a5bca012e7080879996fa24be72675e52450eb7bfb83b4fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->