### PR TITLE
Ship references/email.md from qm init

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -235,7 +235,7 @@ function scaffoldDeploymentSkill(dir: string): void {
     ["deployment.md"],
     [".codex", "skills", "deploy-qm", "SKILL.md"],
     [".codex", "skills", "deploy-qm", "agents", "openai.yaml"],
-    ...["fly", "aws", "slack"].map((name) => [".codex", "skills", "deploy-qm", "references", `${name}.md`]),
+    ...["fly", "aws", "slack", "email"].map((name) => [".codex", "skills", "deploy-qm", "references", `${name}.md`]),
   ];
   for (const segments of files) {
     const source =

--- a/cli/templates/deployment/references/email.md
+++ b/cli/templates/deployment/references/email.md
@@ -57,6 +57,46 @@ optional settings live in `env.auth`:
 `qm doctor` proves the relay is reachable and answers. It does not authenticate;
 wrong credentials surface on the first real send.
 
+### Gmail / Google Workspace app password
+
+The fastest SMTP path when the operator already has a Google account: no new
+account, no DNS wait.
+
+1. The account must have 2-Step Verification enabled — Google only offers app
+   passwords with it on.
+2. Operator visits <https://myaccount.google.com/apppasswords>, creates an app
+   password, and hands you the 16-character value.
+3. `qm setup` values: `SMTP_HOST` is `smtp.gmail.com`, `SMTP_USERNAME` is the
+   full address of the account that minted the app password, `SMTP_PASSWORD` is
+   the app password (spaces optional).
+4. Set `AUTH_EMAIL_FROM` to that same address — Gmail rewrites the From header
+   to the authenticated account, so any other sender silently becomes wrong.
+
+Two limits to raise with the operator: Gmail caps sending at roughly 2,000
+messages a day (a few hundred for free accounts), fine for sign-in links but
+not bulk mail; and a Workspace admin can disable app passwords org-wide, in
+which case the page in step 2 refuses to create one and you need a different
+relay.
+
+### Amazon SES when there is no domain
+
+SES works without owning a domain: verify a single email address instead.
+
+1. In the SES console, under **Identities**, create an email-address identity
+   and click the verification link SES sends to it.
+2. Under **SMTP settings**, create SMTP credentials (an IAM user with a
+   generated SMTP password — not the AWS access key itself).
+3. `qm setup` values: `SMTP_HOST` is the region endpoint (for example
+   `email-smtp.us-east-1.amazonaws.com`), `SMTP_USERNAME` and `SMTP_PASSWORD`
+   are the generated SMTP credentials, and `AUTH_EMAIL_FROM` is the verified
+   address.
+
+New SES accounts start in the sandbox, which only delivers to verified
+addresses. That is enough for a single administrator signing in with the
+verified address; for a whole team, the operator requests production access
+from the SES console (usually granted within a day) or verifies each
+recipient.
+
 ## Who may sign in
 
 Set one of these, or the broker refuses to start:

--- a/cli/test/init.test.ts
+++ b/cli/test/init.test.ts
@@ -517,7 +517,7 @@ test("the scaffold is an npm-backed deployment repository with no CI coupling an
     assert.equal(packageJson.scripts?.check, "qm check");
     assert.ok(existsSync(join(dir, "deployment.md")));
     assert.ok(existsSync(join(dir, ".codex", "skills", "deploy-qm", "SKILL.md")));
-    for (const provider of ["fly", "aws", "slack"]) {
+    for (const provider of ["fly", "aws", "slack", "email"]) {
       assert.ok(existsSync(join(dir, ".codex", "skills", "deploy-qm", "references", `${provider}.md`)));
     }
     assert.match(readFileSync(join(dir, ".gitignore"), "utf8"), /^node_modules\/$/m);


### PR DESCRIPTION
## Problem

`deployment.md` instructs the operator's agent to read `.codex/skills/deploy-qm/references/email.md` before collecting secrets, but `qm init` only copied `fly.md`, `aws.md`, and `slack.md` into `references/`. The template existed at `cli/templates/deployment/references/email.md` and was simply omitted from the copy list in `scaffoldDeploymentSkill`. Two real setup sessions each stalled on "how do I get SMTP credentials" because the referenced guide was missing.

## Fix

- Add `email` to the reference list in `cli/src/commands/init.ts`, so init ships the file the docs already point at.
- Extend the template with the concrete walkthroughs the stalled sessions needed:
  - **Gmail / Google Workspace app password**: 2-Step Verification prerequisite, myaccount.google.com/apppasswords, `SMTP_HOST=smtp.gmail.com`, `SMTP_USERNAME` must be the app-password account, `AUTH_EMAIL_FROM` must match because Gmail rewrites From, ~2,000/day cap, and the Workspace-admin-can-disable-app-passwords caveat.
  - **Amazon SES without a domain**: verify a single email identity, SMTP credentials (not the AWS access key), region endpoint host, and the sandbox only delivering to verified addresses.
- Extend the init test to assert `email.md` is scaffolded.

Env var names and transport values (`AUTH_EMAIL_TRANSPORT` = `resend`/`smtp`, `SMTP_HOST`/`SMTP_USERNAME`/`SMTP_PASSWORD`, `RESEND_API_KEY`, `AUTH_EMAIL_FROM`) match `cli/src/secrets.ts`.

## Testing

- `node --test test/init.test.ts` in `cli/` — 16 pass
- `npm run typecheck` in `cli/` and `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787962359&installation_model_id=19911&pr_number=17&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F17&signature=a7849d55f5b7e4c9c7c6f0b191fb8e7ae4d1eebc3fa82fd05a31c84a8a644ee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->