### PR TITLE
Offer a retry link on the stale sign-in link page

### DIFF
--- a/plugins/auth/src/pages.ts
+++ b/plugins/auth/src/pages.ts
@@ -166,7 +166,16 @@ export function confirmSignInPage(o: { brandName: string; action: string }): str
   });
 }
 
-export function problemPage(o: { brandName: string; heading: string; msg: string; detail?: string }): string {
+export function problemPage(o: {
+  brandName: string;
+  heading: string;
+  msg: string;
+  detail?: string;
+  retryUrl?: string;
+}): string {
+  const detail = o.detail ? `<p class="reason"><strong>Details</strong>${escapeHtml(o.detail)}</p>` : "";
+  const retry = o.retryUrl ? `<a class="btn" href="${escapeHtml(o.retryUrl)}">Request a new sign-in link</a>` : "";
+  const body = `${detail}${retry}`;
   return page({
     title: "Sign-in problem",
     brandName: o.brandName,
@@ -174,7 +183,7 @@ export function problemPage(o: { brandName: string; heading: string; msg: string
     warn: true,
     heading: o.heading,
     msg: o.msg,
-    ...(o.detail ? { body: `<p class="reason"><strong>Details</strong>${escapeHtml(o.detail)}</p>` } : {}),
+    ...(body ? { body } : {}),
     help: "If this keeps happening, contact your administrator.",
   });
 }

--- a/plugins/auth/src/server.ts
+++ b/plugins/auth/src/server.ts
@@ -123,12 +123,24 @@ export function createAuthHandler(deps: AuthDeps): (req: IncomingMessage, res: S
   const problem = (res: ServerResponse, status: number, heading: string, msg: string, detail?: string): void =>
     sendHtml(res, status, problemPage({ brandName: cfg.brandName, heading, msg, ...(detail ? { detail } : {}) }));
 
+  const signInUrl = ((): string | undefined => {
+    try {
+      return new URL("/auth/login", cfg.redirectUri).toString();
+    } catch {
+      return undefined;
+    }
+  })();
+
   const staleLink = (res: ServerResponse): void =>
-    problem(
+    sendHtml(
       res,
       400,
-      "This sign-in link no longer works",
-      "Sign-in links work once and expire quickly. Request a fresh one and open it right away.",
+      problemPage({
+        brandName: cfg.brandName,
+        heading: "This sign-in link no longer works",
+        msg: "Sign-in links work once and expire quickly. Request a fresh one and open it right away.",
+        ...(signInUrl ? { retryUrl: signInUrl } : {}),
+      }),
     );
 
   async function authorizeForm(res: ServerResponse, params: URLSearchParams): Promise<void> {

--- a/plugins/auth/test/flow.test.ts
+++ b/plugins/auth/test/flow.test.ts
@@ -147,7 +147,9 @@ test("a replayed magic link is refused", async (t) => {
   assert.equal((await openLink(h, link)).status, 302);
   const replay = await openLink(h, link);
   assert.equal(replay.status, 400);
-  assert.match(await replay.text(), /no longer works/);
+  const stale = await replay.text();
+  assert.match(stale, /no longer works/);
+  assert.match(stale, /href="https:\/\/agent\.example\.test\/auth\/login"/);
 });
 
 test("a replayed authorization code is refused", async (t) => {
@@ -169,6 +171,7 @@ test("an expired magic link is refused", async (t) => {
   h.now.ms += (h.cfg.linkTtlS + 60) * 1000;
   const late = await openLink(h, link);
   assert.equal(late.status, 400);
+  assert.match(await late.text(), /href="https:\/\/agent\.example\.test\/auth\/login"/);
   assert.equal(
     h.claims.calls.some((ids) => ids[0]?.startsWith("link:")),
     false,


### PR DESCRIPTION
## Problem

When a one-time sign-in link fails to verify — expired, bad signature, or already claimed (e.g. a mail scanner or a second open spent it) — the auth service renders "This sign-in link no longer works" with no way forward. It's a UX dead end: a real user hit this during a Fly deployment and had to ask how to retry; the answer was just "go back to the portal sign-in form", which the page never offered.

## Fix

Both stale-link branches in `plugins/auth/src/server.ts` (failed `openLink` and failed single-use claim) render the same page via `staleLink`, which now includes a "Request a new sign-in link" button. The destination is `new URL("/auth/login", cfg.redirectUri)` — the portal's login route, derived from the already-configured `AUTH_REDIRECT_URI` (the portal registers `${PUBLIC_URL}/auth/callback`), so no hostname is hardcoded. If `redirectUri` doesn't parse, the page renders without the button, exactly as before.

`problemPage` gains an optional `retryUrl`; all other problem pages are unchanged.

## Screenshot

Rendered by generating the `problemPage` HTML with realistic data (brand "qm", portal login URL) and screenshotting in headless Chrome — the auth service serves this exact markup:

The card shows the warning icon, "This sign-in link no longer works", the existing explanation, and a full-width primary button "Request a new sign-in link" linking to the portal login, above the "contact your administrator" help line. Screenshot verified locally; GitHub offers no CLI path to upload images into a PR body, so the exact render is reproducible with: `node --input-type=module -e` importing `problemPage` from `plugins/auth/src/pages.ts` and opening the output in a browser.

## Tests

Extended `plugins/auth/test/flow.test.ts`: the replayed-link and expired-link tests now assert the response contains `href="https://agent.example.test/auth/login"`. Full auth plugin suite: 25/25 pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
