### PR TITLE
Make the admin onboarding view reachable

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4727,7 +4727,7 @@
         { views: ["history", "slack", "judgments"] },
         { label: "Artifacts", views: ["files", "skills", "memory", "deployments", "crons"] },
         { label: "System", views: ["metrics"] },
-        { label: "Admin", views: ["governance", "connectors", "users", "keychain", "egress", "audit"] },
+        { label: "Admin", views: ["onboarding", "governance", "connectors", "users", "keychain", "egress", "audit"] },
         { label: "Insights", views: ["retention"] },
       ];
 

--- a/plugins/admin/test/onboarding-view.test.ts
+++ b/plugins/admin/test/onboarding-view.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+
+function slice(from: string, to: string): string {
+  const start = html.indexOf(from);
+  const end = html.indexOf(to, start);
+  assert.ok(start >= 0 && end > start, `could not extract ${from}`);
+  return html.slice(start, end);
+}
+
+function resolveView(pathname: string, search: string): string {
+  const src = [
+    slice("const SECTIONS = [", "const DISABLED_VIEWS"),
+    slice("const DEFAULT_VIEW = ", ";") + ";",
+    slice("function urlToState() {", "let transcriptObserver"),
+    "urlToState().view;",
+  ].join("\n");
+  const context = vm.createContext({
+    URLSearchParams,
+    API_BASE: "/admin",
+    scope: "org",
+    location: { pathname, search },
+  });
+  return vm.runInContext(src, context);
+}
+
+test("onboarding is a navigable view", () => {
+  assert.match(html, /\{ label: "Admin", views: \["onboarding",/);
+});
+
+test("/admin/onboarding resolves to the onboarding view", () => {
+  assert.equal(resolveView("/admin/onboarding", ""), "onboarding");
+});
+
+test("?view=onboarding resolves to the onboarding view", () => {
+  assert.equal(resolveView("/admin/", "?view=onboarding"), "onboarding");
+});
+
+test("unknown views still fall back to the default view", () => {
+  assert.equal(resolveView("/admin/no-such-view", ""), "history");
+});


### PR DESCRIPTION
## Bug

Found during a real AWS deployment: the first admin sign-in landed on a 403 web UI with no way to enter a model key. The onboarding view — the only place an operator can enter the first model API key — was unreachable dead code.

In `plugins/admin/public/index.html`:
- `SECTIONS` defines every nav group, and `onboarding` appeared in none of them.
- `VIEWS` is derived from `SECTIONS`.
- `urlToState()` only honors a view if `VIEWS.includes(v)`, otherwise it falls back to `DEFAULT_VIEW = "history"`.

So no tab rendered for onboarding, and both `/admin/onboarding` and `?view=onboarding` silently landed on the Sessions view. The markup, `VIEW_TITLE.onboarding`, `loadOnboarding()`, and the model-key form all existed but could never be shown. The existing test (`plugins/admin/test/default-view.test.ts`) only asserted the markup was present, which is why this shipped.

## Fix

- Add `onboarding` to the Admin group in `SECTIONS`, so the tab renders and `urlToState()` accepts the view.
- New test `plugins/admin/test/onboarding-view.test.ts` extracts the page's actual `SECTIONS`/`urlToState()` and evaluates them in a `node:vm` context, asserting that both `/admin/onboarding` and `?view=onboarding` resolve to the onboarding view and that unknown views still fall back to history — exercising route resolution, not just markup presence.

## Screenshot

Rendered locally by serving `index.html` against stubbed API responses (fresh-deploy shape: no model key configured); the live admin server needs a full core deployment which was not feasible here.

![Onboarding view reachable from the Admin nav group](https://raw.githubusercontent.com/yc-software/qm/b335cf8be914c35dcc91bbba561b4deff23fc12f/onboarding.png)

## Verification

- `node --test test/onboarding-view.test.ts test/default-view.test.ts` — 29/29 pass
- `tsc --noEmit` — clean
- `eslint plugins/admin` and `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787962412&installation_model_id=19911&pr_number=19&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F19&signature=bd73b7837186e233088a7078a1da679c18702c1ee28379b006209a189414261b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->