### PR TITLE
Warn after fly secrets push when staged secrets are not live on running machines

### DIFF
--- a/cli/src/backends/fly.ts
+++ b/cli/src/backends/fly.ts
@@ -408,6 +408,15 @@ function flyOrgApps(flyOrg: string): Set<string> {
   );
 }
 
+function appHasMachines(app: string): boolean {
+  try {
+    const parsed = JSON.parse(fly(["status", "-a", app, "--json"])) as { Machines?: unknown[] };
+    return (parsed.Machines?.length ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
 function ensureApp(app: string, flyOrg: string, orgId: string, appPrefix: string): void {
   const out = fly(["apps", "create", app, "--org", flyOrg], { allow: /already been taken/i });
   const marker = flyOwnershipMarker(flyOrg, orgId, appPrefix);
@@ -1620,6 +1629,7 @@ export async function flySecretsPush(config: QmConfig, configDir: string, envFil
   for (const plugin of pluginNames) ensureApp(`${prefix}-${plugin}`, ctx.flyOrg, ctx.orgId, ctx.appPrefix);
   unsetDisabledSecurityScreenToken(config, prefix);
   unsetDisabledFlyPublisherToken(config, prefix);
+  const stagedApps = new Set<string>();
   for (const secret of operatorSecrets) {
     const supplied = deploymentSecretValue(secret.name, values.get(secret.name));
     if (!secret.required && !supplied) {
@@ -1635,6 +1645,7 @@ export async function flySecretsPush(config: QmConfig, configDir: string, envFil
       destinations.set(`${prefix}-${workload}`, names);
     }
     for (const [app, names] of destinations) {
+      stagedApps.add(app);
       for (const name of names) {
         stageSecret(app, name, value);
       }
@@ -1642,4 +1653,9 @@ export async function flySecretsPush(config: QmConfig, configDir: string, envFil
     step(`${secret.name}: staged on ${[...destinations].map(([app]) => app).join(", ")}`);
   }
   ok("operator secrets staged on Fly");
+  const running = [...stagedApps].filter(appHasMachines);
+  if (running.length) {
+    warn(`staged secrets are NOT live yet on ${running.join(", ")}: running machines keep their old values`);
+    warn("run `qm up` to apply them — a plain machine restart does not");
+  }
 }

--- a/cli/test/fly-sandbox.test.ts
+++ b/cli/test/fly-sandbox.test.ts
@@ -306,6 +306,114 @@ test("fly secrets push stages a dual-role secret under BOTH names on the core ap
   }
 });
 
+test("fly secrets push warns that staged secrets are not live when machines are running", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-fly-push-staged-warn-"));
+  const config: QmConfig = {
+    contract: 1,
+    orgId: "acme",
+    publicUrl: "https://acme.example.com",
+    target: "fly",
+    region: "sjc",
+    flyOrg: "personal",
+    services: ["core"],
+    plugins: [],
+    skills: [],
+    env: { core: { HARNESS: "mock" } },
+    imageOverrides: {},
+    sandbox: { app: "acme-sb" },
+  };
+  writeFileSync(
+    join(dir, ".env"),
+    [
+      "CAPABILITY_SECRET=capability-secret-that-is-long-enough",
+      `CONNECTOR_SECRET_KEY=${"connector".repeat(4)}`,
+      `CORE_SIGNING_SECRET=${"core-signing".repeat(3)}`,
+      "PORTAL_IDENTITY_SECRET=portal-identity-secret-that-is-long-enough",
+      `SKILL_SIGNING_SECRET=${"skill-signing".repeat(3)}`,
+      "FLY_SANDBOX_API_TOKEN=fly",
+    ].join("\n"),
+  );
+  const fake = fakeFly(
+    dir,
+    `
+if (a.startsWith("status -a acme-core")) console.log(JSON.stringify({ Machines: [{ id: "m1", state: "started" }] }));
+else if (a.startsWith("secrets set ")) fs.readFileSync(0, "utf8");
+`,
+  );
+  const log = console.log;
+  const warnLog = console.warn;
+  const warnings: string[] = [];
+  console.log = (): void => {};
+  console.warn = (msg: string): void => {
+    warnings.push(msg);
+  };
+  try {
+    await flySecretsPush(config, dir);
+    assert.ok(
+      warnings.some((line) => line.includes("staged secrets are NOT live yet on acme-core")),
+      warnings.join("\n"),
+    );
+    assert.ok(warnings.some((line) => line.includes("run `qm up`")));
+  } finally {
+    console.log = log;
+    console.warn = warnLog;
+    fake.restore();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("fly secrets push stays quiet about staging when no machines are running", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-fly-push-staged-quiet-"));
+  const config: QmConfig = {
+    contract: 1,
+    orgId: "acme",
+    publicUrl: "https://acme.example.com",
+    target: "fly",
+    region: "sjc",
+    flyOrg: "personal",
+    services: ["core"],
+    plugins: [],
+    skills: [],
+    env: { core: { HARNESS: "mock" } },
+    imageOverrides: {},
+    sandbox: { app: "acme-sb" },
+  };
+  writeFileSync(
+    join(dir, ".env"),
+    [
+      "CAPABILITY_SECRET=capability-secret-that-is-long-enough",
+      `CONNECTOR_SECRET_KEY=${"connector".repeat(4)}`,
+      `CORE_SIGNING_SECRET=${"core-signing".repeat(3)}`,
+      "PORTAL_IDENTITY_SECRET=portal-identity-secret-that-is-long-enough",
+      `SKILL_SIGNING_SECRET=${"skill-signing".repeat(3)}`,
+      "FLY_SANDBOX_API_TOKEN=fly",
+    ].join("\n"),
+  );
+  const fake = fakeFly(
+    dir,
+    `
+if (a.startsWith("status -a")) console.log(JSON.stringify({ Machines: [] }));
+else if (a.startsWith("secrets set ")) fs.readFileSync(0, "utf8");
+`,
+  );
+  const log = console.log;
+  const warnLog = console.warn;
+  const warnings: string[] = [];
+  console.log = (): void => {};
+  console.warn = (msg: string): void => {
+    warnings.push(msg);
+  };
+  try {
+    await flySecretsPush(config, dir);
+    assert.ok(!warnings.some((line) => line.includes("staged secrets are NOT live")), warnings.join("\n"));
+  } finally {
+    console.log = log;
+    console.warn = warnLog;
+    fake.restore();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("fly secrets push removes the disabled Fly app publisher token", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-fly-push-publisher-off-"));
   const config: QmConfig = {


### PR DESCRIPTION
## Why

In a real deployment, an operator ran `qm secrets push` and then restarted the Fly machines expecting the new secrets to take effect. On Fly, `secrets set --stage` only stages values — they are applied by the next deploy/machine update, not by `flyctl machine restart`. The result was the auth service running with no SMTP credentials at all until a full `qm up` was run. The command's existing output mentioned staging, but not strongly or actionably enough to prevent the mistake.

## What

- `flySecretsPush` now tracks every app that received staged secrets and checks each for running machines (`fly status --json`). If any have machines, the command ends with an explicit warning:
  - `staged secrets are NOT live yet on <apps>: running machines keep their old values`
  - `run \`qm up\` to apply them — a plain machine restart does not`
- Fresh installs (no machines yet) see no warning, so first-time setup output stays clean.
- No new flags or behavior changes — staging semantics are untouched; this only closes the messaging gap at the single layer all Fly secret pushes flow through.

## Tests

- New test: warning is printed when a staged app has running machines.
- New test: no warning when no machines are running.
- `cli` suite (`node --test test/fly-sandbox.test.ts`): 33/33 pass. `npm run typecheck` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787962431&installation_model_id=19911&pr_number=20&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F20&signature=c2f6d0dc57102b8111f313783af1bf07b1312e3927e32935aff7a65a17435671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->