### PR TITLE
Fix the auth-gate lockouts found in review

### DIFF
--- a/plugins/chassis/src/env.ts
+++ b/plugins/chassis/src/env.ts
@@ -1,8 +1,10 @@
 export const CORE_API_URL = (process.env.CORE_API_URL ?? "http://localhost:8080").replace(/\/$/, "");
 export const CORE_ORG_ID = process.env.CORE_ORG_ID ?? "acme";
-export const CORE_SIGNING_SECRET = process.env.CORE_SIGNING_SECRET;
-export const PORTAL_IDENTITY_SECRET = process.env.PORTAL_IDENTITY_SECRET ?? CORE_SIGNING_SECRET;
-if (!process.env.PORTAL_IDENTITY_SECRET && CORE_SIGNING_SECRET) {
+const secret = (raw: string | undefined): string | undefined => (raw?.trim() ? raw : undefined);
+
+export const CORE_SIGNING_SECRET = secret(process.env.CORE_SIGNING_SECRET);
+export const PORTAL_IDENTITY_SECRET = secret(process.env.PORTAL_IDENTITY_SECRET) ?? CORE_SIGNING_SECRET;
+if (!secret(process.env.PORTAL_IDENTITY_SECRET) && CORE_SIGNING_SECRET) {
   console.warn(
     "[chassis] PORTAL_IDENTITY_SECRET unset — signing portal identity with CORE_SIGNING_SECRET (dev fallback)",
   );

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -239,9 +239,14 @@ function conversationForScope(
   return { kind, channelRef: ref, threadRef, ...(channelName ? { channelName } : {}) };
 }
 
-function resolveIdentity(
-  req: IncomingMessage,
-): { user: string; name: string | null; impersonator: string | null } | null {
+interface Identity {
+  user: string;
+  name: string | null;
+  impersonator: string | null;
+}
+type Denial = "unauthenticated" | "not_allowed";
+
+function authenticate(req: IncomingMessage): { identity: Identity } | { denied: Denial } {
   let user: string | null | undefined;
   let name: string | null | undefined;
   let impersonator: string | null | undefined;
@@ -254,18 +259,29 @@ function resolveIdentity(
     name = claims.n ?? null;
     impersonator = claims.imp ?? null;
   } else {
-    if (!COOKIE_AUTH) return null;
+    if (!COOKIE_AUTH) return { denied: "unauthenticated" };
     user = cookie(req, "webuiuser");
     name = cookie(req, "webuiuser_name");
     impersonator = cookie(req, "webui_impersonator");
   }
-  if (!user) return null;
-  if (ALLOW.length > 0 && !ALLOW.includes(user)) return null;
-  return { user, name: name?.trim() || null, impersonator: impersonator ?? null };
+  if (!user) return { denied: "unauthenticated" };
+  if (ALLOW.length > 0 && !ALLOW.includes(user)) return { denied: "not_allowed" };
+  return { identity: { user, name: name?.trim() || null, impersonator: impersonator ?? null } };
+}
+
+function resolveIdentity(req: IncomingMessage): Identity | null {
+  const outcome = authenticate(req);
+  return "identity" in outcome ? outcome.identity : null;
 }
 
 function cookieUser(req: IncomingMessage): string | null {
   return resolveIdentity(req)?.user ?? null;
+}
+
+function unauthorized(res: ServerResponse, req: IncomingMessage): void {
+  const outcome = authenticate(req);
+  const denied = "denied" in outcome ? outcome.denied : "unauthenticated";
+  return json(res, 401, { error: "sign in", mode: AUTH_MODE, reason: denied });
 }
 
 const SESSION_TTL_S = 90 * 24 * 60 * 60;
@@ -749,7 +765,7 @@ const routeRequest = async (req: IncomingMessage, res: ServerResponse) => {
 
   if (path === "/me" || path.startsWith("/api/")) {
     const user = cookieUser(req);
-    if (!user) return json(res, 401, { error: "sign in", mode: AUTH_MODE });
+    if (!user) return unauthorized(res, req);
 
     if (path === "/me") {
       res.setHeader("set-cookie", sessionCookie(user));
@@ -1833,7 +1849,7 @@ const routeRequest = async (req: IncomingMessage, res: ServerResponse) => {
 
   if (method === "GET" && path.startsWith("/deployments/")) {
     const user = cookieUser(req);
-    if (!user) return json(res, 401, { error: "sign in", mode: AUTH_MODE });
+    if (!user) return unauthorized(res, req);
     const rest = path.slice("/deployments/".length);
     const slash = rest.indexOf("/");
     const id = decodeURIComponent(slash === -1 ? rest : rest.slice(0, slash));

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -344,7 +344,10 @@ async function toCoreAttachment(a: PiAttachment): Promise<CoreAttachment> {
     headers: { "content-type": "application/octet-stream" },
     body: bytes as unknown as BodyInit,
   });
-  if (!r.ok) throw new ApiError(`attachment upload failed: HTTP ${r.status}`, r.status);
+  if (!r.ok) {
+    if (r.status === 401) reportSigninRequired(await r.json().catch(() => ({})));
+    throw new ApiError(`attachment upload failed: HTTP ${r.status}`, r.status);
+  }
   const { blobId, sizeBytes } = (await r.json()) as { blobId: string; sizeBytes: number };
   return { name: a.fileName, mimetype: a.mimeType, sizeBytes: sizeBytes ?? a.size, blobId };
 }
@@ -358,6 +361,21 @@ export class ApiError extends Error {
   }
 }
 
+export interface SigninRequired {
+  mode?: "portal" | "dev";
+  reason?: "unauthenticated" | "not_allowed";
+}
+
+let onSigninRequired: ((detail: SigninRequired) => void) | null = null;
+
+export function setSigninRequiredHandler(fn: (detail: SigninRequired) => void): void {
+  onSigninRequired = fn;
+}
+
+export function reportSigninRequired(detail: SigninRequired): void {
+  onSigninRequired?.(detail);
+}
+
 export async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(withBase(path), { headers: { "content-type": "application/json" }, ...init });
   const text = await r.text();
@@ -368,6 +386,7 @@ export async function api<T = unknown>(path: string, init?: RequestInit): Promis
     swallow("web-ui: parse api response body", e);
   }
   if (!r.ok) {
+    if (r.status === 401 && path !== "/signin") reportSigninRequired(body as SigninRequired);
     const msg =
       (body as { error?: string; message?: string })?.message ??
       (body as { error?: string })?.error ??

--- a/plugins/web-ui/src/files.ts
+++ b/plugins/web-ui/src/files.ts
@@ -1,6 +1,6 @@
 import { html, nothing, render } from "lit";
 import { File, Image, Upload } from "lucide";
-import { api, withBase } from "./core-bridge";
+import { api, reportSigninRequired, type SigninRequired, withBase } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
 import { browserRenderableImage, formatBytes, icon, relTime } from "./ui";
 import { contextsState, ensureContexts, personalScopeId, scopeChip, scopeFilterControl } from "./contexts";
@@ -221,7 +221,8 @@ async function uploadOne(file: globalThis.File): Promise<void> {
     const text = await r.text();
     let message = `Upload failed (${r.status})`;
     try {
-      const parsed = JSON.parse(text) as { message?: string; error?: string };
+      const parsed = JSON.parse(text) as { message?: string; error?: string } & SigninRequired;
+      if (r.status === 401) reportSigninRequired(parsed);
       message = parsed.message ?? parsed.error ?? message;
     } catch {
       if (text.trim()) message = text.trim();

--- a/plugins/web-ui/src/main.ts
+++ b/plugins/web-ui/src/main.ts
@@ -1,7 +1,6 @@
 import "dockview-core/dist/styles/dockview.css";
 import "./shell.css";
-import { swallow } from "../../chassis/src/errors";
-import { appState, boot, renderAuthGate } from "./shell";
+import { bootSafely } from "./shell";
 import { closeFormMenus } from "./ui";
 import { drawActiveChat } from "./chat";
 import { composerState, slashQuery } from "./composer";
@@ -45,7 +44,4 @@ document.addEventListener("keydown", (e) => {
   if (changed) drawActiveChat();
 });
 
-void boot().catch((e: unknown) => {
-  if (appState.me) swallow("web-ui: boot", e);
-  else renderAuthGate({ kind: "unreachable" });
-});
+void bootSafely();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -17,9 +17,17 @@ import {
   type IconNode,
 } from "lucide";
 import "@mariozechner/mini-lit/dist/ThemeToggle.js";
-import { api, fetchRuntimeConfig, fetchTranscript, TAIL_TURNS, withBase } from "./core-bridge";
+import {
+  api,
+  fetchRuntimeConfig,
+  fetchTranscript,
+  setSigninRequiredHandler,
+  type SigninRequired,
+  TAIL_TURNS,
+  withBase,
+} from "./core-bridge";
 import { applyRuntimeOptions } from "./model-options";
-import { errMessage } from "../../chassis/src/errors";
+import { errMessage, swallow } from "../../chassis/src/errors";
 import { brandMark, brandName, icon, initials } from "./ui";
 import {
   chatState,
@@ -67,6 +75,12 @@ import { trapDialogFocus } from "./dialog-focus";
 export { appState, can, type Me, type View } from "./shell-state";
 
 let authMode: AuthMode = "portal";
+let shellMounted = false;
+
+setSigninRequiredHandler((detail) => {
+  authMode = detail.mode ?? authMode;
+  renderAuthGate(gateFor(authMode, detail.reason));
+});
 
 export const ADMIN_BASE = (() => {
   const base = ((import.meta as unknown as { env?: { BASE_URL?: string } }).env?.BASE_URL ?? "/").replace(/\/$/, "");
@@ -180,10 +194,13 @@ const ICON = {
 };
 
 export async function signOut(): Promise<void> {
-  try {
-    await api("/signout", { method: "POST" });
-  } catch {
-    void 0;
+  const portal = authMode === "portal";
+  if (!portal) {
+    try {
+      await api("/signout", { method: "POST" });
+    } catch {
+      void 0;
+    }
   }
   appState.me = null;
   clearAllDrafts();
@@ -195,16 +212,23 @@ export async function signOut(): Promise<void> {
   resetContextsState();
   resetKeychainState();
   resetComposer();
-  if (authMode === "portal") {
-    try {
-      await fetch("/auth/logout", { method: "POST", headers: { accept: "application/json" } });
-    } catch {
-      void 0;
-    }
-    location.href = "/";
+  if (!portal) {
+    renderAuthGate({ kind: "dev" });
     return;
   }
-  renderAuthGate({ kind: "dev" });
+  let endedSession: boolean;
+  try {
+    const r = await fetch("/auth/logout", { method: "POST", headers: { accept: "application/json" } });
+    endedSession = r.ok;
+  } catch {
+    endedSession = false;
+  }
+  if (!endedSession) {
+    renderAuthGate({ kind: "portal" });
+    return;
+  }
+  clearPortalAttempt();
+  location.href = "/";
 }
 
 export async function exitImpersonation(): Promise<void> {
@@ -248,12 +272,48 @@ function gateShell(body: unknown) {
   `;
 }
 
+const PORTAL_ATTEMPT_KEY = "qm.portal.signin.attempt";
+const PORTAL_ATTEMPT_WINDOW_MS = 20_000;
+
+function portalAttemptedRecently(): boolean {
+  try {
+    const at = Number(sessionStorage.getItem(PORTAL_ATTEMPT_KEY) ?? "");
+    return Number.isFinite(at) && Date.now() - at < PORTAL_ATTEMPT_WINDOW_MS;
+  } catch {
+    return false;
+  }
+}
+
 function signInWithPortal(): void {
+  try {
+    sessionStorage.setItem(PORTAL_ATTEMPT_KEY, String(Date.now()));
+  } catch {
+    void 0;
+  }
   const returnTo = `${location.pathname}${location.search}`;
   location.href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
 }
 
+function clearPortalAttempt(): void {
+  try {
+    sessionStorage.removeItem(PORTAL_ATTEMPT_KEY);
+  } catch {
+    void 0;
+  }
+}
+
 function portalGate() {
+  if (portalAttemptedRecently())
+    return gateShell(html`
+      <h1>Sign in through the portal</h1>
+      <p class="signin-body">
+        This surface is reached through the portal, and signing in there didn't produce a session for it. Open the
+        portal address directly rather than this one.
+      </p>
+      <div class="hint">
+        If you opened this surface's own address, that's the cause — it can't authenticate anyone on its own.
+      </div>
+    `);
   return gateShell(html`
     <h1>Your session ended</h1>
     <p class="signin-body">You've been signed out. Sign in again and you'll come back to this page.</p>
@@ -261,31 +321,54 @@ function portalGate() {
   `);
 }
 
+function deniedGate() {
+  return gateShell(html`
+    <h1>You don't have access</h1>
+    <p class="signin-body">
+      Your account is signed in and verified — it just isn't allowed on this instance. Ask an administrator to add you.
+    </p>
+    <button class="btn" type="button" @click=${signOut}>Sign out</button>
+    ${
+      authMode === "dev"
+        ? html`<div class="hint">This instance lists its principals in <b>WEB_UI_PRINCIPALS</b>.</div>`
+        : nothing
+    }
+  `);
+}
+
+function retryBoot(): void {
+  void bootSafely();
+}
+
 function unreachableGate() {
   return gateShell(html`
     <h1>We couldn't reach the assistant</h1>
     <p class="signin-body">The service didn't respond. This is usually temporary.</p>
-    <button class="btn primary" type="button" @click=${() => void boot()}>Try again</button>
+    <button class="btn primary" type="button" @click=${retryBoot}>Try again</button>
     <div class="hint">If this keeps happening, the core service may be down.</div>
   `);
 }
 
-function devGate(errorText: string) {
+async function submitDevSignin(user: string): Promise<void> {
+  renderAuthGate({ kind: "dev", value: user, pending: true });
+  try {
+    await api("/signin", { method: "POST", body: JSON.stringify({ user }) });
+  } catch (err) {
+    renderAuthGate({ kind: "dev", value: user, error: errMessage(err, "Sign-in failed.") });
+    return;
+  }
+  await bootSafely();
+}
+
+function devGate(gate: { value?: string; error?: string; pending?: boolean }) {
   return gateShell(html`
     <form
-      @submit=${async (e: Event) => {
+      @submit=${(e: Event) => {
         e.preventDefault();
-        const form = e.target as HTMLFormElement;
-        const input = form.querySelector("input") as HTMLInputElement | null;
+        if (gate.pending) return;
+        const input = (e.target as HTMLFormElement).querySelector("input") as HTMLInputElement | null;
         const user = input?.value.trim();
-        if (!user || form.dataset.pending === "1") return;
-        form.dataset.pending = "1";
-        try {
-          await api("/signin", { method: "POST", body: JSON.stringify({ user }) });
-          await boot();
-        } catch (err) {
-          renderAuthGate({ kind: "dev", error: errMessage(err, "Sign-in failed.") });
-        }
+        if (user) void submitDevSignin(user);
       }}
     >
       <h1>Dev sign-in</h1>
@@ -293,29 +376,54 @@ function devGate(errorText: string) {
         No identity provider is configured, so this instance trusts a local cookie. Set
         <b>CORE_SIGNING_SECRET</b> and run the portal to use real sign-in.
       </p>
-      <label for="dev-principal">Work email</label>
-      <input id="dev-principal" name="principal" type="email" autocomplete="username" autofocus spellcheck="false" />
-      <button class="btn primary" type="submit">Continue</button>
-      ${errorText ? html`<div class="hint error" role="alert">${errorText}</div>` : nothing}
+      <label for="dev-principal">Principal</label>
+      <input
+        id="dev-principal"
+        name="principal"
+        type="text"
+        inputmode="email"
+        autocomplete="username"
+        spellcheck="false"
+        required
+        autofocus
+        placeholder="you@org.com"
+        .value=${gate.value ?? ""}
+        ?disabled=${gate.pending === true}
+      />
+      <button class="btn primary" type="submit" ?disabled=${gate.pending === true}>
+        ${gate.pending ? "Signing in…" : "Continue"}
+      </button>
+      ${gate.error ? html`<div class="hint error" role="alert">${gate.error}</div>` : nothing}
     </form>
   `);
 }
 
-export type AuthGate = { kind: "portal" } | { kind: "unreachable" } | { kind: "dev"; error?: string };
+export type AuthGate =
+  | { kind: "portal" }
+  | { kind: "denied" }
+  | { kind: "unreachable" }
+  | { kind: "dev"; value?: string; error?: string; pending?: boolean };
 
 export function renderAuthGate(gate: AuthGate): void {
-  if (gate.kind === "dev") authMode = "dev";
+  shellMounted = false;
   const body = (() => {
     switch (gate.kind) {
       case "portal":
         return portalGate();
+      case "denied":
+        return deniedGate();
       case "unreachable":
         return unreachableGate();
       default:
-        return devGate(gate.error ?? "");
+        return devGate(gate);
     }
   })();
   render(body, appEl as HTMLElement);
+}
+
+function gateFor(mode: AuthMode, reason: "unauthenticated" | "not_allowed" | undefined): AuthGate {
+  if (reason === "not_allowed") return { kind: "denied" };
+  return mode === "dev" ? { kind: "dev" } : { kind: "portal" };
 }
 
 export function mountShell(): void {
@@ -329,6 +437,7 @@ export function mountShell(): void {
     appState.topEl = null;
     appState.listEl = null;
     appState.mainEl = (appEl as HTMLElement).querySelector("#main");
+    shellMounted = true;
     return;
   }
   applySavedSidebarWidth();
@@ -392,6 +501,7 @@ export function mountShell(): void {
   renderSidebarTop();
   updateSidebarToggleLabels();
   syncSidebarAccessibility(false);
+  shellMounted = true;
 }
 
 export function renderSidebarTop(): void {
@@ -688,6 +798,15 @@ function openAppEditChat(slug: string): void {
   renderList();
 }
 
+export async function bootSafely(): Promise<void> {
+  try {
+    await boot();
+  } catch (e) {
+    if (shellMounted) swallow("web-ui: boot", e);
+    else renderAuthGate({ kind: "unreachable" });
+  }
+}
+
 export async function boot(): Promise<void> {
   let r: Response;
   try {
@@ -697,12 +816,9 @@ export async function boot(): Promise<void> {
     return;
   }
   if (r.status === 401) {
-    const mode = await r
-      .json()
-      .then((b: { mode?: AuthMode }) => b.mode)
-      .catch(() => undefined);
-    authMode = mode ?? "portal";
-    renderAuthGate(authMode === "dev" ? { kind: "dev" } : { kind: "portal" });
+    const body = (await r.json().catch(() => ({}))) as SigninRequired;
+    authMode = body.mode ?? "portal";
+    renderAuthGate(gateFor(authMode, body.reason));
     return;
   }
   if (!r.ok) {
@@ -712,6 +828,7 @@ export async function boot(): Promise<void> {
   resetKeychainState();
   appState.me = (await r.json()) as Me;
   authMode = appState.me.mode ?? "portal";
+  clearPortalAttempt();
   const runtimeConfig = await fetchRuntimeConfig(`personal:${appState.me.user}`);
   if (runtimeConfig)
     applyRuntimeOptions(

--- a/plugins/web-ui/test/auth-mode-dev.test.ts
+++ b/plugins/web-ui/test/auth-mode-dev.test.ts
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const core = createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end("{}");
+});
+await new Promise<void>((r) => core.listen(0, r));
+
+process.env.CORE_API_URL = `http://localhost:${(core.address() as AddressInfo).port}`;
+delete process.env.CORE_SIGNING_SECRET;
+delete process.env.PORTAL_IDENTITY_SECRET;
+process.env.WEB_UI_PRINCIPALS = "alice";
+process.env.ALLOW_UNSIGNED_TEST_IDENTITY = "0";
+
+const { handler } = await import("../server/index.ts");
+const surface = createServer((req, res) => void handler(req, res));
+await new Promise<void>((r) => surface.listen(0, r));
+const base = `http://localhost:${(surface.address() as AddressInfo).port}`;
+
+const signin = (user: unknown) =>
+  fetch(`${base}/signin`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user }),
+  });
+
+test.after(() => {
+  surface.close();
+  core.close();
+});
+
+test("with no signing secret the surface advertises dev mode", async () => {
+  const r = await fetch(`${base}/me`);
+  assert.equal(r.status, 401);
+  assert.deepEqual(await r.json(), { error: "sign in", mode: "dev", reason: "unauthenticated" });
+});
+
+test("a bare principal id — not just an email — can sign in", async () => {
+  const r = await signin("alice");
+  assert.equal(r.status, 200);
+  const cookie = r.headers.get("set-cookie") ?? "";
+  assert.match(cookie, /webuiuser=alice/);
+
+  const me = await fetch(`${base}/me`, { headers: { cookie: cookie.split(";")[0] } });
+  assert.equal(me.status, 200);
+  const body = await me.json();
+  assert.equal(body.user, "alice");
+  assert.equal(body.mode, "dev");
+});
+
+test("a principal outside the allowlist is refused with a message naming the env var", async () => {
+  const r = await signin("mallory");
+  assert.equal(r.status, 403);
+  const body = await r.json();
+  assert.equal(body.error, "not_allowed");
+  assert.match(body.message, /WEB_UI_PRINCIPALS/);
+  assert.match(body.message, /mallory/);
+});
+
+test("an empty principal is a 400 with guidance, distinct from being refused", async () => {
+  const r = await signin("");
+  assert.equal(r.status, 400);
+  const body = await r.json();
+  assert.equal(body.error, "bad_request");
+  assert.match(body.message, /Enter a principal/);
+});
+
+test("an over-long principal is truncated in the echoed error", async () => {
+  const r = await signin("z".repeat(500));
+  assert.equal(r.status, 403);
+  assert.ok(((await r.json()).message as string).length < 400);
+});

--- a/plugins/web-ui/test/auth-mode-portal.test.ts
+++ b/plugins/web-ui/test/auth-mode-portal.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
+
+const core = createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end("{}");
+});
+await new Promise<void>((r) => core.listen(0, r));
+
+const SECRET = "auth-mode-portal-test-secret";
+process.env.CORE_API_URL = `http://localhost:${(core.address() as AddressInfo).port}`;
+process.env.CORE_SIGNING_SECRET = SECRET;
+process.env.WEB_UI_PRINCIPALS = "alice";
+process.env.ALLOW_UNSIGNED_TEST_IDENTITY = "0";
+
+const { handler } = await import("../server/index.ts");
+const surface = createServer((req, res) => void handler(req, res));
+await new Promise<void>((r) => surface.listen(0, r));
+const base = `http://localhost:${(surface.address() as AddressInfo).port}`;
+
+test.after(() => {
+  surface.close();
+  core.close();
+});
+
+test("an unauthenticated request advertises portal mode so the client never offers the dev form", async () => {
+  const r = await fetch(`${base}/me`);
+  assert.equal(r.status, 401);
+  assert.deepEqual(await r.json(), { error: "sign in", mode: "portal", reason: "unauthenticated" });
+});
+
+test("POST /signin does not exist once a signing secret makes cookie auth dead", async () => {
+  const r = await fetch(`${base}/signin`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user: "alice" }),
+  });
+  assert.equal(r.status, 404);
+  assert.equal((await r.json()).error, "not_found");
+});
+
+test("a webuiuser cookie confers nothing in portal mode", async () => {
+  const r = await fetch(`${base}/me`, { headers: { cookie: "webuiuser=alice" } });
+  assert.equal(r.status, 401);
+  assert.equal((await r.json()).reason, "unauthenticated");
+});
+
+test("a verified principal outside WEB_UI_PRINCIPALS is not_allowed, not unauthenticated", async () => {
+  const token = mintPortalIdentity({ p: "mallory", exp: Date.now() + 60_000 }, SECRET);
+  const r = await fetch(`${base}/me`, { headers: { [PORTAL_IDENTITY_HEADER]: token } });
+  assert.equal(r.status, 401);
+  const body = await r.json();
+  assert.equal(body.reason, "not_allowed");
+  assert.equal(body.mode, "portal");
+});
+
+test("a verified allowed principal gets through and /me reports the mode", async () => {
+  const token = mintPortalIdentity({ p: "alice", exp: Date.now() + 60_000 }, SECRET);
+  const r = await fetch(`${base}/me`, { headers: { [PORTAL_IDENTITY_HEADER]: token } });
+  assert.equal(r.status, 200);
+  const body = await r.json();
+  assert.equal(body.user, "alice");
+  assert.equal(body.mode, "portal");
+});

--- a/scripts/google-oauth-smoke.ts
+++ b/scripts/google-oauth-smoke.ts
@@ -12,6 +12,7 @@ import { createServer } from "../src/api/server.ts";
 import { PROVIDERS } from "../src/connectors/oauth.ts";
 import { scopeId } from "../src/types.ts";
 import { buildGoogleWorkspaceReadSmokeCommand } from "./google-workspace-read-smoke-command.ts";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../plugins/chassis/src/portal-identity.ts";
 
 type Json = Record<string, unknown>;
 
@@ -218,21 +219,15 @@ try {
   });
   await waitFor(`${webBase}/healthz`, 10_000);
 
-  const signin = await fetch(`${webBase}/signin`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ user: actor }),
-  });
-  const signinBody = await readJson(signin);
-  assertOk(signin, signinBody, "web signin");
-  const cookie = signin.headers.get("set-cookie")?.split(";")[0] ?? "";
-  if (!cookie) throw new Error("web signin did not return a session cookie");
+  const identity = {
+    [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: actor, exp: Date.now() + 10 * 60_000 }, secret),
+  };
 
-  const statusBefore = await fetch(`${webBase}/api/connectors`, { headers: { cookie } });
+  const statusBefore = await fetch(`${webBase}/api/connectors`, { headers: identity });
   const statusBeforeBody = await readJson(statusBefore);
   assertOk(statusBefore, statusBeforeBody, "web connector status");
 
-  const start = await fetch(`${webBase}/api/connectors/google/start`, { method: "POST", headers: { cookie } });
+  const start = await fetch(`${webBase}/api/connectors/google/start`, { method: "POST", headers: identity });
   const startBody = await readJson(start);
   assertOk(start, startBody, "web connector start");
   const authorize = new URL(String(startBody.authorizeUrl ?? ""));
@@ -274,7 +269,7 @@ try {
     const deadline = Date.now() + timeoutMs;
     let connected = false;
     while (Date.now() < deadline) {
-      const status = await fetch(`${webBase}/api/connectors`, { headers: { cookie } });
+      const status = await fetch(`${webBase}/api/connectors`, { headers: identity });
       const statusBody = await readJson(status);
       assertOk(status, statusBody, "web connector status during interactive wait");
       connected = providerStatus(statusBody).connected;


### PR DESCRIPTION
Follow-on to #23. An xhigh code review returned 15 findings, 12 confirmed — four of them reachable lockouts on the sign-in path. This fixes all of them.

## The central one

"Your session ended" was wired only into `boot()`'s `/me` 401. But `boot()` runs exactly twice, and the portal 302s unauthenticated document requests to `/auth/login` before the SPA ever mounts. The path that *actually* produces an expired session is an `api()` call from the mounted shell — which had no 401 handling at all.

So the gate was near-unreachable in the deployment it was written for, and an expired session still rendered the literal string `sign in` as a turn error. That is the same defect #23 set out to fix, relocated rather than removed.

`api()` now reports every 401 through a handler the shell registers, so a 401 from anywhere reaches the gate. The two raw uploader `fetch`es report through the same hook.

## The other lockouts

- **The dev form bricked after one error.** `data-pending` was never cleared and lit reuses the `<form>` node across an error re-render, so a corrected retry hit the guard forever. Pending is render state now, and the typed value survives the error.
- **`type="email"` blocked bare principal ids** like `alice` — the form the repo's own tests and docs use. Back to `text` with `inputmode="email"` and `required`.
- **An allowlist rejection rendered as "Your session ended"** and bounced off `/auth/login` forever. `authenticate()` distinguishes `unauthenticated` from `not_allowed`, and the client has a distinct "You don't have access" state.
- **The portal gate's Sign in looped** wherever the portal wasn't the front door (direct `:8096`, the smoke image, a misconfigured deploy). A one-shot attempt marker breaks it after a single try and explains the real cause.

## Everything else the review found

- `boot()` rejections route through `bootSafely()` keyed on whether the shell actually mounted — a throw between `/me` and `mountShell()` no longer leaves a blank page. "Try again" gets the same handler instead of a bare `void boot()`.
- `authMode` is refreshed from every `/me` rather than only ever pushed toward `dev`, so an open tab can't keep a mode the server no longer serves.
- Sign-out checks the logout response instead of navigating as if it worked, and skips the dead `/signout` round-trip in portal mode.
- **chassis** treats a blank signing secret as unset, so an empty `CORE_SIGNING_SECRET` can no longer silently select cookie auth. Fixed at the shared layer because admin carries the identical falsy check.
- The Google OAuth smoke script mints a portal identity instead of calling the now-404ing dev endpoint.

## Tests

The auth-mode contract shipped in #23 with no coverage at all. Adds 10 cases across two files (mode is fixed at module load, so one process each): the `/signin` gate, the 400/403 split, the `mode` and `reason` fields, that a cookie confers nothing in portal mode, and that a bare principal id can still sign in.

440 web-ui tests pass. Repo typecheck, all three web-ui tsconfigs, and eslint clean.

## Verification

Exercised the *actions* this time, not just the renders — that gap is what let the original bugs through:

- Submitted a rejected principal, then corrected it and resubmitted → signs in. The value survives the error.
- Signed in as a bare id (`alice`), no `@`.
- Mounted the shell, dropped the cookie server-side, clicked one nav item → `api()` 401 → gate. Confirms the central hook.
- Revoked a signed-in principal → "You don't have access", not "Your session ended".
- Clicked Sign in in portal mode with no portal → one bounce, then "Sign in through the portal".

Screenshots of the two new states: **https://claude.ai/code/artifact/d81b8955-230d-40db-996f-40edabc1a8fe**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787986156&installation_model_id=19911&pr_number=24&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F24&signature=46d620927e26ec92e50df94e471fcd3c6e4fc44c0a42f0ab9b196f68983cac02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->