### PR TITLE
Treat fast mode as opt-in

### DIFF
--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -1034,6 +1034,22 @@ const FAST_MODE_BETA = "fast-mode-2026-02-01";
 
 export { modelSupportsFastMode } from "../model/pi-models.ts";
 
+/**
+ * Whether a turn should run in fast mode.
+ *
+ * Fast mode is OPT-IN: only an explicit `true` selects it. An unset `fastMode` means the
+ * caller expressed no preference, and treating that as "yes" bills the turn against a tier
+ * it never asked for — or fails it outright on an organization with no fast-mode quota,
+ * where the provider answers `rate_limit_error: … 0 fast mode input tokens per minute`.
+ *
+ * Only the web UI ever sets the field today, so every other entry point (CLI, API clients,
+ * integrations) leaves it undefined. `claude-harness` already reads it as opt-in
+ * (`turn.fastMode && …`); this keeps both harnesses agreeing on the same default.
+ */
+export function wantsFastMode(fastMode: boolean | undefined, modelId: string | undefined): boolean {
+  return fastMode === true && modelSupportsFastMode(modelId);
+}
+
 export const TURN_PROVIDER_EFFORT_ALIASES: Record<string, string | null> = {
   max: "max",
   ultracode: "max",
@@ -1447,7 +1463,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           entry.ref.toolApprovalGate = turn.toolApprovalGate;
 
           const desiredModelId = turn.model ?? resolveModelId(turn.scopeLabel);
-          const wantFast = turn.fastMode !== false && modelSupportsFastMode(desiredModelId);
+          const wantFast = wantsFastMode(turn.fastMode, desiredModelId);
           const current = entry.agentSession.model as { id?: string; headers?: Record<string, string> } | undefined;
           const currentFast = Boolean(current?.headers?.["anthropic-beta"]?.includes(FAST_MODE_BETA));
           if (current?.id !== desiredModelId || currentFast !== wantFast) {
@@ -1707,7 +1723,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
             console.error(
               `[pi] provider refusal — retrying on fallback model ${fromId} -> ${fallbackId} session=${turn.session.id}: ${refusal}`,
             );
-            const wantFast = turn.fastMode !== false && modelSupportsFastMode(fallbackId);
+            const wantFast = wantsFastMode(turn.fastMode, fallbackId);
             await entry.agentSession.setModel(wantFast ? withFastModeHeaders(fallback) : fallback);
             const active = entry.agentSession.model as { headers?: Record<string, string> } | undefined;
             entry.ref.fast = Boolean(active?.headers?.["anthropic-beta"]?.includes(FAST_MODE_BETA));

--- a/test/pi-harness-fast-mode.test.ts
+++ b/test/pi-harness-fast-mode.test.ts
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { applyFastSpeed, modelSupportsFastMode, TURN_PROVIDER_EFFORT_ALIASES } from "../src/harness/pi-harness.ts";
+import {
+  applyFastSpeed,
+  modelSupportsFastMode,
+  wantsFastMode,
+  TURN_PROVIDER_EFFORT_ALIASES,
+} from "../src/harness/pi-harness.ts";
 import { defaultInteractiveThinkingLevel } from "../src/model/pi-models.ts";
 
 test("modelSupportsFastMode allows only the documented direct Opus ids", () => {
@@ -49,4 +54,19 @@ test("TURN_PROVIDER_EFFORT_ALIASES maps web-ui aliases to Anthropic effort value
 test("defaultInteractiveThinkingLevel keeps human turns light by provider", () => {
   assert.equal(defaultInteractiveThinkingLevel({ provider: "anthropic", api: "anthropic-messages" }), "low");
   assert.equal(defaultInteractiveThinkingLevel({ provider: "openai", api: "openai-responses" }), "auto");
+});
+
+test("fast mode is opt-in: only an explicit true selects it", () => {
+  // A turn that never mentions fastMode has expressed no preference. Reading that as "yes"
+  // bills it against a tier nobody asked for, and on an organization with no fast-mode
+  // quota the provider rejects every such turn outright.
+  assert.equal(wantsFastMode(undefined, "claude-opus-5"), false, "unset must not select fast mode");
+  assert.equal(wantsFastMode(false, "claude-opus-5"), false);
+  assert.equal(wantsFastMode(true, "claude-opus-5"), true, "an explicit opt-in is honoured");
+});
+
+test("an explicit opt-in still cannot select fast mode on a model that lacks it", () => {
+  assert.equal(wantsFastMode(true, "claude-sonnet-5"), false);
+  assert.equal(wantsFastMode(true, undefined), false);
+  assert.equal(wantsFastMode(true, ""), false);
 });


### PR DESCRIPTION
pi-harness reads turn.fastMode !== false, so a turn that never mentions fastMode runs in fast mode on any fast-capable model. Only the web UI ever sets the field, so every other entry point — CLI, API clients, integrations — leaves it undefined and silently opts in.

Two things make this look unintended rather than deliberate:
- claude-harness.ts:475 reads the same field as turn.fastMode && …, i.e. opt-in. The two harnesses disagree on the default for one TurnOptions field, so switching harness silently changes which tier a turn bills against.
- core/turn-options.ts sets NON_INTERACTIVE_FAST_MODE = false for triggered turns and omits the field otherwise — deliberately keeping turns off fast mode, which pi-harness then reads as "on".

This is generated by QM.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788024102&installation_model_id=19911&pr_number=26&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F26&signature=9972e5cbe40b91a63990f6cf331dfbbd5a24a589c03858525436276fee355e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->