### PR TITLE
Route the first admin to onboarding instead of a 403 web UI

### DIFF
--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -71,10 +71,19 @@ const LOCAL_AUTH_PRINCIPAL = process.env.PORTAL_DEV_PRINCIPAL || process.env.USE
 const DEPLOYMENTS_ENABLED = process.env.PORTAL_DEPLOYMENTS_ENABLED === "1";
 const NEUTRAL_ACCENT = "#4f46e5";
 let brandAccent = NEUTRAL_ACCENT;
-let brandAccentNextAt = 0;
-async function refreshBrandAccent(): Promise<void> {
-  if (Date.now() < brandAccentNextAt) return;
-  brandAccentNextAt = Date.now() + 5_000;
+let modelProviderConfigured: boolean | undefined;
+let surfaceConfigNextAt = 0;
+let surfaceConfigInflight: Promise<void> | null = null;
+function refreshSurfaceConfig(): Promise<void> {
+  if (Date.now() >= surfaceConfigNextAt) {
+    surfaceConfigNextAt = Date.now() + 5_000;
+    surfaceConfigInflight = fetchSurfaceConfig().finally(() => {
+      surfaceConfigInflight = null;
+    });
+  }
+  return surfaceConfigInflight ?? Promise.resolve();
+}
+async function fetchSurfaceConfig(): Promise<void> {
   try {
     const path = withSourceAuthNonce("/v1/surface-config", CORE_SIGNING_SECRET);
     const r = await fetch(`${CORE}${path}`, {
@@ -82,9 +91,11 @@ async function refreshBrandAccent(): Promise<void> {
       signal: AbortSignal.timeout(2_000),
     });
     if (r.ok) {
-      const b = ((await r.json()) as { branding?: { accent?: unknown } }).branding;
-      brandAccent = typeof b?.accent === "string" ? b.accent : NEUTRAL_ACCENT;
-      brandAccentNextAt = Date.now() + 30_000;
+      const body = (await r.json()) as { branding?: { accent?: unknown }; modelProviderConfigured?: unknown };
+      brandAccent = typeof body.branding?.accent === "string" ? body.branding.accent : NEUTRAL_ACCENT;
+      modelProviderConfigured =
+        typeof body.modelProviderConfigured === "boolean" ? body.modelProviderConfigured : undefined;
+      surfaceConfigNextAt = Date.now() + (modelProviderConfigured === false ? 5_000 : 30_000);
     }
   } catch {
     void 0;
@@ -447,6 +458,18 @@ export function nonAdminDeniedHtml(o: { sub: string; org: string }): string {
   });
 }
 
+export function notConfiguredHtml(): string {
+  return cardPage({
+    title: "Not set up yet",
+    heading: "This deployment isn't set up yet",
+    msg: "An admin still needs to finish setup by adding a model API key. Until then the assistant can't answer.",
+    icon: ALERT_ICON,
+    warn: true,
+    actions: `<a class="btn primary" href="/">Try again</a>`,
+    help: "Ask your admin to complete onboarding in the Admin area.",
+  });
+}
+
 export function adminUnavailableHtml(): string {
   return cardPage({
     title: "Admin temporarily unavailable",
@@ -730,7 +753,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   res.setHeader("x-content-type-options", "nosniff");
   res.setHeader("x-frame-options", "DENY");
 
-  void refreshBrandAccent();
+  void refreshSurfaceConfig();
 
   if (method === "GET" && pathname === "/healthz") return json(res, 200, { ok: true });
 
@@ -934,6 +957,17 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
         return sendHtml(res, 403, page);
       }
       return json(res, 403, { error: "forbidden", message: "admin access required" });
+    }
+  }
+
+  if (key === "web-ui" && method === "GET" && wantsHtml(req)) {
+    await refreshSurfaceConfig();
+    if (modelProviderConfigured === false) {
+      if (await isAdmin(session.sub)) {
+        res.writeHead(302, { location: "/admin/onboarding", "cache-control": "no-store" });
+        return void res.end();
+      }
+      return sendHtml(res, 503, notConfiguredHtml());
     }
   }
 

--- a/plugins/portal/test/onboarding-redirect.test.ts
+++ b/plugins/portal/test/onboarding-redirect.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+let providerConfigured = false;
+
+const upstream = createServer((req: IncomingMessage, res) => {
+  if (req.url?.startsWith("/v1/surface-config")) {
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(
+      JSON.stringify({ webuiModels: [], baseModel: "m", harnessId: "pi", modelProviderConfigured: providerConfigured }),
+    );
+  }
+  if (req.url === "/api/whoami") {
+    const m = (req.headers.cookie ?? "").match(/admin=([^;]+)/);
+    const sub = m ? decodeURIComponent(m[1] ?? "") : "";
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(JSON.stringify({ isAdmin: sub === "U-admin" }));
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ url: req.url }));
+});
+await new Promise<void>((r) => upstream.listen(0, r));
+const upstreamUrl = `http://localhost:${(upstream.address() as AddressInfo).port}`;
+
+process.env.PORTAL_PUBLIC_URL = "http://portal.test";
+process.env.PORTAL_SESSION_SECRET = "onboarding-test-portal-secret";
+process.env.CORE_SIGNING_SECRET = "onboarding-test-core-secret";
+process.env.WEB_UI_UPSTREAM = upstreamUrl;
+process.env.ADMIN_UPSTREAM = upstreamUrl;
+process.env.CORE_API_URL = upstreamUrl;
+
+const { server } = await import("../src/index.ts");
+const { deriveKey, seal } = await import("../src/session.ts");
+await new Promise<void>((r) => server.listen(0, r));
+const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+
+const sessionKey = deriveKey("onboarding-test-portal-secret", "portal.session.v1");
+function sessionCookie(sub: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  return `portal_session=${encodeURIComponent(seal({ k: "session", sub, org: "acme", iat: now, exp: now + 28800 }, sessionKey))}`;
+}
+
+test.after(() => {
+  server.close();
+  upstream.close();
+});
+
+test("unconfigured deployment: admin HTML navigation to web-ui redirects to admin onboarding", async () => {
+  const r = await fetch(`${base}/`, {
+    headers: { accept: "text/html", cookie: sessionCookie("U-admin") },
+    redirect: "manual",
+  });
+  assert.equal(r.status, 302);
+  assert.equal(r.headers.get("location"), "/admin/onboarding");
+});
+
+test("unconfigured deployment: non-admin HTML navigation gets a not-set-up page, not a bare 403", async () => {
+  const r = await fetch(`${base}/`, {
+    headers: { accept: "text/html", cookie: sessionCookie("U-member") },
+    redirect: "manual",
+  });
+  assert.equal(r.status, 503);
+  assert.match(await r.text(), /isn&#39;t set up yet/);
+});
+
+test("unconfigured deployment: web-ui JSON requests still proxy through untouched", async () => {
+  const r = await fetch(`${base}/api/sessions`, { headers: { cookie: sessionCookie("U-admin") } });
+  assert.equal(r.status, 200);
+  assert.equal(((await r.json()) as { url: string }).url, "/api/sessions");
+});
+
+test("unconfigured deployment: the admin surface itself is reachable, so onboarding never loops", async () => {
+  const r = await fetch(`${base}/admin/onboarding`, {
+    headers: { accept: "text/html", cookie: sessionCookie("U-admin") },
+    redirect: "manual",
+  });
+  assert.equal(r.status, 200);
+  assert.equal(((await r.json()) as { url: string }).url, "/onboarding");
+});
+
+test("once a provider is configured, admin HTML navigation proxies to web-ui again", async () => {
+  providerConfigured = true;
+  await new Promise((r) => setTimeout(r, 5_200));
+  const r = await fetch(`${base}/`, {
+    headers: { accept: "text/html", cookie: sessionCookie("U-admin") },
+    redirect: "manual",
+  });
+  assert.equal(r.status, 200);
+  assert.equal(((await r.json()) as { url: string }).url, "/");
+});

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -889,6 +889,7 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
     webuiModels: configuredPicker.length ? configuredPicker : allowed,
     baseModel: resolvedBase,
     harnessId,
+    ...(managedKeys ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) } : {}),
     externalSlackParticipants,
     ...(Object.keys(resolvedBranding).length ? { branding: resolvedBranding } : {}),
   });

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -386,6 +386,21 @@ test("a rejected rotation preserves the prior key and disabling suppresses envir
   }
 });
 
+test("surface-config reports whether any model provider is configured", async () => {
+  const srv = start();
+  try {
+    const before = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(before.status, 200);
+    assert.equal(((await before.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, false);
+
+    await srv.built.modelCredentials.set("anthropic", "working-admin-key", "admin-alice@default-org");
+    const after = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(((await after.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, true);
+  } finally {
+    await srv.close();
+  }
+});
+
 test("admin model credentials survive a second app instance on the same durable store", async () => {
   const backing = createMemoryMap<StoredModelCredential>();
   const first = createModelCredentialStore({ backing, keyMaterial: "shared-model-key" });


### PR DESCRIPTION
## Bug

Real incident seen on two fresh deployments (Fly and AWS): with no model provider configured yet, the first admin signs in and lands on the web UI, where core refuses every turn with a 403 — instead of the admin onboarding view (#19), the only place the first model API key can be entered. Nothing pointed the admin there.

## Fix

One layer, the one every browser navigation flows through:

- **Core**: `/v1/surface-config` now reports `modelProviderConfigured`, computed from the model credential store's `availability()` (already accounts for admin-managed keys, environment fallbacks, and disabled overrides). Emitted only when the store is wired.
- **Portal**: the existing surface-config refresh (previously just brand accent) also caches this flag, sharing an inflight promise so the redirect decision never races the fetch. While the flag is `false`:
  - an **admin's** HTML navigation to the web UI 302s to `/admin/onboarding`;
  - a **non-admin** gets a clear "not set up yet" card page (503) instead of a surface that 403s every turn.

JSON/API traffic and the admin surface itself are untouched, so onboarding never loops. A missing flag (old core during blue-green) means pass-through, unchanged behavior. Once a key is saved the flag flips on the next refresh (5s TTL while unconfigured).

## Tests

- `plugins/portal/test/onboarding-redirect.test.ts`: end-to-end against the real portal server — admin redirect, non-admin 503 page, JSON pass-through, admin surface reachable (no loop), and recovery once a provider is configured.
- `test/model-credential-route.test.ts`: `/v1/surface-config` reports `false` with no keys and `true` after a key is saved.

## Verification

- `node --test` portal suite (43/43) and `test/model-credential-route.test.ts` (10/10) — pass
- `tsc --noEmit` (root and portal) — clean
- `eslint .` and `prettier --check` — clean
- Independent fresh-context review of the diff (loops, races, auth bypass, stale cache, blue-green) — safe to ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788036769&installation_model_id=19911&pr_number=29&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F29&signature=0c5b0bda4d69137cda9ffd3e8fd53f1bc6004f525e0f83c1698edc453ae6026d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->