### PR TITLE
Add qm secrets set for safe in-place .env edits

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { CliError, bold, dim, errMessage, note, red } from "./log.ts";
+import { CliError, bold, dim, errMessage, note, ok, red } from "./log.ts";
 import {
   findConfigPath,
   isModelProvider,
@@ -23,7 +24,7 @@ import { runConformance } from "./commands/conformance.ts";
 import { renderSlackFiles, runOutputs } from "./commands/outputs.ts";
 import { cliVersion } from "./manifest.ts";
 import { renderTerraformVars } from "./terraform.ts";
-import { gitTopLevel } from "./util.ts";
+import { gitTopLevel, promptHidden, writeEnvValue } from "./util.ts";
 import { scopeStorageKey } from "./scope-storage-key.ts";
 
 interface Parsed {
@@ -124,6 +125,9 @@ ${bold("DEPLOY (operator)")} ${dim("— runs in the deployment directory")}
   infra delete-task-definitions --yes      delete the stack's AWS ECS task definition revisions
   conformance [dir] [--static]             run static gates and compare the live resolved layer
   secrets push [--from <env-file>]         upload the computed secret set to the target store
+  secrets set <KEY> [<value>]              write one .env value in place (dedupes the key, keeps
+     [--from-file <path>]                  order and file mode); reads stdin or prompts when no
+                                           value is given, so the secret never hits shell history
   status                                   show what's running
   logs [<service>] [-f] [--tail <n>]       tail service logs (omit <service> for all, interleaved)
   down [--purge]                           stop the deployment (--purge drops docker volumes)
@@ -549,7 +553,37 @@ async function dispatch(argv: string[]): Promise<void> {
     }
 
     case "secrets": {
-      if (positionals[0] !== "push") throw new CliError(`usage: ${CLI_NAME} secrets push [--from <env-file>]`);
+      if (positionals[0] === "set") {
+        rejectExtraPositionals(positionals, 3);
+        rejectUnknownFlags(flags, ["config", "env-file", "sandbox-dir", "target", "from-file"]);
+        const key = positionals[1];
+        if (!key) {
+          throw new CliError(`usage: ${CLI_NAME} secrets set <KEY> [<value>] [--from-file <path>]`, {
+            clause: "cli.invocation",
+          });
+        }
+        const fromFile = strFlag(flags, "from-file");
+        if (positionals[2] !== undefined && fromFile !== undefined) {
+          throw new CliError(`secrets set takes a value argument or --from-file, not both`, {
+            clause: "cli.invocation",
+          });
+        }
+        const ctx = deployContext(flags);
+        let value = positionals[2];
+        if (value === undefined && fromFile !== undefined) value = readFileSync(fromFile, "utf8");
+        if (value === undefined) value = process.stdin.isTTY ? await promptHidden(key) : await readStdin();
+        value = value.replace(/\r?\n$/, "");
+        if (!value) throw new CliError(`secrets set: no value provided for ${key}`, { clause: "cli.invocation" });
+        const envPath = ctx.envFile ?? join(ctx.configDir, ".env");
+        writeEnvValue(envPath, key, value);
+        ok(`set ${key} in ${envPath}`);
+        return;
+      }
+      if (positionals[0] !== "push") {
+        throw new CliError(
+          `usage: ${CLI_NAME} secrets push [--from <env-file>] | secrets set <KEY> [<value>] [--from-file <path>]`,
+        );
+      }
       rejectExtraPositionals(positionals, 1);
       rejectUnknownFlags(flags, ["config", "env-file", "sandbox-dir", "target", "from"]);
       const ctx = deployContext(flags);
@@ -560,6 +594,12 @@ async function dispatch(argv: string[]): Promise<void> {
     default:
       throw new CliError(`unknown command: ${cmd}\n\n${HELP}`);
   }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
 }
 
 export async function main(argv: string[]): Promise<void> {

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { existsSync, openSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, openSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { CliError, errMessage } from "./log.ts";
 
@@ -225,6 +225,35 @@ export function readEnvFile(path: string): Map<string, string> {
     if (isEnvVarName(key)) out.set(key, line.slice(eq + 1));
   }
   return out;
+}
+
+export function writeEnvValue(path: string, key: string, value: string): void {
+  if (!isEnvVarName(key)) throw new CliError(`${JSON.stringify(key)} is not a valid environment variable name`);
+  if (/[\r\n]/.test(value)) throw new CliError(`the value for ${key} must be a single line`);
+  const existing = existsSync(path);
+  const mode = existing ? statSync(path).mode & 0o777 : 0o600;
+  const lines = existing ? readFileSync(path, "utf8").split("\n") : [];
+  if (lines.at(-1) === "") lines.pop();
+  const matches = (line: string): boolean => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) return false;
+    const eq = trimmed.indexOf("=");
+    return eq > 0 && trimmed.slice(0, eq).trim() === key;
+  };
+  const entry = `${key}=${value}`;
+  const next: string[] = [];
+  let placed = false;
+  for (const line of lines) {
+    if (!matches(line)) {
+      next.push(line);
+    } else if (!placed) {
+      next.push(entry);
+      placed = true;
+    }
+  }
+  if (!placed) next.push(entry);
+  writeFileSync(path, `${next.join("\n")}\n`, { mode });
+  chmodSync(path, mode);
 }
 
 export function deploymentSecretValue(name: string, fileValue: string | undefined): string | undefined {

--- a/cli/test/util.test.ts
+++ b/cli/test/util.test.ts
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { canonicalJson, flyBin, isInvalidSecret, readEnvFile } from "../src/util.ts";
+import { canonicalJson, flyBin, isInvalidSecret, readEnvFile, writeEnvValue } from "../src/util.ts";
 
 test("managed credential encryption keys require strong material", () => {
   assert.equal(isInvalidSecret("CONNECTOR_SECRET_KEY", "short"), true);
@@ -53,6 +53,55 @@ test("readEnvFile preserves hashes in unquoted values", (t) => {
       ["URL", "https://host/path#fragment"],
     ],
   );
+});
+
+test("writeEnvValue appends a new key with 0600 on a fresh file", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  writeEnvValue(file, "NEW_KEY", "value-1");
+  assert.equal(readFileSync(file, "utf8"), "NEW_KEY=value-1\n");
+  assert.equal(statSync(file).mode & 0o777, 0o600);
+  writeEnvValue(file, "SECOND", "two");
+  assert.equal(readFileSync(file, "utf8"), "NEW_KEY=value-1\nSECOND=two\n");
+});
+
+test("writeEnvValue replaces an existing key in place, preserving order and comments", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  writeFileSync(file, "# comment\nA=1\nB=old\nC=3\n");
+  writeEnvValue(file, "B", "new#value");
+  assert.equal(readFileSync(file, "utf8"), "# comment\nA=1\nB=new#value\nC=3\n");
+  assert.equal(readEnvFile(file).get("B"), "new#value");
+});
+
+test("writeEnvValue collapses duplicate occurrences into the first", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  writeFileSync(file, "A=1\nB=first\nC=3\nB=second\nB=third\n");
+  writeEnvValue(file, "B", "only");
+  assert.equal(readFileSync(file, "utf8"), "A=1\nB=only\nC=3\n");
+});
+
+test("writeEnvValue preserves the existing file mode", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  writeFileSync(file, "A=1\n", { mode: 0o640 });
+  chmodSync(file, 0o640);
+  writeEnvValue(file, "A", "2");
+  assert.equal(statSync(file).mode & 0o777, 0o640);
+  assert.equal(readFileSync(file, "utf8"), "A=2\n");
+});
+
+test("writeEnvValue rejects invalid keys and multi-line values", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  assert.throws(() => writeEnvValue(file, "BAD KEY", "x"));
+  assert.throws(() => writeEnvValue(file, "GOOD_KEY", "a\nb"));
 });
 
 async function withFakeStdin<T>(fn: (emit: (bytes: Buffer) => void) => Promise<T>): Promise<T> {


### PR DESCRIPTION
Operators have been hand-editing `.env`, which produced two real incidents: appending instead of editing left duplicate keys (with the stale first occurrence winning at read time), and pasting values on the command line or into editors echoed secrets into shell history and session transcripts.

This adds `qm secrets set <KEY> [<value>] [--from-file <path>]`:

- with no value argument it reads the value from stdin when piped, or prompts with the existing hidden-input `promptHidden` on a TTY — the value is never echoed and never enters shell history
- the write goes through a new `writeEnvValue` helper in `cli/src/util.ts`, next to the existing `readEnvFile` parser it mirrors: the first occurrence of the key is replaced in place, later duplicate occurrences are removed, all other lines (including comments) and their order are preserved, and the file's mode is kept (0600 for a newly created file)
- invalid key names and multi-line values are rejected; `--env-file` picks the target file as with every other deploy command

Tests in `cli/test/util.test.ts` cover set-new (fresh file gets 0600), replace-existing (order and comments preserved), dedupe-duplicates, mode-preserved (0640 stays 0640), and rejection of bad keys/multi-line values. Also smoke-tested end-to-end against a scaffolded deployment (set, overwrite, dedupe, mode). `npm run typecheck`, eslint, and oxlint clean; util/cli-dispatch/docker-secrets suites pass (40/40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788037125&installation_model_id=19911&pr_number=32&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F32&signature=aad09dc0e529c1d6b24e3cda3a4e504b2921ac3a87f04f505b5b5670ddb5cf12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->