### PR TITLE
Take contributions as human-written text in adrs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+We'd like to try something a little different with this repo. 
+
+Given that coding agents write most underlying code now, we'd prefer PRs in the form of _human-written_
+text.  This can be quite informal — just run your idea by us in the same way you would a coworker or
+friend, say, over Slack. If we're aligned on the change, we're happy to burn our tokens
+on the underlying implementation.
+
+Please do not have AI artificially expand or formalize what you'd like to do into a formal proposal.
+
+Submit changes as `.txt` or `.md` files to the [`adrs/`](./adrs/) folder.
+
+PS: Report any security vulnerabilities privately — see [`SECURITY.md`](./SECURITY.md), not a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
 # Contributing
 
-We'd like to try something a little different with this repo. 
+We'd like to try something a little different with this repo.
 
 Given that coding agents write most underlying code now, we'd prefer PRs in the form of _human-written_
-text.  This can be quite informal — just run your idea by us in the same way you would a coworker or
+text. This can be quite informal — just run your idea by us in the same way you would a coworker or
 friend, say, over Slack. If we're aligned on the change, we're happy to burn our tokens
 on the underlying implementation.
 
 Please do not have AI artificially expand what you'd like to do into a formal proposal.
 
-Submit changes as `.txt` or `.md` files to the [`adrs/`](./adrs/) folder.
+Submit changes as a PR adding a `.txt` or `.md` file to the [`adrs/`](./adrs/) folder.
 
 PS: Report any security vulnerabilities privately — see [`SECURITY.md`](./SECURITY.md), not a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ text.  This can be quite informal — just run your idea by us in the same way y
 friend, say, over Slack. If we're aligned on the change, we're happy to burn our tokens
 on the underlying implementation.
 
-Please do not have AI artificially expand or formalize what you'd like to do into a formal proposal.
+Please do not have AI artificially expand what you'd like to do into a formal proposal.
 
 Submit changes as `.txt` or `.md` files to the [`adrs/`](./adrs/) folder.
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ and this repository has no production deployment workflow. See
 
 ## Contributing
 
-Issues and pull requests are welcome. `npm run typecheck`, `npm run lint`, and `npm test`
-are the checks to run locally — CI adds the Postgres suites, the CLI and plugin builds,
-and the deployment contracts. Report vulnerabilities privately —
-see [`SECURITY.md`](./SECURITY.md), not a public issue.
+We take contributions as _human-written_ text, not code — see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md). Describe the change you'd like informally in a
+`.txt` or `.md` file in [`adrs/`](./adrs/), and if we're aligned we'll handle the
+implementation. Report vulnerabilities privately — see [`SECURITY.md`](./SECURITY.md),
+not a public issue.
 
 ## Customize your instance
 


### PR DESCRIPTION
## Why

Coding agents write most of the underlying code now, so we'd rather receive contributions as informal human-written proposals than AI-expanded code PRs. If we're aligned on an idea, we're happy to spend the tokens on implementation ourselves.

## What

- New `CONTRIBUTING.md` describing the policy: submit informal `.txt`/`.md` proposals to `adrs/`, no AI-formalized text.
- README Contributing section now points there.
- `adrs/` folder created (with `.gitkeep`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788041384&installation_model_id=19911&pr_number=34&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F34&signature=07bbeeb42b574c59dddfa9be8f0dfc160915a94dabfbaccbcbaf7a0cab22bc47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->