### PR TITLE
Add portal playground mode: anonymous browser-pinned sessions

### DIFF
--- a/plugins/auth/src/index.ts
+++ b/plugins/auth/src/index.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from "node:url";
 import { json } from "../../chassis/src/http.ts";
 import { portFromEnv } from "../../chassis/src/env.ts";
 import { bootProblems, readConfig } from "./config.ts";
-import { coreClaimStore } from "./claims.ts";
+import { coreClaimStore } from "../../chassis/src/claims.ts";
 import { mailerFor } from "./email.ts";
 import { loadSigningKey } from "./keys.ts";
 import { TokenSigner } from "./tokens.ts";
@@ -27,7 +27,7 @@ export async function startServer(): Promise<void> {
     cfg: CFG,
     signingKey,
     signer: new TokenSigner(CFG.tokenSecret, CFG.issuer),
-    claims: coreClaimStore(CFG.coreApiUrl, CFG.coreSigningSecret),
+    claims: coreClaimStore(CFG.coreApiUrl, CFG.coreSigningSecret, "auth"),
     mailer: mailerFor(CFG),
   });
   const server = createServer((req, res) => {

--- a/plugins/auth/src/server.ts
+++ b/plugins/auth/src/server.ts
@@ -3,7 +3,7 @@ import { readBody, PayloadTooLargeError, serveEmojiFavicon } from "../../chassis
 import { errMessage } from "../../chassis/src/errors.ts";
 import type { AuthConfig } from "./config.ts";
 import { validEmail } from "./config.ts";
-import { claimOnce, withinRateLimit, type ClaimStore } from "./claims.ts";
+import { claimOnce, withinRateLimit, type ClaimStore } from "../../chassis/src/claims.ts";
 import { mintIdToken, pkceMatches, safeEqual, subjectFor, TokenSigner, type AuthRequest } from "./tokens.ts";
 import { ID_TOKEN_ALG, type SigningKey } from "./keys.ts";
 import { renderSignInEmail, type Mailer } from "./email.ts";

--- a/plugins/auth/test/helpers.ts
+++ b/plugins/auth/test/helpers.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from "node:http";
 import { createHash, generateKeyPairSync, randomBytes } from "node:crypto";
 import { readConfig, type AuthConfig } from "../src/config.ts";
-import type { ClaimStore } from "../src/claims.ts";
+import type { ClaimStore } from "../../chassis/src/claims.ts";
 import type { Mailer, OutgoingEmail } from "../src/email.ts";
 import { loadSigningKey } from "../src/keys.ts";
 import { TokenSigner } from "../src/tokens.ts";

--- a/plugins/chassis/src/claims.ts
+++ b/plugins/chassis/src/claims.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
-import { signedHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
-import { errMessage } from "../../chassis/src/errors.ts";
+import { signedHeaders, withSourceAuthNonce } from "./core-client.ts";
+import { errMessage } from "./errors.ts";
 
 export interface ClaimStore {
   claimFirst(ids: readonly string[], expiresAtMs: number): Promise<string | null>;
@@ -9,7 +9,7 @@ export interface ClaimStore {
 const CLAIM_PATH = "/v1/auth/broker/claim";
 const CLAIM_TIMEOUT_MS = 4_000;
 
-export function coreClaimStore(coreApiUrl: string, signingSecret: string | undefined): ClaimStore {
+export function coreClaimStore(coreApiUrl: string, signingSecret: string | undefined, label = "chassis"): ClaimStore {
   return {
     async claimFirst(ids, expiresAtMs) {
       const path = withSourceAuthNonce(CLAIM_PATH, signingSecret);
@@ -22,13 +22,13 @@ export function coreClaimStore(coreApiUrl: string, signingSecret: string | undef
           signal: AbortSignal.timeout(CLAIM_TIMEOUT_MS),
         });
         if (!r.ok) {
-          console.error(`[auth] core refused a single-use claim: HTTP ${r.status}`);
+          console.error(`[${label}] core refused a single-use claim: HTTP ${r.status}`);
           return null;
         }
         const parsed = (await r.json()) as { claimed?: unknown };
         return typeof parsed.claimed === "string" ? parsed.claimed : null;
       } catch (e) {
-        console.error(`[auth] core single-use claim failed: ${errMessage(e)}`);
+        console.error(`[${label}] core single-use claim failed: ${errMessage(e)}`);
         return null;
       }
     },

--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -67,6 +67,34 @@ surfaces, and it does **not** import the core.
   session before `exp`; the core's `canAdminister` (re-read per request) remains the live admin
   revocation path. Slack has no RP-initiated end-session, so SSO re-login is silent.
 
+## Playground mode
+
+`PORTAL_PLAYGROUND=1` turns the deployment into a public try-it instance: an
+unauthenticated browser navigation (a `GET` that accepts HTML) mints an anonymous
+principal (`playground-<random>`), seals it into the ordinary `portal_session`
+cookie, and continues — so each visitor's sessions, files, memory, and sandbox are
+pinned to their browser through the same scoping that isolates real teammates.
+Non-HTML requests without a session still get `401`, so the SPA's API calls ride
+the cookie from the first page load and bare `curl` never mints.
+
+What playground mode does **not** change: `/auth/login` still runs the full OIDC
+flow (that's how the one admin signs in — production still demands the usual OIDC
+config), `/admin` refuses anonymous sessions outright, and admin identity remains
+the core's `ADMIN_GRANTS`. Signing out of an anonymous session just clears the
+cookie; the next visit starts a fresh playground identity.
+
+Minting is rate-limited per client IP through the core's Postgres-backed
+single-use claim store (the same one the sign-in broker uses), so restarts and
+blue-green deploys can't reset it; if the core can't record the claim the portal
+fails closed and answers 429. `PORTAL_PLAYGROUND_MINTS_PER_IP` (default 30) per
+`PORTAL_PLAYGROUND_MINT_WINDOW_S` (default 3600) tunes it. A cleared cookie mints
+a fresh principal, so pair this with the core's real brakes:
+`BUDGET_USD_PER_WINDOW`, `ORG_BUDGET_USD_PER_WINDOW`, `RATE_LIMIT_PER_WINDOW`,
+and a single pinned model via the admin `base-model` / `webui-models` resources.
+Run a playground as its own deployment — anonymous visitors share the `org:`
+scope's published resources, and nothing garbage-collects an abandoned visitor's
+scope yet.
+
 ## Env
 
 Non-secret (`[env]`): `PORT` (8097 local / 8080 image), `PORTAL_PUBLIC_URL`, `CORE_API_URL`,

--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -83,17 +83,40 @@ config), `/admin` refuses anonymous sessions outright, and admin identity remain
 the core's `ADMIN_GRANTS`. Signing out of an anonymous session just clears the
 cookie; the next visit starts a fresh playground identity.
 
-Minting is rate-limited per client IP through the core's Postgres-backed
+Minting is rate-limited per client address through the core's Postgres-backed
 single-use claim store (the same one the sign-in broker uses), so restarts and
 blue-green deploys can't reset it; if the core can't record the claim the portal
-fails closed and answers 429. `PORTAL_PLAYGROUND_MINTS_PER_IP` (default 30) per
-`PORTAL_PLAYGROUND_MINT_WINDOW_S` (default 3600) tunes it. A cleared cookie mints
-a fresh principal, so pair this with the core's real brakes:
-`BUDGET_USD_PER_WINDOW`, `ORG_BUDGET_USD_PER_WINDOW`, `RATE_LIMIT_PER_WINDOW`,
-and a single pinned model via the admin `base-model` / `webui-models` resources.
-Run a playground as its own deployment — anonymous visitors share the `org:`
-scope's published resources, and nothing garbage-collects an abandoned visitor's
-scope yet.
+fails closed and answers 429. `PORTAL_PLAYGROUND_MINTS_PER_IP` (default 30, at
+most 64 — the core grants at most 64 claim slots per request) per
+`PORTAL_PLAYGROUND_MINT_WINDOW_S` (default 3600, at most 86400 — the core's
+claim horizon); the portal refuses to boot outside those ranges rather than
+silently serving 429 to everyone. IPv6 clients are bucketed per /64, not per
+address, so a visitor with a routed prefix can't rotate through fresh budgets.
+The client address comes from `clientIpOf` — on Fly that's `fly-client-ip`;
+elsewhere set `PORTAL_XFF_TRUSTED_HOPS` when a reverse proxy fronts the portal,
+or every visitor (and every crawler that accepts HTML) shares the socket
+address's one bucket.
+
+Because playground authority must never leave this origin, the portal refuses
+to boot with `PORTAL_PLAYGROUND` alongside `PORTAL_COOKIE_DOMAIN`,
+`PORTAL_APPS_DOMAIN`, or `PORTAL_DEPLOYMENTS_ENABLED` — a domain-wide cookie or
+the deployment proxy would hand anonymous sessions to surfaces that never see
+the `anon` flag. Anonymous sessions are also refused the `/connect/*` and
+`/drop/*` flows, so a visitor can't attach real OAuth tokens or dropped secrets
+to a throwaway principal that a cleared cookie orphans.
+
+The `anon` flag lives only in the portal's session cookie — it does not cross
+the portal identity boundary. To the core, a playground visitor is an ordinary
+**internal** principal of the deployment's org: they can run turns, use their
+sandbox, create crons, and reach anything granted or published at `org:` scope,
+including org-granted credentials. That is the design — visitors are members of
+the playground org — so a playground must be its own deployment with nothing
+sensitive at org scope: no org-wide credential grants, no real connector
+credentials, no company data. A cleared cookie mints a fresh principal, so pair
+this with the core's real brakes: `BUDGET_USD_PER_WINDOW`,
+`ORG_BUDGET_USD_PER_WINDOW`, `RATE_LIMIT_PER_WINDOW`, and a single pinned model
+via the admin `base-model` / `webui-models` resources. Nothing
+garbage-collects an abandoned visitor's scope yet.
 
 ## Env
 

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -71,11 +71,14 @@ const LOCAL_AUTH_BYPASS = LOCAL_AUTH_BYPASS_REQUESTED && !IS_PROD && isLocalPort
 const LOCAL_AUTH_PRINCIPAL = process.env.PORTAL_DEV_PRINCIPAL || process.env.USER || "dev-admin";
 const DEPLOYMENTS_ENABLED = process.env.PORTAL_DEPLOYMENTS_ENABLED === "1";
 const PLAYGROUND = process.env.PORTAL_PLAYGROUND === "1";
-const PLAYGROUND_MINTS_PER_IP = Math.max(1, Math.trunc(Number(process.env.PORTAL_PLAYGROUND_MINTS_PER_IP ?? 0)) || 30);
-const PLAYGROUND_MINT_WINDOW_S = Math.max(
-  60,
-  Math.trunc(Number(process.env.PORTAL_PLAYGROUND_MINT_WINDOW_S ?? 0)) || 3600,
-);
+function playgroundIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isInteger(n) ? n : NaN;
+}
+const PLAYGROUND_MINTS_PER_IP = playgroundIntEnv("PORTAL_PLAYGROUND_MINTS_PER_IP", 30);
+const PLAYGROUND_MINT_WINDOW_S = playgroundIntEnv("PORTAL_PLAYGROUND_MINT_WINDOW_S", 3600);
 const NEUTRAL_ACCENT = "#4f46e5";
 let brandAccent = NEUTRAL_ACCENT;
 let modelProviderConfigured: boolean | undefined;
@@ -720,7 +723,22 @@ function setSession(res: ServerResponse, headers: string[]): void {
   res.setHeader("set-cookie", headers);
 }
 
-const playgroundClaims = coreClaimStore(CORE, CORE_SIGNING_SECRET, "portal");
+const playgroundClaims = PLAYGROUND ? coreClaimStore(CORE, CORE_SIGNING_SECRET, "portal") : null;
+
+export function mintBucketOf(ip: string): string {
+  if (!ip.includes(":")) return ip;
+  const zoneless = ip.split("%")[0] ?? "";
+  if (zoneless.toLowerCase().startsWith("::ffff:") && zoneless.includes(".")) return zoneless.slice(7);
+  const [headRaw = "", tailRaw = ""] = zoneless.split("::", 2);
+  const head = headRaw ? headRaw.split(":") : [];
+  const tail = tailRaw ? tailRaw.split(":") : [];
+  const groups = [...head, ...Array<string>(Math.max(0, 8 - head.length - tail.length)).fill("0"), ...tail];
+  const prefix = groups
+    .slice(0, 4)
+    .map((g) => (g || "0").toLowerCase().replace(/^0+(?=.)/, ""))
+    .join(":");
+  return `${prefix}::/64`;
+}
 
 export function playgroundBusyHtml(): string {
   return cardPage({
@@ -734,11 +752,23 @@ export function playgroundBusyHtml(): string {
   });
 }
 
+export function playgroundRestrictedHtml(): string {
+  return cardPage({
+    title: "Not available in the playground",
+    heading: "Not available in the playground",
+    msg: "Connecting accounts and dropping secrets are disabled for anonymous playground sessions — clearing your cookie would orphan real credentials.",
+    icon: LOCK_ICON,
+    actions: `<a class="btn primary" href="/">Back to the playground</a>`,
+    help: "Sign in with a real account at /auth/login to use this link.",
+  });
+}
+
 async function mintPlaygroundSession(req: IncomingMessage, res: ServerResponse): Promise<SessionClaims | null> {
+  if (!playgroundClaims) return null;
   const allowed = await withinRateLimit(playgroundClaims, {
     secret: SESSION_SECRET ?? DEV_SECRET,
     kind: "playground-mint",
-    value: clientIpOf(req),
+    value: mintBucketOf(clientIpOf(req)),
     limit: PLAYGROUND_MINTS_PER_IP,
     windowS: PLAYGROUND_MINT_WINDOW_S,
     nowMs: Date.now(),
@@ -900,6 +930,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   const redeem = /^\/connect\/redeem\/([^/]+)$/.exec(pathname);
   if (method === "GET" && redeem) {
     if (!session) return consentBounce();
+    if (session.anon) return sendHtml(res, 403, playgroundRestrictedHtml());
     return handleConsentRedeem(res, {
       corePath: `/v1/connectors/oauth/consent/redeem/${redeem[1]}${url.search}`,
       session,
@@ -908,6 +939,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   const selfConnect = /^\/connect\/([^/]+)\/self-connect$/.exec(pathname);
   if (method === "GET" && selfConnect) {
     if (!session) return consentBounce();
+    if (session.anon) return sendHtml(res, 403, playgroundRestrictedHtml());
     return handleSelfConnect(res, { provider: decodeURIComponent(selfConnect[1] ?? ""), session });
   }
 
@@ -918,6 +950,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   const dropForm = /^\/drop\/([^/]+)\/form$/.exec(pathname);
   if (method === "GET" && dropForm) {
     if (!session) return consentBounce();
+    if (session.anon) return sendHtml(res, 403, playgroundRestrictedHtml());
     return handleSecretDrop(req, res, {
       method,
       corePath: `/v1/keychain/drops/${dropForm[1]}/form${url.search}`,
@@ -932,6 +965,8 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
         message: "your session expired — re-open the link, sign in, and paste again",
       });
     if (!sameOriginRequest(req)) return json(res, 403, { error: "forbidden", message: "cross-origin request refused" });
+    if (session.anon)
+      return json(res, 403, { error: "forbidden", message: "secret drops are disabled for playground sessions" });
     return handleSecretDrop(req, res, {
       method,
       corePath: `/v1/keychain/drops/${dropSubmit[1]}${url.search}`,
@@ -1139,6 +1174,32 @@ export function bootChecks(): void {
   if (LOCAL_AUTH_BYPASS_REQUESTED && !isLocalPortalUrl(PUBLIC_URL)) {
     problems.push("PORTAL_LOCAL_AUTH_BYPASS requires a localhost, 127.0.0.1, or ::1 PORTAL_PUBLIC_URL");
   }
+  if (PLAYGROUND) {
+    if (!Number.isInteger(PLAYGROUND_MINTS_PER_IP) || PLAYGROUND_MINTS_PER_IP < 1 || PLAYGROUND_MINTS_PER_IP > 64) {
+      problems.push(
+        "PORTAL_PLAYGROUND_MINTS_PER_IP must be an integer between 1 and 64 (the core grants at most 64 claim slots per request)",
+      );
+    }
+    if (
+      !Number.isInteger(PLAYGROUND_MINT_WINDOW_S) ||
+      PLAYGROUND_MINT_WINDOW_S < 60 ||
+      PLAYGROUND_MINT_WINDOW_S > 86400
+    ) {
+      problems.push(
+        "PORTAL_PLAYGROUND_MINT_WINDOW_S must be an integer between 60 and 86400 (the core's claim horizon is 24 hours)",
+      );
+    }
+    if (COOKIE_DOMAIN || APPS_DOMAIN) {
+      problems.push(
+        "PORTAL_PLAYGROUND requires PORTAL_COOKIE_DOMAIN and PORTAL_APPS_DOMAIN unset — a domain-wide cookie would carry anonymous sessions to app subdomains, which never see the anon flag",
+      );
+    }
+    if (DEPLOYMENTS_ENABLED) {
+      problems.push(
+        "PORTAL_PLAYGROUND requires PORTAL_DEPLOYMENTS_ENABLED unset — anonymous visitors must not reach deployed apps",
+      );
+    }
+  }
   if (APPS_DOMAIN && !COOKIE_DOMAIN) {
     problems.push(
       "PORTAL_APPS_DOMAIN requires PORTAL_COOKIE_DOMAIN (app returnTo without a domain-wide session cookie loops sign-in forever)",
@@ -1267,6 +1328,10 @@ export function startServer(): void {
     if (PLAYGROUND)
       console.warn(
         `[portal] PORTAL_PLAYGROUND=1 -- unauthenticated visitors get anonymous browser-pinned sessions (${PLAYGROUND_MINTS_PER_IP} mints per IP per ${PLAYGROUND_MINT_WINDOW_S}s); admin sign-in stays on /auth/login`,
+      );
+    if (PLAYGROUND && !ON_FLY && XFF_TRUSTED_HOPS === 0)
+      console.warn(
+        "[portal] playground mint limits key on the socket address — set PORTAL_XFF_TRUSTED_HOPS when behind a reverse proxy, or every visitor shares one bucket",
       );
     console.log(
       "[portal] /admin access is derived (portal → admin surface /api/whoami over 6PN → core canAdminister); the core's ADMIN_GRANTS is the one source of admin identity",

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -37,6 +37,7 @@ import {
   FORWARD_BROKER_HEADERS,
 } from "./proxy.ts";
 import { signedHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
+import { coreClaimStore, withinRateLimit } from "../../chassis/src/claims.ts";
 import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
 import { errMessage } from "../../chassis/src/errors.ts";
 import { json, escapeHtml, serveEmojiFavicon } from "../../chassis/src/http.ts";
@@ -69,6 +70,12 @@ const LOCAL_AUTH_BYPASS_REQUESTED = process.env.PORTAL_LOCAL_AUTH_BYPASS === "1"
 const LOCAL_AUTH_BYPASS = LOCAL_AUTH_BYPASS_REQUESTED && !IS_PROD && isLocalPortalUrl(PUBLIC_URL);
 const LOCAL_AUTH_PRINCIPAL = process.env.PORTAL_DEV_PRINCIPAL || process.env.USER || "dev-admin";
 const DEPLOYMENTS_ENABLED = process.env.PORTAL_DEPLOYMENTS_ENABLED === "1";
+const PLAYGROUND = process.env.PORTAL_PLAYGROUND === "1";
+const PLAYGROUND_MINTS_PER_IP = Math.max(1, Math.trunc(Number(process.env.PORTAL_PLAYGROUND_MINTS_PER_IP ?? 0)) || 30);
+const PLAYGROUND_MINT_WINDOW_S = Math.max(
+  60,
+  Math.trunc(Number(process.env.PORTAL_PLAYGROUND_MINT_WINDOW_S ?? 0)) || 3600,
+);
 const NEUTRAL_ACCENT = "#4f46e5";
 let brandAccent = NEUTRAL_ACCENT;
 let modelProviderConfigured: boolean | undefined;
@@ -713,6 +720,45 @@ function setSession(res: ServerResponse, headers: string[]): void {
   res.setHeader("set-cookie", headers);
 }
 
+const playgroundClaims = coreClaimStore(CORE, CORE_SIGNING_SECRET, "portal");
+
+export function playgroundBusyHtml(): string {
+  return cardPage({
+    title: "Playground is busy",
+    heading: "The playground is busy",
+    msg: "We couldn't start a fresh playground session for you right now. Waiting a little while and reloading resolves most cases.",
+    icon: ALERT_ICON,
+    warn: true,
+    actions: `<a class="btn primary" href="/">Try again</a>`,
+    help: "Playground sessions are limited per visitor to keep the demo responsive for everyone.",
+  });
+}
+
+async function mintPlaygroundSession(req: IncomingMessage, res: ServerResponse): Promise<SessionClaims | null> {
+  const allowed = await withinRateLimit(playgroundClaims, {
+    secret: SESSION_SECRET ?? DEV_SECRET,
+    kind: "playground-mint",
+    value: clientIpOf(req),
+    limit: PLAYGROUND_MINTS_PER_IP,
+    windowS: PLAYGROUND_MINT_WINDOW_S,
+    nowMs: Date.now(),
+  });
+  if (!allowed) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const session: SessionClaims = {
+    k: "session",
+    sub: `playground-${randomToken(8)}`,
+    org: ORG,
+    name: "Guest",
+    anon: true,
+    auth: now,
+    iat: now,
+    exp: now + SESSION_TTL_S,
+  };
+  setSession(res, sessionCookieSet(seal(session, sessionKey)));
+  return session;
+}
+
 function renewSessionCookie(req: IncomingMessage, res: ServerResponse): void {
   const session = openSession(
     readCookie(req.headers.cookie, "portal_session"),
@@ -793,7 +839,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     );
   }
 
-  const session = currentSession(req);
+  let session = currentSession(req);
   if (session) renewSessionCookie(req, res);
 
   if (pathname === "/auth/impersonate" && method === "POST") {
@@ -920,11 +966,17 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
 
   if (!session) {
     if (method === "GET" && wantsHtml(req)) {
-      const returnTo = encodeURIComponent(`${pathname}${url.search}`);
-      res.writeHead(302, { location: `/auth/login?returnTo=${returnTo}` });
-      return void res.end();
+      if (PLAYGROUND) {
+        session = await mintPlaygroundSession(req, res);
+        if (!session) return sendHtml(res, 429, playgroundBusyHtml());
+      } else {
+        const returnTo = encodeURIComponent(`${pathname}${url.search}`);
+        res.writeHead(302, { location: `/auth/login?returnTo=${returnTo}` });
+        return void res.end();
+      }
+    } else {
+      return json(res, 401, { error: "sign in" });
     }
-    return json(res, 401, { error: "sign in" });
   }
 
   if (method !== "GET" && method !== "HEAD" && !sameOriginRequest(req)) {
@@ -950,6 +1002,10 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
 
   const key = surfaceKey as string;
   if (key === "admin") {
+    if (session.anon) {
+      if (wantsHtml(req)) return sendHtml(res, 403, nonAdminDeniedHtml({ sub: session.sub, org: session.org }));
+      return json(res, 403, { error: "forbidden", message: "admin access required" });
+    }
     const probe = await adminProbe(session.sub);
     if (!probe.isAdmin) {
       if (wantsHtml(req)) {
@@ -1207,6 +1263,10 @@ export function startServer(): void {
     if (LOCAL_AUTH_BYPASS)
       console.warn(
         `[portal] PORTAL_LOCAL_AUTH_BYPASS=1 -- using ${LOCAL_AUTH_PRINCIPAL} as the local session principal (dev/test only)`,
+      );
+    if (PLAYGROUND)
+      console.warn(
+        `[portal] PORTAL_PLAYGROUND=1 -- unauthenticated visitors get anonymous browser-pinned sessions (${PLAYGROUND_MINTS_PER_IP} mints per IP per ${PLAYGROUND_MINT_WINDOW_S}s); admin sign-in stays on /auth/login`,
       );
     console.log(
       "[portal] /admin access is derived (portal → admin surface /api/whoami over 6PN → core canAdminister); the core's ADMIN_GRANTS is the one source of admin identity",

--- a/plugins/portal/src/session.ts
+++ b/plugins/portal/src/session.ts
@@ -32,6 +32,7 @@ export interface SessionClaims {
   org: string;
   name?: string;
   auth?: number;
+  anon?: boolean;
   iat: number;
   exp: number;
 }

--- a/plugins/portal/test/playground.test.ts
+++ b/plugins/portal/test/playground.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
+import { spawnSync } from "node:child_process";
+import { deriveKey, seal, openSession, type SessionClaims } from "../src/session.ts";
 
 const claimed = new Set<string>();
 let claimCalls = 0;
@@ -42,7 +44,7 @@ process.env.PORTAL_PLAYGROUND = "1";
 process.env.PORTAL_PLAYGROUND_MINTS_PER_IP = "3";
 delete process.env.PORTAL_LOCAL_AUTH_BYPASS;
 
-const { server } = await import("../src/index.ts");
+const { server, mintBucketOf } = await import("../src/index.ts");
 await new Promise<void>((r) => server.listen(0, r));
 const base = `http://localhost:${(server.address() as AddressInfo).port}`;
 
@@ -95,6 +97,88 @@ test("explicit sign-in still goes to the identity provider", async () => {
   const login = await fetch(`${base}/auth/login`, { redirect: "manual" });
   assert.equal(login.status, 302);
   assert.match(login.headers.get("location") ?? "", /^https:\/\/slack\.com\/openid\/connect\/authorize/);
+});
+
+test("sliding renewal preserves the anon flag", async () => {
+  const key = deriveKey("playground-test-portal-secret", "portal.session.v1");
+  const now = Math.floor(Date.now() / 1000);
+  const aged: SessionClaims = {
+    k: "session",
+    sub: "playground-deadbeef",
+    org: process.env.CORE_ORG_ID ?? "acme",
+    name: "Guest",
+    anon: true,
+    auth: now - 15000,
+    iat: now - 15000,
+    exp: now + 13800,
+  };
+  const res = await fetch(`${base}/`, {
+    headers: { ...HTML, cookie: `portal_session=${encodeURIComponent(seal(aged, key))}` },
+    redirect: "manual",
+  });
+  assert.equal(res.status, 200);
+  const renewed = openSession(decodeURIComponent(sessionCookieOf(res).split("=")[1]!), key, Date.now());
+  assert.ok(renewed, "expected a renewed session");
+  assert.equal(renewed.anon, true);
+  assert.equal(renewed.sub, "playground-deadbeef");
+  assert.ok(renewed.iat > aged.iat, "expected a re-stamped iat");
+});
+
+test("anonymous sessions are refused the connect and secret-drop flows", async () => {
+  const visit = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
+  const cookie = sessionCookieOf(visit);
+  for (const path of ["/connect/redeem/tok123", "/connect/google/self-connect", "/drop/tok123/form"]) {
+    const r = await fetch(`${base}${path}`, { headers: { ...HTML, cookie } });
+    assert.equal(r.status, 403, `${path} must refuse anon sessions`);
+  }
+  const drop = await fetch(`${base}/drop/tok123`, {
+    method: "POST",
+    headers: { cookie, origin: "http://localhost:18196" },
+  });
+  assert.equal(drop.status, 403);
+  assert.match(((await drop.json()) as { message: string }).message, /playground/);
+});
+
+test("mintBucketOf keys IPv4 per address and IPv6 per /64", () => {
+  assert.equal(mintBucketOf("203.0.113.9"), "203.0.113.9");
+  assert.equal(mintBucketOf("::ffff:203.0.113.9"), "203.0.113.9");
+  assert.equal(mintBucketOf("2001:db8:1:2:3:4:5:6"), "2001:db8:1:2::/64");
+  assert.equal(mintBucketOf("2001:db8:1:2:ffff::1"), mintBucketOf("2001:db8:1:2:3:4:5:6"));
+  assert.notEqual(mintBucketOf("2001:db8:1:3::1"), mintBucketOf("2001:db8:1:2::1"));
+  assert.equal(mintBucketOf("2001:db8::1"), "2001:db8:0:0::/64");
+  assert.equal(mintBucketOf("fe80::1%en0"), "fe80:0:0:0::/64");
+});
+
+test("boot refuses playground configurations that leak or brick", () => {
+  const command = "import('./src/index.ts').then(m => m.bootChecks())";
+  const baseEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: "test",
+    PORTAL_PUBLIC_URL: "http://localhost:18196",
+    PORTAL_PLAYGROUND: "1",
+  };
+  delete baseEnv.PORTAL_COOKIE_DOMAIN;
+  delete baseEnv.PORTAL_APPS_DOMAIN;
+  delete baseEnv.PORTAL_DEPLOYMENTS_ENABLED;
+  delete baseEnv.PORTAL_PLAYGROUND_MINTS_PER_IP;
+  delete baseEnv.PORTAL_PLAYGROUND_MINT_WINDOW_S;
+  const boot = (env: NodeJS.ProcessEnv) =>
+    spawnSync(process.execPath, ["--input-type=module", "-e", command], { cwd: process.cwd(), env, encoding: "utf8" });
+  assert.equal(boot(baseEnv).status, 0);
+  const bad: Array<[NodeJS.ProcessEnv, RegExp]> = [
+    [{ PORTAL_PLAYGROUND_MINTS_PER_IP: "0" }, /between 1 and 64/],
+    [{ PORTAL_PLAYGROUND_MINTS_PER_IP: "65" }, /between 1 and 64/],
+    [{ PORTAL_PLAYGROUND_MINTS_PER_IP: "lots" }, /between 1 and 64/],
+    [{ PORTAL_PLAYGROUND_MINT_WINDOW_S: "30" }, /between 60 and 86400/],
+    [{ PORTAL_PLAYGROUND_MINT_WINDOW_S: "172800" }, /between 60 and 86400/],
+    [{ PORTAL_COOKIE_DOMAIN: "qm.example.com" }, /PORTAL_COOKIE_DOMAIN and PORTAL_APPS_DOMAIN unset/],
+    [{ PORTAL_DEPLOYMENTS_ENABLED: "1" }, /PORTAL_DEPLOYMENTS_ENABLED unset/],
+  ];
+  for (const [extra, pattern] of bad) {
+    const r = boot({ ...baseEnv, ...extra });
+    assert.notEqual(r.status, 0, `expected boot failure for ${JSON.stringify(extra)}`);
+    assert.match(r.stderr, pattern);
+  }
 });
 
 test("mints beyond the per-IP budget are refused, and refusal sets no cookie", async () => {

--- a/plugins/portal/test/playground.test.ts
+++ b/plugins/portal/test/playground.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const claimed = new Set<string>();
+let claimCalls = 0;
+let refuseClaims = false;
+
+const upstream = createServer((req: IncomingMessage, res) => {
+  if (req.method === "POST" && req.url?.startsWith("/v1/auth/broker/claim")) {
+    claimCalls++;
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      if (refuseClaims) return void res.end(JSON.stringify({ claimed: null }));
+      const { ids } = JSON.parse(Buffer.concat(chunks).toString("utf8")) as { ids: string[] };
+      const winner = ids.find((id) => !claimed.has(id)) ?? null;
+      if (winner) claimed.add(winner);
+      res.end(JSON.stringify({ claimed: winner }));
+    });
+    return;
+  }
+  if (req.url === "/api/whoami") {
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(JSON.stringify({ isAdmin: false }));
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ url: req.url, cookie: req.headers.cookie ?? null }));
+});
+await new Promise<void>((r) => upstream.listen(0, r));
+const upstreamUrl = `http://localhost:${(upstream.address() as AddressInfo).port}`;
+
+process.env.PORTAL_PUBLIC_URL = "http://localhost:18196";
+process.env.PORTAL_SESSION_SECRET = "playground-test-portal-secret";
+process.env.CORE_SIGNING_SECRET = "playground-test-core-secret";
+process.env.WEB_UI_UPSTREAM = upstreamUrl;
+process.env.ADMIN_UPSTREAM = upstreamUrl;
+process.env.CORE_API_URL = upstreamUrl;
+process.env.PORTAL_PLAYGROUND = "1";
+process.env.PORTAL_PLAYGROUND_MINTS_PER_IP = "3";
+delete process.env.PORTAL_LOCAL_AUTH_BYPASS;
+
+const { server } = await import("../src/index.ts");
+await new Promise<void>((r) => server.listen(0, r));
+const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+
+test.after(() => {
+  server.close();
+  upstream.close();
+});
+
+const HTML = { accept: "text/html" };
+
+function sessionCookieOf(res: Response): string {
+  const raw = res.headers.getSetCookie().find((c) => c.startsWith("portal_session=") && !/portal_session=;/.test(c));
+  assert.ok(raw, "expected a portal_session cookie");
+  return raw.split(";")[0]!;
+}
+
+test("an unauthenticated browser visit mints an anonymous session pinned to the cookie", async () => {
+  const first = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
+  assert.equal(first.status, 200);
+  const cookie = sessionCookieOf(first);
+  const body = (await first.json()) as { cookie: string };
+  const principal = /webuiuser=(playground-[0-9a-f]+)/.exec(body.cookie)?.[1];
+  assert.ok(principal, `expected a playground principal, got: ${body.cookie}`);
+
+  const callsBefore = claimCalls;
+  const again = await fetch(`${base}/`, { headers: { ...HTML, cookie }, redirect: "manual" });
+  assert.equal(again.status, 200);
+  const reuse = (await again.json()) as { cookie: string };
+  assert.match(reuse.cookie, new RegExp(`webuiuser=${principal}`));
+  assert.equal(claimCalls, callsBefore, "a returning session must not mint again");
+});
+
+test("API requests without a session still require sign-in", async () => {
+  const api = await fetch(`${base}/api/state`, { headers: { accept: "application/json" } });
+  assert.equal(api.status, 401);
+  const post = await fetch(`${base}/api/turn`, { method: "POST", headers: HTML });
+  assert.equal(post.status, 401);
+});
+
+test("anonymous sessions are refused the admin surface", async () => {
+  const visit = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
+  const cookie = sessionCookieOf(visit);
+  const admin = await fetch(`${base}/admin/`, { headers: { ...HTML, cookie } });
+  assert.equal(admin.status, 403);
+  const adminApi = await fetch(`${base}/admin/api/me`, { headers: { accept: "application/json", cookie } });
+  assert.equal(adminApi.status, 403);
+});
+
+test("explicit sign-in still goes to the identity provider", async () => {
+  const login = await fetch(`${base}/auth/login`, { redirect: "manual" });
+  assert.equal(login.status, 302);
+  assert.match(login.headers.get("location") ?? "", /^https:\/\/slack\.com\/openid\/connect\/authorize/);
+});
+
+test("mints beyond the per-IP budget are refused, and refusal sets no cookie", async () => {
+  let last: Response | null = null;
+  for (let i = 0; i < 10; i++) last = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
+  assert.equal(last!.status, 429);
+  assert.equal(last!.headers.getSetCookie().length, 0);
+
+  refuseClaims = true;
+  try {
+    const down = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
+    assert.equal(down.status, 429, "a failed claim must fail closed");
+  } finally {
+    refuseClaims = false;
+  }
+});


### PR DESCRIPTION
## What

`PORTAL_PLAYGROUND=1` turns a deployment into a public try-it instance with one real admin. An unauthenticated browser navigation (a `GET` that accepts HTML) mints an anonymous `playground-<random>` principal, seals it into the ordinary `portal_session` cookie, and continues. Each visitor's sessions, files, memory, keychain view, and sandbox are pinned to their browser through the same `personal:<principal>` scoping that isolates real teammates — no new isolation machinery.

What playground mode deliberately does **not** change:

- `/auth/login` still runs the full OIDC flow; production still demands the usual OIDC config. That is how the one admin signs in, and admin identity remains the core's `ADMIN_GRANTS`, derived per request.
- `/admin` refuses anonymous sessions outright (HTML card or JSON 403).
- Non-HTML requests without a session still get `401` — the SPA's API calls ride the cookie from the first page load, and bare `curl` never mints.
- Sign-out just clears the cookie; the next visit starts a fresh identity.

## Abuse containment

Minting is rate-limited per client IP (`clientIpOf`, Fly-header aware) through the core's Postgres-backed single-use claim store — the same `/v1/auth/broker/claim` slot pattern the sign-in broker uses — so restarts, blue-green deploys, and multiple portal instances share one budget. If the core can't record the claim, the portal fails closed with a 429 card. Tunables: `PORTAL_PLAYGROUND_MINTS_PER_IP` (default 30) per `PORTAL_PLAYGROUND_MINT_WINDOW_S` (default 3600).

A cleared cookie is a fresh principal, so the per-principal core brakes are soft; the README directs operators to the real ones — `ORG_BUDGET_USD_PER_WINDOW`, `BUDGET_USD_PER_WINDOW`, `RATE_LIMIT_PER_WINDOW`, and pinning a single model via the admin `base-model` / `webui-models` resources — and to run a playground as its own deployment. Known gap, stated in the README: nothing garbage-collects an abandoned visitor's scope yet.

## Moved

`plugins/auth/src/claims.ts` → `plugins/chassis/src/claims.ts` (the claim-store client + `withinRateLimit` slot math), now that both the auth broker and the portal consume it. Chassis is the sanctioned home for plugin↔core plumbing; the log prefix became a parameter.

## New surface

The only new rendered page is the 429 "playground is busy" card, built from the existing portal card system. Rendered from the real `playgroundBusyHtml()` output (the live path needs an exhausted IP budget, so this is a direct render — same bytes):

![The playground busy 429 card](https://gist.githubusercontent.com/16francej/75287d4ad90aaf39c6e981e831ad40e7/raw/playground-busy.jpg)

## Testing

- New `plugins/portal/test/playground.test.ts` boots the real portal server against a stub core + upstream and covers: mint-on-first-visit with cookie pinning (no re-mint on return), 401 for sessionless API calls, `/admin` refusal for anonymous sessions, `/auth/login` still reaching the IdP, per-IP budget exhaustion → 429 with no cookie, and fail-closed when the claim store refuses.
- Portal: 101/101 tests, typecheck, lint. Auth: 52/52, typecheck (import-path move only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788044677&installation_model_id=19911&pr_number=38&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F38&signature=61aa0ec890578d512657f14de5c165e8b2cb3eb8ef0ca0a1199a95ce72705e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->