### PR TITLE
Document playground deployments in the deployment workflow

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -158,21 +158,12 @@ A playground must be its **own deployment**, never a flag on a working org's
 instance: every visitor is an ordinary internal principal of the deployment's
 org, so anything granted or published at org scope — including org-granted
 credentials — is theirs. Grant nothing sensitive at org scope, connect no real
-connector credentials, and load no company data.
-
-Because a cleared cookie is a fresh identity, the per-principal brakes are
-soft; set the real ones in the same pass: `env.core.ORG_BUDGET_USD_PER_WINDOW`
-(the one hard spend ceiling), `BUDGET_USD_PER_WINDOW` and
-`RATE_LIMIT_PER_WINDOW` per principal, and after first boot pin a single model
-through the Admin page's base-model and web-UI model resources. The portal
-refuses to boot a playground alongside `PORTAL_COOKIE_DOMAIN`,
-`PORTAL_APPS_DOMAIN`, or `PORTAL_DEPLOYMENTS_ENABLED`, and refuses mint limits
-outside the claim store's bounds. Anonymous visitors are denied `/admin` and
-the connect and secret-drop flows. Nothing garbage-collects an abandoned
-visitor's scope yet, so expect storage to grow with traffic.
-`plugins/portal/README.md` § "Playground mode" documents the mechanism,
-including the per-address mint rate limits and how the client address is
-derived behind a proxy.
+connector credentials, and load no company data. A cleared cookie is a fresh
+identity, so set `env.core.ORG_BUDGET_USD_PER_WINDOW` — the one hard spend
+ceiling — in the same pass, and pin a single model from the Admin page after
+first boot. Nothing garbage-collects an abandoned visitor's scope yet.
+`plugins/portal/README.md` § "Playground mode" covers the rest: per-address
+mint limits, the boot refusals, and what anonymous visitors are denied.
 
 ### The base model
 

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -143,6 +143,37 @@ endpoints and the email gate in `env.portal`. For Google Workspace:
 }
 ```
 
+### Playground mode
+
+A playground is a public try-it deployment: unauthenticated visitors get
+anonymous browser-pinned identities instead of a sign-in page, while the one
+administrator still signs in through whichever route above the deployment
+configured. Enable it in `qm.config.jsonc`:
+
+```json
+"env": { "portal": { "PORTAL_PLAYGROUND": "1" } }
+```
+
+A playground must be its **own deployment**, never a flag on a working org's
+instance: every visitor is an ordinary internal principal of the deployment's
+org, so anything granted or published at org scope — including org-granted
+credentials — is theirs. Grant nothing sensitive at org scope, connect no real
+connector credentials, and load no company data.
+
+Because a cleared cookie is a fresh identity, the per-principal brakes are
+soft; set the real ones in the same pass: `env.core.ORG_BUDGET_USD_PER_WINDOW`
+(the one hard spend ceiling), `BUDGET_USD_PER_WINDOW` and
+`RATE_LIMIT_PER_WINDOW` per principal, and after first boot pin a single model
+through the Admin page's base-model and web-UI model resources. The portal
+refuses to boot a playground alongside `PORTAL_COOKIE_DOMAIN`,
+`PORTAL_APPS_DOMAIN`, or `PORTAL_DEPLOYMENTS_ENABLED`, and refuses mint limits
+outside the claim store's bounds. Anonymous visitors are denied `/admin` and
+the connect and secret-drop flows. Nothing garbage-collects an abandoned
+visitor's scope yet, so expect storage to grow with traffic.
+`plugins/portal/README.md` § "Playground mode" documents the mechanism,
+including the per-address mint rate limits and how the client address is
+derived behind a proxy.
+
 ### The base model
 
 Whichever sign-in route the deployment takes, the base model needs a key in the

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -160,8 +160,9 @@ org, so anything granted or published at org scope — including org-granted
 credentials — is theirs. Grant nothing sensitive at org scope, connect no real
 connector credentials, and load no company data. A cleared cookie is a fresh
 identity, so set `env.core.ORG_BUDGET_USD_PER_WINDOW` — the one hard spend
-ceiling — in the same pass, and pin a single model from the Admin page after
-first boot. Nothing garbage-collects an abandoned visitor's scope yet.
+ceiling — in the same pass, and from the Admin page after first boot restrict
+the model picker to the subset you want to offer (one model or several).
+Nothing garbage-collects an abandoned visitor's scope yet.
 `plugins/portal/README.md` § "Playground mode" covers the rest: per-address
 mint limits, the boot refusals, and what anonymous visitors are denied.
 

--- a/src/api/app-turn.ts
+++ b/src/api/app-turn.ts
@@ -172,7 +172,7 @@ export function createTurnMethods(
         const configuredWebuiModels = await deps.config.getWebuiModelsDurable(org);
         let enabledWebuiModels: string[] | null = null;
         if (configuredWebuiModels?.length) {
-          enabledWebuiModels = configuredWebuiModels;
+          enabledWebuiModels = [...new Set([...configuredWebuiModels, orgRuntime.modelId])];
         } else if (providers?.openrouter) {
           enabledWebuiModels = [
             ...new Set([

--- a/src/api/app-turn.ts
+++ b/src/api/app-turn.ts
@@ -5,7 +5,7 @@ import { isHalt, routeWake, type Wake } from "../wake/wake.ts";
 import type { OrchestratorInput } from "../core/orchestrator.ts";
 import { resolveTurnOrigin } from "../core/turn-origin.ts";
 import { isTerminal, leaseLapsed } from "../runs/run-store.ts";
-import { turnModelOptions, validateWebTurnModelOptions } from "../core/turn-options.ts";
+import { turnModelOptions, validateWebTurnModelOptions, webTurnRuntimeModelRefusal } from "../core/turn-options.ts";
 import { isProjectGroupRef, projectIdFromGroupRef } from "../projects/project-store.ts";
 import {
   defaultModelForHarness,
@@ -184,7 +184,9 @@ export function createTurnMethods(
             ]),
           ];
         }
-        const invalidModelOption = validateWebTurnModelOptions(req, enabledWebuiModels, providers);
+        const invalidModelOption =
+          validateWebTurnModelOptions(req, enabledWebuiModels, providers) ??
+          webTurnRuntimeModelRefusal(runtime.modelId, orgRuntime.modelId, configuredWebuiModels);
         if (invalidModelOption) return { status: "refused", reason: invalidModelOption };
       }
 

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1015,6 +1015,16 @@ async function getRuntimeConfig(ctx: ApiCtx): Promise<void> {
   return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.scope));
 }
 
+async function webuiModelEnabled(ctx: ApiCtx, modelId: string): Promise<boolean> {
+  const config = ctx.deps.config!;
+  const picker = await config.getWebuiModelsDurable(orgScope(ctx.deps));
+  if (!picker?.length || picker.includes(modelId)) return true;
+  const org = orgScope(ctx.deps);
+  const stored = await config.getRuntimeSelectionDurable(org);
+  const orgModel = stored?.modelId ?? (await config.getBaseModelOwnDurable(org)) ?? runtimeFallback(ctx).modelId;
+  return modelId === orgModel;
+}
+
 async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
   if (!ctx.deps.config || !isObj(ctx.body)) return sendJson(ctx.res, 400, { error: "bad_request" });
   if (ctx.capability && ctx.capability.liveActor !== true)
@@ -1033,7 +1043,8 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       if (
         legacyModel &&
         approved.includes(fallback.harnessId) &&
-        modelSupportedByHarness(legacyModel, fallback.harnessId)
+        modelSupportedByHarness(legacyModel, fallback.harnessId) &&
+        (await webuiModelEnabled(ctx, legacyModel))
       ) {
         await config.setRuntimeSelectionLatest(target.scope, { harnessId: fallback.harnessId, modelId: legacyModel });
       }
@@ -1047,8 +1058,7 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "harness_not_approved" });
     if (typeof modelId !== "string" || !modelSupportedByHarness(modelId, harnessId))
       return sendJson(ctx.res, 400, { error: "model_not_supported" });
-    const picker = await config.getWebuiModelsDurable(orgScope(ctx.deps));
-    if (picker?.length && !picker.includes(modelId)) return sendJson(ctx.res, 400, { error: "model_not_enabled" });
+    if (!(await webuiModelEnabled(ctx, modelId))) return sendJson(ctx.res, 400, { error: "model_not_enabled" });
     await config.setRuntimeSelectionLatest(target.scope, { harnessId, modelId });
   }
   audit(ctx.deps, {

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1047,6 +1047,8 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "harness_not_approved" });
     if (typeof modelId !== "string" || !modelSupportedByHarness(modelId, harnessId))
       return sendJson(ctx.res, 400, { error: "model_not_supported" });
+    const picker = await config.getWebuiModelsDurable(orgScope(ctx.deps));
+    if (picker?.length && !picker.includes(modelId)) return sendJson(ctx.res, 400, { error: "model_not_enabled" });
     await config.setRuntimeSelectionLatest(target.scope, { harnessId, modelId });
   }
   audit(ctx.deps, {

--- a/src/core/turn-options.ts
+++ b/src/core/turn-options.ts
@@ -34,6 +34,16 @@ export function turnModelOptions(input: { triggered?: boolean; thinkingLevel?: s
   };
 }
 
+export function webTurnRuntimeModelRefusal(
+  runtimeModelId: string,
+  orgModelId: string,
+  configuredWebuiModels: readonly string[] | null | undefined,
+): string | null {
+  if (!configuredWebuiModels?.length) return null;
+  if (runtimeModelId === orgModelId) return null;
+  return configuredWebuiModels.includes(runtimeModelId) ? null : "that model is not enabled for the web UI";
+}
+
 export function validateWebTurnModelOptions(
   input: { model?: string; thinkingLevel?: string },
   enabledModels: readonly string[] | null,

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -256,7 +256,7 @@ test("runtime-config lets a person set, keep, and inherit an approved personal r
         principalId: "alice",
         scopeId: "personal:alice",
         harnessId: "claude",
-        modelId: "claude-opus-4-8",
+        modelId: "claude-haiku-4-5",
       }),
     });
     assert.equal(outsidePicker.status, 400);

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -249,6 +249,19 @@ test("runtime-config lets a person set, keep, and inherit an approved personal r
     ]);
     assert.deepEqual(initial.modelsByHarness.codex, ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
 
+    const outsidePicker = await fetch(`${srv.base}/v1/runtime-config`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        principalId: "alice",
+        scopeId: "personal:alice",
+        harnessId: "claude",
+        modelId: "claude-opus-4-8",
+      }),
+    });
+    assert.equal(outsidePicker.status, 400);
+    assert.equal(((await outsidePicker.json()) as { error: string }).error, "model_not_enabled");
+
     const set = await fetch(`${srv.base}/v1/runtime-config`, {
       method: "PUT",
       headers: { "content-type": "application/json" },

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -411,3 +411,38 @@ test("admin model credentials survive a second app instance on the same durable 
   assert.doesNotMatch(JSON.stringify(await backing.all()), /durable-openrouter-key/);
   assert.doesNotMatch(JSON.stringify(await second.statuses()), /durable-openrouter-key/);
 });
+
+test("a stored scope override outside the configured picker refuses web turns; the org default stays exempt", async () => {
+  const srv = start({ anthropicApiKey: "deployment-anthropic-key" });
+  try {
+    srv.built.config.setRuntimeSelection("org:default-org", { harnessId: "mock", modelId: "claude-opus-4-8" });
+    srv.built.config.setWebuiModels("org:default-org", ["claude-sonnet-4-6"]);
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.config.setRuntimeSelectionLatest("personal:alice", {
+      harnessId: "mock",
+      modelId: "claude-haiku-4-5",
+    });
+    const turn = (threadRef: string, model?: string) =>
+      srv.built.app.turn({
+        surface: "web",
+        actor: { externalId: "alice" },
+        conversation: { kind: "dm", threadRef },
+        text: "hello",
+        ...(model ? { model } : {}),
+        async: true,
+      });
+
+    const stale = await turn("web:alice:stale-override");
+    assert.equal(stale.status, "refused");
+    assert.match(stale.reason ?? "", /not enabled for the web UI/);
+
+    const explicitOrgDefault = await turn("web:alice:org-default", "claude-opus-4-8");
+    assert.equal(explicitOrgDefault.status, "queued");
+
+    await srv.built.config.setRuntimeSelectionLatest("personal:alice", null);
+    const inherited = await turn("web:alice:inherited");
+    assert.equal(inherited.status, "queued");
+  } finally {
+    await srv.close();
+  }
+});

--- a/test/turn-options.test.ts
+++ b/test/turn-options.test.ts
@@ -5,6 +5,7 @@ import {
   NON_INTERACTIVE_THINKING_LEVEL,
   turnModelOptions,
   validateWebTurnModelOptions,
+  webTurnRuntimeModelRefusal,
 } from "../src/core/turn-options.ts";
 
 test("triggered turns default to extra-high thinking and non-fast mode", () => {
@@ -28,6 +29,18 @@ test("web model controls are bounded by admin configuration", () => {
   );
   assert.equal(validateWebTurnModelOptions({ thinkingLevel: "infinite" }, null), "unsupported thinking level");
   assert.equal(validateWebTurnModelOptions({ model: "claude-opus-4-8", thinkingLevel: "high" }, null), null);
+});
+
+test("a resolved scope override outside the configured picker is refused, the org default is not", () => {
+  const picker = ["claude-sonnet-4-6"];
+  assert.equal(
+    webTurnRuntimeModelRefusal("claude-opus-4-8", "claude-sonnet-4-6", picker),
+    "that model is not enabled for the web UI",
+  );
+  assert.equal(webTurnRuntimeModelRefusal("claude-sonnet-4-6", "claude-opus-4-8", picker), null);
+  assert.equal(webTurnRuntimeModelRefusal("claude-opus-4-8", "claude-opus-4-8", picker), null);
+  assert.equal(webTurnRuntimeModelRefusal("claude-opus-4-8", "claude-sonnet-4-6", null), null);
+  assert.equal(webTurnRuntimeModelRefusal("claude-opus-4-8", "claude-sonnet-4-6", []), null);
 });
 
 test("interactive turns do not force model options", () => {


### PR DESCRIPTION
Follow-up to #38, which added playground mode but documented it only in the portal README — an operator following the deploy path could never discover it.

Adds a "Playground mode" subsection to step 3 of the deployment workflow (`cli/templates/deployment/deployment.md`, materialized into every org's deployment directory by `qm init`), covering:

- the `env.portal.PORTAL_PLAYGROUND` stack snippet
- the its-own-deployment rule: visitors are ordinary internal principals of the org, so nothing sensitive at org scope, no real connector credentials, no company data
- the real brakes to set in the same pass: `ORG_BUDGET_USD_PER_WINDOW` as the hard ceiling, per-principal `BUDGET_USD_PER_WINDOW` / `RATE_LIMIT_PER_WINDOW`, and a pinned model via the Admin page's base-model / web-UI model resources
- the boot refusals and anon restrictions the portal enforces, the scope-GC gap, and a pointer to the portal README for the mechanism

Docs only; CLI init tests pass (17/17).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788049131&installation_model_id=19911&pr_number=39&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F39&signature=be8208eae500f63b25a3fa7f510128b4b48368d1fae5a2bd7d4696be7d5afc39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Why the CLI version bump

`cli/templates/deployment/deployment.md` ships inside the `@yc-software/qm` npm package (it's what `qm init` materializes into a deployment repo). CI's "CLI version bump" check refuses any change to packaged files without a version bump past the published `0.1.2`, so this PR bumps `cli/package.json` to `0.1.3`. Doc template change only — no CLI code changes ride along.

## Also: enforce the web-UI model picker at every core entry

Reviewing the docs claim surfaced a bypass: `webui-models` only gated the explicit per-turn `model:` option. `PUT /v1/runtime-config` accepted any model an approved harness supports, so a user could pin an excluded model as a scope override and turns ran it without re-validation.

Fixed at both entries: the route now refuses a model outside the configured picker (`400 model_not_enabled`), and web turn resolution refuses a resolved scope override outside it (covers overrides that predate a picker change). The org default stays exempt — the picker already treats it as the default selection. Unconfigured picker keeps current behavior.

Verified live against a running dev instance: stale override → 403 refused; PUT excluded model → 400; explicit per-turn excluded model → 403; org default turn → 202 queued. Plus unit/integration tests (`turn-options`, `admin-resources`).
