### PR TITLE
Restrict the web-ui model picker to the org allowed-models list

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4303,14 +4303,22 @@
                 </section>
                 <section class="card hidden" id="card-webui-models">
                   <div class="head">
-                    <h2>Web UI model picker</h2>
+                    <h2>Allowed models</h2>
                     <p>
-                      Which models appear in the web UI's per-turn model picker, org-wide. Check the ones to offer and
-                      pick which is pre-selected by default. Leave all unchecked to restore the built-in set.
+                      Restrict which models the web UI offers and accepts, org-wide. Add the models to allow and pick
+                      which is pre-selected by default. Remove every chip to allow the deployment's full model set.
                     </p>
                   </div>
                   <div class="body">
-                    <div id="webui-models-list" style="display: flex; flex-direction: column; gap: 6px"></div>
+                    <div id="webui-models-chips" style="display: flex; flex-wrap: wrap; gap: 6px; align-items: center">
+                      <input
+                        id="webui-models-add"
+                        list="webui-models-catalog"
+                        placeholder="+ Add model"
+                        style="max-width: 240px"
+                      />
+                      <datalist id="webui-models-catalog"></datalist>
+                    </div>
                     <label for="webui-models-default" style="margin-top: 10px">Default</label>
                     <select id="webui-models-default" style="max-width: 360px"></select>
                   </div>
@@ -4820,6 +4828,7 @@
       let memDraft = null;
       let memDraftScope = null;
       let cronDestinationEditId = null;
+      let webuiModelIds = [];
       const transcriptVisibility = { thinking: true, toolResults: true };
 
       const API_BASE = "__ADMIN_BASE__";
@@ -6305,48 +6314,84 @@
         const showWebuiModels = scope.startsWith("org:") && opts.length > 0;
         $("card-webui-models").classList.toggle("hidden", !showWebuiModels);
         if (showWebuiModels) {
-          const configured = Array.isArray(r.data.webuiModels) ? r.data.webuiModels : null;
-          const enabledIds = configured && configured.length ? configured : opts.map((m) => m.id);
-          const list = $("webui-models-list");
-          list.textContent = "";
-
-          const ordered = [
-            ...enabledIds.filter((id) => opts.some((m) => m.id === id)),
-            ...opts.map((m) => m.id).filter((id) => !enabledIds.includes(id)),
-          ];
-          ordered.forEach((id) => {
-            const m = opts.find((x) => x.id === id) || { id, name: id };
-            const row = document.createElement("label");
-            row.style.display = "flex";
-            row.style.gap = "8px";
-            row.style.alignItems = "center";
-            const cb = document.createElement("input");
-            cb.type = "checkbox";
-            cb.value = id;
-            cb.checked = enabledIds.includes(id);
-            const span = document.createElement("span");
-            span.textContent = m.name + " (" + id + ")";
-            row.appendChild(cb);
-            row.appendChild(span);
-            list.appendChild(row);
-          });
+          const catalogModels = Object.values(modelsByHarness)
+            .flat()
+            .concat(opts)
+            .filter((m, i, all) => m && m.id && all.findIndex((x) => x && x.id === m.id) === i);
+          const modelLabel = (id) => {
+            const m = catalogModels.find((x) => x.id === id);
+            return m && m.name && m.name !== id ? m.name + " (" + id + ")" : id;
+          };
+          const configured = Array.isArray(r.data.webuiModels) ? r.data.webuiModels.filter(Boolean) : [];
+          webuiModelIds = [...configured];
+          const chips = $("webui-models-chips");
+          const addInput = $("webui-models-add");
           const syncDefault = () => {
             const dsel = $("webui-models-default");
             const prev = dsel.value;
-            const checked = Array.from(list.querySelectorAll("input[type=checkbox]:checked")).map((c) => c.value);
             dsel.textContent = "";
-            checked.forEach((id) => {
-              const m = opts.find((x) => x.id === id) || { id, name: id };
+            webuiModelIds.forEach((id) => {
               const o = document.createElement("option");
               o.value = id;
-              o.textContent = m.name + " (" + id + ")";
+              o.textContent = modelLabel(id);
               dsel.appendChild(o);
             });
-            dsel.value = checked.includes(prev) ? prev : checked[0] || "";
+            dsel.value = webuiModelIds.includes(prev) ? prev : webuiModelIds[0] || "";
+            dsel.disabled = !webuiModelIds.length;
           };
-          list.oninput = syncDefault;
+          const renderChips = () => {
+            chips.querySelectorAll("[data-chip]").forEach((n) => n.remove());
+            webuiModelIds.forEach((id) => {
+              const chip = document.createElement("span");
+              chip.dataset.chip = id;
+              chip.style.cssText =
+                "display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border:1px solid var(--border, #d4d4d4);border-radius:999px;font-size:13px";
+              const label = document.createElement("span");
+              label.textContent = modelLabel(id);
+              const x = document.createElement("button");
+              x.type = "button";
+              x.textContent = "×";
+              x.setAttribute("aria-label", "Remove " + id);
+              x.style.cssText = "border:0;background:none;cursor:pointer;padding:0;font-size:14px;line-height:1";
+              x.onclick = () => {
+                webuiModelIds = webuiModelIds.filter((v) => v !== id);
+                renderChips();
+                syncDefault();
+              };
+              chip.appendChild(label);
+              chip.appendChild(x);
+              chips.insertBefore(chip, addInput);
+            });
+            const dl = $("webui-models-catalog");
+            dl.textContent = "";
+            catalogModels
+              .filter((m) => !webuiModelIds.includes(m.id))
+              .forEach((m) => {
+                const o = document.createElement("option");
+                o.value = m.id;
+                o.label = m.name;
+                dl.appendChild(o);
+              });
+          };
+          const addModel = () => {
+            const raw = addInput.value.trim();
+            if (!raw) return;
+            const byName = catalogModels.find((m) => m.name === raw || m.name + " (" + m.id + ")" === raw);
+            const id = catalogModels.some((m) => m.id === raw) ? raw : byName ? byName.id : raw;
+            if (!webuiModelIds.includes(id)) webuiModelIds.push(id);
+            addInput.value = "";
+            renderChips();
+            syncDefault();
+          };
+          addInput.onchange = addModel;
+          addInput.onkeydown = (e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addModel();
+            }
+          };
+          renderChips();
           syncDefault();
-          $("webui-models-default").value = enabledIds[0] || "";
         }
         const showPeopleDirectory = scope.startsWith("org:");
         $("card-people-directory").classList.toggle("hidden", !showPeopleDirectory);
@@ -7731,11 +7776,9 @@
           ),
         }),
         "webui-models": () => {
-          const enabled = Array.from(document.querySelectorAll("#webui-models-list input[type=checkbox]:checked")).map(
-            (c) => c.value,
-          );
           const dflt = $("webui-models-default").value;
-          const ids = dflt && enabled.includes(dflt) ? [dflt, ...enabled.filter((id) => id !== dflt)] : enabled;
+          const ids =
+            dflt && webuiModelIds.includes(dflt) ? [dflt, ...webuiModelIds.filter((id) => id !== dflt)] : webuiModelIds;
           return { ids };
         },
         "people-directory-url": () => ({ url: $("people-directory-url").value.trim() }),

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -971,9 +971,12 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   }
   const effective = scopeOverride ?? orgDefault;
   const selected = [orgDefault, scopeOverride, effective].filter((choice) => choice !== null);
+  const allowlist = await config.getWebuiModelsDurable(org);
   const modelsByHarness = Object.fromEntries(
     approvedHarnesses.map((harnessId) => {
-      const ids = selectableCatalogForHarness(catalog, harnessId).map((model) => model.id);
+      const ids = allowlist?.length
+        ? allowlist.filter((id) => modelSupportedByHarness(id, harnessId))
+        : selectableCatalogForHarness(catalog, harnessId).map((model) => model.id);
       for (const choice of selected) {
         if (
           choice.harnessId === harnessId &&

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -240,14 +240,8 @@ test("runtime-config lets a person set, keep, and inherit an approved personal r
     };
     assert.equal(initial.effective.harnessId, "pi");
     assert.equal(initial.scopeOverride, null);
-    assert.deepEqual(initial.modelsByHarness.claude, [
-      "claude-fable-5",
-      "claude-opus-5",
-      "claude-opus-4-8",
-      "claude-sonnet-5",
-      "claude-haiku-4-5",
-    ]);
-    assert.deepEqual(initial.modelsByHarness.codex, ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+    assert.deepEqual(initial.modelsByHarness.claude, ["claude-sonnet-4-6"]);
+    assert.deepEqual(initial.modelsByHarness.codex, ["gpt-5.5"]);
 
     const outsidePicker = await fetch(`${srv.base}/v1/runtime-config`, {
       method: "PUT",

--- a/test/webui-model-allowlist.test.ts
+++ b/test/webui-model-allowlist.test.ts
@@ -1,0 +1,72 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+const ADMIN = { "content-type": "application/json", "x-admin-actor": "admin-alice@default-org" };
+
+test("the org allowed-models list restricts the runtime-config picker and clearing restores the catalog", async () => {
+  const modelCredentialFetch: typeof fetch = async () =>
+    Response.json({
+      data: [
+        { id: "anthropic/claude-sonnet-4.5", name: "Anthropic: Claude Sonnet 4.5", supported_parameters: ["tools"] },
+        { id: "deepseek/deepseek-chat-v3.1", name: "DeepSeek: DeepSeek V3.1", supported_parameters: ["tools"] },
+      ],
+    });
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "webui-model-allowlist-")),
+      openrouterApiKey: "deployment-openrouter-key",
+    }),
+    { modelCredentialFetch },
+  );
+  const server = createInsecureTestServer(built.app, {
+    config: built.config,
+    modelCredentials: built.modelCredentials,
+    modelCredentialFetch,
+    harnessId: "pi",
+    providerKeys: { anthropic: false, openai: false, openrouter: true },
+    admin: built.admin,
+    auditLog: built.auditLog,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  const runtimeModels = async (): Promise<string[]> => {
+    const response = await fetch(`${base}/v1/runtime-config?principalId=alice&scopeId=personal%3Aalice`);
+    assert.equal(response.status, 200);
+    return ((await response.json()) as { modelsByHarness: Record<string, string[]> }).modelsByHarness.pi!;
+  };
+  try {
+    const unrestricted = await runtimeModels();
+    assert.ok(unrestricted.includes("anthropic/claude-sonnet-4.5"));
+    assert.ok(unrestricted.includes("deepseek/deepseek-chat-v3.1"));
+
+    const saved = await fetch(`${base}/v1/admin/scopes/org%3Adefault-org/webui-models`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ ids: ["deepseek/deepseek-chat-v3.1", "openrouter/auto"] }),
+    });
+    assert.equal(saved.status, 200);
+
+    assert.deepEqual(await runtimeModels(), ["deepseek/deepseek-chat-v3.1", "openrouter/auto"]);
+
+    const cleared = await fetch(`${base}/v1/admin/scopes/org%3Adefault-org/webui-models`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ ids: [] }),
+    });
+    assert.equal(cleared.status, 200);
+    const restored = await runtimeModels();
+    assert.ok(restored.includes("anthropic/claude-sonnet-4.5"));
+    assert.ok(restored.includes("deepseek/deepseek-chat-v3.1"));
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
An org admin can now pin the web UI's model picker to an explicit allowlist from a chips-style **Allowed models** card in Admin → Governance. Empty list = current behavior (every serviceable model).

The durable `webui-models` allowlist already existed and was enforced at the turn endpoint — but `runtime-config` still advertised the full catalog (so the dropdown offered models the turn refused as `model_not_enabled`), and the old checkbox-per-catalog-entry Admin card couldn't express an OpenRouter allowlist at catalog scale.

- `surface.ts`: `modelsByHarness` is built from the allowlist when non-empty (filtered per harness); org-default force-include and serviceability filtering unchanged.
- Admin card: removable chips + `+ Add model` datalist over the live catalog; first chip is the picker default; removing all chips clears the restriction.
- `test/webui-model-allowlist.test.ts`: allowlist collapses the picker, clearing restores it (fails on unpatched `surface.ts`).
- `test/admin-resources.test.ts`: updated expectations that encoded the old picker/enforcement disagreement.

**Change explainer:** https://claude.ai/code/artifact/d550f492-cab9-4e3e-8de4-28f2e3060e45

Screenshots (live dev instance: core + admin + web-ui from this branch, real OpenRouter catalog) are embedded in the explainer: the governance card with DeepSeek V4 Flash + GPT-5.6 Luna chips, and the composer dropdown offering exactly those two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788108882&installation_model_id=19911&pr_number=40&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F40&signature=e5f08fe32569285a5ea2fabe251a89c41fbaeb233138636574c877580b7c1a6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->