### PR TITLE
Use @latest in the qm init bootstrap instead of a version placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ known limitations.
 Create an organization-owned deployment repository that depends on `@yc-software/qm`:
 
 ```bash
-npm exec --yes --package=@yc-software/qm@<exact-version> -- \
+npm exec --yes --package=@yc-software/qm@latest -- \
   qm init . --org <slug> --target <fly-or-aws>
 npm install
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@ security guarantees, target behavior, and lifecycle are in
 the agent-consumable package runbook into the deployment repository.
 
 ```bash
-npm exec --yes --package=@yc-software/qm@<exact-version> -- \
+npm exec --yes --package=@yc-software/qm@latest -- \
   qm init . --org acme --target aws
 npm install
 npm exec qm -- check

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -57,13 +57,17 @@ contracts are scaffolded as one unit.
 Require Node 24+, npm, Git, Docker with Buildx, and `openssl`.
 
 For a repository without `qm.config.jsonc`, first confirm the hosting target
-and the derived slug, install an exact CLI version, and initialize its root:
+and the derived slug, then initialize its root with the current CLI:
 
 ```bash
-npm exec --yes --package=@yc-software/qm@<exact-version> -- \
+npm exec --yes --package=@yc-software/qm@latest -- \
   qm init . --org <slug> --target <fly-or-aws> --model-provider <provider>
 npm install
 ```
+
+`qm init` writes the version it resolved to as an exact dependency, so the pin
+lands in the deployment repository and its lockfile rather than in the command
+that bootstraps it.
 
 `--model-provider` takes `anthropic`, `openai`, or `openrouter` and defaults to
 `anthropic`. It writes `modelProvider` into the scaffolded config, which is what


### PR DESCRIPTION
The bootstrap snippet in the README asks the reader to substitute a version they have no way to know:

```bash
npm exec --yes --package=@yc-software/qm@<exact-version> -- \
  qm init . --org <slug> --target <fly-or-aws>
npm install
```

Copy-pasted literally it fails, and nothing on the page says where to find a version. The only way forward is to go read the registry — a papercut in the first command a new operator runs.

## Why the placeholder isn't needed

The pin doesn't come from this command. `qm init` writes the version of the CLI that ran it into the deployment repository's `package.json` as an exact dependency — a bare version string, no range (`cli/src/commands/init.ts`, `installedPackage` falling back to `cliVersion()`) — and the `npm install` on the next line locks it.

Confirmed against the published CLI, initializing a scratch directory:

```
$ npm exec --yes --package=@yc-software/qm@latest -- qm init . --org testorg --target aws
CLI 0.1.3 selects immutable runtime image digests from its release manifest.

$ cat package.json
"dependencies": { "@yc-software/qm": "0.1.3" }
```

Exact, no caret. So the bootstrap invocation only decides which CLI does the scaffolding; the reproducibility the docs care about is established by `qm init` and the lockfile, downstream of it. `@latest` gets the newest CLI, which then pins itself.

## Changes

`@<exact-version>` → `@latest` in the three places the snippet appears:

- `README.md`
- `cli/README.md`
- `cli/templates/deployment/deployment.md`

`deployment.md` also described the step as "install an exact CLI version", which is the reasoning that produced the placeholder. It now says where the pin actually lands, so the next reader doesn't reintroduce one.

## Note for reviewers

This does mean a reader who wants a specific older CLI has to say so explicitly rather than being prompted to by the placeholder. That seems like the right default: pinning the bootstrap only matters if you need to *reproduce* an old scaffold, which is rare, whereas every new operator hits this command. Happy to switch to a `$(npm view @yc-software/qm version)` form instead if you'd rather the resolved version be visible in the terminal.

Docs only — no runtime or CLI behaviour changes, and nothing rendered to screenshot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788111120&installation_model_id=19911&pr_number=41&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F41&signature=6461667ab185c071650b5e895677e22d26ef3143b20edd313205fbb891b85581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->