### PR TITLE
Enforce scope membership for shared SOUL writes

### DIFF
--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -577,10 +577,11 @@ export function createSessionMethods(
       };
     },
 
-    async updateSoul(scopeIdValue, content, actorId, opts) {
+    async updateSoul(scopeIdValue, content, actorId) {
       const { kind, ref } = parseScopeId(scopeIdValue);
       const allowedPersonal = kind === "personal" && samePerson(ref, actorId);
-      const allowedShared = opts?.allowSharedScope && (kind === "channel" || kind === "group");
+      const allowedShared =
+        (kind === "channel" || kind === "group") && (await principalCanManageScope(actorId, scopeIdValue));
       if (!allowedPersonal && !allowedShared) {
         throw new Error("not authorized to update SOUL for this scope");
       }

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -300,12 +300,7 @@ export interface App {
     orgSoulVersion: number;
     effectiveSoul: string;
   };
-  updateSoul(
-    scopeId: ScopeId,
-    content: string,
-    actorId: string,
-    opts?: { allowSharedScope?: boolean },
-  ): Promise<number>;
+  updateSoul(scopeId: ScopeId, content: string, actorId: string): Promise<number>;
   createCron(input: CreateCronInput): Promise<Cron>;
   getCron(id: string): Promise<Cron | null>;
   listCrons(): Promise<Cron[]>;

--- a/src/api/control-service.ts
+++ b/src/api/control-service.ts
@@ -578,9 +578,7 @@ export function createControlService(app: App, scheduler?: Scheduler): ControlSe
 
     async writeSoul(content, capability) {
       try {
-        const version = await app.updateSoul(capability.scopeId, content, capability.actorId, {
-          allowSharedScope: true,
-        });
+        const version = await app.updateSoul(capability.scopeId, content, capability.actorId);
         return { ok: true, version };
       } catch (e) {
         return { ok: false, code: "soul_update_denied", message: errMessage(e) };

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1101,16 +1101,8 @@ export async function postSoul(ctx: ApiCtx): Promise<void> {
     content = b.content;
     actorId = b.actorId;
   }
-  const allowSharedScope =
-    Boolean(capability) ||
-    (parseScopeId(scopeIdVal).kind !== "personal" && (await app.managesScope(actorId, scopeIdVal as ScopeId)));
   try {
-    const version = await app.updateSoul(
-      scopeIdVal,
-      content,
-      actorId,
-      allowSharedScope ? { allowSharedScope: true } : undefined,
-    );
+    const version = await app.updateSoul(scopeIdVal, content, actorId);
     return sendJson(res, 200, { ok: true, version });
   } catch (e) {
     const message = errMessage(e);

--- a/test/capability-routes.test.ts
+++ b/test/capability-routes.test.ts
@@ -44,11 +44,11 @@ describe("capability-token control plane (crons + SOUL)", () => {
     audienceScopeId: scopeId("channel", "C"),
     label: "#eng (the whole channel)",
   } as const;
-  const capChannel = async (actorId: string) =>
+  const capChannel = async (actorId: string, channelId = "C") =>
     await mintCapabilityToken(
       {
         actorId,
-        scopeId: scopeId("channel", "C"),
+        scopeId: scopeId("channel", channelId),
         destination: { type: THREAD.type, target: THREAD.target, audienceScopeId: THREAD.audienceScopeId },
         destinations: [THREAD, ROOT],
         defaultDestinationKey: THREAD.key,
@@ -242,20 +242,38 @@ describe("capability-token control plane (crons + SOUL)", () => {
     assert.equal(built.config.soulVersion(scopeId("org", "default-org")), orgVerBefore, "org SOUL floor untouched");
   });
 
-  it("updates the token's shared-scope SOUL without touching the actor's personal SOUL", async () => {
+  it("allows a private-channel member to update shared SOUL and rejects the same token after removal", async () => {
     const personalScope = scopeId("personal", "U8");
-    const channelScope = scopeId("channel", "C");
+    const channelId = "C-soul";
+    const channelScope = scopeId("channel", channelId);
+    await built.app.upsertChannels([{ channelId, name: "eng", isPrivate: true }], [{ channelId, principalId: "U8" }]);
     const personalBefore = built.config.soulVersion(personalScope);
+    const capability = await capChannel("U8", channelId);
     const res = await post(
       "/v1/soul",
       { content: "Channel C speaks in haiku.", scopeId: personalScope, actorId: "U2" },
-      { "x-agent-capability": await capChannel("U8") },
+      { "x-agent-capability": capability },
     );
     assert.equal(res.status, 200);
 
     assert.equal(built.config.getSoul(channelScope), "Channel C speaks in haiku.");
     assert.ok(built.config.soulVersion(channelScope) >= 1, "channel SOUL was updated");
     assert.equal(built.config.soulVersion(personalScope), personalBefore, "actor's personal SOUL was not touched");
+
+    await built.app.upsertChannels([{ channelId, name: "eng", isPrivate: true }], []);
+    const revoked = await post("/v1/soul", { content: "revoked" }, { "x-agent-capability": capability });
+    assert.equal(revoked.status, 403);
+  });
+
+  it("rejects a public-channel capability from updating shared SOUL", async () => {
+    const channelId = "C-soul-public";
+    await built.app.upsertChannels([{ channelId, name: "eng", isPrivate: false }], [{ channelId, principalId: "U8" }]);
+    const res = await post(
+      "/v1/soul",
+      { content: "public channel floor" },
+      { "x-agent-capability": await capChannel("U8", channelId) },
+    );
+    assert.equal(res.status, 403);
   });
 
   it("does not let capability self-update org or team SOUL", async () => {

--- a/test/control-service.test.ts
+++ b/test/control-service.test.ts
@@ -722,10 +722,19 @@ test("soul read returns the effective SOUL; write replaces this scope's SOUL and
   assert.match(after.effectiveSoul, /Always greet in Spanish\./);
 });
 
-test("soul write in a shared (channel) scope is allowed (allowSharedScope, like the agent route)", async () => {
-  const { control } = setup();
-  const w = await control.writeSoul("Channel standing note.", claims("U1", scopeId("channel", "C9")));
+test("soul write in a shared scope requires current management access", async () => {
+  const { built, control } = setup();
+  await built.app.upsertChannels(
+    [{ channelId: "C9", name: "eng", isPrivate: true }],
+    [{ channelId: "C9", principalId: "U1" }],
+  );
+  const scope = scopeId("channel", "C9");
+  const w = await control.writeSoul("Channel standing note.", claims("U1", scope));
   assert.ok(w.ok, JSON.stringify(w));
-  const after = control.readSoul(claims("U1", scopeId("channel", "C9")));
-  assert.equal(after.soul, "Channel standing note.");
+  assert.equal(control.readSoul(claims("U1", scope)).soul, "Channel standing note.");
+
+  await built.app.upsertChannels([{ channelId: "C9", name: "eng", isPrivate: true }], []);
+  const revoked = await control.writeSoul("revoked note", claims("U1", scope));
+  assert.equal(revoked.ok, false);
+  assert.equal(revoked.ok ? "" : revoked.code, "soul_update_denied");
 });

--- a/test/member-edit-authz.test.ts
+++ b/test/member-edit-authz.test.ts
@@ -232,9 +232,10 @@ test("SOUL: a private-channel or group member may edit; a public-channel member 
   assert.equal(await app.managesScope(GROUP_MEMBER, groupScope), true, "group member may set the floor");
   assert.equal(await app.managesScope(PUB_MEMBER, pubScope), false, "public member may NOT set the floor");
   assert.equal(await app.managesScope(OUTSIDER, privScope), false, "a non-member may NOT");
-  assert.ok((await app.updateSoul(privScope, "be terse", PRIV_MEMBER, { allowSharedScope: true })) > 0);
-  assert.ok((await app.updateSoul(groupScope, "be kind", GROUP_MEMBER, { allowSharedScope: true })) > 0);
-  await assert.rejects(() => app.updateSoul(privScope, "x", PRIV_MEMBER), /not authorized/);
+  assert.ok((await app.updateSoul(privScope, "be terse", PRIV_MEMBER)) > 0);
+  assert.ok((await app.updateSoul(groupScope, "be kind", GROUP_MEMBER)) > 0);
+  await assert.rejects(() => app.updateSoul(pubScope, "x", PUB_MEMBER), /not authorized/);
+  await assert.rejects(() => app.updateSoul(privScope, "x", OUTSIDER), /not authorized/);
 });
 
 test("SOUL: shared-lock writers refresh fleet state before assigning the next version", async () => {
@@ -245,9 +246,9 @@ test("SOUL: shared-lock writers refresh fleet state before assigning the next ve
   const left = createApp(makeDeps({ config: leftConfig, advisoryLock: lock }) as unknown as AppDeps);
   const right = createApp(makeDeps({ config: rightConfig, advisoryLock: lock }) as unknown as AppDeps);
 
-  assert.equal(await left.updateSoul(privScope, "left", PRIV_MEMBER, { allowSharedScope: true }), 1);
+  assert.equal(await left.updateSoul(privScope, "left", PRIV_MEMBER), 1);
   assert.equal(rightConfig.soulVersion(privScope), 0, "the second core starts with a stale cache");
-  assert.equal(await right.updateSoul(privScope, "right", PRIV_MEMBER, { allowSharedScope: true }), 2);
+  assert.equal(await right.updateSoul(privScope, "right", PRIV_MEMBER), 2);
   assert.equal((await souls.get(privScope))?.version, 2);
   assert.equal((await souls.get(privScope))?.content, "right");
 });
@@ -257,12 +258,9 @@ test("SOUL: a durable write failure rejects and restores the live cache", async 
   const souls = failingPutMap<PersistedSoul>(control);
   const config = createMemoryConfigStore(ORG, { souls });
   const app = createApp(makeDeps({ config }) as unknown as AppDeps);
-  assert.equal(await app.updateSoul(privScope, "durable", PRIV_MEMBER, { allowSharedScope: true }), 1);
+  assert.equal(await app.updateSoul(privScope, "durable", PRIV_MEMBER), 1);
   control.fail = true;
-  await assert.rejects(
-    () => app.updateSoul(privScope, "cache only", PRIV_MEMBER, { allowSharedScope: true }),
-    /forced durable put failure/,
-  );
+  await assert.rejects(() => app.updateSoul(privScope, "cache only", PRIV_MEMBER), /forced durable put failure/);
   assert.equal(config.getSoul(privScope), "durable");
   assert.equal(config.soulVersion(privScope), 1);
 });


### PR DESCRIPTION
## Problem

Shared SOUL writes relied on callers to pass an `allowSharedScope` flag. That left the owning write path without an independent check of the current scope-management policy.

## Change

- Remove the caller-controlled shared-write flag from the `App` contract.
- Make `updateSoul` require current management access for channel and group scopes while preserving personal-scope writes.
- Keep the HTTP and control-service callers on the same authorization path.

## Regression coverage

- A private-channel member can write shared SOUL.
- The same retained capability is denied after membership removal.
- A public-channel member is denied shared SOUL writes.
- The control-service path applies the same membership check.

## Validation

- `npx --yes node@24.15.0 --experimental-test-module-mocks --test test/member-edit-authz.test.ts test/capability-routes.test.ts test/control-service.test.ts test/project-trigger-auth.test.ts` — 70 passed.
- `npx --yes node@24.15.0 --experimental-test-module-mocks --test test/capability-routes.test.ts test/control-service.test.ts` — 57 passed.
- The same two-file regression command on base `7f2c916360f1797a8ff2a77ce2ce40c5fabab087` — 54 passed, 3 expected authorization failures.
- `npx --yes node@24.15.0 node_modules/typescript/bin/tsc --noEmit` — passed.
- Focused ESLint, Oxlint, and Prettier checks — passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788116983&installation_model_id=19911&pr_number=45&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F45&signature=3247886666b6d480b68f91424b69f2e69d74365d93e4dc5bcf5983f663329c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->