### PR TITLE
ADRs: memory provenance and sensitivity labels for scoped memory

### DIFF
--- a/adrs/memory-provenance.md
+++ b/adrs/memory-provenance.md
@@ -1,0 +1,9 @@
+# Memory provenance for shared room memory
+
+I've been working on an open-source project called startup-stack, where an AI works from a company's shared files and knowledge base. One of the biggest problems we ran into was not whether the agent could remember something, but whether anyone could tell where that memory came from or whether it had been checked.
+
+The convention we use is simple. Every factual claim carries a source and one of four states: confirmed, unverified, TBD, or conflict. Anything an agent extracts starts as unverified. Only a human can promote it to confirmed. If two sources disagree, both versions stay visible instead of the agent quietly choosing one.
+
+I think a lightweight version of this could be useful for qm's shared room memory. Multiple agents and people can write into the same memory, so over time it becomes important to distinguish something a person confirmed from something an agent inferred or copied from an old message.
+
+This would not need to prescribe a particular storage format. It could just be a convention that room-memory implementations or skills can follow. The goal is to stop agents confidently repeating a wrong fact after everyone has forgotten where it originally came from.

--- a/adrs/sensitivity-labels.md
+++ b/adrs/sensitivity-labels.md
@@ -1,0 +1,9 @@
+# Sensitivity labels for scoped memory
+
+qm already has a clear model for controlling what an agent is allowed to do inside a room or personal scope. I think there may be a related question around what information is allowed to leave that scope.
+
+In startup-stack, each file can be marked public, internal, or restricted. When an agent creates something shareable, it builds that output from the private master rather than sharing the master itself. Public material can be used freely, internal material needs explicit approval, and restricted material is never included.
+
+A similar convention could fit qm's room and person scopes. A room might contain information that is fine for everyone in that room but should not appear in another room, a public response, or an exported file. The agent could check the sensitivity label before moving or summarising content outside its original scope.
+
+This feels complementary to qm's existing security postures. Those control what actions the agent may take. Sensitivity labels would control where the information involved in those actions may travel.


### PR DESCRIPTION
Adding two short proposals to adrs/ per the contributing guide. They're
related, so I've put them in one PR.

1. Memory provenance (adrs/memory-provenance.md) — a lightweight
convention so facts in shared room memory keep their origin and
verification state visible: every claim carries a source and one of
four states (confirmed / unverified / TBD / conflict), anything an
agent writes starts as unverified, and only a human promotes it to
confirmed.

2. Sensitivity labels (adrs/sensitivity-labels.md) — a complementary
convention for what information may leave a scope. Your security
postures control what actions an agent may take; sensitivity labels
(public / internal / restricted) would control where the information
involved in those actions may travel.

Both come from conventions I've been using in practice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117164&installation_model_id=19911&pr_number=47&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F47&signature=036c07af8b5411a6b63a83b01ed43246e37dadb93d66669e750b38d2c1ccfc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->