### PR TITLE
The destructive-SQL rule in the command policy never fires

### DIFF
--- a/adrs/destructive-sql-command-rule.md
+++ b/adrs/destructive-sql-command-rule.md
@@ -1,0 +1,30 @@
+# The destructive-SQL rule in the command policy never fires
+
+I was reading through `command-policy.ts` and I think the `drop|truncate table` floor rule
+is dead code in practice.
+
+`scannableCommand` strips quoted multi-word strings down to `""` before the rules run. SQL
+always has spaces in it, so anything you'd actually type gets emptied out first:
+
+```
+psql -c "DROP TABLE users"      ->  allow             (scans as: psql -c "")
+psql --command 'DROP TABLE x'   ->  allow
+truncate users                  ->  allow             (Postgres doesn't need TABLE)
+drop table users                ->  require_approval
+```
+
+I ran those through `evaluateCommand` with `defaultOrgPolicy()`. The only spelling that
+trips the rule is the bare one, which is also the one nobody types — you reach a database
+through a client, and the client takes the statement as a quoted argument.
+
+The quote-stripping itself looks deliberate and I don't think it should change: `git commit
+-m "drop table users"` has to stay allowed, and there's a test pinning exactly that. What
+seems missing is on the rule side — something that pulls the statement out of `psql -c` /
+`mysql -e` and scans it, the same way `pipedShellPayloads` already pulls the payload out of
+a pipe-to-shell so that rule can work.
+
+To be clear about scope: SECURITY.md already says the command policy is a speed bump rather
+than a boundary, and I'm not treating this as a security hole. It's just that this
+particular speed bump can't catch the accident it was written for.
+
+Happy to leave it alone if you'd rather not touch it.


### PR DESCRIPTION
Adding an ADR in `adrs/`, per CONTRIBUTING.

Short version: the `drop|truncate table` rule in the org floor policy can't fire on any
spelling people actually type, because `scannableCommand` empties quoted strings before the
rules run and SQL always has spaces. `psql -c "DROP TABLE users"` comes out as `psql -c ""`.

Not a security report — SECURITY.md already calls the command policy a speed bump rather
than a boundary. It's just that this particular one can't catch the accident it was written
for. Details and the cases I ran are in the file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117728&installation_model_id=19911&pr_number=49&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F49&signature=04ae94561aec5a80ff8e100855a4ac9029dab8721ae52c6e92f34650c59b3f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->