### PR TITLE
fix(slack): acknowledge terminal delivery after verified post

### DIFF
--- a/src/api/app-messaging.ts
+++ b/src/api/app-messaging.ts
@@ -49,6 +49,8 @@ export function createMessagingMethods(
   | "fulfillContextRequest"
   | "ackDelivery"
   | "ackDeliveryByKey"
+  | "recordDeliveryAttachment"
+  | "recordRunDeliveryAttachment"
   | "setRunDeliveryState"
   | "upsertDirectory"
   | "upsertChannels"
@@ -295,6 +297,12 @@ export function createMessagingMethods(
     },
     async ackDeliveryByKey(idempotencyKey) {
       await deps.deliveries.ackByKey(idempotencyKey, Date.now());
+    },
+    async recordDeliveryAttachment(id, index) {
+      await deps.deliveries.recordAttachment(id, index);
+    },
+    async recordRunDeliveryAttachment(runId, index) {
+      await deps.deliveries.recordAttachmentByKey(`run:${runId}`, index);
     },
     async setRunDeliveryState(runId, state) {
       const found = await deps.runs.setDeliveryState(runId, null, state);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -348,6 +348,8 @@ export interface App {
   ): Promise<AmbientDecision>;
   ackDelivery(id: string, slackApiMs?: number): Promise<void>;
   ackDeliveryByKey(idempotencyKey: string): Promise<void>;
+  recordDeliveryAttachment(id: string, index: number): Promise<void>;
+  recordRunDeliveryAttachment(runId: string, index: number): Promise<void>;
   setRunDeliveryState(runId: string, state: RunDeliveryState): Promise<boolean>;
   upsertDirectory(members: DirectoryMember[]): Promise<void>;
   upsertChannels(channels: DirectoryChannel[], channelMembers?: ChannelMembership[]): Promise<void>;

--- a/src/api/slack-core-client.ts
+++ b/src/api/slack-core-client.ts
@@ -68,6 +68,8 @@ export interface SlackCoreClient {
   pushDirectory(body: DirectoryPush): Promise<void>;
   claimDeliveries(type: string, claimMs: number): Promise<Delivery[]>;
   ackDelivery(id: string, body?: { recipientThreadRef?: string; slackApiMs?: number }): Promise<void>;
+  recordDeliveryAttachment(id: string, index: number): Promise<void>;
+  recordRunDeliveryAttachment(runId: string, index: number): Promise<void>;
   onDeliveryEnqueued(listener: () => void): () => void;
   pendingContextRequests(): Promise<SurfaceContextRequest[]>;
   onContextRequest(listener: (request: SurfaceContextRequest) => void): () => void;
@@ -287,6 +289,14 @@ export function createSlackCoreClient(deps: SlackCoreClientDeps): SlackCoreClien
     async ackDelivery(id, body) {
       if (body?.recipientThreadRef) await deps.app.recordPrincipalDelivery(id, body.recipientThreadRef);
       await deps.app.ackDelivery(id, body?.slackApiMs);
+    },
+
+    async recordDeliveryAttachment(id, index) {
+      await deps.app.recordDeliveryAttachment(id, index);
+    },
+
+    async recordRunDeliveryAttachment(runId, index) {
+      await deps.app.recordRunDeliveryAttachment(runId, index);
     },
 
     onDeliveryEnqueued(listener) {

--- a/src/delivery/delivery-store.ts
+++ b/src/delivery/delivery-store.ts
@@ -17,6 +17,8 @@ export interface DeliveryStore {
   ack(id: string, at: number, slackApiMs?: number): Promise<void>;
   ackByKey(idempotencyKey: string, at: number): Promise<void>;
   setEditRefByKey(idempotencyKey: string, editRef: string): Promise<void>;
+  recordAttachment(id: string, index: number): Promise<void>;
+  recordAttachmentByKey(idempotencyKey: string, index: number): Promise<void>;
   get(id: string): Promise<Delivery | null>;
   recordRecipientThread(id: string, recipientThreadRef: string, at: number): Promise<void>;
   listByRecipientThread(recipientThreadRef: string, opts?: { limit?: number }): Promise<Delivery[]>;
@@ -30,15 +32,25 @@ export function createDeliveryStore(): DeliveryStore {
   const deliveries = new Map<string, Delivery>();
   const byKey = new Map<string, string>();
   const claimedUntil = new Map<string, number>();
+  const pendingAttachmentIndexes = new Map<string, Set<number>>();
   const enqueueListeners = new Set<() => void>();
+
+  const withAttachmentIndex = (destination: Destination, index: number): Destination => {
+    const indexes = new Set(destination.uploadedAttachmentIndexes ?? []);
+    indexes.add(index);
+    return { ...destination, uploadedAttachmentIndexes: [...indexes].sort((a, b) => a - b) };
+  };
 
   return {
     async enqueue(input) {
       const existingId = byKey.get(input.idempotencyKey);
       if (existingId) return deliveries.get(existingId)!;
+      const pending = pendingAttachmentIndexes.get(input.idempotencyKey);
+      const destination = pending ? [...pending].reduce(withAttachmentIndex, input.destination) : input.destination;
+      pendingAttachmentIndexes.delete(input.idempotencyKey);
       const delivery: Delivery = {
         id: randomUUID(),
-        destination: input.destination,
+        destination,
         text: input.text,
         ...(input.attachments?.length ? { attachments: input.attachments } : {}),
         ...(input.provenance ? { provenance: input.provenance } : {}),
@@ -101,6 +113,20 @@ export function createDeliveryStore(): DeliveryStore {
       const existingId = byKey.get(idempotencyKey);
       const d = existingId ? deliveries.get(existingId) : undefined;
       if (d && d.deliveredAt === null) d.destination = { ...d.destination, editRef };
+    },
+    async recordAttachment(id, index) {
+      const d = deliveries.get(id);
+      if (d && d.deliveredAt === null) d.destination = withAttachmentIndex(d.destination, index);
+    },
+    async recordAttachmentByKey(idempotencyKey, index) {
+      const existingId = byKey.get(idempotencyKey);
+      if (existingId) {
+        await this.recordAttachment(existingId, index);
+        return;
+      }
+      const pending = pendingAttachmentIndexes.get(idempotencyKey) ?? new Set<number>();
+      pending.add(index);
+      pendingAttachmentIndexes.set(idempotencyKey, pending);
     },
     async get(id) {
       return deliveries.get(id) ?? null;

--- a/src/delivery/postgres-delivery-store.ts
+++ b/src/delivery/postgres-delivery-store.ts
@@ -31,6 +31,11 @@ export function createPostgresDeliveryStore(connectionString: string): DeliveryS
         created_at BIGINT NOT NULL,
         delivered_at BIGINT
       )`,
+    `CREATE TABLE IF NOT EXISTS delivery_attachment_progress(
+        idempotency_key TEXT NOT NULL,
+        attachment_index INT NOT NULL,
+        PRIMARY KEY (idempotency_key, attachment_index)
+      )`,
     `CREATE INDEX IF NOT EXISTS idx_deliveries_pending
         ON deliveries ((destination->>'type'), created_at) WHERE delivered_at IS NULL`,
     `ALTER TABLE deliveries ADD COLUMN IF NOT EXISTS attachments JSONB`,
@@ -52,6 +57,21 @@ export function createPostgresDeliveryStore(connectionString: string): DeliveryS
 
   const enqueueListeners = new Set<() => void>();
 
+  async function withAttachmentProgress(row: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const progress = await q(
+      "SELECT attachment_index FROM delivery_attachment_progress WHERE idempotency_key = $1 ORDER BY attachment_index",
+      [row.idempotency_key],
+    );
+    if (!progress.length) return row;
+    return {
+      ...row,
+      destination: {
+        ...(row.destination as Destination),
+        uploadedAttachmentIndexes: progress.map((item) => Number(item.attachment_index)),
+      },
+    };
+  }
+
   return {
     async enqueue(input) {
       const inserted = await q(
@@ -72,11 +92,11 @@ export function createPostgresDeliveryStore(connectionString: string): DeliveryS
       );
       if (inserted[0]) {
         if (input.shadow !== true) for (const l of enqueueListeners) l();
-        return rowToDelivery(inserted[0]);
+        return rowToDelivery(await withAttachmentProgress(inserted[0]));
       }
       const existing = await q("SELECT * FROM deliveries WHERE idempotency_key = $1", [input.idempotencyKey]);
       if (!existing[0]) throw new Error(`delivery enqueue lost a race for key ${input.idempotencyKey}`);
-      return rowToDelivery(existing[0]);
+      return rowToDelivery(await withAttachmentProgress(existing[0]));
     },
     async pending(type) {
       const rows = await q(
@@ -134,6 +154,38 @@ export function createPostgresDeliveryStore(connectionString: string): DeliveryS
         `UPDATE deliveries SET destination = jsonb_set(destination, '{editRef}', to_jsonb($2::text))
          WHERE idempotency_key = $1 AND delivered_at IS NULL`,
         [idempotencyKey, editRef],
+      );
+    },
+    async recordAttachment(id, index) {
+      await query(
+        `UPDATE deliveries
+            SET destination = jsonb_set(
+              destination,
+              '{uploadedAttachmentIndexes}',
+              COALESCE(destination->'uploadedAttachmentIndexes', '[]'::jsonb) || jsonb_build_array($2::int),
+              true
+            )
+          WHERE id = $1 AND delivered_at IS NULL`,
+        [id, index],
+      );
+    },
+    async recordAttachmentByKey(idempotencyKey, index) {
+      await query(
+        `INSERT INTO delivery_attachment_progress (idempotency_key, attachment_index)
+         VALUES ($1, $2)
+         ON CONFLICT (idempotency_key, attachment_index) DO NOTHING`,
+        [idempotencyKey, index],
+      );
+      await query(
+        `UPDATE deliveries
+            SET destination = jsonb_set(
+              destination,
+              '{uploadedAttachmentIndexes}',
+              COALESCE(destination->'uploadedAttachmentIndexes', '[]'::jsonb) || jsonb_build_array($2::int),
+              true
+            )
+          WHERE idempotency_key = $1 AND delivered_at IS NULL`,
+        [idempotencyKey, index],
       );
     },
     async get(id) {

--- a/src/slack/attachments.ts
+++ b/src/slack/attachments.ts
@@ -193,8 +193,9 @@ export async function uploadAttachments(
   attachments: readonly OutgoingAttachment[],
   fetchBlob: (blobId: string) => Promise<Buffer>,
   fetchArtifact?: (artifactId: string, viewerId: string) => Promise<Buffer>,
+  onUploaded?: (index: number) => Promise<void> | void,
 ): Promise<void> {
-  for (const a of attachments) {
+  for (const [index, a] of attachments.entries()) {
     let file: Buffer;
     try {
       file = await fetchBlob(a.blobId);
@@ -202,7 +203,10 @@ export async function uploadAttachments(
       if (!fetchArtifact || !a.artifactId || !a.artifactViewerId) throw err;
       file = await fetchArtifact(a.artifactId, a.artifactViewerId);
     }
-    if (file.length === 0) continue;
+    if (file.length === 0) {
+      await onUploaded?.(index);
+      continue;
+    }
     const res = (await client.files.uploadV2({
       channel_id: channel,
       ...(threadTs ? { thread_ts: threadTs } : {}),
@@ -211,6 +215,7 @@ export async function uploadAttachments(
     })) as any;
     const fileId = res?.files?.[0]?.files?.[0]?.id ?? res?.files?.[0]?.id ?? res?.file?.id;
     if (fileId) await waitForShareCommit(client, channel, fileId);
+    await onUploaded?.(index);
   }
 }
 

--- a/src/slack/core-bridge.ts
+++ b/src/slack/core-bridge.ts
@@ -24,6 +24,7 @@ export interface CoreBridge {
   ackRunDeliveryWithRetry(runId: string): void;
   reportTurnMetrics(runId: string, patch: { deliverMs?: number; slackInflightMs?: number }): void;
   checkpointRunEditRef(runId: string, editRef: string): Promise<void>;
+  checkpointRunAttachment(runId: string, index: number): Promise<void>;
   reportRunEditRef(runId: string, editRef: string): void;
   stageBlobInCore(bytes: Uint8Array): Promise<{ blobId: string; sizeBytes: number }>;
   fetchBlobFromCore(blobId: string): Promise<Buffer>;
@@ -98,6 +99,10 @@ export function createCoreBridge(core: SlackCoreClient): CoreBridge {
     await core.reportRunEditRef(runId, editRef);
   }
 
+  async function checkpointRunAttachment(runId: string, index: number): Promise<void> {
+    await core.recordRunDeliveryAttachment(runId, index);
+  }
+
   function reportRunEditRef(runId: string, editRef: string): void {
     void checkpointRunEditRef(runId, editRef).catch((err) =>
       console.error(`[slack-plugin] delivery-state checkpoint failed for run ${runId}:`, (err as Error).message),
@@ -151,9 +156,7 @@ export function createCoreBridge(core: SlackCoreClient): CoreBridge {
     if (result?.status === "refused" && result.refusalKind === "security_quarantine") {
       return result;
     }
-    if (result && (result.status === "ok" || result.status === "refused" || result.status === "failed")) {
-      ackRunDeliveryWithRetry(runId);
-    } else {
+    if (result?.status !== "ok" && result?.status !== "refused" && result?.status !== "failed") {
       inFlightRuns.delete(runId);
     }
     if (result) return result;
@@ -169,6 +172,7 @@ export function createCoreBridge(core: SlackCoreClient): CoreBridge {
     ackRunDeliveryWithRetry,
     reportTurnMetrics,
     checkpointRunEditRef,
+    checkpointRunAttachment,
     reportRunEditRef,
     stageBlobInCore,
     fetchBlobFromCore,

--- a/src/slack/deliveries.ts
+++ b/src/slack/deliveries.ts
@@ -105,20 +105,38 @@ export function createDeliveryPoller(deps: {
             const text = toSlackMrkdwn(runId ? cleanAgentReplyForSlack(d.text).text : stripSlackDirectives(d.text));
             const replayAttachments = async (root?: string): Promise<void> => {
               if (!d.attachments?.length) return;
+              const completed = new Set(d.destination.uploadedAttachmentIndexes ?? []);
+              const pending = d.attachments
+                .map((attachment, index) => ({ attachment, index }))
+                .filter(({ index }) => !completed.has(index));
+              if (!pending.length) return;
               try {
                 await uploadAttachments(
                   client,
                   channel,
                   root,
-                  d.attachments,
+                  pending.map(({ attachment }) => attachment),
                   fetchBlobFromCore,
                   fetchFileArtifactFromCore,
+                  async (pendingIndex) => {
+                    const index = pending[pendingIndex]!.index;
+                    await core.recordDeliveryAttachment(d.id, index);
+                    const indexes = new Set(d.destination.uploadedAttachmentIndexes ?? []);
+                    indexes.add(index);
+                    d.destination = {
+                      ...d.destination,
+                      uploadedAttachmentIndexes: [...indexes].sort((a, b) => a - b),
+                    };
+                  },
                 );
               } catch (err) {
                 console.error(`[slack-plugin] delivery ${d.id} attachment upload failed:`, (err as Error).message);
-                await client.chat
-                  .postMessage(slackReplyArgs(channel, uploadFailureNote(err), root))
-                  .catch(swallowAs("slack: post upload-failure note", undefined));
+                await postWithVerify(
+                  postClient,
+                  { ...slackReplyArgs(channel, uploadFailureNote(err), root) },
+                  `${d.idempotencyKey ?? d.id}:attachment-failure`,
+                  { verifyFirst: true },
+                ).catch(swallowAs("slack: post upload-failure note", undefined));
               }
             };
             const taskList = d.destination.taskList?.length ? renderTaskList(d.destination.taskList) : undefined;

--- a/src/slack/delivery.ts
+++ b/src/slack/delivery.ts
@@ -283,6 +283,20 @@ export function createDeliveryTracker(opts: { maxAttempts?: number; maxTracked?:
   };
 }
 
+export async function postThenAckDelivery(opts: {
+  post: () => Promise<unknown>;
+  ack: () => void;
+  release: () => void;
+}): Promise<void> {
+  try {
+    await opts.post();
+  } catch (err) {
+    opts.release();
+    throw err;
+  }
+  opts.ack();
+}
+
 export async function deliverWithRetry(opts: {
   tracker: DeliveryTracker;
   id: string;

--- a/src/slack/lib.ts
+++ b/src/slack/lib.ts
@@ -1,4 +1,5 @@
-export { isBoundaryRefusal, refusalDelivery, postThenAckRunDelivery, refusalNote } from "./refusals.ts";
+export { isBoundaryRefusal, refusalDelivery, refusalNote } from "./refusals.ts";
+export { postThenAckDelivery } from "./delivery.ts";
 export { inlineCode, clip, sleep } from "./util.ts";
 export {
   decodeSlackEntities,

--- a/src/slack/refusals.ts
+++ b/src/slack/refusals.ts
@@ -12,20 +12,6 @@ export function refusalDelivery(
   return result.refusalKind === "security_quarantine" ? "thread" : "requester";
 }
 
-export async function postThenAckRunDelivery(opts: {
-  post: () => Promise<unknown>;
-  ack: () => void;
-  release: () => void;
-}): Promise<void> {
-  try {
-    await opts.post();
-  } catch (err) {
-    opts.release();
-    throw err;
-  }
-  opts.ack();
-}
-
 export function refusalNote(
   result: { reason?: string; adminUrl?: string; refusalKind?: "security_quarantine" },
   kind: "dm" | "channel",

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -31,7 +31,7 @@ import {
   isMpim,
   type SurfaceHeaderClient,
   maybeInterceptStop,
-  postThenAckRunDelivery,
+  postThenAckDelivery,
   postWithVerify,
   processInboundFiles,
   refusalDelivery,
@@ -157,6 +157,7 @@ export function createTurnHandler(deps: {
     ackRunDeliveryWithRetry,
     reportTurnMetrics,
     checkpointRunEditRef,
+    checkpointRunAttachment,
     stageBlobInCore,
     fetchBlobFromCore,
     fetchFileArtifactFromCore,
@@ -203,12 +204,19 @@ export function createTurnHandler(deps: {
     let slackIdsByPrincipal: Map<string, string> | undefined;
     let conversationKind: SlackConversationKind = inc.kind;
     let allowedTs: Set<string> = new Set();
-    const postReply = async (msg: string, blocks?: Array<Record<string, unknown>>): Promise<string | undefined> => {
-      const posted = await client.chat.postMessage({
+    const postReply = async (
+      msg: string,
+      blocks?: Array<Record<string, unknown>>,
+      idempotencyKey?: string,
+    ): Promise<string | undefined> => {
+      const args = {
         ...slackReplyArgs(inc.channel, msg, replyThreadTs, { threadOnly: inc.kind === "channel", unfurlLinks: false }),
         ...(blocks ? { blocks } : {}),
-      });
-      const ts = posted.ts as string | undefined;
+      };
+      const posted = idempotencyKey
+        ? await postWithVerify(client, args, idempotencyKey, { verifyFirst: true })
+        : await client.chat.postMessage(args);
+      const ts = typeof posted?.ts === "string" ? posted.ts : undefined;
       mirrorSelfPost(inc.channel, ts, msg, { sub: replyThreadTs });
       return ts;
     };
@@ -495,7 +503,16 @@ export function createTurnHandler(deps: {
 
     if (result.status === "silent") {
       if (inc.unprompted) console.error(`[slack-plugin] turn.silent (no reply) ch=${inc.channel} ts=${inc.ts}`);
-      await settleAck();
+      if (queuedRunId) {
+        const runId = queuedRunId;
+        await postThenAckDelivery({
+          post: settleAck,
+          ack: () => ackRunDeliveryWithRetry(runId),
+          release: () => inFlightRuns.delete(runId),
+        });
+      } else {
+        await settleAck();
+      }
       return;
     }
 
@@ -523,29 +540,46 @@ export function createTurnHandler(deps: {
       const postText = reply;
       const tDeliverStart = performance.now();
       let finalizedTaskList = false;
-      if (result.attachments?.length) {
+      const deliverReply = async (): Promise<void> => {
         let uploadError: unknown;
-        try {
-          await uploadAttachments(
-            client,
-            inc.channel,
-            replyThreadTs,
-            result.attachments,
-            fetchBlobFromCore,
-            fetchFileArtifactFromCore,
-          );
-        } catch (err) {
-          uploadError = err;
-          console.error("[slack-plugin] file upload failed:", (err as Error).message);
+        if (result.attachments?.length) {
+          try {
+            await uploadAttachments(
+              client,
+              inc.channel,
+              replyThreadTs,
+              result.attachments,
+              fetchBlobFromCore,
+              fetchFileArtifactFromCore,
+              queuedRunId ? (index) => checkpointRunAttachment(queuedRunId!, index) : undefined,
+            );
+          } catch (err) {
+            uploadError = err;
+            console.error("[slack-plugin] file upload failed:", (err as Error).message);
+          }
         }
         await settleAck();
         if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
-        if (postText && !finalizedTaskList) await postReply(postText);
-        if (uploadError) await postReply(uploadFailureNote(uploadError));
+        if (postText && !finalizedTaskList)
+          await postReply(postText, undefined, queuedRunId ? `run:${queuedRunId}` : undefined);
+        if (uploadError) {
+          await postReply(
+            uploadFailureNote(uploadError),
+            undefined,
+            queuedRunId ? `run:${queuedRunId}:attachment-failure` : undefined,
+          );
+          if (queuedRunId) throw uploadError;
+        }
+      };
+      if (queuedRunId) {
+        const runId = queuedRunId;
+        await postThenAckDelivery({
+          post: deliverReply,
+          ack: () => ackRunDeliveryWithRetry(runId),
+          release: () => inFlightRuns.delete(runId),
+        });
       } else {
-        await settleAck();
-        if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
-        if (postText && !finalizedTaskList) await postReply(postText);
+        await deliverReply();
       }
       if (queuedRunId) {
         reportTurnMetrics(queuedRunId, {
@@ -614,13 +648,13 @@ export function createTurnHandler(deps: {
         });
       }
     } else {
-      await settleAck();
       const delivery = refusalDelivery(result, inc.unprompted === true);
       if (delivery === "thread") {
         if (queuedRunId) {
           const runId = queuedRunId;
           const text = refusalNote(result, inc.kind);
           const post = async () => {
+            await settleAck();
             const posted = await postWithVerify(
               client,
               {
@@ -633,25 +667,53 @@ export function createTurnHandler(deps: {
             );
             mirrorSelfPost(inc.channel, posted.ts, text, { sub: replyThreadTs });
           };
-          await postThenAckRunDelivery({
+          await postThenAckDelivery({
             post,
             ack: () => ackRunDeliveryWithRetry(runId),
             release: () => inFlightRuns.delete(runId),
           });
         } else {
+          await settleAck();
           await postReply(refusalNote(result, inc.kind));
         }
         return;
       }
       if (delivery === "silent") {
-        if (queuedRunId && result.refusalKind === "security_quarantine") inFlightRuns.delete(queuedRunId);
+        if (queuedRunId) {
+          const runId = queuedRunId;
+          await postThenAckDelivery({
+            post: settleAck,
+            ack: () => ackRunDeliveryWithRetry(runId),
+            release: () => inFlightRuns.delete(runId),
+          });
+        } else {
+          await settleAck();
+        }
         console.error(
           `[slack-plugin] unprompted turn ${result.status} (staying quiet) ch=${inc.channel} ts=${inc.ts}: ${result.reason ?? "refused"}`,
         );
         return;
       }
-      if (ack?.postedAck()) await postReply(refusalNote(result, inc.kind));
-      else await ephemeralOrSay(refusalNote(result, inc.kind));
+      const refusalText = refusalNote(result, inc.kind);
+      if (queuedRunId) {
+        const runId = queuedRunId;
+        await postThenAckDelivery({
+          post: async () => {
+            await settleAck();
+            if (inc.kind === "channel" && !ack?.postedAck()) {
+              await client.chat.postEphemeral({ channel: inc.channel, user: inc.userId, text: refusalText });
+              return;
+            }
+            await postReply(refusalText, undefined, `run:${runId}`);
+          },
+          ack: () => ackRunDeliveryWithRetry(runId),
+          release: () => inFlightRuns.delete(runId),
+        });
+      } else {
+        await settleAck();
+        if (ack?.postedAck()) await postReply(refusalText);
+        else await ephemeralOrSay(refusalText);
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,7 @@ export interface Destination {
   audienceScopeId?: ScopeId;
   onBehalfOf?: string;
   editRef?: string;
+  uploadedAttachmentIndexes?: number[];
   taskList?: Array<{
     id: string;
     title: string;

--- a/test/delivery-store-contract.ts
+++ b/test/delivery-store-contract.ts
@@ -100,6 +100,20 @@ export async function exerciseDeliveryStore(store: DeliveryStore): Promise<void>
     "attachments round-trip",
   );
   assert.equal(d.attachments, undefined, "attachment-less deliveries stay bare");
+  await store.recordAttachmentByKey("run:r-4", 1);
+  const progress = await store.enqueue({
+    destination: { type: "slack", target: "C5" },
+    text: "attachment progress",
+    attachments: [
+      { name: "one.txt", mimetype: "text/plain", sizeBytes: 1, blobId: "blob-1" },
+      { name: "two.txt", mimetype: "text/plain", sizeBytes: 1, blobId: "blob-2" },
+    ],
+    idempotencyKey: "run:r-4",
+  });
+  assert.deepEqual(progress.destination.uploadedAttachmentIndexes, [1]);
+  await store.recordAttachment(progress.id, 0);
+  assert.deepEqual((await store.get(progress.id))?.destination.uploadedAttachmentIndexes, [0, 1]);
+  await store.ack(progress.id, 150);
   await store.ackByKey("run:r-1", 200);
   assert.equal((await store.get(recovery.id))?.deliveredAt, 200);
   await store.ackByKey("run:r-1", 300);

--- a/test/slack-attachments.test.ts
+++ b/test/slack-attachments.test.ts
@@ -308,6 +308,31 @@ test("uploadAttachments falls back to durable file artifacts when the transient 
   assert.equal(Buffer.from(calls[0]!.file as Uint8Array).toString("utf8"), "artifact:A1:U1");
 });
 
+test("uploadAttachments reports each completed attachment", async () => {
+  const uploaded: number[] = [];
+  const client = {
+    files: {
+      uploadV2: async () => ({ ok: true }),
+      info: async () => ({ file: { shares: {} } }),
+    },
+  };
+  await uploadAttachments(
+    client,
+    "C1",
+    undefined,
+    [
+      { name: "x.txt", mimetype: "text/plain", sizeBytes: 2, blobId: "B1" },
+      { name: "empty.txt", mimetype: "text/plain", sizeBytes: 0, blobId: "B2" },
+    ],
+    async (id) => (id === "B1" ? Buffer.from("data") : Buffer.alloc(0)),
+    undefined,
+    (index) => {
+      uploaded.push(index);
+    },
+  );
+  assert.deepEqual(uploaded, [0, 1]);
+});
+
 test("uploadAttachments propagates an upload failure (so the caller can report it)", async () => {
   const client = {
     files: {

--- a/test/slack-delivery.test.ts
+++ b/test/slack-delivery.test.ts
@@ -9,6 +9,7 @@ import {
   deliveryCandidatesFor,
   createDeliveryTracker,
   deliverWithRetry,
+  postThenAckDelivery,
   postWithVerify,
   channelSurfaceUrl,
   channelWelcomeMessage,
@@ -185,6 +186,41 @@ test("deliverWithRetry: transient post failures recover before the cap", async (
   assert.equal(h.posts.length, 1);
   assert.equal(h.acks.length, 1);
   assert.ok(!h.tracker.givenUp("d1"));
+});
+
+test("postThenAckDelivery: acknowledges only after the Slack post succeeds", async () => {
+  const calls: string[] = [];
+  let finishPost!: () => void;
+  const posting = postThenAckDelivery({
+    post: () =>
+      new Promise<void>((resolve) => {
+        calls.push("post");
+        finishPost = resolve;
+      }),
+    ack: () => calls.push("ack"),
+    release: () => calls.push("release"),
+  });
+
+  assert.deepEqual(calls, ["post"]);
+  finishPost();
+  await posting;
+  assert.deepEqual(calls, ["post", "ack"]);
+});
+
+test("postThenAckDelivery: releases recovery when the Slack post fails", async () => {
+  const calls: string[] = [];
+  await assert.rejects(
+    postThenAckDelivery({
+      post: async () => {
+        calls.push("post");
+        throw new Error("Slack unavailable");
+      },
+      ack: () => calls.push("ack"),
+      release: () => calls.push("release"),
+    }),
+    /Slack unavailable/,
+  );
+  assert.deepEqual(calls, ["post", "release"]);
 });
 
 test("createDeliveryTracker: a posted-but-unacked entry evicted by the cap is given up on, never re-posted", () => {

--- a/test/slack-index.integration.test.ts
+++ b/test/slack-index.integration.test.ts
@@ -18,6 +18,8 @@ class FakeSlackClient {
   readonly deletes: any[] = [];
   readonly reactionsAdded: any[] = [];
   readonly reactionsRemoved: any[] = [];
+  postError: Error | undefined;
+  uploadError: Error | undefined;
   readonly usersById = new Map<string, any>();
   readonly channelsById = new Map<string, any>();
   readonly membersByChannel = new Map<string, string[]>();
@@ -70,6 +72,7 @@ class FakeSlackClient {
   readonly purposes: { channel: string; purpose: string }[] = [];
   readonly chat = {
     postMessage: async (body: any) => {
+      if (this.postError) throw this.postError;
       this.posts.push(body);
       return { ok: true, ts: `posted-${++this.postSequence}` };
     },
@@ -98,7 +101,10 @@ class FakeSlackClient {
     get: async () => ({}),
   };
   readonly files = {
-    uploadV2: async () => ({ ok: true }),
+    uploadV2: async () => {
+      if (this.uploadError) throw this.uploadError;
+      return { ok: true };
+    },
     info: async () => ({ file: {} }),
   };
   readonly bots = { info: async () => ({ bot: {} }) };
@@ -190,6 +196,7 @@ class FakeCore implements SlackCoreClient {
   queuedRunId: string | undefined;
   private heldRunClaimed = false;
   readonly polled: string[] = [];
+  readonly ackedRuns: string[] = [];
   private runGate: Promise<void> | undefined;
   private releaseRun: (() => void) | undefined;
 
@@ -203,7 +210,7 @@ class FakeCore implements SlackCoreClient {
     return { blobId: "blob-1", sizeBytes: bytes.byteLength };
   }
   async readBlob(): Promise<Buffer> {
-    return Buffer.alloc(0);
+    return Buffer.from("file");
   }
   async readFileArtifact(): Promise<Buffer> {
     return Buffer.alloc(0);
@@ -250,9 +257,13 @@ class FakeCore implements SlackCoreClient {
   async signalRunAbort(runId: string): Promise<void> {
     this.abortedRuns.push(runId);
   }
-  async ackRunDelivery(): Promise<void> {}
+  async ackRunDelivery(runId: string): Promise<void> {
+    this.ackedRuns.push(runId);
+  }
   async reportTurnMetrics(): Promise<void> {}
   async reportRunEditRef(): Promise<void> {}
+  async recordDeliveryAttachment(): Promise<void> {}
+  async recordRunDeliveryAttachment(): Promise<void> {}
   async getApproval(): Promise<null> {
     return null;
   }
@@ -386,6 +397,111 @@ test("a DM becomes one scoped live turn and one Slack reply", async () => {
       f.client.posts.map((p) => p.text),
       ["agent reply"],
     );
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a queued normal reply posts run metadata before acknowledging recovery", async () => {
+  const f = await fixture();
+  try {
+    f.core.holdRun("R1");
+    const turn = f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "hello agent", ts: "100.2" });
+    await waitFor(() => f.core.polled.length === 1);
+    f.core.finishRun({ status: "ok", reply: "agent reply" });
+    await turn;
+    await waitFor(() => f.core.ackedRuns.length === 1);
+
+    const post = f.client.posts.find((candidate) => candidate.text === "agent reply");
+    assert.deepEqual(post?.metadata, {
+      event_type: "qm_delivery",
+      event_payload: { idempotency_key: "run:R1" },
+    });
+    assert.deepEqual(f.core.ackedRuns, ["R1"]);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a queued normal reply does not acknowledge recovery when its Slack post fails", async () => {
+  const f = await fixture();
+  try {
+    f.client.postError = new Error("Slack unavailable");
+    f.core.holdRun("R2");
+    const turn = f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "hello agent", ts: "100.3" });
+    await waitFor(() => f.core.polled.length === 1);
+    f.core.finishRun({ status: "ok", reply: "agent reply" });
+    await turn;
+    assert.deepEqual(f.core.ackedRuns, []);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a queued silent result acknowledges without a Slack post", async () => {
+  const f = await fixture();
+  try {
+    f.core.holdRun("R3");
+    const turn = f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "hello agent", ts: "100.4" });
+    await waitFor(() => f.core.polled.length === 1);
+    f.core.finishRun({ status: "silent" });
+    await turn;
+    await waitFor(() => f.core.ackedRuns.length === 1);
+    assert.deepEqual(f.core.ackedRuns, ["R3"]);
+    assert.deepEqual(f.client.posts, []);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a queued silent refusal acknowledges without a Slack post", async () => {
+  const f = await fixture();
+  try {
+    f.client.channelsById.set("G1", { id: "G1", name: "", is_member: true, is_private: true, is_mpim: true });
+    f.client.membersByChannel.set("G1", ["U1", "U2", "UBOT"]);
+    f.client.messagesByChannel.set("G1", [
+      { channel: "G1", user: "U1", text: "kick off", ts: "100.5" },
+      { channel: "G1", user: "UBOT", text: "on it", ts: "100.6", thread_ts: "100.5" },
+    ]);
+    f.core.holdRun("R5");
+    const turn = f.app.emitMessage({
+      channel: "G1",
+      channel_type: "mpim",
+      user: "U2",
+      text: "hello agent",
+      ts: "100.7",
+      thread_ts: "100.5",
+    });
+    await waitFor(() => f.core.polled.length === 1);
+    f.core.finishRun({ status: "refused", reason: "not addressed" });
+    await turn;
+    await waitFor(() => f.core.ackedRuns.length === 1);
+    assert.deepEqual(f.core.ackedRuns, ["R5"]);
+    assert.deepEqual(f.client.posts, []);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a queued attachment failure keeps recovery claimable and keys its failure note", async () => {
+  const f = await fixture();
+  try {
+    f.client.uploadError = new Error("files unavailable");
+    f.core.holdRun("R4");
+    const turn = f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "hello agent", ts: "100.5" });
+    await waitFor(() => f.core.polled.length === 1);
+    f.core.finishRun({
+      status: "ok",
+      reply: "agent reply",
+      attachments: [{ name: "report.txt", mimetype: "text/plain", sizeBytes: 4, blobId: "blob-1" }],
+    });
+    await turn;
+    assert.deepEqual(f.core.ackedRuns, []);
+    const failure = f.client.posts.find((candidate) => candidate.text?.includes("couldn't attach"));
+    assert.deepEqual(failure?.metadata, {
+      event_type: "qm_delivery",
+      event_payload: { idempotency_key: "run:R4:attachment-failure" },
+    });
   } finally {
     await f.stop();
   }

--- a/test/slack-refusals.test.ts
+++ b/test/slack-refusals.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { refusalNote, refusalDelivery, postThenAckRunDelivery, isBoundaryRefusal } from "../src/slack/lib.ts";
+import { refusalNote, refusalDelivery, isBoundaryRefusal } from "../src/slack/lib.ts";
 
 const ADMIN_URL = "https://portal.example.com/admin/?view=history&session=s-1";
 
@@ -48,41 +48,6 @@ test("refusalDelivery: quarantine posts in-thread only when addressed; every unp
   assert.equal(refusalDelivery({ refusalKind: "security_quarantine" }, true), "silent");
   assert.equal(refusalDelivery({}, true), "silent");
   assert.equal(refusalDelivery({}, false), "requester");
-});
-
-test("postThenAckRunDelivery: acknowledges only after the Slack post succeeds", async () => {
-  const calls: string[] = [];
-  let finishPost!: () => void;
-  const posting = postThenAckRunDelivery({
-    post: () =>
-      new Promise<void>((resolve) => {
-        calls.push("post");
-        finishPost = resolve;
-      }),
-    ack: () => calls.push("ack"),
-    release: () => calls.push("release"),
-  });
-
-  assert.deepEqual(calls, ["post"]);
-  finishPost();
-  await posting;
-  assert.deepEqual(calls, ["post", "ack"]);
-});
-
-test("postThenAckRunDelivery: releases recovery when the Slack post fails", async () => {
-  const calls: string[] = [];
-  await assert.rejects(
-    postThenAckRunDelivery({
-      post: async () => {
-        calls.push("post");
-        throw new Error("Slack unavailable");
-      },
-      ack: () => calls.push("ack"),
-      release: () => calls.push("release"),
-    }),
-    /Slack unavailable/,
-  );
-  assert.deepEqual(calls, ["post", "release"]);
 });
 
 test("isBoundaryRefusal: only internal-only reasons are boundary refusals", () => {


### PR DESCRIPTION
Fixes #44

The Slack bridge was acknowledging a terminal run before the live reply was durably visible. A normal reply used a plain `chat.postMessage`, so an uncertain Slack failure could leave the recovery copy acknowledged with no reliable way to find an already accepted post.

This changes the terminal protocol so the live handler posts with `postWithVerify(..., "run:<id>")`, completes the text/update, attachment uploads, and task-list finalization, and only then starts the recovery-copy ack. Failed posts release the local claim and leave the durable delivery pending. The post-before-ack helper now lives with the delivery code and is shared by normal terminal replies and refusal delivery. Existing `ackByKey` tombstones are unchanged.

Attachment completion is also recorded per delivery index, including the enqueue race, so a recovery attempt does not upload files that the live attempt already completed. Requester-only channel refusals remain ephemeral by design; those refusal results do not create a durable recovery delivery.

Validation:
- 125 focused Slack, delivery, attachment, and run-result tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`