### PR TITLE
adr: Superserve sandbox backend

### DIFF
--- a/adrs/superserve-sandbox-backend.md
+++ b/adrs/superserve-sandbox-backend.md
@@ -1,0 +1,3 @@
+Can we add support for Superserve sandbox backend? (https://superserve.ai)
+
+We'd love to run qm on Superserve internally (to build Superserve :) ) and start offloading company operations to it. Would also be nice to be able to offer qm to our community that's already using Superserve sandboxes.


### PR DESCRIPTION
Can we add support for Superserve sandbox backend? (https://superserve.ai)

We'd love to run qm on Superserve internally (to build Superserve :) ) and start offloading company operations to it. Would also be nice to be able to offer qm to our community that's already using Superserve sandboxes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788121777&installation_model_id=19911&pr_number=52&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F52&signature=a410249bffb6d9577fa86a84bf928cc1f0e96a8b65f6170fb3ad584ca63f0399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->