### PR TITLE
Propose Foundry and Bedrock model backends

### DIFF
--- a/adrs/foundry-and-bedrock-model-backends.md
+++ b/adrs/foundry-and-bedrock-model-backends.md
@@ -1,0 +1,51 @@
+# Azure Foundry and Bedrock model backends
+
+I've been setting up qm for my team and already have a lot of inexpensive model
+capacity in an Azure AI Foundry deployment. I wanted to use that deployment with
+the Codex harness instead of having to buy the same model capacity again directly
+from OpenAI.
+
+I got this working with a small generic change to qm. When `OPENAI_BASE_URL` is
+present, qm writes an isolated Codex provider configuration under the jailed
+`CODEX_HOME` that looks like this:
+
+```toml
+model_provider = "qm-openai-compatible"
+
+[model_providers.qm-openai-compatible]
+name = "OpenAI-compatible"
+base_url = "https://example.invalid/openai/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+supports_websockets = false
+```
+
+The implementation passes `OPENAI_BASE_URL` only to the Codex child, validates
+that it is an HTTP(S) URL without credentials, a query, or a fragment, normalizes
+trailing slashes, and keeps the generated config and auth files inside Codex's
+isolated home with mode `0600`. I also changed `qm doctor` so it validates the
+configured endpoint before probing it, and added tests for the environment
+boundary, generated TOML, URL rejection, normalization, and doctor behavior.
+
+This is working in a real deployment now. The implementation is generic rather
+than Azure-specific: it should work for a Responses-compatible endpoint that Codex
+can authenticate to with the configured API key. I would love for this to be a
+supported qm path.
+
+I have a similar need for Claude through Amazon Bedrock. Claude Code already
+supports this with `CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, the normal AWS
+credential chain, and optional `ANTHROPIC_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL`
+values. qm's Claude child-environment allowlist does not currently pass the
+Bedrock/AWS variables through. I have not implemented that half yet, but it seems
+like the same kind of provider-routing problem and I would be happy to test it.
+
+I wonder if qm should distinguish the model family from the backend used to reach
+it. For example, the family would still be `openai` or `anthropic`, while a backend
+could be `direct`, `azure-foundry`, or `bedrock`. That would avoid teaching the
+model registry that Bedrock is itself a model family, and would also let setup and
+doctor ask for the right credentials without requiring `ANTHROPIC_API_KEY` when
+Claude is running through Bedrock.
+
+Would you be open to supporting these as first-class backends? I can contribute or
+hand over the working Foundry/Codex implementation and its tests, then help verify
+the Bedrock/Claude path against a real AWS account.


### PR DESCRIPTION
Adds a short ADR proposing first-class cloud model backends for:

- OpenAI models reached through an Azure AI Foundry Responses-compatible endpoint with Codex
- Anthropic models reached through Amazon Bedrock with Claude Code

The ADR includes the concrete behavior of a working generic Codex custom-endpoint implementation and suggests keeping model family separate from delivery backend. It also identifies the Claude environment boundary that currently prevents Bedrock configuration from reaching the child process.

This is a text-only contribution under `adrs/`, following the repository's contribution process. No runtime code changes are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788125719&installation_model_id=19911&pr_number=60&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F60&signature=28e9058c0ab3d4f280c78a06530e2d52f2e7b3063a525d6923b7feed942cd3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->