### PR TITLE
Typed and compiled resource definitions as pre-runtime authoring layer

### DIFF
--- a/adrs/typeference-authoring-layer.md
+++ b/adrs/typeference-authoring-layer.md
@@ -1,0 +1,7 @@
+Hey there, I’ve been working independently on a tool that seems to share a pretty exact seam with QM. It’s called TypeFerence. I didn’t build it for QM or write any QM code. I saw your release and realized the two projects may solve complementary halves of the same problem.
+
+My read is that QM handles runtime layering well: an org soul, scoped skills, and narrower scopes that can shadow broader ones. TypeFerence handles the authoring side before that runtime resolution happens. It treats Markdown roughly how TypeScript treats raw JavaScript, letting organizational intent be assembled from typed, reusable enterprise, team, and role definitions with inheritance, controlled overrides, versioned packages, provenance, and conflict checking.
+
+I’m not proposing that you merge a giant implementation as-is. It’s a fairly built-out independent project with enough specification, examples, and conformance work that you could point your agents at it and decide what, if anything, you want to take from it. It could become QM’s authoring layer, stay separate as an upstream compiler that feeds QM, or just contribute ideas. The fit seemed too close not to send it your way.
+
+[buchk/TypeFerence](https://github.com/buchk/TypeFerence)


### PR DESCRIPTION
Hey there, I’ve been working independently on a tool that seems to share a pretty exact seam with QM. It’s called TypeFerence. I didn’t build it for QM or write any QM code. I saw your release and realized the two projects may solve complementary halves of the same problem.

My read is that QM handles runtime layering well: an org soul, scoped skills, and narrower scopes that can shadow broader ones. TypeFerence handles the authoring side before that runtime resolution happens. It treats Markdown roughly how TypeScript treats raw JavaScript, letting organizational intent be assembled from typed, reusable enterprise, team, and role definitions with inheritance, controlled overrides, versioned packages, provenance, and conflict checking.

I’m not proposing that you merge a giant implementation as-is. It’s a fairly built-out independent project with enough specification, examples, and conformance work that you could point your agents at it and decide what, if anything, you want to take from it. It could become QM’s authoring layer, stay separate as an upstream compiler that feeds QM, or just contribute ideas. The fit seemed too close not to send it your way.

[buchk/TypeFerence](https://github.com/buchk/TypeFerence)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127125&installation_model_id=19911&pr_number=61&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F61&signature=7dd073d844f9377c90bf15e20081fddd41da893f7a3392e32fabe7ab5b3c8ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->