### PR TITLE
The durable map accepts strings Postgres can't store

### DIFF
--- a/adrs/durable-map-unstorable-strings.md
+++ b/adrs/durable-map-unstorable-strings.md
@@ -1,0 +1,67 @@
+# The durable map accepts strings Postgres can't store
+
+`createMemoryMap` and `createPostgresMap` don't agree on what a valid value is. The memory
+map takes any JS string; the Postgres map writes `JSON.stringify(value)` into a `jsonb`
+column, and Postgres rejects two things that are perfectly legal in a JS string: a NUL, and
+an unpaired surrogate.
+
+I ran this against a real Postgres 18 with the repo's own `createPostgresMapFactory`:
+
+```
+memory map:    put title with NUL          -> OK
+postgres map:  put title with NUL          -> unsupported Unicode escape sequence
+postgres map:  merge title with NUL        -> unsupported Unicode escape sequence
+postgres map:  put lone surrogate          -> invalid input syntax for type json
+                                              (22P02, "Unicode low surrogate must follow a high surrogate")
+```
+
+So every artifact store behind `artifactMap(...)` — crons, projects, skills, monitors,
+souls, keychain asks, the rest — can be handed a value that works in every test and throws
+in production.
+
+The part that makes this more than a theoretical edge case is that qm manufactures those
+strings itself, out of clean input. Several clamps cut with a bare `.slice()`, and cutting
+mid-emoji strands half a surrogate pair:
+
+- `cleanName` in `project-store.ts` (`.slice(0, 200)`) → `projects`
+- `normalizeTitle` in `cron-store.ts` (`.slice(0, 79)`) → `crons`
+- `truncate` in `scheduler.ts` (`.slice(0, maxChars - 3)`) → the cron fire log
+
+The project one is the easiest to see. Name a project 200+ characters with an emoji sitting
+across character 200 and nothing about the input is unusual:
+
+```
+project name length: 216 (cleanName clamps at 200)
+memory map (every test):     OK -> stored name ends with "bcd\ud83d"
+postgres map (production):   THREW -> invalid input syntax for type json
+```
+
+The cron one I chased through the scheduler because I wanted to know how bad it gets. A
+fire whose reply is over 2000 characters with an emoji on the clamp boundary throws out of
+`recordFire`, the exception unwinds through `fireDue` and `tick`, the sweeper logs it, and
+`markFired` never runs. Next tick the cron is still due and `fire()` runs again — but
+`runTrigger`'s idempotency key catches it, so the turn isn't repeated and the schedule
+advances. Net damage is one lost fire-log entry and a `[scheduler] tick failed` line. Less
+bad than I expected, and worth saying out loud since the ordering there is doing real work.
+
+You already treat both characters as unstorable in four other places — `jsonbSafeStringify`
+for session payloads, the explicit "the store cannot persist" checks in
+`deployment-layer-store.ts`, the NUL strip the session store does in SQL on its read path,
+`toWellFormed()` in `security-screener.ts`. What's missing is the one layer they'd all flow
+through anyway. `headSlice`/`tailSlice` are already in `util/text.ts` for exactly the
+clamp problem, with a test pinning the invariant — the three call sites above just don't use
+them.
+
+Two things I'd suggest, and I think the second matters more than the first:
+
+1. Normalize in the map's serializer rather than at call sites, so a store can't be added
+   later that forgets. `.toWellFormed()` plus the NUL strip you already do is enough.
+2. Make the two maps agree. Right now the memory map is more permissive than the real one,
+   which is why a suite this thorough can't see any of this. CI does run the Postgres map
+   tests (`core-postgres` / `npm run test:pg`), so a case in `postgres-map.test.ts` would
+   actually run — it just isn't there today. If both maps went through one serializer, one
+   test would cover every artifact store you ever add.
+
+Not filing this as a security issue — nothing crosses a scope and the failures are loud and
+recoverable. It's a production-only shape that the test suite is structurally unable to
+reach, which is the part I'd want to know about.


### PR DESCRIPTION
Adding an ADR in `adrs/`, per CONTRIBUTING.

Short version: `createMemoryMap` and `createPostgresMap` disagree about what's storable.
The memory map takes any JS string; the Postgres map writes `JSON.stringify(value)` into
`jsonb`, and Postgres rejects a NUL and an unpaired surrogate. Every store behind
`artifactMap(...)` sits on that seam.

What makes it more than an edge case is that qm produces the bad string itself: `cleanName`,
`normalizeTitle` and the scheduler's `truncate` all clamp with a bare `.slice()`, which
strands half a surrogate pair when the cut lands mid-emoji. A 200+ character project name
with an emoji across character 200 is enough:

```
memory map (every test):     OK -> stored name ends with "bcd\ud83d"
postgres map (production):   THREW -> invalid input syntax for type json
```

I ran it against Postgres 18 using the repo's own `createPostgresMapFactory`, project store
and cron scheduler; `test/postgres-map.test.ts` passes clean against the same instance, so
this isn't the environment. I also chased the cron path to the end to check how bad it gets,
and it's milder than it first looks — `runTrigger`'s idempotency key absorbs the retry, so
the damage is one lost fire-log entry rather than a repeated turn. That's in the file too.

`headSlice`/`tailSlice` and `jsonbSafeStringify` already exist for exactly this, and four
places in the repo already treat both characters as unstorable — just not the layer they all
write through. Details, the cases I ran, and what I'd suggest are in the file.

Not a security report: nothing crosses a scope and the failures are loud and recoverable.
The reason I thought it was worth writing up is that it can only fail on a real deployment,
so the suite can't see it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788127725&installation_model_id=19911&pr_number=62&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F62&signature=a56d305e5910c537f403b4951b58128dd8a245a804080a592b710adab8e3fde0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->