### PR TITLE
The cron fire log grows without bound, and every fire rewrites all of it

### DIFF
--- a/adrs/cron-fire-log-unbounded.md
+++ b/adrs/cron-fire-log-unbounded.md
@@ -1,0 +1,63 @@
+# The cron fire log grows without bound, and every fire rewrites all of it
+
+Follow-up to the durable-map ADR — same corner of the code, different disease. This one is
+about `fireLog` on the cron record.
+
+`recordFire` appends an entry per fire and nothing ever trims it. Not archive, not disable,
+not any sweeper — the only way the log shrinks is deleting the cron. Silent fires append
+too: a polling cron that says `[no-update]` every minute still gains an entry per minute,
+forever. And because the log lives inside the cron's own jsonb row, appending entry N
+means reading and rewriting all N entries: `recordFire` parses the full row under
+`FOR UPDATE`, dedupes and re-sorts the whole array in JS, and writes the whole thing back.
+
+I measured it with the repo's own `createCronStore` on `createPostgresMapFactory`, after
+recording 6,670 fires with 2,000-char replies — that's one every-minute cron after ~4.6
+days:
+
+```
+row state: 6,670 entries, 14.5 MB raw JSON (TOAST compresses my filler to ~280 KB)
+
+recordFire (one more entry)          median 229 ms
+crons.get (fireJob / claimSlot read) median  50 ms
+crons.list cold (reconcile path)     median  90 ms
+crons.list cached (structuredClone)  median  23 ms
+WAL written per recordFire           ~300 KB
+```
+
+recordFire on a young cron is 1–2 ms, so that's ~150× at day five, and the cost is linear
+in the entry count — the total work is quadratic in the life of the cron. My filler text
+compresses ~50×; realistic varied replies won't, so the on-disk row and per-fire WAL for a
+real deployment sit closer to the raw numbers than the compressed ones.
+
+The reads multiply it. In job-queue mode each fire does `crons.get` (full row), `claimSlot`
+(full row under `FOR UPDATE`, full rewrite), `recordFire` (again), and `enqueueNext`'s
+`crons.get` (again) — call it four full-log round-trips per fire. `reconcile` calls
+`crons.list()` about every 5 seconds, and since every fire anywhere bumps the map's version
+counter, that's routinely a cold read: every cron's full log, parsed, plus a
+`structuredClone` of the lot on every call even when cached. None of these readers wants
+the log — `nextSlot` needs three timestamps; the API's `runs` view slices the tail
+(`fireLog.slice(-limit)`).
+
+Left alone it also has an end state: a single jsonb value has hard size limits in Postgres,
+and once the row is too big to write, `recordFire` throws on every fire from then on. The
+schedule survives that (same path as the other ADR: tick logs an error, idempotency absorbs
+the retry) but the log is permanently unwritable and every fire still pays the failed
+multi-MB attempt first.
+
+Issue 46 already treats this class as a bug — "`tool_calls` has no retention — nothing
+deletes from it" — and I think `fireLog` is the same disease in a worse home, because a
+retention-less _table_ at least appends in O(1), while a retention-less _jsonb array_ makes
+every writer and every reader pay for the whole history.
+
+What I'd actually do: cap it in `recordFire` — keep the newest N entries (50? 100?) with a
+`slice(-N)` after the existing sort. One line, and it bounds the row, the per-fire cost, the
+WAL, and the reconcile scan all at once. It also matches what the system already believes
+about this data: the fire input tells the agent the log shows "how prior fires went", the
+reply inside an entry is already clamped to 2,000 chars for exactly this reason, and every
+consumer reads the tail. If someone truly wants full fire history it wants to be an
+append-only table with retention — but I'd take the cap first; it's the version that
+shrinks the system.
+
+Not a security issue — nothing crosses a scope. It's a slow-burn operational one: nothing
+looks wrong in week one, and by month three every active cron is quietly the biggest row in
+the database and the scheduler is spending its ticks re-parsing history nobody reads.


### PR DESCRIPTION
Adding an ADR in `adrs/`, per CONTRIBUTING. Follow-up to #62 — same corner of the code, different disease.

Short version: `recordFire` appends to the cron's `fireLog` and nothing ever trims it — not archive, not disable, and silent `[no-update]` fires append too. Because the log lives inside the cron's own jsonb row, appending entry N rewrites all N entries, each fire does about four full-log round-trips (`get`, `claimSlot`, `recordFire`, `enqueueNext`), and the reconcile loop re-parses every cron's full history roughly every five seconds.

I measured it with the repo's own `createCronStore` on `createPostgresMapFactory`. At 6,670 entries — one every-minute cron after ~4.6 days — the row is 14.5 MB of raw JSON, `recordFire` is ~229 ms (vs 1–2 ms young), and each fire writes ~300 KB of WAL. Cost is linear in entry count, so total work is quadratic over the cron's life, and there's an end state: once the row exceeds what a jsonb value can hold, the log is permanently unwritable.

None of the readers wants the history — `nextSlot` needs three timestamps and the `runs` view slices the tail. Issue 46 already flags the same class for `tool_calls`, and this is the same disease in a worse home, since a retention-less table at least appends in O(1).

What I'd do is in the file: cap the log at the newest N entries in `recordFire` — one `slice(-N)`, which bounds the row, the per-fire cost, the WAL, and the reconcile scan at once, and matches the 2,000-char reply clamp that already exists inside each entry.

Not a security issue — it's a slow burn. Nothing looks wrong in week one; by month three every active cron is quietly the biggest row in the database.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788129891&installation_model_id=19911&pr_number=64&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F64&signature=90666046cf87e9ea71f14b891c25a4fa62905bf2dc82f8154661e4b5c76bdf23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->