### PR TITLE
Support TinyFish through OAuth MCP

### DIFF
--- a/adrs/tinyfish-mcp.md
+++ b/adrs/tinyfish-mcp.md
@@ -1,0 +1,16 @@
+# TinyFish MCP
+
+Could QM support an org-configured remote MCP server that people connect to with OAuth?
+
+We want to connect `https://agent.tinyfish.ai/mcp` without a skill or API key. For now we need these TinyFish tools:
+
+- `search` for external knowledge and finding pages
+- `fetch_content` for reading supplied URLs
+- `run_web_automation` for interactive website tasks
+- `run_web_automation_async` only when someone explicitly asks to run the task in the background
+
+I tested the endpoint directly with OAuth. Tool discovery returned all four tools. Search found the TinyFish docs, fetch returned the Example Domain page, synchronous automation returned its title, and asynchronous automation completed with the same result through `get_run`.
+
+The connection should belong to the person who authorized it. It should not be stored in an ephemeral harness home or shared with a room.
+
+The QM checks should prove that a current-web question selects `search`, a supplied URL selects `fetch_content`, an interactive website request selects `run_web_automation`, and an explicitly backgrounded website request selects `run_web_automation_async`.

--- a/adrs/tinyfish-mcp.md
+++ b/adrs/tinyfish-mcp.md
@@ -1,18 +1,16 @@
 # TinyFish MCP
 
-Could QM support an org-configured remote MCP server that people connect to with OAuth?
-
-We want to connect `https://agent.tinyfish.ai/mcp` without a skill or API key. For now we need these TinyFish tools:
+We want QM to connect `https://agent.tinyfish.ai/mcp` without a skill or API key. For now we need these TinyFish tools:
 
 - `search` for external knowledge and finding pages
 - `fetch_content` for reading supplied URLs
 - `run_web_automation` for interactive website tasks
 - `run_web_automation_async` only when someone explicitly asks to run the task in the background
 
+When someone messages QM, it should use that speaker's TinyFish OAuth connection and add these tools to the same shared tool set every harness receives. The model can then select them from TinyFish's existing descriptions. Scheduled work should use the instruction owner's connection. MCP calls and results should go through QM's existing approval, external-content screening, and audit paths.
+
+The connection should belong to the person who authorized it. It should not be stored in an ephemeral harness home or shared with a room. A channel message can use its speaker's connection, but another participant or an unowned automation should not inherit it.
+
 I tested the endpoint directly with OAuth. Tool discovery returned all four tools. Search found the TinyFish docs, fetch returned the Example Domain page, synchronous automation returned its title, and asynchronous automation completed with the same result through `get_run`.
 
-This proposal does not itself connect TinyFish to a QM agent. QM still needs to load these remote MCP tools into the active harness tool set before the model can select them.
-
-The connection should belong to the person who authorized it. It should not be stored in an ephemeral harness home or shared with a room.
-
-The QM checks should prove that a current-web question selects `search`, a supplied URL selects `fetch_content`, an interactive website request selects `run_web_automation`, and an explicitly backgrounded website request selects `run_web_automation_async`.
+The QM checks should exercise the full Slack-to-tool path and prove that a current-web question selects `search`, a supplied URL selects `fetch_content`, an interactive website request selects `run_web_automation`, and an explicitly backgrounded website request selects `run_web_automation_async`.

--- a/adrs/tinyfish-mcp.md
+++ b/adrs/tinyfish-mcp.md
@@ -11,6 +11,8 @@ We want to connect `https://agent.tinyfish.ai/mcp` without a skill or API key. F
 
 I tested the endpoint directly with OAuth. Tool discovery returned all four tools. Search found the TinyFish docs, fetch returned the Example Domain page, synchronous automation returned its title, and asynchronous automation completed with the same result through `get_run`.
 
+This proposal does not itself connect TinyFish to a QM agent. QM still needs to load these remote MCP tools into the active harness tool set before the model can select them.
+
 The connection should belong to the person who authorized it. It should not be stored in an ephemeral harness home or shared with a room.
 
 The QM checks should prove that a current-web question selects `search`, a supplied URL selects `fetch_content`, an interactive website request selects `run_web_automation`, and an explicitly backgrounded website request selects `run_web_automation_async`.


### PR DESCRIPTION
Enable TinyFish as a per-person OAuth MCP connection in QM, without a skill or API key.

Requested QM behavior:
- identify the Slack speaker or scheduled-instruction owner
- use that person’s TinyFish OAuth connection
- inject search, fetch_content, run_web_automation, run_web_automation_async, and get_run into the shared harness tool set
- pass calls and results through QM approvals, external-content screening, and audit
- never share one participant’s connection with another

Live TinyFish verification completed: OAuth, tool discovery, search, fetch, synchronous automation, and asynchronous automation through get_run all succeeded.

The requested QM checks cover the full Slack-to-tool path for search, URL fetch, interactive automation, and explicitly backgrounded automation.