### PR TITLE
Running on a Claude subscription trips the "deployment isn't set up" gate

### DIFF
--- a/adrs/claude-subscription-counts-as-model-provider.md
+++ b/adrs/claude-subscription-counts-as-model-provider.md
@@ -1,0 +1,41 @@
+# Running on a Claude subscription trips the "deployment isn't set up" gate
+
+I ran QM locally with `HARNESS=claude` and a `CLAUDE_CODE_OAUTH_TOKEN` from
+`claude setup-token` — no API key, just my Claude subscription. Chat turns work
+fine end to end. But the portal blocks the whole UI with "This deployment isn't
+set up yet — an admin still needs to finish setup by adding a model API key",
+even though the assistant answers happily underneath.
+
+Where it comes from: the portal gates on `modelProviderConfigured === false`
+(`plugins/portal/src/index.ts:1056`), which the core computes in
+`src/api/routes/surface.ts:892` from `ModelCredentialStore.availability()`
+(`src/model/model-credential-store.ts`) — and that only counts
+anthropic/openai/openrouter API keys from env or the admin panel. It never
+considers `CLAUDE_CODE_OAUTH_TOKEN`, even though the claude harness passes that
+token through to the Claude Code child and serves turns with it.
+
+The local fix that worked for me, in `src/wiring.ts` right after
+`createModelCredentialStore(...)` (line ~397): when `config.harness === "claude"`
+and `config.claudeProcessEnv.CLAUDE_CODE_OAUTH_TOKEN` (or
+`ANTHROPIC_AUTH_TOKEN`) is set, wrap the store so `availability()` reports
+`anthropic: true`:
+
+```ts
+const claudeSubscriptionAuth =
+  config.harness === "claude" &&
+  Boolean(config.claudeProcessEnv.CLAUDE_CODE_OAUTH_TOKEN ?? config.claudeProcessEnv.ANTHROPIC_AUTH_TOKEN);
+const modelCredentials: ModelCredentialStore = claudeSubscriptionAuth
+  ? {
+      ...storedModelCredentials,
+      availability: async () => ({ ...(await storedModelCredentials.availability()), anthropic: true }),
+    }
+  : storedModelCredentials;
+```
+
+I deliberately didn't fake an anthropic key in `resolve()`/`fallback`, because
+resolved keys get injected into harness child processes and an invalid
+`ANTHROPIC_API_KEY` would override the OAuth login inside Claude Code.
+
+Ask: count a Claude subscription token as a configured model provider (here or
+wherever you'd rather put it), so subscription-only setups don't get told they
+aren't set up.


### PR DESCRIPTION
ADR proposing that a Claude subscription token (`CLAUDE_CODE_OAUTH_TOKEN`) count as a configured model provider when `HARNESS=claude`, so the portal doesn't block the UI on setups that have no API key. Details, root cause, and the local fix that worked are in the file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788135713&installation_model_id=19911&pr_number=67&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F67&signature=438306be55f95c799a0c7aa9731d0a25b230da50c7816a514c1e30549cb2adfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->