### PR TITLE
Make qm init pin the executing CLI version

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -173,6 +173,10 @@ function template(rel: string): string {
   return readFileSync(existsSync(source) ? source : packaged, "utf8");
 }
 
+function isLocalDependencySpec(spec: string): boolean {
+  return spec.startsWith("file:") || spec.startsWith("link:");
+}
+
 function packageContent(dir: string, orgId: string): string {
   const packagePath = join(dir, "package.json");
   let existing: Record<string, unknown> = {};
@@ -206,7 +210,9 @@ function packageContent(dir: string, orgId: string): string {
   const engines = { ...objectField("engines"), node: ">=24.0.0" };
   const packageName = cliPackageName();
   const dependencies = objectField("dependencies");
-  const installedPackage = typeof dependencies[packageName] === "string" ? dependencies[packageName] : cliVersion();
+  const existingSpec = dependencies[packageName];
+  const installedPackage =
+    typeof existingSpec === "string" && isLocalDependencySpec(existingSpec) ? existingSpec : cliVersion();
   delete dependencies["qm-cli"];
   delete dependencies[packageName];
   for (const group of ["devDependencies", "optionalDependencies"] as const) {

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -65,9 +65,13 @@ npm exec --yes --package=@yc-software/qm@latest -- \
 npm install
 ```
 
-`qm init` writes the version it resolved to as an exact dependency, so the pin
-lands in the deployment repository and its lockfile rather than in the command
-that bootstraps it.
+`qm init` pins `@yc-software/qm` to the version it resolved to as an exact
+dependency, so the pin lands in the deployment repository and its lockfile
+rather than in the command that bootstraps it. It overwrites any existing
+exact, ranged, or tagged registry specification already in `package.json`,
+but leaves a local dependency (`file:` or `link:`) untouched, since that form
+is intentional — used for development against an unpublished CLI or for
+packed-artifact tests.
 
 `--model-provider` takes `anthropic`, `openai`, or `openrouter` and defaults to
 `anthropic`. It writes `modelProvider` into the scaffolded config, which is what

--- a/cli/test/init.test.ts
+++ b/cli/test/init.test.ts
@@ -487,6 +487,55 @@ test("init preserves an installed local package artifact", () => {
   }
 });
 
+test("init preserves an installed local package artifact linked for development", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-init-linked-package-"));
+  try {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        private: true,
+        dependencies: { "@yc-software/qm": "link:../qm/cli" },
+      }),
+    );
+
+    quiet(() => runInit({ dir, org: "acme", target: "fly" }));
+
+    const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    assert.equal(manifest.dependencies?.["@yc-software/qm"], "link:../qm/cli");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("init replaces stale registry dependency specifications with the executing CLI version", () => {
+  const dirs = ["0.1.0", "^0.1.0", "latest"].map((stale) => ({
+    stale,
+    dir: mkdtempSync(join(tmpdir(), "qm-init-registry-package-")),
+  }));
+  try {
+    for (const { stale, dir } of dirs) {
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({
+          private: true,
+          dependencies: { "@yc-software/qm": stale },
+        }),
+      );
+
+      quiet(() => runInit({ dir, org: "acme", target: "fly" }));
+
+      const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+        dependencies?: Record<string, string>;
+      };
+      assert.equal(manifest.dependencies?.["@yc-software/qm"], cliVersion(), `stale spec "${stale}" is replaced`);
+    }
+  } finally {
+    for (const { dir } of dirs) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("init --target aws vendors a contract-valid Terraform deployment", () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-init-aws-"));
   try {


### PR DESCRIPTION
## Summary

`qm init` writes `dependencies["@yc-software/qm"]` in the generated `package.json`. The old code only wrote `cliVersion()` when no entry existed yet — an old exact version, a semver range, or `latest` already in `package.json` stayed untouched. `npm install` could then pull a different CLI than the one that generated the deployment files.

`packageContent` (cli/src/commands/init.ts) now keeps the existing spec only when it's a local dependency (`file:` or `link:`, npm's two local-package protocols). Every registry spec — exact, ranged, tagged, or missing — gets replaced with `cliVersion()`.

## Changes

- `cli/src/commands/init.ts`: added `isLocalDependencySpec`, used it to gate preservation of the existing dependency string.
- `cli/test/init.test.ts`: added a test for `link:` local specs staying untouched, and a test asserting exact/ranged/`latest` specs get replaced with `cliVersion()`.
- `cli/templates/deployment/deployment.md`: corrected the doc to describe the pin accurately, including the local-dependency exception.

## Test plan

- [x] `node --test test/init.test.ts` — 19/19 pass
- [x] `npm run typecheck`
- [x] `npx eslint` on the changed files

Closes #43

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788137488&installation_model_id=19911&pr_number=68&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F68&signature=9edb01c737994e6ddc9df1aa4b99133cfca87b66a8bf9dc6d90cdcdacef49392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->