### PR TITLE
Memory benchmark fails when repository path contains spaces

### DIFF
--- a/adrs/memory-benchmark-path-spaces.md
+++ b/adrs/memory-benchmark-path-spaces.md
@@ -1,0 +1,11 @@
+# Memory benchmark fails when repository path contains spaces
+
+I ran into this while testing on macOS.
+
+If the repo lives in a path with spaces (for example `~/Documents/YC QM/qm`), `npm run bench:memory` fails before it even reaches the model call.
+
+Looks like the file URL is ending up with `%20` instead of being converted back into a filesystem path.
+
+I can reproduce it consistently by cloning into a directory with a space in its name.
+
+Happy to work on a fix if this seems like the right direction.


### PR DESCRIPTION
# Memory benchmark fails when repository path contains spaces

I ran into this while testing on macOS.

If the repo lives in a path with spaces (for example `~/Documents/YC QM/qm`), `npm run bench:memory` fails before it even reaches the model call.

Looks like the file URL is ending up with `%20` instead of being converted back into a filesystem path.

I can reproduce it consistently by cloning into a directory with a space in its name.

Happy to work on a fix if this seems like the right direction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788155973&installation_model_id=19911&pr_number=77&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F77&signature=bbd8411c710ac419180781b85e1ffd970b49873831989ec1893e8cda6fe74bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->