### PR TITLE
Scratch-memory promotion can overwrite newer edits

### DIFF
--- a/adrs/scratch-memory-promotion-cas.md
+++ b/adrs/scratch-memory-promotion-cas.md
@@ -1,0 +1,9 @@
+# Scratch-memory promotion can overwrite newer edits
+
+I noticed a race in scratch-memory promotion.
+
+If promotion starts from revision `r0`, then someone saves a newer revision `r1` while the model is still running, the older promotion can finish later and overwrite that newer edit.
+
+I think promotion should only commit if the revision it started from is still current. Otherwise it should discard the stale result and retry from the latest state.
+
+Does it make sense to make atomic compare-and-set part of the memory store contract?


### PR DESCRIPTION
# Scratch-memory promotion can overwrite newer edits

I noticed a race in scratch-memory promotion.

If promotion starts from revision `r0`, then someone saves a newer revision `r1` while the model is still running, the older promotion can finish later and overwrite that newer edit.

I think promotion should only commit if the revision it started from is still current. Otherwise it should discard the stale result and retry from the latest state.

Does it make sense to make atomic compare-and-set part of the memory store contract?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788158127&installation_model_id=19911&pr_number=79&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F79&signature=ba94463e49a1fed70274d3be9cc1ec4768b9009868ca1988384c1a3a9ccc88a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->