### PR TITLE
Two small gaps in the command redactor

### DIFF
--- a/adrs/redact-command-gaps.md
+++ b/adrs/redact-command-gaps.md
@@ -1,0 +1,20 @@
+# A couple of gaps in the command redactor
+
+Was reading through `redactCommand` in `src/sandbox/exec-process-session.ts`, the function
+that scrubs a command before it gets logged or audited, and noticed two small holes that make
+it do less than it looks like it does.
+
+First, base64url values don't get masked. `createSecretValueMasker` builds redaction needles
+for the raw secret value, the percent-encoded value, and standard base64, but not base64url
+(the `-_` alphabet, usually unpadded). So a secret that shows up in a command in URL-safe
+encoded form, like a JWT-shaped token, gets logged in the clear even though the plain base64
+form would have been caught.
+
+Second, the `--with-token` line is a no-op. `.replace(/(--with-token\b)/gi, "$1")` swaps the
+match for itself, so it does nothing. Either it was meant to redact the token that follows the
+flag, or it's leftover and can just go.
+
+Neither one is a live exploit. This redactor is defense in depth for what ends up in logs and
+audit, not a security boundary. But both are cheap to close, and the audit trail is worth
+keeping clean given how much of the security story leans on it. Happy to send the change if you
+want it.


### PR DESCRIPTION
Adding an ADR for this rather than a diff, per CONTRIBUTING.

Was reading through `redactCommand` in `src/sandbox/exec-process-session.ts`, the function that scrubs a command before it lands in logs or audit, and hit two small holes.

First, base64url values don't get masked. `createSecretValueMasker` makes redaction needles for the raw value, the percent-encoded value, and standard base64, but not base64url (`-_`, usually unpadded). So a secret that appears in a command in URL-safe encoded form, like a JWT-shaped token, gets logged in the clear even though the plain base64 form would have been caught.

Second, the `--with-token` line does nothing. `.replace(/(--with-token\b)/gi, "$1")` replaces the match with itself, so it's a no-op. Either it was meant to redact the token after the flag, or it's leftover and can go.

Neither is a live exploit. It's defense in depth for the audit trail, not a boundary. But both are cheap to close, and the audit trail is worth keeping clean. Happy to send the change if you'd like it.
