### PR TITLE
adr: stop rebuilding the tool_calls primary key on every boot

### DIFF
--- a/adrs/tool-calls-primary-key-rebuild.md
+++ b/adrs/tool-calls-primary-key-rebuild.md
@@ -1,0 +1,23 @@
+# Stop rebuilding the tool_calls primary key on every boot
+
+Looked at this while poking around the run store, following up on #46.
+
+One detail I think makes it worse than the race in that description: `applyDdl` runs each
+statement on its own with no wrapping transaction, so the two ALTERs autocommit separately.
+That means you don't need a concurrent writer to get stuck at all. If the process dies
+between them (OOM, deploy timeout, anything that kills the boot midway) the DROP is already
+committed and there's nothing to roll back. Table sits with no PK, the sibling instance
+writes duplicates into it freely, and every boot after that fails on the ADD.
+
+The same file already has the pattern for this, which is what makes lines 76-77 stand out.
+The migrations above them are already idempotent — the duplicate-running-rows UPDATE matches
+nothing once it's run, the rest are IF NOT EXISTS — and both the directory store and the task
+store guard their one-time DDL in DO $$ blocks. This is the one pair that never got the same
+treatment. Reading the current PK's column list out of pg_constraint and skipping the whole
+thing when it already matches would cover the boot cost, and since a DO block is one
+transaction the drop and add can't come apart the way they can now.
+
+One thing the guard doesn't solve on its own: a database that's already in the broken state
+has duplicate rows in it, so the ADD will keep failing there until they're cleared. Worth
+deciding whether the migration should clean those up itself or whether that stays a manual
+step, since the two answers have pretty different risk profiles.


### PR DESCRIPTION
Notes on #46.

The DROP/ADD pair at the end of the run store schema runs on every boot, but there's a
failure mode the issue doesn't cover: applyDdl has no wrapping transaction, so the two
ALTERs autocommit separately. A process death between them (OOM, deploy timeout) leaves
the table with no primary key permanently, and every boot after that fails on the ADD —
no concurrent writer needed.

The repo already guards one-time DDL this way elsewhere (directory store, task store),
so this is mostly about bringing those two lines in line with the rest.

Text not code, per CONTRIBUTING.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788167261&installation_model_id=19911&pr_number=81&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F81&signature=433a54d7a572b97eab199e1a8a9ddc3d7a455c25071795bfd21ef790fb77a292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->