### PR TITLE
Slack text splitters can cut an emoji or link in half

### DIFF
--- a/adrs/slack-text-splitters.md
+++ b/adrs/slack-text-splitters.md
@@ -1,0 +1,22 @@
+# The Slack text splitters can cut an emoji or a link in half
+
+`slackSectionBlocks` in `src/slack/mrkdwn.ts` chops a long reply into 2900-character section
+blocks with a plain `text.slice` at fixed offsets. That's a UTF-16 code-unit cut, so anything
+above the basic plane gets guillotined at the boundary. An emoji that lands across the 2900
+mark comes out as two lone surrogates, one stranded at the end of one block and the other at the
+start of the next, and Slack renders a replacement box in both. Any reply longer than 2900
+characters can trip this, and long agent replies aren't exactly rare.
+
+The same offset cut also runs straight through a Slack entity like `<https://…|label>` or a
+`*bold*` run, so a link can turn into a raw `<https://…` fragment and a stray asterisk leaks
+into the text.
+
+The naive slice shows up in a couple of neighbours too. `clip` and `inlineCode` in
+`src/slack/util.ts` both truncate with `text.slice(0, max)` and can leave a dangling half-emoji
+sitting right before the `…`. It feels like these want one small shared helper that cuts on a
+safe boundary (a whole code point at minimum, and for the block splitter ideally a newline or
+space, and not inside a `<…>` entity) instead of a raw character offset.
+
+Nothing here is a logic bug, it just produces output that looks broken to whoever's reading in
+Slack, which is the kind of rough edge people notice. Cheap to close. Happy to send the change
+if you want it.


### PR DESCRIPTION
Adding an ADR for this rather than a diff, per CONTRIBUTING.

`slackSectionBlocks` in `src/slack/mrkdwn.ts` chops a long reply into 2900-character section blocks with a plain `text.slice` at fixed offsets. That's a UTF-16 code-unit cut, so anything above the basic plane gets guillotined at the boundary. An emoji that lands across the 2900 mark comes out as two lone surrogates, one at the end of a block and the other at the start of the next, and Slack renders a replacement box in both. Any reply longer than 2900 characters can trip this.

Quick check that it really happens:

```
node -e 's="a".repeat(2899)+"\u{1F600}"; console.log(JSON.stringify(s.slice(0,2900).slice(-2)), JSON.stringify(s.slice(2900).slice(0,2)))'
// "a\ud83d" "\ude00"   <- the emoji is now two broken halves
```

The same offset cut also runs straight through a Slack entity like `<https://…|label>` or a `*bold*` run, so a link can turn into a raw `<https://…` fragment and a stray asterisk leaks into the text.

The naive slice shows up in a couple of neighbours too. `clip` and `inlineCode` in `src/slack/util.ts` both truncate with `text.slice(0, max)` and can leave a dangling half-emoji right before the `…`. Feels like these want one small shared helper that cuts on a safe boundary (a whole code point at minimum, and for the block splitter ideally a newline or space, and not inside a `<…>` entity) instead of a raw character offset.

Nothing here is a logic bug, it just produces output that looks broken to whoever's reading in Slack. Cheap to close. Happy to send the change if you want it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788167939&installation_model_id=19911&pr_number=82&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F82&signature=cd834947253c5d90d011f862512a01684d427d051978f5912945e8a10d24f674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->