### PR TITLE
adr: local dev needs a Slack pool slot with no way in for outside contributors

### DIFF
--- a/adrs/local-dev-without-slack-pool.md
+++ b/adrs/local-dev-without-slack-pool.md
@@ -1,0 +1,5 @@
+Tried to get a local dev instance running on a fresh fork today. npm install worked fine. npm run dev-instance fails though, "no free pool app" / "no poolN.env files in the pool store." Dug into scripts/dev/cli.ts and it looks like dev up always tries to claim a pre-provisioned pool slot, and each slot has real Slack app credentials attached. Makes sense for internal YC use where those slots already exist, but as an outside contributor there's no poolN.env.example and no documented way to mint your own, so local dev is a dead end out of the box.
+
+--sandbox local doesn't help either, that's about where code execution happens, not the Slack token requirement.
+
+Would it make sense to have a Slack-free local mode (skip Slack plugin entirely, just run core + web UI) for people who don't have pool access? Happy to be wrong if I'm missing something.


### PR DESCRIPTION
see adrs/local-dev-without-slack-pool.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788169449&installation_model_id=19911&pr_number=83&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F83&signature=8df80f5c525badb97a702c54490cc2e35a631f2738aa5572ead89bf3342ebff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->