### PR TITLE
Mid-run steer drops attachments

### DIFF
--- a/adrs/mid-run-steer-attachments.md
+++ b/adrs/mid-run-steer-attachments.md
@@ -1,0 +1,26 @@
+# Mid-run steer drops attachments
+
+I opened #48 about this — writing it up here too, per CONTRIBUTING.
+
+If you send a message while a run is still going, only the text reaches the run.
+`app-turn.ts` builds the steer out of `req.text` alone, and the run reads only `s.text`. The
+full request does ride along on the signal, but nothing looks at it until orphan replay,
+which only happens after the run has already died.
+
+So a message with a caption and a file steers the caption, and the file is never seen.
+
+The one that actually bit me is the version with no caption. `routeWake` calls that
+`drop: "empty-mid-turn"`, but `app-turn` still returns `steered: true`, so the Slack handler
+stands down and posts nothing — and by then the file has already been downloaded and staged.
+Nothing happens after that. No reply, ever.
+
+It's easy to hit because it's the shape the agent itself asks for: it says "send me the
+screenshot", you paste the image while it's still working, and that's the end of it.
+
+`test/wake-steering.test.ts` only covers the whitespace-only case with no attachments, so
+none of this trips anything today.
+
+I don't have a strong opinion on the fix. Carrying the attachments through on the signal
+looks natural since the request is already attached to it, but you'd know better whether a
+live run can absorb them mid-turn. At a minimum, a message that has attachments shouldn't be
+counted as empty.


### PR DESCRIPTION
Adding an ADR in `adrs/`, per CONTRIBUTING. Same thing I reported in #48, written up here as
text rather than as a bug ticket.

Short version: a message sent while a run is live only steers its text — attachments are
dropped, and an attachment-only message is treated as empty and disappears entirely, with the
Slack handler standing down because the turn still reports `steered: true`. Easy to hit,
since it's the shape the agent asks for when it says "send me the screenshot".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788177409&installation_model_id=19911&pr_number=89&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F89&signature=82cf5b5f2bd8448c9256ba75618a98a3312c9045db28b2f989152dc400ecea86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->