### PR TITLE
Handle PostgreSQL poll failures in run waitFor

### DIFF
--- a/adrs/postgres-wait-for-poll-failure.md
+++ b/adrs/postgres-wait-for-poll-failure.md
@@ -1,0 +1,9 @@
+# PostgreSQL poll failures in `waitFor`
+
+I ran into this while testing PostgreSQL-backed run completion.
+
+If a polling `getRun` call fails, the error escapes the promise returned by `waitFor()` and can become an unhandled rejection. The polling interval also leaves its timeout scheduled after the run finishes.
+
+I think `waitFor()` should reject with the original database error and clear the poll, timeout, and listener whenever it settles. I am not sure whether transient database errors should be retried first, so it would be good to agree on that behavior.
+
+Happy to work on a fix if the proposed error behavior makes sense.


### PR DESCRIPTION
I ran into this while testing PostgreSQL-backed run completion.

The proposal is in `adrs/postgres-wait-for-poll-failure.md`.

Happy to work on a fix if the proposed error behavior makes sense.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788183792&installation_model_id=19911&pr_number=90&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F90&signature=b52b7b63e752f6a224748709ab4c93b84e4bf1e361ecdb59f4359d12922bde2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->