### PR TITLE
ci(.github): add PR labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,83 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    name: Apply PR labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR from title
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7.0.1
+        with:
+          script: |
+            const title = context.payload.pull_request.title.toLowerCase();
+
+            const typeMap = {
+              enhancement: [
+                /^feat\b/,
+                /^feature\b/,
+                /^perf\b/,
+                /^refactor\b/,
+                /^test\b/,
+                /^chore\b/,
+                /^ci\b/,
+                /^build\b/,
+                /^style\b/,
+              ],
+              bug: [/^fix\b/],
+              documentation: [/^docs\b/],
+            };
+
+            const typeLabels = [];
+            for (const [label, patterns] of Object.entries(typeMap)) {
+              if (patterns.some((pattern) => pattern.test(title))) {
+                typeLabels.push(label);
+                break;
+              }
+            }
+
+            const priorityPatterns = {
+              'priority:high': [
+                /\bpriority\s*:\s*high\b/,
+                /\bhotfix\b/,
+                /\burgent\b/,
+                /\bcritical\b/,
+              ],
+              'priority:low': [
+                /\bpriority\s*:\s*low\b/,
+                /\bminor\b/,
+                /\bnit\b/,
+                /\bpolish\b/,
+              ],
+            };
+
+            let priorityLabel = 'priority:medium';
+            for (const [label, patterns] of Object.entries(priorityPatterns)) {
+              if (patterns.some((pattern) => pattern.test(title))) {
+                priorityLabel = label;
+                break;
+              }
+            }
+
+            const labelsToAdd = [...typeLabels, priorityLabel];
+            if (labelsToAdd.length === 0) {
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: labelsToAdd,
+            });


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically labels pull requests based on the PR title.

### Labels applied
- **Type label** derived from the conventional-commit prefix:
  - `feat`, `feature`, `perf`, `refactor`, `test`, `chore`, `ci`, `build`, `style` → `enhancement`
  - `fix` → `bug`
  - `docs` → `documentation`
- **Priority label** derived from keywords in the title:
  - `priority:high`, `hotfix`, `urgent`, `critical` → `priority:high`
  - `priority:low`, `minor`, `nit`, `polish` → `priority:low`
  - everything else → `priority:medium`

### Design notes
- Uses `pull_request_target` with minimal `pull-requests: write` permission so the workflow can label PRs opened from forks.
- Does not check out the PR branch, so untrusted PR code is never executed in the privileged context.
- Labels are applied via the GitHub API using `actions/github-script`.

### Required labels
The following labels must exist in `yc-software/qm` for the action to apply them:
- `enhancement`, `bug`, `documentation` (already exist)
- `priority:high`, `priority:medium`, `priority:low` (need to be created)

I created the priority labels in my fork as a reference; the suggested colors are `#d73a4a`, `#fbca04`, and `#cfd3d7`.