### PR TITLE
adr: reject unknown top-level config fields

### DIFF
--- a/adrs/config-unknown-top-level-fields.md
+++ b/adrs/config-unknown-top-level-fields.md
@@ -1,0 +1,11 @@
+# Reject unknown top-level fields in qm.config.jsonc
+
+Saw #54 and went looking at the validation to see if it was real. It is.
+
+`validate` in `cli/src/config.ts` (around line 481) reads each known field out of the parsed object individually — `o["contract"]`, `o["orgId"]`, `o["basePort"]`, etc. — but never iterates `Object.keys` to see if there's anything it didn't expect. A misspelled optional field like `baseProt` just sits there unread, and the default kicks in with no feedback.
+
+The pattern for catching this already exists in the same file. `validateSecurityScreen` (line 426) builds a `Set` of allowed keys and throws a `CliError` for anything outside it. The top-level validator never got the same treatment.
+
+One thing worth deciding: error or warning. An error is stricter and catches typos immediately, but it also means a future CLI version adding a new optional field would break configs written for that version if someone runs an older CLI against them. A warning is friendlier for forward compat but easier to miss. The nested objects already chose "error," so matching precedent seems natural — but whether cross-version config compat matters for deployed repos is your call.
+
+Happy to help test whatever direction you pick.


### PR DESCRIPTION
Looked into #54 and verified the gap — writing up the finding and a question about error vs warning, per CONTRIBUTING.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788191779&installation_model_id=19911&pr_number=95&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F95&signature=99422784ddb0bbc004c77bcea1594da917211a9708dda51df0729592370310d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->