### PR TITLE
adr: require publicUrl to be an origin on every target

### DIFF
--- a/adrs/public-url-origin-validation.md
+++ b/adrs/public-url-origin-validation.md
@@ -1,0 +1,13 @@
+# Require publicUrl to be an origin on every target
+
+Saw #55 and checked the config validation to see how publicUrl is handled. The gap is real, and there's an extra wrinkle the issue doesn't mention.
+
+`publicUrl` validation in `cli/src/config.ts` (around line 500) only checks that the value is non-empty and parses as an `http:` or `https:` URL. It doesn't reject paths, query strings, fragments, or credentials. Meanwhile `apiUrl` (line 511) in the same file already does exactly this — it checks `pathname !== "/"`, `search`, `hash`, `username`, `password`, even trailing dots on the hostname.
+
+The check does exist for AWS deployments. `validateAwsFrontDoor` (around line 859) enforces origin-only on publicUrl, but it's gated behind `if (target === "aws")`. Docker and Fly targets never hit it.
+
+The wrinkle: downstream code assumes publicUrl is an origin. `orgEnv()` in `cli/src/services.ts` does `publicUrl.replace(/\/$/, "")` and appends paths directly. `slack-manifests.ts` string-concatenates `/auth/callback` onto it. If someone puts a query string in publicUrl, every URL built from it breaks silently — the appended path lands after the `?`.
+
+Seems like the simplest fix would be to move the origin check from `validateAwsFrontDoor` into the main publicUrl validation block so it applies regardless of target. The `apiUrl` validation is right there as a reference. Whether that's a breaking change for anyone who's currently running with a path in their publicUrl on docker/fly, I'm not sure — you'd have better visibility into that than I would.
+
+Happy to help verify the fix once it's in.


### PR DESCRIPTION
Verified #55 — the origin check exists for AWS but not docker/fly, and downstream code assumes origin-only format. Notes on what breaks and a question about backwards compat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192031&installation_model_id=19911&pr_number=96&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F96&signature=8963500d6520bb46311756aba956d62f1712d86ba8ed0c1ef1747aaf8e886c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->