### PR TITLE
adr: align CLI dotenv parsing with Node --env-file

### DIFF
--- a/adrs/dotenv-parsing-alignment.md
+++ b/adrs/dotenv-parsing-alignment.md
@@ -1,0 +1,15 @@
+# Align CLI dotenv parsing with Node's --env-file
+
+Saw #56 and traced the parser to confirm. Both bugs are there.
+
+`readEnvFile` in `cli/src/util.ts` (line 216) splits on the first `=` and takes everything after it verbatim. No quote stripping, no comment handling. So `TOKEN="abc#def"` gives you `"abc#def"` — literal double quotes included — while Node's `--env-file` gives you `abc#def`. And `VALUE=abc#def` comes back as `abc#def` where Node treats the `#` as an inline comment and gives you `abc`.
+
+There's actually a test that asserts the wrong behavior: `"readEnvFile preserves hashes in unquoted values"` in `cli/test/util.test.ts` explicitly expects `abc#def` from an unquoted hash. That test was written as intentional, but it's documenting the divergence rather than the correct behavior.
+
+One extra thing: there's a second copy of the same parser in `scripts/dev/lib/util.ts` (around line 32) with the same bugs. Whichever direction the fix goes, both copies need it.
+
+The issue mentions `qm secrets set` and the setup writer as callers that would upload values with literal quotes into deployment secrets. That's the real downstream cost — it's not just a cosmetic mismatch, it's data corruption at the boundary between local dev and deployed config.
+
+I don't have a strong view on whether to write a parser from scratch or lean on a well-known package. Node's `--env-file` semantics are documented but have some quirks of their own. Either way, the two copies probably want to become one.
+
+Happy to help test the fix against the edge cases in the issue.


### PR DESCRIPTION
Verified #56 — both bugs confirmed in cli/src/util.ts, plus a duplicate parser in scripts/dev/. Notes on the test that asserts the wrong behavior and the downstream secrets corruption.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192078&installation_model_id=19911&pr_number=97&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F97&signature=49195c651ed4a4ced3fc770928455c79f12e9ec5d9fc97ad982c4ebc0524097b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->