### PR TITLE
adr: detect Slack OIDC by hostname, not substring

### DIFF
--- a/adrs/slack-oidc-hostname-detection.md
+++ b/adrs/slack-oidc-hostname-detection.md
@@ -1,0 +1,13 @@
+# Detect Slack OIDC by hostname, not substring
+
+Saw #58 and checked the code. The substring match is there and it's worse than it sounds at first glance.
+
+`usesSlackOidc` in `cli/src/slack-manifests.ts` (line 37) checks whether any of the four OIDC endpoint env vars contain `"slack.com"` using `.includes()` on the raw URL string. A URL like `https://not-slack.com.example/idp` or `https://evil-slack.com/auth` would match, because the string contains the substring regardless of where the hostname boundary actually falls.
+
+The function drives real behavior: it's called from `cli/src/commands/outputs.ts` (decides whether to render the SSO manifest) and `cli/src/commands/init.ts` (scaffolds the manifest on first setup). So a false match doesn't just log something wrong — it generates a Slack SSO manifest for a non-Slack provider, which is confusing at best.
+
+Worth noting: the actual runtime OIDC verification in `plugins/portal/src/oidc.ts` uses `jose`'s `jwtVerify` with an exact issuer match, so this isn't an auth bypass. It's purely a CLI tooling bug — wrong manifest gets generated, operator sees unexpected Slack SSO files in their output.
+
+The fix direction seems straightforward — parse the URL and compare the hostname — but I'm not sure whether subdomains like `enterprise.slack.com` are valid Slack OIDC issuers or if it's always bare `slack.com`. That would affect whether you do an exact match or an `.endsWith` check.
+
+Happy to help verify once a fix is in.


### PR DESCRIPTION
Verified #58 — .includes("slack.com") on raw URL strings in usesSlackOidc. Notes on what it actually affects and a question about subdomain handling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192212&installation_model_id=19911&pr_number=98&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F98&signature=5548222470f5e5af80f88d8ff0523351aa39b98218e941761096be364a4bef3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->