### PR TITLE
adr: enforce dependency cooldown during CLI bootstrap

### DIFF
--- a/adrs/bootstrap-cooldown-bypass.md
+++ b/adrs/bootstrap-cooldown-bypass.md
@@ -1,0 +1,13 @@
+# Enforce the dependency cooldown during CLI bootstrap
+
+Saw #42 and traced the bootstrap path to see if the cooldown actually applies. It doesn't.
+
+The project's `.npmrc` sets `min-release-age=7`, which tells npm to reject packages published less than seven days ago. But that file lives in the qm source repo root. When a user runs the documented bootstrap command — `npm exec --yes --package=@yc-software/qm@latest -- qm init .` — that runs in their empty deployment directory, which has no `.npmrc`. The qm repo's cooldown is never consulted.
+
+`qm init` then writes the resolved version into `package.json` as an exact dependency (around line 209 of `cli/src/commands/init.ts`), and the subsequent `npm install` locks it — still with no `.npmrc` in the directory, so no age gate on what gets installed.
+
+The scaffolding in `init.ts` and `provider-scaffold.ts` writes `qm.config.jsonc`, `package.json`, `.env.example`, `.gitignore`, `AGENTS.md`, and provider-specific files — but never an `.npmrc`. So even after init, the deployment repo has no cooldown protection for any future `npm install` or `npm update`.
+
+I'm not sure whether the fix is just scaffolding an `.npmrc` with `min-release-age=7`, or whether the bootstrap npm exec itself needs a flag or wrapper to enforce the age check on its own resolution of `@latest`. The second one seems harder since you don't control the user's global npm config. But you'd know better whether there's a mechanism for that.
+
+Happy to help test whichever approach you go with.


### PR DESCRIPTION
Verified #42 — the min-release-age=7 npmrc lives in the source repo but qm init never scaffolds one in the deployment directory. Notes on two possible fix directions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192497&installation_model_id=19911&pr_number=99&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F99&signature=722edbdb2cab93efa358286b707f2a063a5d0106cbc7630e662a8bc9e66006a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->