### PR TITLE
docs: fix non-standard word 'roled' to 'role-based' in src/slack/README.md

### DIFF
--- a/src/slack/README.md
+++ b/src/slack/README.md
@@ -82,7 +82,7 @@ the tokens, core simply runs without Slack.
   with `reactions.add` to the message that triggered the turn — or, when the directive carries an
   `@ <id>` target (`[[react: tada @ ~abc123]]`), to that _specific_ earlier message instead. So the
   agent can resolve a phrase like "react to Alice's last message," each channel turn
-  reconstructs the conversation as structured roled turns (`renderConversationView`, fed by a
+  reconstructs the conversation as structured role-based turns (`renderConversationView`, fed by a
   best-effort `conversations.history`/`replies` fetch that reuses the `channels:history` /
   `groups:history` scopes); every reaction-eligible message carries a **short, stable id** in
   brackets like `[~abc123]` — the message's Slack `ts` packed into base36 (`encodeTs`), written


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `src/slack/README.md` (line 85).

## Problem

"roled" is not a standard English word. It appears to be shorthand for "role-assigned" or "role-based" turns, but without an apostrophe or hyphenation it reads as a typo.

The problematic text:

```markdown
reconstructs the conversation as structured roled turns
```

## Fix

Replaced with:

```markdown
reconstructs the conversation as structured role-based turns
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788192730&installation_model_id=19911&pr_number=100&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F100&signature=d28c1b9d1555426f0c8b3722ee9bc8b600badec462e21125503bcf327f4dfef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->