### PR TITLE
docs: add ADR exploring trust signals for agent selection

### DIFF
--- a/adrs/Trace.txt
+++ b/adrs/Trace.txt
@@ -1,8 +1,8 @@
-So as and when qm grows, I think you'll eventually reach a point where
-multiple agents can satisfy the same prompt. Right now the scheduler appears to choose
-based on capability, but I think it could eventually benefit from
-considering trust signals as well. Like rather than treating every agent equally qm could maintain 
-a lightweight agent metadata such as success rates, policy violations, recent behavioural change, etc.
+As QM grows, I think you’ll eventually reach a point where multiple agents can satisfy the same prompt.
+Right now the scheduler appears to choose based on capability, but it could also benefit from trust signals.
+Rather than treating every agent equally, QM could maintain lightweight per-agent metadata such as
+success rates, policy violations, and recent behavioral changes.
+These signals could provide an additional confidence score that helps the scheduler make better decisions.
 These would simply provide an additional confidence score that helps the scheduler make better decisions.
 
 

--- a/adrs/Trace.txt
+++ b/adrs/Trace.txt
@@ -1,0 +1,12 @@
+So as and when qm grows, I think you'll eventually reach a point where
+multiple agents can satisfy the same prompt. Right now the scheduler appears to choose
+based on capability, but I think it could eventually benefit from
+considering trust signals as well. Like rather than treating every agent equally qm could maintain 
+a lightweight agent metadata such as success rates, policy violations, recent behavioural change, etc.
+These would simply provide an additional confidence score that helps the scheduler make better decisions.
+
+
+Me and my friend explored a similar problem while building Trace, a trust routing system we developed
+as part of our yc application. Trace focused on decentralized agent to agent marketplaces. so its assumptions dont directly
+mirror here, but the idea that may transfer is separating "can execute" from "should execute". I'd be happy to discuss how a 
+lightweight version might fit qm


### PR DESCRIPTION
So as and when qm grows, I think you'll eventually reach a point where
multiple agents can satisfy the same prompt. Right now the scheduler appears to choose
based on capability, but I think it could eventually benefit from
considering trust signals as well. Like rather than treating every agent equally qm could maintain 
a lightweight agent metadata such as success rates, policy violations, recent behavioural change, etc.
These would simply provide an additional confidence score that helps the scheduler make better decisions.


Me and my friend explored a similar problem while building Trace, a trust routing system we developed
as part of our yc application. Trace focused on decentralized agent to agent marketplaces. so its assumptions dont directly
mirror here, but the idea that may transfer is separating "can execute" from "should execute". I'd be happy to discuss how a 
lightweight version might fit qm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788198324&installation_model_id=19911&pr_number=103&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F103&signature=056d63aa98cec0c58db3016827cc359516bfadfe5574811a749e4cb92228f007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->