### PR TITLE
adr: Eden AI as an EU-resident model provider

### DIFF
--- a/adrs/edenai.md
+++ b/adrs/edenai.md
@@ -1,0 +1,35 @@
+# Eden AI as an EU-resident model provider
+
+## Why
+
+There's currently no `MODEL_PROVIDER` value that keeps a turn inside the EU. Anthropic, OpenAI and
+OpenRouter all route outside it, so an org with a data-residency requirement can't adopt qm at all.
+
+That tends to be a hard gate rather than a preference. GDPR makes each cross-border transfer
+something you have to justify, and for European public sector, healthcare and finance teams it's
+usually settled by procurement before anyone gets to evaluate the product. It also isn't only
+about where the datacentre sits: EU teams increasingly want the processor itself under EU
+jurisdiction, which is why routing to a US vendor's EU region doesn't always close the question.
+
+Eden AI is a French AI gateway, backed by Olivier Pomel (Datadog) and Nicolas Dessaigne (Algolia).
+We run a separate EU endpoint, `https://api.eu.edenai.run/v3`, that only serves models meeting
+European residency requirements. It speaks `openai-completions`, so this is a provider id plus
+model cards rather than new request-building code.
+
+Disclosure: I work at Eden AI.
+
+## What
+
+- `edenai` as a fourth `MODEL_PROVIDERS` entry, with `EDENAI_API_KEY` on the same secret-gate path
+  `OPENROUTER_API_KEY` already takes.
+- A curated list (Claude, GPT, Mistral, Qwen, open-weight) rather than all 202 models the endpoint
+  serves, each one verified end to end against the pi harness.
+- Base URL hardcoded with no override, since an escape hatch would just defeat the point.
+- Labels carry the residency guarantee rather than the hub, so a deployment holding both an
+  Anthropic and an Eden AI key shows unambiguous pairs in the picker.
+
+Prototype, if it's useful: https://github.com/SamyMe/qm/tree/edenai-eu-provider
+
+Happy to send over an API key with credits so you can try it without spending anything, just say
+where. Only real open question from my side is how many models you'd want exposed: a curated dozen
+keeps the operator dropdown legible, the full catalog matches how OpenRouter behaves.


### PR DESCRIPTION
Hi! There's no `MODEL_PROVIDER` value today that keeps a turn inside the EU, which is a hard blocker for orgs with a data-residency requirement rather than a nice-to-have. Short notes on adding Eden AI's EU endpoint, plus a question about how many models to expose.

Prototyped it at https://github.com/SamyMe/qm/tree/edenai-eu-provider if that's useful, and happy to send over an API key with credits so you can try it without spending anything. Disclosure: I work at Eden AI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788204841&installation_model_id=19911&pr_number=104&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F104&signature=884b72fd81e14ec5d3c23e9f18587bf5ce94286c148ff1318490ce217814dcee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->