### PR TITLE
docs: propose hostname validation for Slack OIDC

### DIFF
--- a/adrs/slack-oidc-hostname-validation.md
+++ b/adrs/slack-oidc-hostname-validation.md
@@ -1,0 +1,28 @@
+# Validate Slack OIDC endpoints by hostname
+
+I noticed that the Slack OIDC detection currently looks for `slack.com` as a
+substring in the configured endpoint.
+
+That can produce a false positive. For example, an endpoint such as
+`https://not-slack.com.example/idp` would be treated as Slack even though it
+belongs to another identity provider. The CLI could then advertise Slack SSO
+configuration for a deployment that does not use Slack identity.
+
+I think the smallest safe change is to parse each endpoint as a URL and compare
+its hostname against an explicit Slack hostname allowlist. Malformed endpoints
+should fail closed.
+
+The tests could cover:
+
+- the legitimate Slack hostname;
+- any intentionally supported Slack subdomains;
+- a hostname that only contains `slack.com` as a substring;
+- malformed endpoint values;
+- mixed endpoint configurations.
+
+The implementation should also make the mixed-value behavior explicit: a
+malformed or non-Slack value must not turn a non-Slack configuration into a
+Slack configuration, and the accepted URL scheme should be documented.
+
+This keeps the security decision in one shared helper and avoids silently
+generating the wrong authentication setup.


### PR DESCRIPTION
## Proposal

This adds a short ADR proposing hostname-based validation for Slack OIDC endpoint detection.

## Why

The current substring check can classify an unrelated hostname as Slack. That can cause the CLI to generate or advertise the wrong authentication setup.

## Scope

The ADR suggests parsing configured endpoints as URLs, comparing hostnames against an explicit allowlist, failing closed for malformed values, and adding focused tests for exact hosts, subdomains, substring lookalikes, malformed values, and mixed configurations.

This PR intentionally contains only the proposal. It does not change runtime code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788207669&installation_model_id=19911&pr_number=105&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F105&signature=672a7ebda557f91cb21de66d51aff0865137620cb4b97b9cd0cd62b73d1214db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->