### PR TITLE
A claim/heartbeat/release protocol for concurrent scope writes

### DIFF
--- a/adrs/concurrent-scope-writes.md
+++ b/adrs/concurrent-scope-writes.md
@@ -1,0 +1,22 @@
+# A claim/heartbeat/release protocol for concurrent writes to shared scope state
+
+Multiple sessions writing into the same room/scope memory is exactly the failure
+class behind #79 (scratch-memory promotion overwriting newer edits) and the
+durable-map issue in #62 — two agents, or a person and an agent, touching the same
+shared state with no coordination layer between them.
+
+We hit this exact problem running a multi-agent orchestrator that dispatches several
+coding agents into the same workspace concurrently. The fix that's worked for us in
+production: before an agent claims write-ownership of a piece of shared state (a
+file, a worktree, a memory key), it registers a claim with an intent string and a
+scope, sends a heartbeat while working, and releases on exit. A second agent trying
+to claim overlapping scope gets a hard collision instead of a silent overwrite — it
+waits, queues, or negotiates, it doesn't race.
+
+For qm this could sit as a thin layer under durable-map / scratch-memory writes:
+`claim(key, intent) -> write -> release(key)`, with heartbeat-based staleness so a
+crashed agent doesn't hold a claim forever. It generalizes #79 instead of patching
+promotion timing as a one-off, and heads off the same bug class showing up again in
+crons, watches, and multi-agent room work as usage grows. Happy to sketch the
+interface in more detail — this is closer to a battle-tested pattern than an idea for
+us at this point.


### PR DESCRIPTION
Adding `adrs/concurrent-scope-writes.md` per the contributing guide.

Generalizes the failure class behind #79 and #62 (concurrent writes to shared scope state silently overwriting each other) into a claim/heartbeat/release convention. We run this pattern in production for a multi-agent orchestrator and it's held up well.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788210293&installation_model_id=19911&pr_number=106&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F106&signature=762dbc5d0d295a695401c349aebc112adc0d5bf1c21323e2eb1d1a074dffc917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->