### PR TITLE
Generalize secret-schema-drift into a doc-map drift guard

### DIFF
--- a/adrs/doc-map-drift-guard.md
+++ b/adrs/doc-map-drift-guard.md
@@ -1,0 +1,21 @@
+# Generalize secret-schema-drift into a doc-map drift guard
+
+`test/secret-schema-drift.test.ts` already encodes a pattern worth pulling out as a
+general convention: two sources of truth (CLI secret specs and runtime secret specs)
+are checked to stay in agreement instead of trusting someone to update both by hand.
+That's the right instinct — and at 89+ PRs in the first 3 days, qm's docs (README,
+deployment.md, SECURITY.md, docs/getting-started.md, docs/deploy-directory.md,
+cli/README.md, deploy/layers/README.md) are going to drift from the code they
+describe faster than anyone updating them by hand can keep up with. #7, #8, #9, and
+#13 are already docs-vs-reality fixes from the first three days.
+
+The convention we use for this across our own repos is a tiny `doc-map.yaml` per
+protected doc: `doc -> [source files it describes]`. A CI check or session-start hook
+reads it and warns (doesn't block) whenever a source file listed under a doc changes
+without the doc changing in the same PR — cheap, git-diff-only, no LLM call needed
+for the check itself. It's the same idea as secret-schema-drift.test.ts, generalized
+from one pair of files to any doc/source relationship, scoped to a whitelist so it
+never nags about undocumented internals.
+
+This is running in production for us already; happy to describe the exact schema,
+hook trigger, and whitelist rules in more detail if it's a direction you'd want.


### PR DESCRIPTION
Adding `adrs/doc-map-drift-guard.md` per the contributing guide.

Pulls the two-sources-of-truth idea already in `test/secret-schema-drift.test.ts` into a general doc/source drift check (a small `doc-map.yaml` + a warn-only diff check). We run this convention across our own repos.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788210320&installation_model_id=19911&pr_number=107&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F107&signature=c369da78904e763983d2be3a42f55e126fb89a456b1827fece9e461cab2d0601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->