### PR TITLE
Let a deployment point model providers at its own gateway

### DIFF
--- a/src/api/routes/admin/model-providers.ts
+++ b/src/api/routes/admin/model-providers.ts
@@ -1,24 +1,34 @@
-import { isModelProvider, type ModelProvider } from "../../../model/pi-models.ts";
+import { isModelProvider, providerBaseUrl, type ModelProvider } from "../../../model/pi-models.ts";
 import { selectableModelCatalog } from "../../../model/model-catalog.ts";
 import { sendJson } from "../../http.ts";
 import type { ApiCtx } from "../route.ts";
 import { audit, authorizeAdmin, orgScope } from "../shared.ts";
 
-const VALIDATION_REQUESTS: Record<ModelProvider, { url: string; headers: (apiKey: string) => Record<string, string> }> =
-  {
-    anthropic: {
-      url: "https://api.anthropic.com/v1/models",
-      headers: (apiKey) => ({ "x-api-key": apiKey, "anthropic-version": "2023-06-01" }),
-    },
-    openai: {
-      url: "https://api.openai.com/v1/models",
-      headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
-    },
-    openrouter: {
-      url: "https://openrouter.ai/api/v1/key",
-      headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
-    },
-  };
+const VALIDATION_REQUESTS: Record<
+  ModelProvider,
+  { baseUrl: string; path: string; headers: (apiKey: string) => Record<string, string> }
+> = {
+  anthropic: {
+    baseUrl: "https://api.anthropic.com",
+    path: "/v1/models",
+    headers: (apiKey) => ({ "x-api-key": apiKey, "anthropic-version": "2023-06-01" }),
+  },
+  openai: {
+    baseUrl: "https://api.openai.com/v1",
+    path: "/models",
+    headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    path: "/key",
+    headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  },
+};
+
+function validationUrl(provider: ModelProvider): string {
+  const request = VALIDATION_REQUESTS[provider];
+  return `${providerBaseUrl(provider) ?? request.baseUrl}${request.path}`;
+}
 
 async function actor(ctx: ApiCtx) {
   const scope = orgScope(ctx.deps);
@@ -26,10 +36,9 @@ async function actor(ctx: ApiCtx) {
 }
 
 async function validate(ctx: ApiCtx, provider: ModelProvider, apiKey: string): Promise<boolean> {
-  const request = VALIDATION_REQUESTS[provider];
   try {
-    const response = await (ctx.deps.modelCredentialFetch ?? fetch)(request.url, {
-      headers: request.headers(apiKey),
+    const response = await (ctx.deps.modelCredentialFetch ?? fetch)(validationUrl(provider), {
+      headers: VALIDATION_REQUESTS[provider].headers(apiKey),
       signal: AbortSignal.timeout(5_000),
     });
     return response.ok;

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export interface Config {
   anthropicApiKey?: string;
   openaiApiKey?: string;
   openrouterApiKey?: string;
+  providerBaseUrls: Partial<Record<ModelProvider, string>>;
   modelProvider?: ModelProvider;
   piCaptureRequests: boolean;
   piSystemCacheSplit: boolean;
@@ -373,6 +374,21 @@ const DEFAULT_ORG_ID = "default-org";
 
 export function orgId(): string {
   return process.env.ORG_ID ?? DEFAULT_ORG_ID;
+}
+
+const PROVIDER_BASE_URL_ENV: Record<ModelProvider, string> = {
+  anthropic: "ANTHROPIC_BASE_URL",
+  openai: "OPENAI_BASE_URL",
+  openrouter: "OPENROUTER_BASE_URL",
+};
+
+export function providerBaseUrlsFromEnv(env: NodeJS.ProcessEnv): Partial<Record<ModelProvider, string>> {
+  const urls: Partial<Record<ModelProvider, string>> = {};
+  for (const provider of MODEL_PROVIDERS) {
+    const configured = env[PROVIDER_BASE_URL_ENV[provider]]?.trim().replace(/\/+$/, "");
+    if (configured) urls[provider] = configured;
+  }
+  return urls;
 }
 
 export function orgScope(): string {
@@ -727,6 +743,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     ...(env.ANTHROPIC_API_KEY ? { anthropicApiKey: env.ANTHROPIC_API_KEY } : {}),
     ...(env.OPENAI_API_KEY ? { openaiApiKey: env.OPENAI_API_KEY } : {}),
     ...(env.OPENROUTER_API_KEY ? { openrouterApiKey: env.OPENROUTER_API_KEY } : {}),
+    providerBaseUrls: providerBaseUrlsFromEnv(env),
     ...(modelProvider ? { modelProvider } : {}),
     ...(env.ADMIN_GRANTS ? { adminGrants: env.ADMIN_GRANTS } : {}),
     piCaptureRequests: boolEnvStrict("PI_CAPTURE_REQUESTS", env.PI_CAPTURE_REQUESTS) ?? true,

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -20,6 +20,16 @@ export function isHarnessId(value: unknown): value is HarnessId {
   return typeof value === "string" && (HARNESS_IDS as readonly string[]).includes(value);
 }
 
+let configuredBaseUrls: Partial<Record<ModelProvider, string>> = {};
+
+export function setProviderBaseUrls(urls: Partial<Record<ModelProvider, string>>): void {
+  configuredBaseUrls = { ...urls };
+}
+
+export function providerBaseUrl(provider: ModelProvider): string | undefined {
+  return configuredBaseUrls[provider];
+}
+
 type PiModel = Model<Api>;
 
 interface ModelEntry {
@@ -103,10 +113,15 @@ export const SELECTABLE_BASE_MODELS: ReadonlyArray<{ id: string; name: string }>
   (m) => m.base,
 ).map((m) => ({ id: m.id, name: m.name }));
 
+function atConfiguredBaseUrl(model: PiModel): PiModel {
+  const baseUrl = configuredBaseUrls[model.provider as ModelProvider];
+  return baseUrl && baseUrl !== model.baseUrl ? { ...model, baseUrl } : model;
+}
+
 function builtinModel(id: string): PiModel | undefined {
   for (const provider of MODEL_PROVIDERS) {
     const m = getModel(provider, id);
-    if (m) return m;
+    if (m) return atConfiguredBaseUrl(m);
   }
   return undefined;
 }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -238,6 +238,7 @@ import {
   defaultModelForHarness,
   modelProviderAvailabilityFor,
   type HarnessId,
+  setProviderBaseUrls,
 } from "./model/pi-models.ts";
 import { createAdminService, bootAdminGrantSeed, type AdminService } from "./admin/admin-service.ts";
 import { createAdminGrantStore, createMapAdminGrantPersistence, type AdminGrant } from "./admin/admin-grant-store.ts";
@@ -369,6 +370,7 @@ export function buildApp(
     modelCredentialFetch?: typeof fetch;
   } = {},
 ): BuiltApp {
+  setProviderBaseUrls(config.providerBaseUrls);
   if (config.databaseUrl && !config.connectorSecretKey) {
     throw new Error("CONNECTOR_SECRET_KEY is required with durable storage");
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -409,3 +409,15 @@ test("baseModelProviders constrains the base model only when a provider is decla
     "with no declaration the shipped default stands, so upgrading never moves a deployment's model or its billing",
   );
 });
+
+test("provider base urls are read from env and normalized", () => {
+  assert.deepEqual(loadConfig({}).providerBaseUrls, {});
+  assert.deepEqual(
+    loadConfig({
+      ANTHROPIC_BASE_URL: "https://gateway.example.com/",
+      OPENAI_BASE_URL: "  https://oai.example.com/v1//  ",
+    }).providerBaseUrls,
+    { anthropic: "https://gateway.example.com", openai: "https://oai.example.com/v1" },
+  );
+  assert.deepEqual(loadConfig({ OPENROUTER_BASE_URL: "   " }).providerBaseUrls, {});
+});

--- a/test/pi-models.test.ts
+++ b/test/pi-models.test.ts
@@ -13,6 +13,7 @@ import {
   MODEL_PROVIDERS,
   SELECTABLE_BASE_MODELS,
   contextTokenBudgetForModel,
+  setProviderBaseUrls,
 } from "../src/model/pi-models.ts";
 
 test("every selectable base model resolves against the pi-ai registry", () => {
@@ -173,5 +174,33 @@ test("context token budget is half of each model's real input room", () => {
   for (const m of SELECTABLE_BASE_MODELS) {
     const budget = contextTokenBudgetForModel(m.id);
     assert.ok(budget !== undefined && budget >= 60_000, `${m.id} budget ${budget} suspiciously small`);
+  }
+});
+
+test("a configured provider base url replaces the vendor endpoint, including for cloned models", () => {
+  const gateway = "https://gateway.example.com";
+  try {
+    assert.equal(getRequiredModel("claude-opus-4-8").baseUrl, "https://api.anthropic.com");
+    assert.equal(getRequiredModel("claude-opus-5").baseUrl, "https://api.anthropic.com");
+
+    setProviderBaseUrls({ anthropic: gateway });
+
+    assert.equal(getRequiredModel("claude-opus-4-8").baseUrl, gateway, "direct builtin follows the gateway");
+    assert.equal(getRequiredModel("claude-opus-5").baseUrl, gateway, "cloned model inherits the gateway");
+    assert.equal(getRequiredModel("claude-opus-5").id, "claude-opus-5", "the clone keeps its own id");
+    assert.ok(getRequiredModel("gpt-5.6-sol").baseUrl?.startsWith("https://api.openai.com"), "openai untouched");
+  } finally {
+    setProviderBaseUrls({});
+  }
+  assert.equal(getRequiredModel("claude-opus-5").baseUrl, "https://api.anthropic.com", "clearing restores the vendor");
+});
+
+test("each provider is redirected independently", () => {
+  try {
+    setProviderBaseUrls({ openai: "https://oai.example.com/v1" });
+    assert.equal(getRequiredModel("gpt-5.6-sol").baseUrl, "https://oai.example.com/v1");
+    assert.equal(getRequiredModel("claude-opus-5").baseUrl, "https://api.anthropic.com");
+  } finally {
+    setProviderBaseUrls({});
   }
 });


### PR DESCRIPTION
The in-process Pi harness can only ever reach the vendor endpoints. `pi-ai` bakes `baseUrl` into each provider's model record and nothing read an override, so `resolveModel` always returns `https://api.anthropic.com` / `https://api.openai.com/v1` / `https://openrouter.ai/api/v1`.

The child-process harnesses are already in a different position. `config.ts` forwards `ANTHROPIC_BASE_URL` into `claudeProcessEnv` and `OPENAI_BASE_URL` into `codexProcessEnv`, and each vendor SDK honours them. So on a deployment behind a gateway, Claude Code and Codex work and Pi doesn't — a difference in reach that the harness abstraction is otherwise good at hiding. I hit this running QM against a self-hosted Anthropic-compatible gateway: switching the org to Pi silently pointed every request back at the vendor.

Config now parses `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL` and `OPENROUTER_BASE_URL` — the same variables the SDKs read — and `buildApp` hands them to the model registry.

### Where the override lands

In `builtinModel`, not in `resolveModel`'s return. `MODEL_REGISTRY` clones some entries from a template (`claude-opus-5` is a clone of `claude-opus-4-8`), and `cloneModel` spreads the template — so overriding the template covers the clone, while overriding only the direct return path would leave clones pointing at the vendor while their template moved. Everything that issues a request resolves through `builtinModel`, so the agent loop, judge, compaction, title, ack and detect calls all follow one setting.

The value replaces the vendor base URL verbatim. Providers disagree about whether the version prefix belongs in it — anthropic omits `/v1` and pi-harness appends `/v1/messages`, openai includes it — and matching each provider's own convention is what keeps these variables interchangeable with the SDKs that already read them.

### Injection rather than a direct env read

`pi-models.ts` can't import `config.ts`: config already imports pi-models, so it would be a cycle. And reading `process.env` from pi-models is what the repo's own lint rule exists to prevent. So config parses, `buildApp` injects via `setProviderBaseUrls`, and pi-models keeps the resolved value. Threading it through `resolveModel`'s ~15 call sites across 8 files was the alternative; it seemed a lot of surface for a value that is fixed for the process lifetime.

### Admin key validation

`putModelProvider` posted to a hardcoded vendor URL to check a key. Against a gateway that never sees the vendor's key, that fails a key which actually works, so the admin UI refuses to save it. It now resolves through the same setting.

### Verification

`npm run typecheck` and `npm run lint` clean; full root suite 3715 tests, 0 failures. New tests cover the parse (including trailing-slash and whitespace normalization) and the resolution, with the clone case pinned explicitly — that one fails if the override moves to `resolveModel`.

Beyond the suite, this is running on a live single-user deployment pointed at an Anthropic-compatible gateway. With `HARNESS=pi` the agent completes turns and drives the sandbox through the gateway; both Pi and Claude Code are approved on the same org and both execute against the same gateway with no vendor key present anywhere. Before the change the same instance could only run Claude Code.

No screenshot — this is config plumbing with no rendered surface. The only UI it touches is the admin model-provider form, which behaves as it did except that a gateway-issued key now validates.

### Not addressed

`secret-schema.ts` still requires `ANTHROPIC_API_KEY` when the base model is Anthropic. A gateway deployment typically carries its token in `ANTHROPIC_AUTH_TOKEN` (which `claudeChildEnv` already forwards), so it ends up setting both to the same value. Accepting either felt like a separate call about what the schema is asserting, so I left it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788227051&installation_model_id=19911&pr_number=110&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F110&signature=311b4e79e1dcfcbfc046f6cb99027271e77b44d3e85d5849b894f44ad4c8cc31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->