### PR TITLE
Add GitHub Actions workflow to build and push QM Docker image

### DIFF
--- a/.github/workflows/build-and-push-qm.yml
+++ b/.github/workflows/build-and-push-qm.yml
@@ -1,0 +1,46 @@
+name: Build and push QM Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerhub_username:
+        description: 'Docker Hub username (alternatively set DOCKERHUB_USERNAME secret)'
+        required: false
+      dockerhub_token:
+        description: 'Docker Hub access token (alternatively set DOCKERHUB_TOKEN secret)'
+        required: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Get short SHA
+        id: vars
+        run: echo "short_sha=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
+          password: ${{ github.event.inputs.dockerhub_token || secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: deploy/core/Dockerfile
+          push: true
+          tags: |
+            docker.io/${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}/qm:latest
+            docker.io/${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}/qm:${{ steps.vars.outputs.short_sha }}
+          platforms: linux/amd64
+      - name: Output pushed digests
+        run: |
+          echo "Pushed tags:"
+          echo "docker.io/${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}/qm:latest"
+          echo "docker.io/${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}/qm:${{ steps.vars.outputs.short_sha }}"
+          echo "To inspect digest after pull: docker pull <tag> && docker inspect --format='{{{{index .RepoDigests 0}}}}' <tag>"


### PR DESCRIPTION
## Purpose
Add a workflow to build the QM Docker image using `deploy/core/Dockerfile` and push both tags to Docker Hub.

## Changes
- New workflow: `.github/workflows/build-and-push-qm.yml`
- Builds from `deploy/core/Dockerfile`
- Tags: `docker.io/<username>/qm:latest` and `docker.io/<username>/qm:<short-sha>`
- Triggered via `workflow_dispatch` (manual trigger in Actions UI)

## How to use
1. Set repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (or pass them when triggering workflow_dispatch)
2. Go to Actions > Build and push QM Docker image > Run workflow
3. Optionally override username/token in workflow inputs
4. After completion, image digests will be in the job logs

## Notes
- Uses `docker/build-push-action@v4` for multiplatform build support
- Targets `linux/amd64`
- Short SHA is 7 characters from commit hash

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788234095&installation_model_id=19911&pr_number=112&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F112&signature=9c782d2aac5757d4cb4cdde247a2cb20d7e27da559a1cc43f58011324c6b05e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->