### PR TITLE
Let coding agents hand work to QM

### DIFF
--- a/adrs/agent-client-cli.md
+++ b/adrs/agent-client-cli.md
@@ -1,0 +1,24 @@
+# Let coding agents hand work to QM
+
+I spend most of the day in coding agents, and I'd like to hand a job to QM without switching to Slack or the web UI. A small user-facing CLI would give Claude Code, Codex, Cursor, and plain shell scripts one integration instead of needing a plugin for each one.
+
+I think this would make QM useful to a group it does not naturally reach today. Slack and the web are good places to talk to QM, but development teams already live in terminals and coding agents. A CLI turns QM's durable work, company context, credentials, files, and background runs into something those agents can call as part of their normal workflow. It makes QM more than another chat surface: it becomes the place local agents can hand off work that needs organizational context or should keep running after the terminal closes.
+
+Something like this would cover my first use case:
+
+```sh
+qm login https://qm.example.com
+qm ask "investigate this failure" --file ./build.log --detach
+qm run watch <run-id>
+qm run steer <run-id> "also compare the previous release"
+qm run cancel <run-id>
+qm files pull <file-id>
+```
+
+I don't feel strongly about whether these are commands on the existing `qm` binary or a separate client. Reusing `qm` may be less surprising if it can tell whether a command needs a deployment directory.
+
+The important part for me is that login uses the deployment's normal browser identity, with no capability token to copy into a dotfile, and that the CLI never gets more access than the signed-in user. A lost device should be revocable.
+
+Files are also why I'd start with an API client rather than MCP. The CLI can stream bytes between a local path and QM while commands and model context only carry file IDs. Long work can return a run ID immediately, then survive terminal and network disconnects while the client watches or reconnects later.
+
+A useful small first version would be login/logout/whoami, a personal-scope `ask`, file upload/download, and run get/watch/steer/cancel. QM already has the web versions of most of these flows, so I hope the first implementation can reuse those authorization, run, and file boundaries rather than create a second system. Shared scopes, Slack delivery, crons, and MCP can wait until the basic handoff feels good.


### PR DESCRIPTION
## Summary

Propose a user-facing CLI for handing work from coding agents to an existing QM deployment, with browser login, file transfer, and durable run controls.

## Scope

ADR text only, following the repository contribution guide.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788256187&installation_model_id=19911&pr_number=119&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F119&signature=67df272b15a3a0f7ee2e091c5f386eafd31cfc5963af1ed27cc02af8f4c0c15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
