### PR TITLE
Count harness-carried model auth in surface config and admin onboarding

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -6984,19 +6984,20 @@
         const baseModel = config.data.baseModel || config.data.baseModelDefault || "";
         const baseProvider = onboardingProviderForModel(baseModel);
         const baseStatus = onboardingModelStatuses.find((item) => item.provider === baseProvider);
-        onboardingBadge(
-          "onboarding-model-badge",
-          baseStatus?.configured ? "Ready" : "Needs a key",
-          Boolean(baseStatus?.configured),
-        );
+        const harnessAuth = models.data.harnessAuth;
+        const baseHarnessAuth = Boolean(harnessAuth && harnessAuth.provider === baseProvider);
+        const baseReady = Boolean(baseModel) && (Boolean(baseStatus?.configured) || baseHarnessAuth);
+        onboardingBadge("onboarding-model-badge", baseReady ? "Ready" : "Needs a key", baseReady);
         $("onboarding-model-summary").textContent = !baseModel
           ? "No base model is configured yet — pick a provider and model below."
           : baseStatus?.configured
             ? baseModel + " · " + (baseStatus.source === "admin" ? "admin-managed key" : "deployment key")
-            : baseModel +
-              " cannot run until its " +
-              (MODEL_PROVIDER_LABELS[baseProvider] || connectorName(baseProvider)) +
-              " key is configured.";
+            : baseHarnessAuth
+              ? baseModel + " · authenticated by the " + harnessAuth.harnessId + " harness — no API key needed."
+              : baseModel +
+                " cannot run until its " +
+                (MODEL_PROVIDER_LABELS[baseProvider] || connectorName(baseProvider)) +
+                " key is configured.";
         renderOnboardingProviderOptions(baseProvider);
         renderOnboardingModelOptions(baseModel);
 

--- a/plugins/admin/test/onboarding-view.test.ts
+++ b/plugins/admin/test/onboarding-view.test.ts
@@ -28,6 +28,98 @@ function resolveView(pathname: string, search: string): string {
   return vm.runInContext(src, context);
 }
 
+interface FakeElement {
+  textContent: string;
+  className: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  href: string;
+  options: Array<{ value?: string; textContent?: string }>;
+  appendChild(option: { value?: string; textContent?: string }): void;
+}
+
+async function runLoadOnboarding(modelProviders: unknown): Promise<Record<string, FakeElement>> {
+  const src = slice("let onboardingModels = {};", '$("onboarding-model-provider").onchange') + "\nloadOnboarding();";
+  const elements: Record<string, FakeElement> = {};
+  const fixtures: Record<string, unknown> = {
+    "/api/model-providers": modelProviders,
+    "/api/slack-installation": { configured: false },
+    "/api/connector-catalog": { catalog: [] },
+    "/api/scopes/org%3Adefault-org": { baseModel: "claude-opus-5" },
+  };
+  const context = vm.createContext({
+    $: (id: string) =>
+      (elements[id] ??= {
+        textContent: "",
+        className: "",
+        value: "",
+        placeholder: "",
+        disabled: false,
+        href: "",
+        options: [],
+        appendChild(option) {
+          this.options.push(option);
+        },
+      }),
+    api: async (_method: string, path: string) => ({ ok: true, data: fixtures[path] ?? {} }),
+    orgScope: () => "org:default-org",
+    encodeURIComponent,
+    setStatus: () => {},
+    connectorName: (id: string) => id,
+    viewLoadedAt: {},
+    Date,
+    document: { createElement: () => ({}) },
+  });
+  await vm.runInContext(src, context);
+  return elements;
+}
+
+const UNCONFIGURED_PROVIDERS = [
+  { provider: "anthropic", configured: false, source: "absent" },
+  { provider: "openai", configured: false, source: "absent" },
+  { provider: "openrouter", configured: false, source: "absent" },
+];
+const ANTHROPIC_MODELS = [{ id: "claude-opus-5", name: "Claude Opus 5", provider: "anthropic" }];
+
+test("harness-carried auth shows the model step as ready without a stored key", async () => {
+  const elements = await runLoadOnboarding({
+    providers: UNCONFIGURED_PROVIDERS,
+    models: ANTHROPIC_MODELS,
+    harnessAuth: { harnessId: "claude", provider: "anthropic" },
+  });
+  assert.equal(elements["onboarding-model-badge"]!.textContent, "Ready");
+  assert.equal(elements["onboarding-model-badge"]!.className, "badge ok");
+  assert.equal(
+    elements["onboarding-model-summary"]!.textContent,
+    "claude-opus-5 · authenticated by the claude harness — no API key needed.",
+  );
+});
+
+test("without harness auth an unconfigured provider still needs a key", async () => {
+  const elements = await runLoadOnboarding({
+    providers: UNCONFIGURED_PROVIDERS,
+    models: ANTHROPIC_MODELS,
+  });
+  assert.equal(elements["onboarding-model-badge"]!.textContent, "Needs a key");
+  assert.equal(elements["onboarding-model-badge"]!.className, "badge warn");
+  assert.match(elements["onboarding-model-summary"]!.textContent, /cannot run until its Anthropic key is configured/);
+});
+
+test("a stored key keeps its summary even when the harness also carries auth", async () => {
+  const elements = await runLoadOnboarding({
+    providers: [
+      { provider: "anthropic", configured: true, source: "admin" },
+      { provider: "openai", configured: false, source: "absent" },
+      { provider: "openrouter", configured: false, source: "absent" },
+    ],
+    models: ANTHROPIC_MODELS,
+    harnessAuth: { harnessId: "claude", provider: "anthropic" },
+  });
+  assert.equal(elements["onboarding-model-badge"]!.textContent, "Ready");
+  assert.equal(elements["onboarding-model-summary"]!.textContent, "claude-opus-5 · admin-managed key");
+});
+
 test("onboarding is a navigable view", () => {
   assert.match(html, /\{ label: "Admin", views: \["onboarding",/);
 });

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderAvailability } from "../model/pi-models.ts";
+import type { ModelProvider, ModelProviderAvailability } from "../model/pi-models.ts";
 import type { ModelCredentialStore } from "../model/model-credential-store.ts";
 import type { ReplayDedupe } from "../auth/replay-dedupe.ts";
 import type { FetchLike, OAuthClientResolver } from "../connectors/oauth.ts";
@@ -83,6 +83,7 @@ export interface ServerDeps {
   modelCredentialFetch?: typeof fetch;
   brandingDefault?: { accent?: string; mark?: string; selfLabel?: string };
   harnessId?: string;
+  harnessCarriedModelAuth?: ModelProvider;
   admin?: AdminService;
   rateLimiter?: RateLimiter;
   sessions?: SessionStore;

--- a/src/api/routes/admin/model-providers.ts
+++ b/src/api/routes/admin/model-providers.ts
@@ -51,6 +51,9 @@ export async function getModelProviders(ctx: ApiCtx): Promise<void> {
   return sendJson(ctx.res, 200, {
     providers: await ctx.deps.modelCredentials.statuses(),
     models: await selectableModelCatalog(ctx.deps.modelCredentialFetch),
+    ...(ctx.deps.harnessCarriedModelAuth
+      ? { harnessAuth: { harnessId: ctx.deps.harnessId ?? "pi", provider: ctx.deps.harnessCarriedModelAuth } }
+      : {}),
   });
 }
 

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -889,7 +889,9 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
     webuiModels: configuredPicker.length ? configuredPicker : allowed,
     baseModel: resolvedBase,
     harnessId,
-    ...(managedKeys ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) } : {}),
+    ...(managedKeys
+      ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) || Boolean(deps.harnessCarriedModelAuth) }
+      : {}),
     externalSlackParticipants,
     ...(Object.keys(resolvedBranding).length ? { branding: resolvedBranding } : {}),
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,6 +162,16 @@ export function baseModelProviders(config: Config): ModelProviderAvailability | 
   return config.modelProvider ? onlyProvider(config.modelProvider) : undefined;
 }
 
+export function harnessCarriedModelAuth(config: Config): ModelProvider | undefined {
+  if (
+    config.harness === "claude" &&
+    (config.claudeProcessEnv.CLAUDE_CODE_OAUTH_TOKEN || config.claudeProcessEnv.ANTHROPIC_AUTH_TOKEN)
+  )
+    return "anthropic";
+  if (config.harness === "codex" && config.codexProcessEnv.CODEX_ACCESS_TOKEN) return "openai";
+  return undefined;
+}
+
 interface AwsSandboxEnv {
   region: string;
   profile?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { baseModelProviders, configuredModelForHarness, loadConfig, providerKeysPresent } from "./config.ts";
+import {
+  baseModelProviders,
+  configuredModelForHarness,
+  harnessCarriedModelAuth,
+  loadConfig,
+  providerKeysPresent,
+} from "./config.ts";
 import { buildApp, stopWithBackstop } from "./wiring.ts";
 import { createServer } from "./api/server.ts";
 import { errMessage } from "./util/errors.ts";
@@ -8,6 +14,7 @@ import { slackPluginConfigFromEnv, startSlackPlugin } from "./slack/index.ts";
 import { createSlackRuntimeReconciler } from "./surfaces/slack-runtime.ts";
 
 const config = loadConfig();
+const carriedModelAuth = harnessCarriedModelAuth(config);
 
 const built = buildApp(config);
 const envSlackConfig = slackPluginConfigFromEnv(process.env);
@@ -35,6 +42,7 @@ const server = createServer(built.app, {
   modelCredentials: built.modelCredentials,
   ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
   harnessId: config.harness,
+  ...(carriedModelAuth ? { harnessCarriedModelAuth: carriedModelAuth } : {}),
   connectorTokens: built.connectorTokens,
   slackInstallation: built.slackInstallation,
   slackEnvironmentState,

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import { createInsecureTestServer } from "../src/api/server.ts";
 import { buildApp, type BuiltApp } from "../src/wiring.ts";
+import { harnessCarriedModelAuth } from "../src/config.ts";
 import { testConfig } from "./support/test-config.ts";
 import { createModelCredentialStore, type StoredModelCredential } from "../src/model/model-credential-store.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
@@ -22,18 +23,17 @@ function start(
   built: BuiltApp;
   close: () => Promise<void>;
 } {
-  const built = buildApp(
-    testConfig({
-      dataDir: mkdtempSync(join(tmpdir(), "model-credential-route-")),
-      ...config,
-    }),
-    { modelCredentialFetch },
-  );
+  const cfg = testConfig({
+    dataDir: mkdtempSync(join(tmpdir(), "model-credential-route-")),
+    ...config,
+  });
+  const built = buildApp(cfg, { modelCredentialFetch });
   const server = createInsecureTestServer(built.app, {
     config: built.config,
     modelCredentials: built.modelCredentials,
     modelCredentialFetch,
     harnessId: config.harness ?? "pi",
+    ...(harnessCarriedModelAuth(cfg) ? { harnessCarriedModelAuth: harnessCarriedModelAuth(cfg) } : {}),
     providerKeys: {
       anthropic: Boolean(config.anthropicApiKey),
       openai: Boolean(config.openaiApiKey),
@@ -396,6 +396,47 @@ test("surface-config reports whether any model provider is configured", async ()
     await srv.built.modelCredentials.set("anthropic", "working-admin-key", "admin-alice@default-org");
     const after = await fetch(`${srv.base}/v1/surface-config`);
     assert.equal(((await after.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, true);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a claude harness with an OAuth token counts as configured without corrupting store statuses", async () => {
+  const srv = start({
+    harness: "claude",
+    claudeProcessEnv: { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat-test" } as NodeJS.ProcessEnv,
+  });
+  try {
+    const surface = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(surface.status, 200);
+    assert.equal(((await surface.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, true);
+
+    const providers = await fetch(`${srv.base}/v1/admin/model-providers`, { headers: ADMIN });
+    assert.equal(providers.status, 200);
+    const body = (await providers.json()) as {
+      providers: Array<{ provider: string; configured: boolean; source: string }>;
+      harnessAuth?: { harnessId: string; provider: string };
+    };
+    assert.deepEqual(body.harnessAuth, { harnessId: "claude", provider: "anthropic" });
+    assert.deepEqual(
+      body.providers.find((item) => item.provider === "anthropic"),
+      { provider: "anthropic", configured: false, source: "absent" },
+    );
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a claude harness without any token stays unconfigured", async () => {
+  const srv = start({ harness: "claude" });
+  try {
+    const surface = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(surface.status, 200);
+    assert.equal(((await surface.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, false);
+
+    const providers = await fetch(`${srv.base}/v1/admin/model-providers`, { headers: ADMIN });
+    assert.equal(providers.status, 200);
+    assert.equal("harnessAuth" in ((await providers.json()) as Record<string, unknown>), false);
   } finally {
     await srv.close();
   }


### PR DESCRIPTION
## Bug

Running `HARNESS=claude` on a Claude subscription (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`, no `ANTHROPIC_API_KEY`) serves turns fine, but the deployment tells everyone it isn't set up:

- `/v1/surface-config` reports `modelProviderConfigured: false`, so the portal 503s non-admins and bounces admins to onboarding (#29's gate).
- The admin onboarding view says **Needs a key** / "claude-opus-5 cannot run until its Anthropic key is configured" — while the assistant answers happily underneath.

Root cause: both read only the model credential store, which counts anthropic/openai/openrouter API keys (env or admin-managed) and knows nothing about auth the harness carries itself. #67 and #109 both hit this and proposed fixes at different layers.

## Fix

`harnessCarriedModelAuth(config)` in `src/config.ts` names the provider a harness authenticates on its own:

- `claude` → `anthropic` when `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_AUTH_TOKEN` is in `claudeProcessEnv`
- `codex` → `openai` when `CODEX_ACCESS_TOKEN` is in `codexProcessEnv`
- otherwise `undefined` (env API keys are already counted through the credential store's fallback, so they aren't double-counted here)

Wired as an optional `ServerDeps.harnessCarriedModelAuth` and surfaced at the two places that were lying:

- **Surface gate**: `getSurfaceConfig` ORs it into `modelProviderConfigured`. Unlike making `modelProviderAvailabilityFor` unconditionally report claude as available (#109's noted downside), a claude deployment with *no* token anywhere still reports unconfigured and keeps the onboarding gate.
- **Admin API**: `GET /v1/admin/model-providers` gains a sibling `harnessAuth: { harnessId, provider }` field. The credential-store `providers` statuses are deliberately untouched — anthropic keeps reporting `absent` when no key is stored, because those keys feed pi-transport calls and adding/deleting them is independent of harness OAuth. Old admin UI against new core ignores the extra field; new UI against old core sees no `harnessAuth` and behaves exactly as before (blue-green safe).
- **Admin onboarding view**: the model-provider step shows **Ready** when the base model's provider is store-configured *or* harness-authenticated, with the summary "claude-opus-5 · authenticated by the claude harness — no API key needed." Stored-key summaries keep precedence; the key form stays usable for feeding pi-transport.

## Screenshots

Admin → Onboarding, `HARNESS=claude` with only `CLAUDE_CODE_OAUTH_TOKEN`:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/haramiya/qm/screenshots/harness-auth-onboarding/onboarding-before.png) | ![after](https://raw.githubusercontent.com/haramiya/qm/screenshots/harness-auth-onboarding/onboarding-after.png) |

Rendered against the admin page served with realistic stubbed API fixtures (the machine's only dev-instance Slack slot was held by another live instance, so this wasn't exercised on a booted stack; the same states are covered by the tests below).

## Tests

- `test/model-credential-route.test.ts`: claude harness + OAuth token → `modelProviderConfigured: true`, `harnessAuth: { harnessId: "claude", provider: "anthropic" }`, and the anthropic status still `{ configured: false, source: "absent" }`; claude harness with no token → still unconfigured, no `harnessAuth` field. `start()` now derives the dep from the test config the same way `src/index.ts` does.
- `plugins/admin/test/onboarding-view.test.ts`: runs the real `loadOnboarding()` (vm-extracted from `index.html`) against stubbed endpoints — harness auth alone → Ready badge + harness summary; no harness auth → Needs a key; stored admin key + harness auth → Ready with the stored-key summary.

## Verification

- `test/model-credential-route.test.ts` 13/13, `test/external-slack-participants.test.ts` + `test/admin-resources.test.ts` 20/20, `plugins/admin` onboarding suite 7/7
- `tsc --noEmit` (root and plugins/admin), `eslint .`, `prettier --check` — clean (`lint:ox` has a pre-existing missing-native-binding failure locally; CI covers it)
- Independent fresh-context adversarial review of the diff — findings resolved before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788278446&installation_model_id=19911&pr_number=128&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F128&signature=a414c11c9b40df685a1714bb86e6d04132b6fd96247d674861c22ba70f689ae8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->