### PR TITLE
Letting agents say what context they did not have

### DIFF
--- a/adrs/missing-context-in-shared-sessions.md
+++ b/adrs/missing-context-in-shared-sessions.md
@@ -1,0 +1,25 @@
+Hi, here is an idea you may be interested in:
+
+I have built a few multi-agent setups. A design council that ran critiques like a design crit in tech companies, a finance council that supported a trading system, and a procurement swarm with shared state and no leader. Call it "emergence". Each one was set up to reach an agreement while still showing the strong opposing views.
+
+The thing that kept catching me out was not the disagreement, and it was not obvious hallucination. It was quieter than that... I would ask for something, the answer would come back sounding confident and reasonable, and I would only realise later that it had answered a slightly different question. This would lead to the focus drifting, we would often refer to this as going onto a tangent. The explanation was not clear enough for me to spot it unless I already knew the subject well.
+
+Missing context has no error message. It fails by changing the subject.
+
+That was survivable when it was just me, because I knew what I had asked for. But QM is built out of places where context gets handed along. Through multiple scopes, projects, shared channels, handoffs between people. Each one is somewhere context can quietly go missing. Often in a shared session, everyone assumes someone else is checking or is up to date with the latest information. A confident output makes nobody feeling responsible for scrutiny and context can go going missing without a sound. That adds up to a system where mistakes do not get caught unless they are deliberately being investigated or called out on. Perhaps that could depend on the level of seniority of the person reviewing the work itself. 
+
+There have been a few things that have helped me:
+
+Firstly, letting the agent say what it did not have. Not just the answer and the evidence, but what it assumed, what was missing, and what it could not judge as a result. That is exactly what someone joining a session halfway through needs to see, and right now they cannot.
+
+Secondly, surfacing assumptions before it starts rather than after. More context up front beat correcting the output later, every time.
+
+Thirdly, breaking output into smaller pieces. This one surprised me. People have got passive with AI. A wall of confident text invites you to accept it. Smaller chunks give you room to think and push back.
+
+Last but not least, having a retro of the session with the agent(s) in the session to see what went well, what didn't go so well and what could be improved, in  a form of a discussion to then apply those learnings into a playbook. 
+
+But, I also keep a running decisions file, a list of corrections and why I made them. It builds up in a way that re prompting does not. That record probably belongs to the scope, and should travel with a handoff feeding them into a decisions.md or where the context lives in a canvas.md.
+
+I have not solved this. Over flagging is its own failure. If every answer opens with uncertainty, people stop reading it, which is the same problem as an approval step that fires every time. The hard part is only surfacing the gaps that actually matter.
+
+There is a UCL paper by Canhui Liu (arXiv 2606.30986) that names this well. It talks about lossy handoffs, agents that manufacture consensus, and asks directly what uncertainty is lost when context crosses a boundary.


### PR DESCRIPTION
Hi, it's my first time contributing here so apologies if this is not quite the right shape.

I have built a few multi agent systems and kept hitting the same failure, where missing context comes back as a confident answer to a slightly different question rather than an error. I have written what I have seen and a few things that have helped me along the way. I hope it's useful for how QM handles context across scopes and handoffs. 

It might have been something you have covered or perhaps it's a direction that you're not going but I'm interested to hear what you have to say :)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788294821&installation_model_id=19911&pr_number=133&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F133&signature=96d7e803bb181ab77305f57f38d6b2b526b2653d4e5681a6510f1f2b6ddc55c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->