### PR TITLE
adrs: ask for read:packages on the GitHub connector

### DIFF
--- a/adrs/github-connector-read-packages.md
+++ b/adrs/github-connector-read-packages.md
@@ -1,0 +1,24 @@
+# GitHub connector scopes: add read:packages
+
+The GitHub OAuth connector asks for `repo` and `read:org` (src/connectors/oauth.ts). That covers
+the git and REST work, but it misses one thing that comes up constantly: installing dependencies.
+
+We hit this today. An agent opened a PR on one of our repos and then couldn't run typecheck or
+tests, because `pnpm install` pulls a private package from GitHub Packages and got a 401. The
+token it had is fine for cloning the repo and pushing the branch. It just can't read the
+registry. So the agent pushed the branch and said "CI will have to verify this," which is a
+worse outcome than it needed to be.
+
+Any org that keeps private packages in GitHub Packages will hit the same wall, and it's invisible
+until an install fails halfway through a task. Adding `read:packages` to that scopes array fixes
+it. It's read-only and it doesn't widen anything a `repo` token can't already reach.
+
+We're unsure on a couple of points and would defer to you:
+
+- Existing connections keep their old scopes until the user reconnects, so people would need a
+  re-consent to pick this up. Worth a nudge in the UI, or fine to let it happen naturally?
+- If you'd rather not add a scope everyone pays for, the alternative is making the scope list
+  configurable per deployment. That's more work and more surface area, and we'd rather just have
+  the scope.
+
+Happy to send the change if you want it.


### PR DESCRIPTION
Short note in `adrs/` per CONTRIBUTING, rather than a code change.

The GitHub connector requests `repo` and `read:org`. That's enough to clone and push, but not to install dependencies from GitHub Packages, so an agent working in a repo with a private package gets a 401 partway through `pnpm install` and can't run typecheck or tests locally. Asking for `read:packages` as well would fix it.

Details and the two open questions are in the file. Happy to send the change if you want it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788298856&installation_model_id=19911&pr_number=134&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F134&signature=6198b651734c838fa90ade0b7b56b92f97209439b744239f76e73458639a9552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->