### PR TITLE
Fix Skills listing N+1 reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:pg": "node --test --test-concurrency=1 test/postgres-store.test.ts test/postgres-grant-store.test.ts test/postgres-admin-grants.test.ts test/postgres-file-artifact-store.test.ts test/postgres-directory-store.test.ts test/postgres-map.test.ts test/cron-queue.test.ts test/postgres-metrics-sink.test.ts test/postgres-error-log.test.ts test/postgres-audit-log.test.ts test/postgres-budget.test.ts test/postgres-rate-limiter.test.ts test/postgres-credential-usage-sink.test.ts test/postgres-config-store.test.ts test/postgres-delivery-store.test.ts test/postgres-replay-dedupe.test.ts test/postgres-egress-audit-sink.test.ts test/postgres-memory-service.test.ts test/run-signal-store.test.ts test/postgres-run-activity-store.test.ts test/leader-lease.test.ts test/advisory-lock.test.ts test/persistence-init-retry.test.ts test/migrate-principals.test.ts test/postgres-surface-cache.test.ts test/postgres-instance-registry.test.ts",
     "livetest": "node scripts/api-livetest.ts",
     "bench:memory": "node --env-file-if-exists=.env scripts/memory-bench.ts",
+    "bench:skills-visible": "node --env-file-if-exists=.env scripts/skills-visible-bench.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:contract": "tsc -p tsconfig.contract.json",
     "format": "prettier --write --ignore-unknown .",

--- a/scripts/skills-visible-bench.ts
+++ b/scripts/skills-visible-bench.ts
@@ -1,0 +1,198 @@
+import { performance } from "node:perf_hooks";
+import type { DurableMap } from "../src/persistence/durable-map.ts";
+import { createSkillStore, type Skill, type SkillResolution } from "../src/skills/skill-store.ts";
+import { isSafeSkillName } from "../src/skills/skill-name.ts";
+import type { ScopeId } from "../src/types.ts";
+
+class LimitedCountingMap<T> implements DurableMap<T> {
+  allCalls = 0;
+  private activeAll = 0;
+  private readonly queue: Array<() => void> = [];
+  private readonly m = new Map<string, T>();
+  private readonly opts: { allLatencyMs: number; allConcurrency: number };
+
+  constructor(opts: { allLatencyMs: number; allConcurrency: number }) {
+    this.opts = opts;
+  }
+
+  resetCounts(): void {
+    this.allCalls = 0;
+  }
+
+  private async withAllSlot<R>(fn: () => Promise<R>): Promise<R> {
+    if (this.activeAll >= this.opts.allConcurrency) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.activeAll += 1;
+    try {
+      return await fn();
+    } finally {
+      this.activeAll -= 1;
+      this.queue.shift()?.();
+    }
+  }
+
+  async all(): Promise<T[]> {
+    this.allCalls += 1;
+    return this.withAllSlot(async () => {
+      if (this.opts.allLatencyMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, this.opts.allLatencyMs));
+      }
+      return [...this.m.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, v]) => v);
+    });
+  }
+
+  async entries(): Promise<Array<[string, T]>> {
+    return [...this.m.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }
+
+  async get(id: string): Promise<T | null> {
+    return this.m.get(id) ?? null;
+  }
+
+  async put(id: string, value: T): Promise<void> {
+    this.m.set(id, value);
+  }
+
+  async putIfAbsent(id: string, value: T): Promise<T> {
+    const existing = this.m.get(id);
+    if (existing !== undefined) return existing;
+    this.m.set(id, value);
+    return value;
+  }
+
+  async insertIfAbsent(id: string, value: T): Promise<boolean> {
+    if (this.m.has(id)) return false;
+    this.m.set(id, value);
+    return true;
+  }
+
+  async merge(id: string, patch: Partial<T>): Promise<T | null> {
+    const current = this.m.get(id);
+    if (!current) return null;
+    const next = { ...current, ...patch } as T;
+    this.m.set(id, next);
+    return next;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.m.delete(id);
+  }
+
+  async take(id: string): Promise<T | null> {
+    const current = this.m.get(id) ?? null;
+    this.m.delete(id);
+    return current;
+  }
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function skill(id: string, name: string, scopeId: ScopeId): Skill {
+  return {
+    id,
+    scopeId,
+    manifest: { name, description: `Skill ${name}`, requiredCapabilities: [], body: "body" },
+    signature: "bench-signature",
+    status: "published",
+    createdBy: "bench",
+    version: 1,
+    grantedCapabilities: [],
+    approvals: [],
+  };
+}
+
+async function legacyResolve(
+  backing: DurableMap<Skill>,
+  name: string,
+  orderedScopes: ScopeId[],
+): Promise<SkillResolution> {
+  if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
+  const all = await backing.all();
+  const published = orderedScopes
+    .map((sc) => all.find((s) => s.status === "published" && s.manifest.name === name && s.scopeId === sc))
+    .filter((s): s is Skill => Boolean(s));
+  const [winner, ...shadowed] = published;
+  return { skill: winner ?? null, shadowed };
+}
+
+async function legacyVisibleFor(backing: DurableMap<Skill>, orderedScopes: ScopeId[]): Promise<SkillResolution[]> {
+  const inScope = new Set(orderedScopes);
+  const names = [
+    ...new Set(
+      (await backing.all())
+        .filter((s) => s.status === "published" && inScope.has(s.scopeId) && isSafeSkillName(s.manifest.name))
+        .map((s) => s.manifest.name),
+    ),
+  ];
+  const resolved = await Promise.all(names.map((n) => legacyResolve(backing, n, orderedScopes)));
+  return resolved.filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
+}
+
+async function measure(
+  label: string,
+  backing: LimitedCountingMap<Skill>,
+  fn: () => Promise<SkillResolution[]>,
+): Promise<{
+  label: string;
+  ms: number;
+  allCalls: number;
+  visible: number;
+}> {
+  backing.resetCounts();
+  const start = performance.now();
+  const visible = await fn();
+  return { label, ms: performance.now() - start, allCalls: backing.allCalls, visible: visible.length };
+}
+
+const names = envInt("SKILLS_BENCH_NAMES", 200);
+const scopesPerName = envInt("SKILLS_BENCH_SCOPES", 2);
+const allLatencyMs = envInt("SKILLS_BENCH_ALL_LATENCY_MS", 2);
+const allConcurrency = envInt("SKILLS_BENCH_ALL_CONCURRENCY", 8);
+
+const backing = new LimitedCountingMap<Skill>({ allLatencyMs, allConcurrency });
+const store = createSkillStore({ signingSecret: "bench-secret", backing });
+const orderedScopes = Array.from(
+  { length: scopesPerName },
+  (_, i) => (i === 0 ? "personal:U1" : i === 1 ? "org:default-org" : `team:T${i}`) as ScopeId,
+);
+
+for (let i = 0; i < names; i += 1) {
+  const name = `bench-skill-${String(i).padStart(4, "0")}`;
+  for (let s = 0; s < orderedScopes.length; s += 1) {
+    const id = `${s}-${i}`;
+    await backing.put(id, skill(id, name, orderedScopes[s]!));
+  }
+}
+
+const legacy = await measure("legacy visibleFor", backing, () => legacyVisibleFor(backing, orderedScopes));
+const optimized = await measure("optimized visibleFor", backing, () => store.visibleFor(orderedScopes));
+
+const speedup = legacy.ms / Math.max(optimized.ms, 0.001);
+const readReduction = legacy.allCalls / Math.max(optimized.allCalls, 1);
+
+console.log("Skills visibleFor benchmark");
+console.log(
+  JSON.stringify(
+    {
+      names,
+      records: names * scopesPerName,
+      scopesPerName,
+      simulatedAllLatencyMs: allLatencyMs,
+      simulatedAllConcurrency: allConcurrency,
+    },
+    null,
+    2,
+  ),
+);
+for (const row of [legacy, optimized]) {
+  console.log(`${row.label}: ${row.ms.toFixed(1)}ms, all() calls=${row.allCalls}, visible=${row.visible}`);
+}
+console.log(
+  `improvement: ${readReduction.toFixed(1)}x fewer full reads, ${speedup.toFixed(1)}x faster in this fixture`,
+);

--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -213,15 +213,19 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
 
     async visibleFor(orderedScopes) {
       const inScope = new Set(orderedScopes);
-      const names = [
-        ...new Set(
-          (await skills.all())
-            .filter((s) => s.status === "published" && inScope.has(s.scopeId) && isSafeSkillName(s.manifest.name))
-            .map((s) => s.manifest.name),
-        ),
-      ];
-      const resolved = await Promise.all(names.map((n) => this.resolve(n, orderedScopes)));
-      return resolved.filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
+      const all = (await skills.all()).filter(
+        (s) => s.status === "published" && inScope.has(s.scopeId) && isSafeSkillName(s.manifest.name),
+      );
+      const names = [...new Set(all.map((s) => s.manifest.name))];
+      return names
+        .map((name) => {
+          const published = orderedScopes
+            .map((sc) => all.find((s) => s.manifest.name === name && s.scopeId === sc))
+            .filter((s): s is Skill => Boolean(s));
+          const [skill, ...shadowed] = published;
+          return skill ? { skill, shadowed } : null;
+        })
+        .filter((r): r is SkillResolution & { skill: Skill } => r !== null);
     },
 
     async promote(id, targetScopeId) {

--- a/test/skills-visible-performance.test.ts
+++ b/test/skills-visible-performance.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { DurableMap } from "../src/persistence/durable-map.ts";
+import { createSkillStore, type Skill } from "../src/skills/skill-store.ts";
+import type { ScopeId } from "../src/types.ts";
+
+class CountingMap<T> implements DurableMap<T> {
+  allCalls = 0;
+  private readonly m = new Map<string, T>();
+
+  async all(): Promise<T[]> {
+    this.allCalls += 1;
+    return [...this.m.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, v]) => v);
+  }
+
+  async entries(): Promise<Array<[string, T]>> {
+    return [...this.m.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }
+
+  async get(id: string): Promise<T | null> {
+    return this.m.get(id) ?? null;
+  }
+
+  async put(id: string, value: T): Promise<void> {
+    this.m.set(id, value);
+  }
+
+  async putIfAbsent(id: string, value: T): Promise<T> {
+    const existing = this.m.get(id);
+    if (existing !== undefined) return existing;
+    this.m.set(id, value);
+    return value;
+  }
+
+  async insertIfAbsent(id: string, value: T): Promise<boolean> {
+    if (this.m.has(id)) return false;
+    this.m.set(id, value);
+    return true;
+  }
+
+  async merge(id: string, patch: Partial<T>): Promise<T | null> {
+    const current = this.m.get(id);
+    if (!current) return null;
+    const next = { ...current, ...patch } as T;
+    this.m.set(id, next);
+    return next;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.m.delete(id);
+  }
+
+  async take(id: string): Promise<T | null> {
+    const current = this.m.get(id) ?? null;
+    this.m.delete(id);
+    return current;
+  }
+}
+
+function skill(id: string, name: string, scopeId: ScopeId): Skill {
+  return {
+    id,
+    scopeId,
+    manifest: { name, description: `Skill ${name}`, requiredCapabilities: [], body: "body" },
+    signature: "test-signature",
+    status: "published",
+    createdBy: "test",
+    version: 1,
+    grantedCapabilities: [],
+    approvals: [],
+  };
+}
+
+test("visibleFor resolves a large shadowed catalog with one full skills read", async () => {
+  const backing = new CountingMap<Skill>();
+  const store = createSkillStore({ signingSecret: "test-secret", backing });
+  const personal = "personal:U1" as ScopeId;
+  const org = "org:default-org" as ScopeId;
+
+  for (let i = 0; i < 200; i += 1) {
+    const name = `bench-skill-${String(i).padStart(3, "0")}`;
+    await backing.put(`personal-${i}`, skill(`personal-${i}`, name, personal));
+    await backing.put(`org-${i}`, skill(`org-${i}`, name, org));
+  }
+
+  backing.allCalls = 0;
+  const visible = await store.visibleFor([personal, org]);
+
+  assert.equal(visible.length, 200);
+  assert.equal(backing.allCalls, 1, "visibleFor should not call skills.all() once per skill name");
+  assert.equal(visible[0]?.skill.scopeId, personal);
+  assert.equal(visible[0]?.shadowed.length, 1);
+  assert.equal(visible[0]?.shadowed[0]?.scopeId, org);
+});


### PR DESCRIPTION
## Summary

Fixes #138.

The Skills listing path had an N+1 full-table-read pattern: `visibleFor()` read the full skills map once to collect names, then called `resolve()` once per name, and each `resolve()` read the full skills map again. With a large shadowed catalog this can fan out hundreds of `skills.all()` calls for one `/v1/skills?...includeShadowed=1` request and starve DB clients under production background load.

This PR changes `visibleFor()` to:

- read `skills.all()` once per request
- filter visible/published/safe skills in memory
- resolve shadowing from that single snapshot
- preserve most-specific-wins ordering and shadowed skill output

It also adds:

- a regression test proving a 200-name, 2-scope catalog uses exactly one full skills read
- a reproducible benchmark script: `npm run bench:skills-visible`

## Benchmark

Command:

```bash
npm run bench:skills-visible
```

Fixture:

- 200 skill names
- 2 scopes per name
- 400 published skill records total
- simulated `all()` latency: 2ms
- simulated `all()` concurrency: 8

Result from this branch:

```text
legacy visibleFor: 219.7ms, all() calls=201, visible=200
optimized visibleFor: 15.9ms, all() calls=1, visible=200
improvement: 201.0x fewer full reads, 13.8x faster in this fixture
```

## Validation

```bash
node --experimental-test-module-mocks --test \
  test/skills-visible-performance.test.ts \
  test/skills-visible.test.ts \
  test/skill-archive.test.ts
```

Result: 9 passed.

```bash
npm run bench:skills-visible
```

Result: benchmark above.

Note: `npm run typecheck` was attempted in the local agent worktree but the process was killed by the environment OOM killer (`exit 137`) before producing type errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788304408&installation_model_id=19911&pr_number=139&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F139&signature=874f74e7fd440702f9ee679be84059ed923d0a653cf5fe2055e9c8be5e6e19dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->