### PR TITLE
ADR: Microsoft Teams as a surface

### DIFF
--- a/adrs/0003-teams-surface.md
+++ b/adrs/0003-teams-surface.md
@@ -1,0 +1,73 @@
+# ADR-0003: Microsoft Teams as a surface
+
+**Status:** Proposed — asking for scope alignment before any implementation
+**Date:** 2026-08-02
+
+## Context
+
+Slack is currently the only chat surface. Organizations standardized on Microsoft
+365 cannot adopt QM where their work already happens, so for those orgs the web UI
+is the whole product and the collaborative half — channels, group messages, shared
+project scopes — is unavailable.
+
+This is a scope question before it is an engineering one. The README describes QM
+as designed for startups, who skew Slack, so Teams may be deliberately out of
+scope. That answer is worth having recorded either way.
+
+## Decision
+
+If Teams is in scope: build on the **Microsoft 365 Agents SDK**, which has a
+JavaScript/TypeScript client. The Bot Framework SDK it supersedes was archived in
+December 2025 and is no longer maintained, so it is not a viable base for new
+work, and the TeamsFx SDK is in deprecation with community-only support through
+September 2026.
+
+Add Teams as a second in-process surface plugin alongside Slack rather than
+generalizing the Slack plugin first. The surfaces already share the core HTTP API,
+and an abstraction drawn from one implementation tends to fit only that
+implementation; a second concrete surface is what shows where the real seam is.
+`plugins/chassis` is the natural home for anything that turns out to be genuinely
+shared.
+
+## Registration model — this fits QM better than it first appears
+
+An Azure Bot resource is still required as the channel registration: the Teams
+channel is enabled on it, and its client ID goes in the Teams app manifest
+alongside the bot's public domain.
+
+Azure has deprecated the multi-tenant bot type — new registrations must be
+single-tenant or use a user-assigned managed identity. That constraint aligns with
+QM's deployment model rather than fighting it. Every deployment already runs in
+the operator's own cloud account, so each operator registers their own bot in
+their own tenant, exactly as they already own their Slack app, their infrastructure
+and their secrets. No shared multi-tenant registration is needed, and the
+`qm init` flow that already scaffolds provider credentials is the natural place to
+generate the manifest.
+
+## Scale, honestly
+
+The Slack plugin is roughly 7,000 lines across ~40 modules — approvals, cards,
+deliveries, identity, attachments, directives, emoji, conversation views. Teams
+parity is that order of work, plus app-manifest packaging and tenant admin consent
+before anyone can install it.
+
+Adaptive Cards cover the approval surface, but their interaction and update model
+differs from Slack Block Kit enough that approvals need their own design rather
+than a port — approval cards, deferred acks, and the delivery/edit path are where
+the real work is, not message plumbing.
+
+## Consequences
+
+- A second surface at parity is a project, not a feature, and it doubles the
+  surface area for every future change to approvals or delivery.
+- Tenant admin consent puts an org-level gate in front of installation that Slack
+  does not have, which affects onboarding, not just the plugin.
+- The Agents SDK is Microsoft's active line but a young one; the surface-plugin
+  boundary keeps that churn out of core.
+- Done second, it likely reveals which parts of the Slack plugin belong in
+  `plugins/chassis`.
+
+## Open question
+
+Is Teams on the roadmap, and would you take it as a contribution? If it is out of
+scope by design, that is a useful thing for this folder to say.


### PR DESCRIPTION
Adds a short proposed ADR asking whether Teams is in scope, before any implementation.

Mostly a scope question — the README says QM is designed for startups, who skew Slack, so Teams may be deliberately out. Either answer is useful to have recorded.

If it is in scope, the ADR argues for the Microsoft 365 Agents SDK (the Bot Framework SDK was archived in December 2025) and notes that Azure's deprecation of the multi-tenant bot type actually fits QM's model — every deployment already runs in the operator's own account, so single-tenant registration per operator is the natural shape. It's honest about scale: Slack-plugin parity is ~7k lines plus manifest packaging and tenant admin consent.

This PR adds only the ADR; it does not change production code.

Drafted with Claude Code and reviewed by me — flagging that given the note in CONTRIBUTING.md; happy to rewrite as informal prose if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788320352&installation_model_id=19911&pr_number=143&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F143&signature=2ec4f80fbd76a54ba46aaceb1e06fe1d35e86c83331004f67c0e4e220e0ef1f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->