### PR TITLE
adr: require SPRITES_TOKEN on fresh fly deploys

### DIFF
--- a/adrs/fly-sprites-token.md
+++ b/adrs/fly-sprites-token.md
@@ -1,6 +1,14 @@
 Fresh fly deploys crash-loop with no warning: the CLI's secret check never
 sees the sprites backend value the runtime derives, so it never asks for
-SPRITES_TOKEN. I'd add the missing entry to the fly defaults table like the
-AWS one has, and maybe check if other secrets have the same blind spot.
+SPRITES_TOKEN.
 
-Context: https://github.com/yc-software/qm/issues/130
+Update after PR feedback: cdolan-personal hit the same crash on the
+docker target — setting the typed sandbox.backend: "sprites" field doesn't
+register the requirement either, since the check only reads the raw env
+var. So instead of just adding the missing entry to the fly defaults
+table like the AWS one has, the fix I'd propose is keying the
+SPRITES_TOKEN requirement off the resolved backend, so every target is
+covered. Still worth checking if other secrets have the same blind spot.
+
+Context: https://github.com/yc-software/qm/issues/130 and the comments on
+this PR.

--- a/adrs/fly-sprites-token.md
+++ b/adrs/fly-sprites-token.md
@@ -1,0 +1,6 @@
+Fresh fly deploys crash-loop with no warning: the CLI's secret check never
+sees the sprites backend value the runtime derives, so it never asks for
+SPRITES_TOKEN. I'd add the missing entry to the fly defaults table like the
+AWS one has, and maybe check if other secrets have the same blind spot.
+
+Context: https://github.com/yc-software/qm/issues/130


### PR DESCRIPTION
Note in adrs/ per CONTRIBUTING, for #130.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788324213&installation_model_id=19911&pr_number=145&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F145&signature=7241b2e07fe271d192b62e1407df2489d5dde113dd5f938d53c8b549bbdebdb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->