### PR TITLE
Recover PostgreSQL session pools after connection failures

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -25,8 +25,30 @@ import { deploymentLayerRoutes } from "./deployment-layer.ts";
 import { egressAuditRoutes } from "./egress-audit.ts";
 import { authBrokerRoutes } from "./auth-broker.ts";
 
+const HEALTH_TIMEOUT_MS = 1_500;
+
 export const rawRoutes: ReadonlyArray<Route<BaseCtx>> = [
-  { method: "GET", path: "/healthz", auth: "public", handle: ({ res }) => sendJson(res, 200, { ok: true }) },
+  {
+    method: "GET",
+    path: "/healthz",
+    auth: "public",
+    handle: async ({ res, deps }) => {
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        await Promise.race([
+          deps.sessions?.health?.(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error("health check timed out")), HEALTH_TIMEOUT_MS);
+          }),
+        ]);
+        sendJson(res, 200, { ok: true });
+      } catch {
+        sendJson(res, 503, { ok: false });
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    },
+  },
   {
     match: (m, p) => (m === "GET" || m === "POST") && p.startsWith(GIT_HTTP_BROKER_PREFIX),
     auth: { aud: "credential-broker" },

--- a/src/directory/postgres-directory-store.ts
+++ b/src/directory/postgres-directory-store.ts
@@ -1,6 +1,6 @@
 import { orgId as configOrgId } from "../config.ts";
 import { createHash } from "node:crypto";
-import { createPgPool, type PoolClient, withPgTransaction } from "../persistence/pg-pool.ts";
+import { createPgPool, type PoolClient } from "../persistence/pg-pool.ts";
 import type { PrincipalType } from "../types.ts";
 import { personKey } from "./person.ts";
 import {
@@ -138,7 +138,8 @@ function dedupMemberships(rows: ChannelMembership[]): ChannelMembership[] {
 }
 
 export function createPostgresDirectoryStore(connectionString: string): DirectoryStore {
-  const { q, pool } = createPgPool(connectionString, SCHEMA);
+  const db = createPgPool(connectionString, SCHEMA);
+  const { q } = db;
   const orgId = configOrgId();
 
   async function pick<T>(
@@ -184,7 +185,7 @@ export function createPostgresDirectoryStore(connectionString: string): Director
     hash: string,
     write: (client: PoolClient) => Promise<void>,
   ): Promise<void> {
-    await withPgTransaction(await pool(), async (client) => {
+    await db.transaction(async (client) => {
       await client.query("SELECT pg_advisory_xact_lock(hashtext('directory'), hashtext($1))", [orgId]);
       const sync = await client.query(`SELECT ${hashCol} FROM directory_sync WHERE org_id = $1`, [orgId]);
       if (sync.rows[0]?.[hashCol] === hash) return;
@@ -334,7 +335,7 @@ export function createPostgresDirectoryStore(connectionString: string): Director
     async upsertGroup(groupId, principalIds) {
       const ids = [...new Set(principalIds.filter(Boolean))];
       if (!groupId || !ids.length) return;
-      await withPgTransaction(await pool(), async (client) => {
+      await db.transaction(async (client) => {
         await client.query("SELECT pg_advisory_xact_lock(hashtext('directory'), hashtext($1))", [orgId]);
         await client.query("DELETE FROM directory_group_members WHERE org_id = $1 AND group_id = $2", [orgId, groupId]);
         await client.query(

--- a/src/memory/postgres-memory-service.ts
+++ b/src/memory/postgres-memory-service.ts
@@ -1,4 +1,4 @@
-import { createPgPool, withPgTransaction } from "../persistence/pg-pool.ts";
+import { createPgPool } from "../persistence/pg-pool.ts";
 import { foldCapture, normalizeReplace, queryBullets, recallBody, type MemoryService } from "./memory-service.ts";
 
 const SCHEMA = [
@@ -16,7 +16,8 @@ const SCHEMA = [
 ];
 
 export function createPostgresMemoryService(connectionString: string): MemoryService {
-  const { q, pool } = createPgPool(connectionString, SCHEMA);
+  const db = createPgPool(connectionString, SCHEMA);
+  const { q } = db;
 
   async function currentBody(scopeId: string): Promise<string> {
     const rows = await q("SELECT body FROM memory_revisions WHERE scope_id = $1 ORDER BY seq DESC LIMIT 1", [scopeId]);
@@ -39,19 +40,14 @@ export function createPostgresMemoryService(connectionString: string): MemorySer
     author: string | undefined,
     op: string,
   ): Promise<boolean> {
-    const client = await (await pool()).connect();
-    try {
-      await client.query("BEGIN");
+    return db.transaction(async (client) => {
       await client.query("SELECT pg_advisory_xact_lock(hashtext('memory'), hashtext($1))", [scopeId]);
       const head = await client.query(
         "SELECT body, seq FROM memory_revisions WHERE scope_id = $1 ORDER BY seq DESC LIMIT 1",
         [scopeId],
       );
       const seq = Number(head.rows[0]?.seq ?? 0);
-      if (seq !== expectedSeq) {
-        await client.query("ROLLBACK");
-        return false;
-      }
+      if (seq !== expectedSeq) return false;
       const next = normalizeReplace(content);
       if (next !== String(head.rows[0]?.body ?? "")) {
         await client.query(
@@ -59,14 +55,8 @@ export function createPostgresMemoryService(connectionString: string): MemorySer
           [scopeId, seq + 1, op, next, author ?? null, Date.now()],
         );
       }
-      await client.query("COMMIT");
       return true;
-    } catch (e) {
-      await client.query("ROLLBACK");
-      throw e;
-    } finally {
-      client.release();
-    }
+    });
   }
 
   async function append(
@@ -76,7 +66,7 @@ export function createPostgresMemoryService(connectionString: string): MemorySer
     author: string | undefined,
     derive: (existing: string) => { body: string } | null,
   ): Promise<void> {
-    await withPgTransaction(await pool(), async (client) => {
+    await db.transaction(async (client) => {
       await client.query("SELECT pg_advisory_xact_lock(hashtext('memory'), hashtext($1))", [scopeId]);
       const head = await client.query(
         "SELECT body, seq FROM memory_revisions WHERE scope_id = $1 ORDER BY seq DESC LIMIT 1",

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -1,4 +1,4 @@
-import type { Pool, PoolClient } from "pg";
+import type { Pool, PoolClient, QueryConfig } from "pg";
 import { swallowAs } from "../util/errors.ts";
 
 export type { Pool, PoolClient };
@@ -8,23 +8,47 @@ export type Rows = Record<string, unknown>[];
 export interface PgPool {
   pool(): Promise<Pool>;
   q(text: string, params?: unknown[]): Promise<Rows>;
-  query(text: string, params?: unknown[]): Promise<{ rows: Rows; rowCount: number }>;
+  query(text: string, params?: unknown[], timeoutMs?: number): Promise<{ rows: Rows; rowCount: number }>;
+  transaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T>;
   schema?(schemaSql: string): Promise<void>;
   close(): Promise<void>;
 }
 
-export async function withPgTransaction<T>(pool: Pool, fn: (client: PoolClient) => Promise<T>): Promise<T> {
-  const client = await pool.connect();
+const CONNECTION_ERROR_CODES = new Set(["57P01", "57P02", "57P03"]);
+const RETIRED_POOL_POLL_MS = 50;
+
+function isConnectionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = "code" in error && typeof error.code === "string" ? error.code : "";
+  if (code.startsWith("08") || CONNECTION_ERROR_CODES.has(code)) return true;
+  const message = "message" in error && typeof error.message === "string" ? error.message : "";
+  return /connection terminated|closed the connection|econnreset|econnrefused|epipe|etimedout/i.test(message);
+}
+
+export async function withPgTransaction<T>(
+  pool: Pool,
+  fn: (client: PoolClient) => Promise<T>,
+  onFailure?: (error: unknown) => void,
+): Promise<T> {
+  let client: PoolClient | null = null;
   try {
+    client = await pool.connect();
     await client.query("BEGIN");
     const result = await fn(client);
     await client.query("COMMIT");
     return result;
   } catch (error) {
-    await client.query("ROLLBACK");
+    if (client) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        onFailure?.(rollbackError);
+      }
+    }
+    onFailure?.(error);
     throw error;
   } finally {
-    client.release();
+    client?.release();
   }
 }
 
@@ -58,12 +82,51 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
   const schema = statements.map((s) => s.trim()).filter((s) => s.length > 0);
   for (const stmt of schema) assertOneStatement(stmt);
   let poolP: Promise<Pool> | null = null;
+  let closed = false;
+  const retiredPools = new Set<Pool>();
+  const closingPools = new Map<Pool, Promise<void>>();
+  function endPool(target: Pool): Promise<void> {
+    const existing = closingPools.get(target);
+    if (existing) return existing;
+    const closing = target.end().finally(() => {
+      retiredPools.delete(target);
+      closingPools.delete(target);
+    });
+    closingPools.set(target, closing);
+    return closing;
+  }
+  function closeWhenDrained(target: Pool): void {
+    if (!retiredPools.has(target)) return;
+    if (target.waitingCount > 0) {
+      const timer = setTimeout(() => closeWhenDrained(target), RETIRED_POOL_POLL_MS);
+      timer.unref();
+      return;
+    }
+    void endPool(target).catch(swallowAs("pg-pool: close retired pool", undefined));
+  }
+  function retirePool(failed: Pool): void {
+    const active = poolP;
+    if (!active) return;
+    void active.then(
+      (current) => {
+        if (current !== failed || poolP !== active) return;
+        poolP = null;
+        retiredPools.add(failed);
+        closeWhenDrained(failed);
+      },
+      () => undefined,
+    );
+  }
   function pool(): Promise<Pool> {
+    if (closed) return Promise.reject(new Error("pg-pool: closed"));
     if (!poolP) {
       poolP = (async () => {
         const pg = (await import("pg")).default;
         const p = new pg.Pool({ connectionString });
-        p.on("error", (err) => console.error("[pg] idle client error:", err));
+        p.on("error", (err) => {
+          console.error("[pg] idle client error; retiring pool:", err);
+          retirePool(p);
+        });
         try {
           await applyDdl(p, schema);
         } catch (e) {
@@ -78,20 +141,56 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
     }
     return poolP;
   }
-  async function query(text: string, params: unknown[] = []): Promise<{ rows: Rows; rowCount: number }> {
-    const res = await (await pool()).query(text, params);
-    return { rows: res.rows as Rows, rowCount: res.rowCount ?? 0 };
+  async function query(
+    text: string,
+    params: unknown[] = [],
+    timeoutMs?: number,
+  ): Promise<{ rows: Rows; rowCount: number }> {
+    const current = await pool();
+    try {
+      const res = timeoutMs
+        ? await current.query({ text, values: params, query_timeout: timeoutMs } as QueryConfig & {
+            query_timeout: number;
+          })
+        : await current.query(text, params);
+      return { rows: res.rows as Rows, rowCount: res.rowCount ?? 0 };
+    } catch (error) {
+      if (timeoutMs || isConnectionError(error)) retirePool(current);
+      throw error;
+    }
   }
   async function q(text: string, params: unknown[] = []): Promise<Rows> {
     return (await query(text, params)).rows;
   }
+  async function transaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const current = await pool();
+    return withPgTransaction(current, fn, (error) => {
+      if (isConnectionError(error)) retirePool(current);
+    });
+  }
   async function close(): Promise<void> {
-    if (poolP) await (await poolP).end();
+    if (closed) return;
+    closed = true;
+    const active = poolP;
+    poolP = null;
+    let initError: unknown;
+    const targets = new Set(retiredPools);
+    if (active) {
+      try {
+        targets.add(await active);
+      } catch (error) {
+        initError = error;
+      }
+    }
+    const results = await Promise.allSettled([...targets].map(endPool));
+    const closeError = results.find((result): result is PromiseRejectedResult => result.status === "rejected")?.reason;
+    if (initError) throw initError;
+    if (closeError) throw closeError;
   }
   async function applySchema(schemaSql: string): Promise<void> {
     const stmt = schemaSql.trim();
     assertOneStatement(stmt);
     await applyDdl(await pool(), [stmt]);
   }
-  return { pool, q, query, schema: applySchema, close };
+  return { pool, q, query, transaction, schema: applySchema, close };
 }

--- a/src/sessions/postgres-session-store.ts
+++ b/src/sessions/postgres-session-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { createPgPool, type PoolClient, withPgTransaction } from "../persistence/pg-pool.ts";
+import { createPgPool, type PoolClient } from "../persistence/pg-pool.ts";
 import { jsonbSafeStringify } from "../util/text.ts";
 import type { Session, SessionEntry, SessionType, ScopeId } from "../types.ts";
 import type {
@@ -149,7 +149,7 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
                   ELSE NULL END
         FROM (SELECT safe_json(replace(${col}, '\\u0000', '')) AS j) _)`;
 
-  const { pool, q } = createPgPool(connectionString, [
+  const db = createPgPool(connectionString, [
     `CREATE OR REPLACE FUNCTION safe_json(t text) RETURNS json
         LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE AS $safe_json$
         BEGIN RETURN t::json; EXCEPTION WHEN others THEN RETURN NULL; END $safe_json$`,
@@ -243,9 +243,10 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
       WHERE s.messages IS NULL
          OR ${lastActivityExpr("s")} > (EXTRACT(EPOCH FROM now()) * 1000)::bigint - 172800000`,
   ]);
+  const { q } = db;
 
   const withLease = async <T>(lease: Lease, invalidMsg: string, fn: (client: PoolClient) => Promise<T>): Promise<T> =>
-    withPgTransaction(await pool(), async (client) => {
+    db.transaction(async (client) => {
       const held = await client.query("SELECT token FROM session_leases WHERE session_id = $1 FOR UPDATE", [
         lease.sessionId,
       ]);
@@ -289,6 +290,14 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
   };
 
   return {
+    async health(): Promise<void> {
+      await db.query("SELECT 1", [], 1_000);
+    },
+
+    async close(): Promise<void> {
+      await db.close();
+    },
+
     async getOrCreateByThread(threadRef, type, scopeId, channelName, surface): Promise<Session> {
       const heal = async (row: Record<string, unknown>): Promise<Session> => {
         const s = rowToSession(row);
@@ -574,7 +583,7 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
     },
 
     async deleteSession(sessionId): Promise<void> {
-      await withPgTransaction(await pool(), async (client) => {
+      await db.transaction(async (client) => {
         await client.query("DELETE FROM session_llm_requests WHERE session_id = $1", [sessionId]);
         await client.query("DELETE FROM session_leases WHERE session_id = $1", [sessionId]);
         await client.query("DELETE FROM participants WHERE session_id = $1", [sessionId]);

--- a/src/sessions/session-store.ts
+++ b/src/sessions/session-store.ts
@@ -323,6 +323,9 @@ interface AddParticipantOptions {
 }
 
 export interface SessionStore {
+  health?(): Promise<void>;
+  close?(): Promise<void>;
+
   getOrCreateByThread(
     threadRef: string,
     type: SessionType,

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -1352,6 +1352,12 @@ export function buildApp(
       );
       await Promise.all(workers.map((w) => w.releaseInFlight()));
       drain.stop();
+      if (sessions.close) {
+        await Promise.race([
+          sessions.close(),
+          sleep(config.shutdownDrainMs).then(() => Promise.reject(new Error("session store close timed out"))),
+        ]).catch(swallowAs("wiring: session store close failed", undefined));
+      }
       runs.close?.();
       void runSignals.close?.();
       void sessionStateBus.close?.();

--- a/test/healthz.test.ts
+++ b/test/healthz.test.ts
@@ -1,0 +1,78 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+async function withServer(health: () => Promise<void>, run: (base: string) => Promise<void>): Promise<void> {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "healthz-")) }));
+  const sessions = built.sessions as typeof built.sessions & { health: () => Promise<void> };
+  sessions.health = health;
+  const server = createInsecureTestServer(built.app, { sessions });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    await run(base);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test("healthz checks the configured session store", async () => {
+  let calls = 0;
+  await withServer(
+    async () => {
+      calls++;
+    },
+    async (base) => {
+      const response = await fetch(`${base}/healthz`);
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), { ok: true });
+    },
+  );
+  assert.equal(calls, 1);
+});
+
+test("healthz reports an unavailable session database without leaking the failure", async () => {
+  await withServer(
+    async () => {
+      throw new Error("postgres://secret-host/internal");
+    },
+    async (base) => {
+      const response = await fetch(`${base}/healthz`);
+      assert.equal(response.status, 503);
+      const body = await response.text();
+      assert.deepEqual(JSON.parse(body), { ok: false });
+      assert.doesNotMatch(body, /secret-host/);
+    },
+  );
+});
+
+test("healthz times out a hanging session database before the deployment probe", async () => {
+  await withServer(
+    () => new Promise<void>(() => {}),
+    async (base) => {
+      const started = Date.now();
+      const response = await fetch(`${base}/healthz`);
+      assert.equal(response.status, 503);
+      assert.ok(Date.now() - started < 1_900);
+    },
+  );
+});
+
+test("runtime stop continues when session store close hangs", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "runtime-stop-")) }));
+  const sessions = built.sessions as typeof built.sessions & { close: () => Promise<void> };
+  sessions.close = () => new Promise<void>(() => {});
+  const started = Date.now();
+
+  await built.runtime.stop();
+
+  assert.ok(Date.now() - started < 1_000);
+});

--- a/test/persistence-init-retry.test.ts
+++ b/test/persistence-init-retry.test.ts
@@ -21,6 +21,7 @@ function flakyPgPool(failures: number): PgPool {
     pool: () => Promise.reject(new Error("not backed by a real pool")),
     query,
     q: async (text, params) => (await query(text, params ?? [])).rows,
+    transaction: () => Promise.reject(new Error("not backed by a real pool")),
     close: async () => {},
   };
 }
@@ -65,10 +66,12 @@ test("pg pool: a failed init is retried with a fresh attempt (rejection not cach
   await pg.close();
 });
 
-test("pg pool: an idle-client 'error' is logged, not fatal", { skip }, async () => {
+test("pg pool: an idle-client error retires the pool without becoming fatal", { skip }, async () => {
   const pg = createPgPool(URL!, ["SELECT 1"]);
   const pool = await pg.pool();
   assert.doesNotThrow(() => pool.emit("error", new Error("backend died")));
-  assert.deepEqual((await pg.query("SELECT 1 AS one")).rows, [{ one: 1 }], "pool keeps serving queries");
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.notEqual(await pg.pool(), pool, "the next checkout creates a healthy pool");
+  assert.deepEqual((await pg.query("SELECT 1 AS one")).rows, [{ one: 1 }]);
   await pg.close();
 });

--- a/test/pg-pool-recovery.test.ts
+++ b/test/pg-pool-recovery.test.ts
@@ -1,0 +1,147 @@
+import { EventEmitter } from "node:events";
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+class FakeClient {
+  queryErrors = new Map<string, Error>();
+
+  async query(text: string): Promise<{ rows: Record<string, unknown>[]; rowCount: number }> {
+    const error = this.queryErrors.get(text);
+    if (error) {
+      this.queryErrors.delete(text);
+      throw error;
+    }
+    return { rows: [], rowCount: 0 };
+  }
+
+  release(): void {}
+}
+
+class FakePool extends EventEmitter {
+  static instances: FakePool[] = [];
+
+  config: Record<string, unknown>;
+  ended = false;
+  endCalls = 0;
+  waitingCount = 0;
+  nextQueryError: Error | null = null;
+  client = new FakeClient();
+
+  constructor(config: Record<string, unknown>) {
+    super();
+    this.config = config;
+    FakePool.instances.push(this);
+  }
+
+  async connect(): Promise<FakeClient> {
+    return this.client;
+  }
+
+  async query(): Promise<{ rows: Record<string, unknown>[]; rowCount: number }> {
+    if (this.nextQueryError) {
+      const error = this.nextQueryError;
+      this.nextQueryError = null;
+      throw error;
+    }
+    return { rows: [{ one: 1 }], rowCount: 1 };
+  }
+
+  async end(): Promise<void> {
+    this.endCalls++;
+    this.ended = true;
+  }
+}
+
+mock.module("pg", { defaultExport: { Pool: FakePool } });
+
+const { createPgPool } = await import("../src/persistence/pg-pool.ts");
+
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+test("an idle-client error retires the pool before the next checkout", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const first = (await db.pool()) as unknown as FakePool;
+
+  first.emit("error", new Error("Connection terminated unexpectedly"));
+  await settle();
+
+  const second = (await db.pool()) as unknown as FakePool;
+  assert.notEqual(second, first);
+  assert.equal(first.ended, true);
+  assert.deepEqual((await db.query("SELECT 1 AS one")).rows, [{ one: 1 }]);
+  await db.close();
+});
+
+test("normal pool checkouts do not inherit the health-check timeout", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const pool = (await db.pool()) as unknown as FakePool;
+
+  assert.equal(pool.config.connectionTimeoutMillis, undefined);
+  await db.close();
+});
+
+test("a connection-level query failure retires the pool for the next request", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const first = (await db.pool()) as unknown as FakePool;
+  first.nextQueryError = Object.assign(new Error("server closed the connection unexpectedly"), { code: "57P01" });
+
+  await assert.rejects(() => db.query("SELECT 1"), /closed the connection/);
+  await settle();
+
+  const second = (await db.pool()) as unknown as FakePool;
+  assert.notEqual(second, first);
+  assert.equal(first.ended, true);
+  await db.close();
+});
+
+test("a retired pool drains queued checkouts before closing", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const first = (await db.pool()) as unknown as FakePool;
+  first.waitingCount = 1;
+
+  first.emit("error", new Error("Connection terminated unexpectedly"));
+  await settle();
+
+  assert.notEqual((await db.pool()) as unknown as FakePool, first);
+  assert.equal(first.ended, false);
+  first.waitingCount = 0;
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  assert.equal(first.ended, true);
+  await db.close();
+});
+
+test("shutdown and deferred retirement close a pool only once", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const first = (await db.pool()) as unknown as FakePool;
+  first.waitingCount = 1;
+
+  first.emit("error", new Error("Connection terminated unexpectedly"));
+  await settle();
+  await db.close();
+  first.waitingCount = 0;
+  await new Promise((resolve) => setTimeout(resolve, 75));
+
+  assert.equal(first.endCalls, 1);
+});
+
+test("a transaction failure retires the pool and preserves an ambiguous commit error", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  const first = (await db.pool()) as unknown as FakePool;
+  first.client.queryErrors.set("COMMIT", Object.assign(new Error("commit outcome unknown"), { code: "08006" }));
+  first.client.queryErrors.set("ROLLBACK", new Error("rollback also failed"));
+
+  await assert.rejects(() => db.transaction(async () => "written"), /commit outcome unknown/);
+  await settle();
+
+  assert.notEqual((await db.pool()) as unknown as FakePool, first);
+  await db.close();
+});
+
+test("close is terminal and cannot reopen the pool", async () => {
+  const db = createPgPool("postgres://example/qm", ["SELECT 1"]);
+  await db.pool();
+  await db.close();
+
+  await assert.rejects(() => db.pool(), /closed/);
+  await assert.rejects(() => db.query("SELECT 1"), /closed/);
+});


### PR DESCRIPTION
## Summary

- retire PostgreSQL pools after connection-level failures so later requests can recover without restarting QM
- route session, directory, and memory transactions through the recoverable pool boundary
- make session-backed health checks bounded and close PostgreSQL session pools during shutdown
- preserve the original transaction error when rollback also fails

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run lint:ox`
- focused route and pool tests: 37 passed, 1 skipped without `DATABASE_URL`
- `npm run test:pg`: 148 passed against PostgreSQL 16
- live PostgreSQL restart: health failed while unavailable, recovered after restart, and retained the existing session
- `npm test`: 3,581 passed, 132 skipped; 10 sandbox migration failures reproduce unchanged on `upstream/main` in the same environment

Fixes #136
