### PR TITLE
fix: catch transient getRun failures in postgres waitFor poll

### DIFF
--- a/src/runs/postgres-run-store.ts
+++ b/src/runs/postgres-run-store.ts
@@ -290,6 +290,7 @@ export function createPostgresRunStore(connectionString: string, opts?: { maxCla
           if (done) return;
           done = true;
           clearInterval(poll);
+          clearTimeout(timer);
           events.off(runId, onSettle);
           resolve(r);
         };
@@ -298,9 +299,13 @@ export function createPostgresRunStore(connectionString: string, opts?: { maxCla
         }
         events.once(runId, onSettle);
         const poll = setInterval(() => {
-          void getRun(runId).then((r) => {
-            if (r && isTerminal(r.status)) finish(r);
-          });
+          void getRun(runId)
+            .then((r) => {
+              if (r && isTerminal(r.status)) finish(r);
+            })
+            .catch((err: unknown) => {
+              console.error(`[postgres-run-store] waitFor poll for run ${runId} failed transiently:`, err);
+            });
         }, 250);
         poll.unref?.();
         const timer = setTimeout(() => {

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -894,6 +894,31 @@ test("pg run store: enqueue dedup, atomic one-per-session claim, fencing, ledger
 });
 
 test(
+  "pg run store: waitFor survives a transient poll failure without an unhandled rejection",
+  { skip },
+  async () => {
+    const { runs, close } = createPostgresRunStore(URL!);
+    let unhandled: unknown;
+    const onUnhandledRejection = (err: unknown): void => {
+      unhandled = err;
+    };
+    process.once("unhandledRejection", onUnhandledRejection);
+    try {
+      const r = (await runs.enqueue({ sessionId: "sWaitFor", request: turn("x") })).run;
+      const pending = runs.waitFor(r.id, 800);
+      // Kill the pool mid-poll: the next getRun() tick will reject, exercising the
+      // catch path instead of leaking an unhandled rejection out of setInterval.
+      await new Promise((res) => setTimeout(res, 50));
+      await close();
+      await assert.rejects(pending, /did not finish within 800ms/, "still settles via its own timeout, not a crash");
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandledRejection);
+    }
+    assert.equal(unhandled, undefined, "a transient poll failure must not escape as an unhandled rejection");
+  },
+);
+
+test(
   "pg run store: releaseLease (deploy drain) hands the run back as a retry without spending budget; stale token is a no-op",
   { skip },
   async () => {


### PR DESCRIPTION
## Issue

`waitFor`'s polling loop in `postgres-run-store.ts` called `getRun(runId).then(...)` with no `.catch()`. A transient query failure (e.g. a brief Postgres blip) became an unhandled rejection outside the returned promise, which can crash the process instead of letting `waitFor` time out normally. `finish()` also only cleared the poll interval, leaving the timeout timer pending.

## Fix

- Poll tick now catches a rejected `getRun` call, logs it, and lets the next tick (or the existing timeout) handle it — no behavior change on the success path.
- `finish()` clears both the poll interval and the timeout timer.
- Added a test that forces a rejection mid-poll and asserts no unhandled rejection occurs and `waitFor` still settles via its timeout.

Fixes #57

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788340491&installation_model_id=19911&pr_number=149&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F149&signature=4a9fb1fc6562ecf808f29ca3fc0a37149bc1086bdbf73c4fb3808c41f4856ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->