### PR TITLE
Align CLI dotenv parsing with the runtime

### DIFF
--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -217,12 +217,18 @@ export function readEnvFile(path: string): Map<string, string> {
   const out = new Map<string, string>();
   if (!existsSync(path)) return out;
   for (const raw of readFileSync(path, "utf8").split("\n")) {
-    const line = raw.trim();
+    let line = raw.trim();
     if (!line || line.startsWith("#")) continue;
+    if (line.startsWith("export ")) line = line.slice(7).trimStart();
     const eq = line.indexOf("=");
     if (eq <= 0) continue;
     const key = line.slice(0, eq).trim();
-    if (isEnvVarName(key)) out.set(key, line.slice(eq + 1));
+    if (!isEnvVarName(key)) continue;
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    out.set(key, val);
   }
   return out;
 }

--- a/cli/test/util.test.ts
+++ b/cli/test/util.test.ts
@@ -41,16 +41,20 @@ test("canonicalJson sorts keys and matches JSON.stringify's undefined semantics"
   }
 });
 
-test("readEnvFile preserves hashes in unquoted values", (t) => {
+test("readEnvFile preserves hashes in unquoted values and strips export/quotes", (t) => {
   const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   const file = join(dir, ".env");
-  writeFileSync(file, "# ignored\nTOKEN=abc#def\nURL=https://host/path#fragment\n");
+  writeFileSync(
+    file,
+    '# ignored\nTOKEN=abc#def\nURL="https://host/path#fragment"\nexport SECRET=\'mysecret\'\n',
+  );
   assert.deepEqual(
     [...readEnvFile(file)],
     [
       ["TOKEN", "abc#def"],
       ["URL", "https://host/path#fragment"],
+      ["SECRET", "mysecret"],
     ],
   );
 });


### PR DESCRIPTION
### Summary
Align `readEnvFile` in `cli/src/util.ts` with Node.js `--env-file` runtime parsing rules by supporting optional `export ` line prefixes and stripping matching outer double or single quotes around values. Includes unit test updates in `cli/test/util.test.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788363697&installation_model_id=19911&pr_number=158&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F158&signature=6c35d210f48b4f022151efc1ae8e3f08c316bf890746ee25b90494e66b5e9370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->