### PR TITLE
Resolve skill shadowing from one catalog snapshot in visibleFor

### DIFF
--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -211,7 +211,6 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
     },
 
     async resolve(name, orderedScopes) {
-      if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
       return resolveFromCatalog(await skills.all(), name, orderedScopes);
     },
 

--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -106,9 +106,7 @@ function publishedByScopeAndName(all: Skill[]): Map<string, Skill> {
 
 function resolveFromIndex(index: Map<string, Skill>, name: string, orderedScopes: ScopeId[]): SkillResolution {
   if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
-  const published = orderedScopes
-    .map((sc) => index.get(`${sc}\u0000${name}`))
-    .filter((s): s is Skill => Boolean(s));
+  const published = orderedScopes.map((sc) => index.get(`${sc}\u0000${name}`)).filter((s): s is Skill => Boolean(s));
   const [skill, ...shadowed] = published;
   return { skill: skill ?? null, shadowed };
 }

--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -94,6 +94,15 @@ function scopeKind(scopeId: ScopeId): string {
   return parseScopeId(scopeId).kind ?? scopeId;
 }
 
+function resolveFromCatalog(all: Skill[], name: string, orderedScopes: ScopeId[]): SkillResolution {
+  if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
+  const published = orderedScopes
+    .map((sc) => all.find((s) => s.status === "published" && s.manifest.name === name && s.scopeId === sc))
+    .filter((s): s is Skill => Boolean(s));
+  const [skill, ...shadowed] = published;
+  return { skill: skill ?? null, shadowed };
+}
+
 export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
   const skills = opts.backing ?? createMemoryMap<Skill>();
   const secret = opts.signingSecret ?? randomUUID();
@@ -203,25 +212,22 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
 
     async resolve(name, orderedScopes) {
       if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
-      const all = await skills.all();
-      const published = orderedScopes
-        .map((sc) => all.find((s) => s.status === "published" && s.manifest.name === name && s.scopeId === sc))
-        .filter((s): s is Skill => Boolean(s));
-      const [skill, ...shadowed] = published;
-      return { skill: skill ?? null, shadowed };
+      return resolveFromCatalog(await skills.all(), name, orderedScopes);
     },
 
     async visibleFor(orderedScopes) {
+      const all = await skills.all();
       const inScope = new Set(orderedScopes);
       const names = [
         ...new Set(
-          (await skills.all())
+          all
             .filter((s) => s.status === "published" && inScope.has(s.scopeId) && isSafeSkillName(s.manifest.name))
             .map((s) => s.manifest.name),
         ),
       ];
-      const resolved = await Promise.all(names.map((n) => this.resolve(n, orderedScopes)));
-      return resolved.filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
+      return names
+        .map((n) => resolveFromCatalog(all, n, orderedScopes))
+        .filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
     },
 
     async promote(id, targetScopeId) {

--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -94,10 +94,20 @@ function scopeKind(scopeId: ScopeId): string {
   return parseScopeId(scopeId).kind ?? scopeId;
 }
 
-function resolveFromCatalog(all: Skill[], name: string, orderedScopes: ScopeId[]): SkillResolution {
+function publishedByScopeAndName(all: Skill[]): Map<string, Skill> {
+  const index = new Map<string, Skill>();
+  for (const s of all) {
+    if (s.status !== "published") continue;
+    const key = `${s.scopeId}\u0000${s.manifest.name}`;
+    if (!index.has(key)) index.set(key, s);
+  }
+  return index;
+}
+
+function resolveFromIndex(index: Map<string, Skill>, name: string, orderedScopes: ScopeId[]): SkillResolution {
   if (!isSafeSkillName(name)) return { skill: null, shadowed: [] };
   const published = orderedScopes
-    .map((sc) => all.find((s) => s.status === "published" && s.manifest.name === name && s.scopeId === sc))
+    .map((sc) => index.get(`${sc}\u0000${name}`))
     .filter((s): s is Skill => Boolean(s));
   const [skill, ...shadowed] = published;
   return { skill: skill ?? null, shadowed };
@@ -211,11 +221,12 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
     },
 
     async resolve(name, orderedScopes) {
-      return resolveFromCatalog(await skills.all(), name, orderedScopes);
+      return resolveFromIndex(publishedByScopeAndName(await skills.all()), name, orderedScopes);
     },
 
     async visibleFor(orderedScopes) {
       const all = await skills.all();
+      const index = publishedByScopeAndName(all);
       const inScope = new Set(orderedScopes);
       const names = [
         ...new Set(
@@ -225,7 +236,7 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
         ),
       ];
       return names
-        .map((n) => resolveFromCatalog(all, n, orderedScopes))
+        .map((n) => resolveFromIndex(index, n, orderedScopes))
         .filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
     },
 

--- a/test/skills-visible.test.ts
+++ b/test/skills-visible.test.ts
@@ -9,6 +9,8 @@ import { buildApp } from "../src/wiring.ts";
 import type { Config } from "../src/config.ts";
 import { scopeId, type ScopeId } from "../src/types.ts";
 import { testConfig } from "./support/test-config.ts";
+import { createMemoryMap } from "../src/persistence/durable-map.ts";
+import { createSkillStore, type Skill } from "../src/skills/skill-store.ts";
 
 function freshApp() {
   const config: Config = testConfig({
@@ -77,4 +79,45 @@ test("an unpublished (draft/reviewed) skill is not visible", async () => {
 
   const visible = await app.listVisibleSkills("U1");
   assert.ok(!visible.some((r) => r.skill!.manifest.name === "wip"));
+});
+
+test("visibleFor reads the full skills table once, not once per skill name", async () => {
+  const backing = createMemoryMap<Skill>();
+  let allReads = 0;
+  const originalAll = backing.all.bind(backing);
+  backing.all = () => {
+    allReads += 1;
+    return originalAll();
+  };
+  const skills = createSkillStore({ backing });
+
+  const org = scopeId("org", "default-org");
+  const personal = scopeId("personal", "U1");
+  for (let i = 0; i < 200; i++) {
+    const scope = i % 2 === 0 ? org : personal;
+    const sk = await skills.create({
+      scopeId: scope,
+      manifest: { name: `skill-${i}`, description: `skill ${i}`, requiredCapabilities: [], body: `# skill-${i}` },
+      createdBy: "author",
+    });
+    await skills.review(sk.id, "reviewer-1", []);
+    await skills.publish(sk.id);
+  }
+  const shadowing = await skills.create({
+    scopeId: personal,
+    manifest: { name: "skill-0", description: "personal override", requiredCapabilities: [], body: "# skill-0" },
+    createdBy: "U1",
+  });
+  await skills.review(shadowing.id, "reviewer-1", []);
+  await skills.publish(shadowing.id);
+
+  allReads = 0;
+  const visible = await skills.visibleFor([personal, org]);
+
+  assert.equal(allReads, 1, "one full skills read per visibleFor call");
+  assert.equal(visible.length, 200);
+  const shadowed = visible.find((r) => r.skill!.manifest.name === "skill-0")!;
+  assert.equal(shadowed.skill!.scopeId, personal);
+  assert.equal(shadowed.shadowed.length, 1);
+  assert.equal(shadowed.shadowed[0]!.scopeId, org);
 });


### PR DESCRIPTION
Fixes #138.

## Problem

`SkillStore.visibleFor()` collected skill names from `skills.all()` and then called `resolve()` once per name via `Promise.all` — and `resolve()` re-reads `skills.all()`. With ~200 published skills, one `GET /v1/skills?includeShadowed=1` issued ~200 parallel full-table reads, starving the Postgres pool so unrelated endpoints, background workers, and the health check timed out.

## Fix

Extract the shadowing logic into a pure `resolveFromCatalog(all, name, orderedScopes)` that works over an in-memory snapshot. `visibleFor()` now reads the table exactly once; `resolve()` delegates to the same helper, so the two paths cannot drift.

## Tests

New regression test publishes 200 skills across personal/org scopes (plus one shadowing pair), wraps the backing map's `all()` with a counter, and asserts `visibleFor` performs exactly one full read while still surfacing shadowed entries correctly. Ran skills-visible, skill-collision, skills-http, skill-archive, skills-callable, skill-conformance plus typecheck and lint locally — all green.

## Not in this PR

The issue also notes one `pg.Pool` is created per store (~20 call sites), multiplying process-wide connections. Sharing a pool per connection string needs ref-counted `close()` semantics across all stores — worth doing, but as its own change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788370864&installation_model_id=19911&pr_number=160&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F160&signature=66e1c0674a7b92cb6be4548d42f54c303eb5d91245a37f0e7d323b34a332a04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->