### PR TITLE
adr: Discord as another agent surface

### DIFF
--- a/adrs/discord.md
+++ b/adrs/discord.md
@@ -1,0 +1,29 @@
+# Discord as another agent surface
+
+We'd like Discord alongside Slack and the web UI.
+
+Discord is the natural cheap alternative to Slack: it's free, bots are trivial to create
+and run, and its bot primitives are in some ways richer than Slack's: threads, forum
+channels, components, reactions. Hermes and OpenClaw both ship Discord surfaces already.
+Like Slack's Socket Mode, the Discord gateway is an outbound WebSocket, so there's no
+public URL, domain or TLS to set up.
+
+Some context on where this is coming from: we run multiplayer Discord agents in production
+for companies in Brazil. None of them use Slack. We've been maintaining that surface for
+some months. Beyond the obvious surface plumbing any integration needs, these are some
+points that came up along the way:
+
+- threads are sessions. When a thread is archived or deleted, the sessions bound to it
+  need to close with a reason;
+- Discord rejects large uploads. Today the Slack surface just refuses the file as too
+  large; we found it's better to publish it as an artifact and reply with a link, which
+  the core already has the pieces for;
+- long messages get chunked, and the chunk boundary must never fall inside a code fence,
+  or the formatting breaks;
+- replies should mention whoever asked, with the mentionable roles coming from config;
+- one preference rather than a gap: when a thread already has a run in flight, we found it
+  works better to say so than to queue silently.
+
+I wouldn't put this in-process like the Slack plugin. A separate service on the chassis,
+talking to core over the HTTP API the way web-ui does, seems cleaner and keeps Discord
+opt-in behind a bot token.


### PR DESCRIPTION
Adds a short ADR proposing Discord as a surface.

We've been running multiplayer Discord agents in production for companies in Brazil, none of which use Slack. The ADR is mostly the list of points that came up while running it — thread lifecycle, upload limits, chunking — in case that's useful input whether or not you want Discord in core.

Happy to help with the surface if there's interest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788379928&installation_model_id=19911&pr_number=162&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F162&signature=4fd7d45f35a99e27ed5cce7635f633d6d447dd981de5ae4b9ac5c12f39f010f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->