### PR TITLE
Fix AWS production deployment blockers

### DIFF
--- a/aws/microvm-agent/Dockerfile
+++ b/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh-2.97.0-1 \
   && dnf clean all \
   && gh --version
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/templates/aws/main.tf
+++ b/cli/templates/aws/main.tf
@@ -569,12 +569,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "objects" {
       expired_object_delete_marker = true
     }
 
-    # The core writes this same rule id via ensureExpiry, with the same 1 day and this same clause,
-    # so whichever applies last leaves an identical config instead of the two stripping each other.
-    # Parts from an upload that died mid-stream are invisible to ListObjects; only this reaps them.
-    abort_incomplete_multipart_upload {
-      days_after_initiation = 1
-    }
   }
 
   rule {
@@ -587,6 +581,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "objects" {
 
     expiration {
       days = 1
+    }
+
+    # Keep this identical to the rule written by the core's ensureExpiry.
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
     }
   }
 }

--- a/cli/templates/aws/microvm-agent/Dockerfile
+++ b/cli/templates/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh-2.97.0-1 \
   && dnf clean all \
   && gh --version
 

--- a/cli/test/terraform.test.ts
+++ b/cli/test/terraform.test.ts
@@ -359,7 +359,10 @@ test("AWS module provisions durable encrypted object storage and configurable sa
   assert.match(mainTf, /expiration\s*\{\s*expired_object_delete_marker\s*= true\s*\}/);
   assert.match(mainTf, /"s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"/);
   assert.match(mainTf, /"s3:ListBucketMultipartUploads"/);
-  assert.match(mainTf, /abort_incomplete_multipart_upload\s*\{\s*days_after_initiation\s*= 1\s*\}/);
+  assert.match(
+    mainTf,
+    /id\s*= "qm-transfer-expiry"[\s\S]*?abort_incomplete_multipart_upload\s*\{\s*days_after_initiation\s*= 1\s*\}/,
+  );
   assert.match(mainTf, /backup_retention_period\s*= var\.db_backup_retention_days/);
   assert.match(mainTf, /multi_az\s*= var\.db_multi_az/);
   assert.match(mainTf, /skip_final_snapshot\s*= var\.db_skip_final_snapshot/);


### PR DESCRIPTION
## Summary
- update the GitHub CLI RPM pin to the currently published 2.97.0 package
- keep the canonical and packaged MicroVM Dockerfiles in sync
- align the Terraform transfer lifecycle rule with the core runtime writer

## Verification
- `node --test cli/test/terraform.test.ts cli/test/microvm-dockerfile.test.ts` (21/21)
- local `docker build aws/microvm-agent`
- AWS Lambda MicroVM image version 2.0 reached `ACTIVE`
- deployment Terraform plan reports no changes