### PR TITLE
Read local Postgres settings from the assembled env, not process.env

### DIFF
--- a/scripts/dev/lib/postgres.ts
+++ b/scripts/dev/lib/postgres.ts
@@ -67,12 +67,16 @@ export interface LocalPostgres {
   url: string;
 }
 
-export async function ensureLocalPostgres(worktree: string, log: (msg: string) => void): Promise<LocalPostgres> {
-  const container = process.env.DEV_INSTANCE_POSTGRES_CONTAINER || "qm-dev-postgres";
-  const port = process.env.DEV_INSTANCE_POSTGRES_PORT || "55432";
-  const image = process.env.DEV_INSTANCE_POSTGRES_IMAGE || POSTGRES_IMAGE;
-  const password = process.env.DEV_INSTANCE_POSTGRES_PASSWORD || "qm-dev";
-  const volume = process.env.DEV_INSTANCE_POSTGRES_VOLUME || "qm-dev-postgres-data";
+export async function ensureLocalPostgres(
+  worktree: string,
+  env: Record<string, string>,
+  log: (msg: string) => void,
+): Promise<LocalPostgres> {
+  const container = env.DEV_INSTANCE_POSTGRES_CONTAINER || "qm-dev-postgres";
+  const port = env.DEV_INSTANCE_POSTGRES_PORT || "55432";
+  const image = env.DEV_INSTANCE_POSTGRES_IMAGE || POSTGRES_IMAGE;
+  const password = env.DEV_INSTANCE_POSTGRES_PASSWORD || "qm-dev";
+  const volume = env.DEV_INSTANCE_POSTGRES_VOLUME || "qm-dev-postgres-data";
   const dbName = worktreeDbName(worktree);
 
   if (!(await ensureDockerDaemon(log))) throw new Error("docker daemon unavailable");

--- a/scripts/dev/lib/postgres.ts
+++ b/scripts/dev/lib/postgres.ts
@@ -134,5 +134,5 @@ export async function ensureLocalPostgres(
     throw new Error(`createdb ${dbName} failed`);
   }
   log(`durability: using local Postgres container ${container} database ${dbName}`);
-  return { url: `postgres://postgres:${password}@127.0.0.1:${port}/${dbName}` };
+  return { url: `postgres://postgres:${encodeURIComponent(password)}@127.0.0.1:${port}/${dbName}` };
 }

--- a/scripts/dev/supervisor/main.ts
+++ b/scripts/dev/supervisor/main.ts
@@ -343,7 +343,7 @@ async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
   let durableAdminPrincipal = "";
   if (!databaseUrl) {
     try {
-      const pg = await ensureLocalPostgres(worktree, log);
+      const pg = await ensureLocalPostgres(worktree, assembled.env, log);
       databaseUrl = pg.url;
       localPg = true;
     } catch (err) {


### PR DESCRIPTION
## Problem

`dev-instance up` failed with `could not connect to DATABASE_URL: password authentication failed for user \"postgres\"` on a machine whose `~/.config/qm/dev.env` sets `DEV_INSTANCE_POSTGRES_PORT=55433`.

The CLI spawns the supervisor with only the caller's env (`scripts/dev/cli.ts`); dev.env is merged into `assembled.env` later by `assembleEnv()`. But `ensureLocalPostgres()` read `DEV_INSTANCE_POSTGRES_*` from `process.env`, so dev.env settings never reached it. It defaulted to port 55432 — which on this machine belongs to a *different* Postgres container with a different password — while the `qm-dev-postgres` container name check passed, producing the misleading auth failure.

## Fix

`ensureLocalPostgres()` takes the env record and the supervisor passes `assembled.env` (which already layers caller env over dev.env). No default-to-`process.env` fallback, so the resolution order is single-sourced.

## Verified

- Before (on `main`): `up` fails as above unless `DEV_INSTANCE_POSTGRES_PORT=55433` is exported manually.
- After: `up` boots clean with no manual export — canary round-trips, core runs `store=postgres` against the dev.env-configured container. Torn down after.
- `dev-cli-lib` and `dev-supervisor-child` tests, typecheck, lint, format all pass.

Found while live-QAing #160.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382958&installation_model_id=19911&pr_number=164&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F164&signature=c8d05e49bdc713b1be037863dd6de860aae95b2b66230de453919ea89c5e62d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->