### PR TITLE
adr: Granola connector

### DIFF
--- a/adrs/granola-connector.txt
+++ b/adrs/granola-connector.txt
@@ -1,0 +1,20 @@
+granola connector
+
+Hey — we're deploying QM for our consulting firm (UK healthcare / life sciences).
+We already use Granola heavily for meeting notes. It would be really useful if
+QM had a first-class Granola connector the same way Google / Slack / GitHub work
+(Admin → Connectors + Keychain per-user connect).
+
+What we'd want, roughly:
+- users connect their own Granola account from Keychain
+- agent can search / read meeting notes and transcripts in-scope for that user
+- ideally read-only to start
+
+Today we can approximate this with a sandbox skill or by piping notes into our
+own knowledge graph, but a native connector would be much cleaner for the whole
+company.
+
+Happy for you to shape the API surface however fits the existing connector
+model. Not a security report — just a product ask.
+
+— Robert (r3.digital)

--- a/adrs/granola-connector.txt
+++ b/adrs/granola-connector.txt
@@ -1,20 +1,16 @@
 granola connector
 
-Hey — we're deploying QM for our consulting firm (UK healthcare / life sciences).
-We already use Granola heavily for meeting notes. It would be really useful if
-QM had a first-class Granola connector the same way Google / Slack / GitHub work
-(Admin → Connectors + Keychain per-user connect).
+It would be really useful if QM had a first-class Granola connector the same way
+Google / Slack / GitHub work (Admin → Connectors + Keychain per-user connect).
 
 What we'd want, roughly:
 - users connect their own Granola account from Keychain
 - agent can search / read meeting notes and transcripts in-scope for that user
 - ideally read-only to start
 
-Today we can approximate this with a sandbox skill or by piping notes into our
-own knowledge graph, but a native connector would be much cleaner for the whole
-company.
+Today this can be approximated with a sandbox skill or by piping notes into a
+separate knowledge store, but a native connector would be much cleaner for a
+whole company rollout.
 
 Happy for you to shape the API surface however fits the existing connector
 model. Not a security report — just a product ask.
-
-— Robert (r3.digital)


### PR DESCRIPTION
Requesting a first-class Granola connector (meeting notes) alongside the existing OAuth connectors.

What we'd want, roughly:
- users connect their own Granola account from Keychain
- agent can search / read meeting notes and transcripts in-scope for that user
- ideally read-only to start

