### PR TITLE
adr: multiple sandbox images

### DIFF
--- a/adrs/multi-sandbox-images.txt
+++ b/adrs/multi-sandbox-images.txt
@@ -1,0 +1,27 @@
+multiple sandbox images
+
+It would be really useful if a single QM deployment could use more than one
+sandbox image — e.g. a "commercial" image (research / CRM / enrichment CLIs +
+skills) and a "dev" image (git, browser, SF CLI, build tools + skills), instead
+of one fat image for every agent turn.
+
+What we'd want, roughly:
+- Admin (or deploy config) can register multiple named sandbox images
+  (digest / tag each), not only a single sandbox.image
+- each image can carry its own tools + skills pack appropriate to a function
+  (commercial vs eng vs …)
+- scopes / rooms / agents can be pinned to an image (or a default image with
+  optional override)
+- qm sandbox publish (or equivalent) can build/push one named image without
+  rebuilding all of them
+- clear docs on when to split images vs one image + many skills
+
+Why this belongs in QM: sandbox images are the runtime shape of the computer.
+Skills alone don't isolate heavy or sensitive toolchains; multiple images let
+orgs keep commercial agents lean and dev agents capable without shipping
+everything everywhere. Today the practical workaround is one mega-image or
+multiple QM deployments, both awkward.
+
+Happy for you to shape the selection model (per-scope, per-room, per-harness,
+label selectors, etc.) however fits core. Not a security report — just a
+product ask.


### PR DESCRIPTION
## Summary
- Short human ADR asking for **multiple named sandbox images** in one QM deploy (e.g. commercial vs dev tool/skill packs).
- Covers register/pin images, scope-or-room selection, and per-image publish.

## Test plan
- [ ] Maintainer review of `adrs/multi-sandbox-images.txt` only (no code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788398761&installation_model_id=19911&pr_number=180&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F180&signature=cb472124ce64f1a4e3e223ac13f5347e07ff0bfe3e9554637f7cbd395b619131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->