### PR TITLE
fix: gate assertAwsDeployImage on usesFlySandboxes

### DIFF
--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -1568,7 +1568,7 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
   assertAwsPublicFrontDoor(config);
   if (!opts.dryRun) await assertAwsPublicNetwork(config);
   assertAwsPublicApiUrl(config);
-  assertAwsDeployImage(config);
+  if (!usesFlySandboxes(config)) assertAwsDeployImage(config);
   header(`qm ${opts.dryRun ? "plan" : "up"} — ${config.orgId} (aws)`);
   const allServices = Object.keys(aws.services);
   assertOwnedServices(config, describedServices(config, allServices), allServices);
@@ -1641,7 +1641,7 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
   let sandboxPinImage: string | undefined;
   let dbSnapshot: string | undefined;
   try {
-    assertAwsDeployImage(config);
+    if (!usesFlySandboxes(config)) assertAwsDeployImage(config);
     before = serviceSnapshot(config, allServices);
     current = currentDeploymentManifest(aws);
     if (usesFlySandboxes(config)) {
@@ -2784,7 +2784,7 @@ export async function awsDoctor(config: QmConfig, configDir: string): Promise<vo
         });
       }
     });
-  check("Lambda MicroVM deploy image", () => assertAwsDeployImage(config));
+  if (!usesFlySandboxes(config)) check("Lambda MicroVM deploy image", () => assertAwsDeployImage(config));
   check("deploy role", () => {
     const expectedSubject = githubTrustSubject(configDir, aws.deployBranch, aws.deployEnvironment);
     const role = awsJson<{ Role?: { Arn?: string; AssumeRolePolicyDocument?: { Statement?: unknown } } }>(aws, [
@@ -2981,7 +2981,7 @@ async function checkLive(
   assertAwsCallerAccount(aws);
   const failures: string[] = [];
   try {
-    assertAwsDeployImage(config);
+    if (!usesFlySandboxes(config)) assertAwsDeployImage(config);
   } catch (error) {
     failures.push(`deploy image drift: ${errMessage(error)}`);
   }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788425139&installation_model_id=19911&pr_number=187&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F187&signature=a31ff3738a33b0f1cd5c389dcd100816bb66242085147082695cf68567169b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->