### PR TITLE
fix(portal): allow single-label container hostnames in private network validation

### DIFF
--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -305,7 +305,7 @@ export function isPrivateNetworkUrl(raw: string): boolean {
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") return false;
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "localhost" || host.endsWith(".localhost") || !host.includes(".")) return true;
   if (host.endsWith(".internal") || host.endsWith(".flycast") || host.endsWith(".local")) return true;
   if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
   if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) return true;

--- a/plugins/portal/test/broker-proxy.test.ts
+++ b/plugins/portal/test/broker-proxy.test.ts
@@ -184,6 +184,7 @@ test("isPrivateNetworkUrl admits only unroutable hosts", () => {
   for (const url of [
     "http://qm-auth.internal:8080",
     "http://qm-web-ui.flycast",
+    "http://auth:8080",
     "http://localhost:8099",
     "http://127.0.0.1:8099",
     "http://10.1.2.3:8080",


### PR DESCRIPTION
When running under Docker Compose, internal upstream services (such as the authentication broker `http://auth:8080`) use bare single-label hostnames without dots (e.g. `auth`).

The previous `isPrivateNetworkUrl` check rejected any non-IP host missing a domain extension or `.local` suffix, causing portal boot checks to fail with a misconfiguration error.

This commit updates `isPrivateNetworkUrl` to accept single-label hostnames (`!host.includes(.)`) as valid private network hosts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788427652&installation_model_id=19911&pr_number=188&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F188&signature=3df5a49741f40625ddf87906f91f2dbc7ee0957a3674fd2635819296562b2e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->