### PR TITLE
Fix dev supervisor readiness after UTF-8 log output

### DIFF
--- a/scripts/dev/supervisor/children.ts
+++ b/scripts/dev/supervisor/children.ts
@@ -93,7 +93,7 @@ export class Child {
       if (this.spec.readiness.kind === "log") {
         const pattern = this.spec.readiness.pattern;
         const offset = this.logOffset;
-        const seen = bestEffortValue(() => readFileSync(this.logFile(), "utf8").slice(offset).includes(pattern));
+        const seen = bestEffortValue(() => readFileSync(this.logFile()).includes(pattern, offset));
         if (seen) return { ok: true };
       } else {
         const url = this.spec.readiness.url;

--- a/test/dev-supervisor-child.test.ts
+++ b/test/dev-supervisor-child.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -33,6 +33,28 @@ function spec(lock: string, port: number, extraArgs: string[] = []): ChildSpec {
     stopGraceMs: 2000,
   };
 }
+
+test("child finds log readiness after existing multibyte UTF-8 content", async () => {
+  const lock = mkdtempSync(join(tmpdir(), "qm-child-"));
+  const port = await freeTcpPort();
+  const child = new Child(
+    spec(lock, port),
+    lock,
+    () => {},
+    () => {},
+  );
+  const prefix = "以前の起動\n";
+  writeFileSync(child.logFile(), prefix);
+  assert.equal(statSync(child.logFile()).size, Buffer.byteLength(prefix));
+
+  try {
+    const res = await child.start();
+    assert.equal(res.ok, true, res.detail);
+  } finally {
+    await child.stop();
+    rmSync(lock, { recursive: true, force: true });
+  }
+});
 
 test("child starts, reports ready via log pattern, and stops with the port released", async () => {
   const lock = mkdtempSync(join(tmpdir(), "qm-child-"));


### PR DESCRIPTION
## Summary

- treat readiness log offsets as byte offsets
- preserve readiness detection after earlier UTF-8 output
- cover the behavior through the real child process lifecycle

## Problem

The supervisor records a log position using the file size in bytes, but readiness polling applied that value as a JavaScript string character offset. Earlier multibyte UTF-8 output could therefore cause a newly appended readiness marker to be skipped.

## Verification

- `node --test test/dev-supervisor-child.test.ts`
- `npm run typecheck`
- targeted ESLint and Prettier checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788431146&installation_model_id=19911&pr_number=189&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F189&signature=90bd17603e37511750ace5c6e288416e9fb9f4470ee6da722615fce99af874a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->