### PR TITLE
Fix rotted gh CLI pin in MicroVM image Dockerfile

### DIFF
--- a/aws/microvm-agent/Dockerfile
+++ b/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh \
   && dnf clean all \
   && gh --version
 

--- a/cli/templates/aws/microvm-agent/Dockerfile
+++ b/cli/templates/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh \
   && dnf clean all \
   && gh --version
 


### PR DESCRIPTION
The Lambda MicroVM agent image fails to build for every new AWS deployment: the
Dockerfile pins `gh-2.96.0-1` from `cli.github.com`'s rpm repo, but that repo keeps
only the latest gh release. `2.96.0` was removed when `2.97.0` shipped, so
`dnf install -y gh-2.96.0-1` fails with "No package matches 'gh-2.96.0-1'".

`qm infra build-image` then dies on the AWS side as a bare
`The container image build failed.` (`CREATE_FAILED` on the image version) with no
exported build logs, which makes the rot look like an account/permission problem
until the Dockerfile is built locally.

Install the repo's current gh release instead of pinning. The repo config stays
`gpgcheck=1`, so packages remain signature-verified; pinning a minor version in a
single-version repo re-breaks on every gh release.

Both copies of the template are updated (`aws/microvm-agent/Dockerfile` and
`cli/templates/aws/microvm-agent/Dockerfile`).

Verified by building the image locally against the pinned base
(`public.ecr.aws/lambda/microvms:al2023-minimal@sha256:05cb9b38d841e7ff1b693dc9e894909612f340bf99ec97d426e8000a5bbe96c3`):
before, the build fails at the gh install step; after, the full image builds cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788445962&installation_model_id=19911&pr_number=193&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F193&signature=74c3002bdbe6078a5d6158eba17679f41bc9cfffc3fb4b66bb7c8c1bed9efde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->