### PR TITLE
credential broker: refuse percent-encoded parent traversal

### DIFF
--- a/src/api/credential-broker.ts
+++ b/src/api/credential-broker.ts
@@ -51,7 +51,33 @@ function brokerHostMatches(requestHost: string, pinnedHost: string): boolean {
   return h === p || h.endsWith(`.${p}`);
 }
 
+/**
+ * A pathname that could resolve to a parent directory upstream must never pass
+ * the prefix check. The prefix match runs on the RAW pathname, but upstream
+ * servers decode percent-escapes and normalize dot segments — so `..` hidden
+ * behind any layer of percent-encoding (`..%2f`, `%2e%2e/`, `%252e%252e`) can
+ * escape the allowed prefix after we've approved it. Decode to a fixed point
+ * (bounded) and refuse any form that ever contains a dot segment; refuse
+ * undecodable paths outright.
+ */
+function resolvesToParentSegment(pathname: string): boolean {
+  let current = pathname;
+  for (let depth = 0; depth < 4; depth++) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(current);
+    } catch {
+      return true;
+    }
+    if (decoded.split(/[/\\]/).some((seg) => seg === ".." || seg === ".")) return true;
+    if (decoded === current) return false;
+    current = decoded;
+  }
+  return true;
+}
+
 export function brokerPathAllowed(pathname: string, prefixes?: string[]): boolean {
+  if (resolvesToParentSegment(pathname)) return false;
   const allow = prefixes && prefixes.length ? prefixes : ["/"];
   return allow.some((pre) =>
     pre.endsWith("/") ? pathname.startsWith(pre) : pathname === pre || pathname.startsWith(`${pre}/`),

--- a/test/credential-broker.test.ts
+++ b/test/credential-broker.test.ts
@@ -218,6 +218,39 @@ test("WHAT path allowlist: an out-of-allowlist path is refused", async () => {
   assert.equal(cap.calls.length, 0);
 });
 
+test("WHAT path allowlist: percent-encoded parent traversal never escapes the prefix", async () => {
+  const mk = () => reader({ slug: "x-firehose", allowedPathPrefixes: ["/2/tweets/search"] });
+  const evil = [
+    "https://api.x.com/2/tweets/search/../secrets", // literal
+    "https://api.x.com/2/tweets/search/..%2fsecrets", // encoded slash
+    "https://api.x.com/2/tweets/search/%2e%2e/secrets", // encoded dots (URL-normalized out of prefix)
+    "https://api.x.com/2/tweets/search/%2e%2e%2fsecrets", // fully encoded
+    "https://api.x.com/2/tweets/search/%252e%252e%252fsecrets", // double-encoded
+    "https://api.x.com/2/tweets/search/..%5csecrets", // encoded backslash
+    "https://api.x.com/2/tweets/search/%zz", // undecodable
+  ];
+  for (const url of evil) {
+    const cap = captureFetch();
+    const r = await brokerCredentialCall(
+      base({ reader: mk(), body: { credential: "x-firehose", url }, fetchImpl: cap.fetch }),
+    );
+    assert.equal(r.status, 403, url);
+    assert.match(JSON.stringify(r.json), /path_not_allowed/, url);
+    assert.equal(cap.calls.length, 0, `no upstream fetch for ${url}`);
+  }
+  // benign lookalikes still pass: dots inside a segment are not dot segments
+  const cap = captureFetch();
+  const ok = await brokerCredentialCall(
+    base({
+      reader: mk(),
+      body: { credential: "x-firehose", url: "https://api.x.com/2/tweets/search/v1..v2/some%20file" },
+      fetchImpl: cap.fetch,
+    }),
+  );
+  assert.equal(ok.status, 200);
+  assert.equal(cap.calls.length, 1);
+});
+
 test("a disabled credential is refused even when the token still names it (live re-check)", async () => {
   const cap = captureFetch();
   const r = await brokerCredentialCall(

--- a/test/git-http-broker.test.ts
+++ b/test/git-http-broker.test.ts
@@ -202,3 +202,37 @@ test("git HTTP broker refuses an env-delivery record like a missing credential",
   assert.equal(c.res.statusCode, 404);
   assert.equal(fetched, false, "no upstream git fetch happens");
 });
+
+test("git HTTP broker refuses encoded parent traversal past the repo path", async () => {
+  for (const path of [
+    "/v1/credentials/git/gitlab/acme/repo.git/..%2fother-repo.git/info/refs",
+    "/v1/credentials/git/gitlab/acme/repo.git/%2e%2e%2fother-repo.git/info/refs",
+    "/v1/credentials/git/gitlab/acme/repo.git/%252e%252e%252fother/info/refs",
+  ]) {
+    let fetched = false;
+    const deps: ServerDeps = {
+      control: {} as ServerDeps["control"],
+      serviceCreds: {
+        getServiceCredentialSecret: async () => ({
+          slug: "gitlab",
+          name: "GitLab git",
+          secret: "dXNlcjp0b2tlbg==",
+          host: "gitlab.example",
+          injection: { scheme: "Basic " },
+          allowedMethods: ["GET", "POST"],
+          allowedPathPrefixes: ["/acme/repo.git"],
+          enabled: true,
+        }),
+      } as unknown as ServerDeps["serviceCreds"],
+      gitHttpFetch: async () => {
+        fetched = true;
+        return { status: 200, headers: {}, body: Readable.from(["0000"]) };
+      },
+    };
+    const c = await ctx(path, "GET", deps);
+    await brokerGitHttp(c);
+    assert.equal(c.res.statusCode, 403, path);
+    assert.match(await text(c.res), /path_not_allowed/);
+    assert.equal(fetched, false, "no upstream git fetch happens");
+  }
+});


### PR DESCRIPTION
Fixes the git-broker finding from #125; reported in #154. The path allowlist checked literal `../` but not percent-encoded forms (single or double). Decode before checking, reject decoded parent traversals, same guard on the git smart-HTTP route. Tests cover both routes, plain/single/double-encoded. Co-authored with the #154 reporter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461862&installation_model_id=19911&pr_number=198&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F198&signature=dee4b79e1fb737cc02455d1a1e2ebd03cd390b3a30014b9a23682f6b62f41852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->