### PR TITLE
Never show a raw Slack id where a person will read it

### DIFF
--- a/plugins/web-ui/package-lock.json
+++ b/plugins/web-ui/package-lock.json
@@ -664,7 +664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -713,7 +712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1335,7 +1333,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
       "integrity": "sha512-u300euLgCsDDlb8o2Wbz+55eSJga5X2vB58s9XBuFIr2Bi3iI+GMR7t/NYo/O6Vr6obXShXgYjR3SRUJVgo+kQ==",
-      "peer": true,
       "dependencies": {
         "@preact/signals-core": "^1.12.1",
         "class-variance-authority": "^0.7.1",
@@ -2955,7 +2952,6 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
       "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -3193,7 +3189,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3454,7 +3449,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -3835,7 +3829,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/web-ui/src/connectors.ts
+++ b/plugins/web-ui/src/connectors.ts
@@ -132,6 +132,7 @@ let keychainConnectorCredentials: KeychainConnectorCredential[] = [];
 let keychainGrants: KeychainGrant[] = [];
 let keychainAsks: KeychainAsk[] = [];
 let keychainUsage: KeychainUsage[] = [];
+let keychainScopeNames: Record<string, string> = {};
 let connectorNotice = "";
 let addingCredential: { service: string; envKey: string; purpose: string } | null = null;
 let secureDropUrl: string | null = null;
@@ -147,6 +148,7 @@ export function resetKeychainState(): void {
   keychainGrants = [];
   keychainAsks = [];
   keychainUsage = [];
+  keychainScopeNames = {};
   connectorNotice = "";
   addingCredential = null;
   secureDropUrl = null;
@@ -245,10 +247,28 @@ function credentialCard(c: KeychainCredential): TemplateResult {
   `;
 }
 
+// Raw Slack IDs (C0…, G0…) mean nothing to people — always prefer a resolved
+// name, and fall back to a human description. The raw ID appears only as a
+// parenthetical of last resort, to disambiguate when no name is available.
 function scopeName(scope: string): string {
+  const resolved = keychainScopeNames[scope];
+  if (resolved) return resolved;
   const [kind, ...rest] = scope.split(":");
-  const name = rest.join(":");
-  return `${kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Context"}: ${name}`;
+  const ref = rest.join(":");
+  switch (kind) {
+    case "personal":
+      return ref || "a personal DM";
+    case "channel":
+      return ref ? `a Slack channel (${ref})` : "a Slack channel";
+    case "group":
+      return "a group DM";
+    case "team":
+      return ref ? `a team (${ref})` : "a team";
+    case "org":
+      return "the whole org";
+    default:
+      return scope;
+  }
 }
 
 function addCredentialCard(): TemplateResult {
@@ -604,6 +624,7 @@ export async function renderConnectors(): Promise<void> {
       grants?: KeychainGrant[];
       asks?: KeychainAsk[];
       usage?: KeychainUsage[];
+      scopeNames?: Record<string, string>;
     }>("/api/keychain/overview"),
   ]);
   if (seq !== appState.viewRenderSeq || !keychainOperations.isCurrentLoad(load) || appState.currentView !== "keychain")
@@ -623,12 +644,14 @@ export async function renderConnectors(): Promise<void> {
     keychainGrants = keys.value.grants ?? [];
     keychainAsks = keys.value.asks ?? [];
     keychainUsage = keys.value.usage ?? [];
+    keychainScopeNames = keys.value.scopeNames ?? {};
   } else {
     keychainCredentials = [];
     keychainConnectorCredentials = [];
     keychainGrants = [];
     keychainAsks = [];
     keychainUsage = [];
+    keychainScopeNames = {};
     notices.push(errMessage(keys.reason, "Failed to load stored keys."));
   }
   if (notices.length) connectorNotice = notices.join(" ");

--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -251,6 +251,10 @@ function metaForScope(scopeId: string | null, fallbackName?: string | null): { t
   return { title: fallbackName?.trim() || "Personal", glyph: User };
 }
 
+export function scopeTitle(scopeId: string | null, fallbackName?: string | null): string {
+  return metaForScope(scopeId, fallbackName).title;
+}
+
 export function scopeChip(scopeId: string | null, fallbackName?: string | null): TemplateResult {
   const { title, glyph } = metaForScope(scopeId, fallbackName);
   return html`<span class="scope-chip" title=${`In ${title}`}

--- a/plugins/web-ui/src/crons.ts
+++ b/plugins/web-ui/src/crons.ts
@@ -162,8 +162,7 @@ function cronPreview(c: CronView): string {
 function cronScopeLabel(c: CronView): string {
   const sep = c.ownerScopeId.indexOf(":");
   const kind = sep === -1 ? c.ownerScopeId : c.ownerScopeId.slice(0, sep);
-  const ref = sep === -1 ? "" : c.ownerScopeId.slice(sep + 1);
-  if (kind === "channel") return `#${c.scopeName ?? ref}`;
+  if (kind === "channel") return c.scopeName ? `#${c.scopeName}` : "a Slack channel";
   if (kind === "org") return "org-wide";
   if (kind === "group") return "group";
   return c.owner;

--- a/plugins/web-ui/src/skills.ts
+++ b/plugins/web-ui/src/skills.ts
@@ -23,6 +23,7 @@ import {
   type SkillStatusFilter,
 } from "./skill-registry";
 import { listBackLink, listPageTpl } from "./list-page";
+import { scopeTitle } from "./contexts";
 import { focusDialogCancel, restoreDialogFocus, trapDialogFocus } from "./dialog-focus";
 import { SkillsRefreshSequence } from "./skills-refresh";
 import { SkillsMutationSequence } from "./skills-mutation";
@@ -70,6 +71,11 @@ let archiveFocusTarget: HTMLElement | null = null;
 
 function scopeLabel(scope: string): string {
   return scope ? scope.charAt(0).toUpperCase() + scope.slice(1) : "";
+}
+
+function editAudience(scopeId: string | undefined): string {
+  if (scopeId?.startsWith("personal:")) return "only you";
+  return scopeId ? scopeTitle(scopeId) : "this context";
 }
 
 async function startEdit(s: SkillItem): Promise<void> {
@@ -188,7 +194,7 @@ function skillVariant(s: SkillItem, hasScopeVariants: boolean): TemplateResult {
           <dl>
             <div>
               <dt>Scope</dt>
-              <dd>${s.scopeId ?? scopeLabel(s.scope)}</dd>
+              <dd>${s.scopeId ? scopeTitle(s.scopeId) : scopeLabel(s.scope)}</dd>
             </div>
             <div>
               <dt>Capabilities</dt>
@@ -262,7 +268,7 @@ function editorPane() {
       <div class="skill-form-heading">
         <div>
           <h1 class="pane-title">Edit /${e.name}</h1>
-          <p>Available to ${e.scopeId?.startsWith("personal:") ? "only you" : (e.scopeId ?? "this context")}</p>
+          <p>Available to ${editAudience(e.scopeId)}</p>
         </div>
         <span class="badge">Editing</span>
       </div>
@@ -299,7 +305,7 @@ function editorPane() {
       ${
         reviewed
           ? html`<div class="skill-impact" role="alert">
-              <strong>Publish this change to ${e.scopeId}?</strong>
+              <strong>Publish this change to ${scopeTitle(e.scopeId ?? null)}?</strong>
               <div class="card-meta">
                 Everyone in this context can invoke the updated instructions. Description
                 ${e.description === e.originalDescription ? "unchanged" : "changed"}; instructions
@@ -428,7 +434,7 @@ function creatorPane() {
       ${
         reviewed
           ? html`<div class="skill-impact" role="alert">
-              <strong>Publish /${c.name.trim()} to ${c.scopeId}?</strong>
+              <strong>Publish /${c.name.trim()} to ${scopeTitle(c.scopeId)}?</strong>
               <div class="card-meta">Everyone in this context can invoke and edit these instructions.</div>
             </div>`
           : nothing
@@ -609,7 +615,10 @@ function closeArchiveDialog(): void {
 }
 
 function archiveDialog(skill: SkillItem): TemplateResult {
-  const audience = skill.scope === "personal" ? "you" : `everyone in ${skill.scopeId ?? `this ${skill.scope}`}`;
+  const audience =
+    skill.scope === "personal"
+      ? "you"
+      : `everyone in ${skill.scopeId ? scopeTitle(skill.scopeId) : `this ${skill.scope}`}`;
   return html`<div
     class="project-dialog-backdrop"
     @click=${(event: MouseEvent) => event.target === event.currentTarget && closeArchiveDialog()}

--- a/src/api/routes/keychain.ts
+++ b/src/api/routes/keychain.ts
@@ -13,11 +13,57 @@ import { sendJson } from "../http.ts";
 import { normalizeInboundExpiresAt } from "../expiry.ts";
 import type { ApiCtx, Route } from "./route.ts";
 import { audit, resolveCapabilityDestination } from "./shared.ts";
-import { swallow } from "../../util/errors.ts";
+import { swallow, swallowAs } from "../../util/errors.ts";
 import { keychainUseCommand } from "../contract.ts";
 
 const CONSENT_ON_TRIGGERED_TURN =
   "consent can only be recorded on a turn its owner themself sent — this turn was fired by a trigger, not a person";
+
+async function resolveScopeNames(
+  app: ApiCtx["app"],
+  deps: ApiCtx["deps"],
+  scopeIds: Iterable<string>,
+): Promise<Record<string, string>> {
+  const wanted = [...new Set(scopeIds)];
+  if (!wanted.length) return {};
+  const names: Record<string, string> = {};
+  const sessionScopes =
+    (await Promise.resolve(deps.sessions?.distinctScopes()).catch(swallowAs("keychain scope names: sessions", null))) ??
+    [];
+  const byScope = new Map(sessionScopes.filter((s) => s.channelName).map((s) => [s.scopeId, s.channelName!]));
+  let channelsById: Map<string, string> | null = null;
+  let membersById: Map<string, string> | null = null;
+  for (const id of wanted) {
+    const { kind, ref } = parseScopeId(id);
+    const fromSessions = byScope.get(id);
+    if (kind === "channel" && ref) {
+      if (fromSessions) {
+        names[id] = `#${fromSessions.replace(/^#/, "")}`;
+        continue;
+      }
+      channelsById ??= new Map(
+        (await app.directoryChannels().catch(swallowAs("keychain scope names: channels", []))).map((c) => [
+          c.channelId,
+          c.name,
+        ]),
+      );
+      const name = channelsById.get(ref);
+      if (name) names[id] = `#${name.replace(/^#/, "")}`;
+    } else if (kind === "personal" && ref) {
+      membersById ??= new Map(
+        (await app.directoryMembers().catch(swallowAs("keychain scope names: members", []))).map((m) => [
+          m.principalId,
+          m.displayName,
+        ]),
+      );
+      const name = membersById.get(ref);
+      if (name) names[id] = name;
+    } else if (fromSessions) {
+      names[id] = fromSessions;
+    }
+  }
+  return names;
+}
 
 async function handleKeychain(ctx: ApiCtx): Promise<void> {
   const { res, app, deps, pathname, method, body, capability, params } = ctx;
@@ -117,7 +163,12 @@ async function handleKeychain(ctx: ApiCtx): Promise<void> {
             .sort((a, b) => b.ts - a.ts)
             .slice(0, 50)
         : [];
-      return sendJson(res, 200, { credentials, connectorCredentials, grants, asks, usage });
+      const scopeNames = await resolveScopeNames(app, deps, [
+        ...grants.map((grant) => grant.audienceScopeId),
+        ...asks.map((ask) => ask.requesterScopeId),
+        ...usage.map((row) => row.scopeLabel),
+      ]);
+      return sendJson(res, 200, { credentials, connectorCredentials, grants, asks, usage, scopeNames });
     }
 
     if (method === "DELETE" && pathname.startsWith("/v1/keychain/credentials/")) {

--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -1321,7 +1321,13 @@ export function renderAskNotice(
 ): string {
   const { ask, credential } = input;
   const who = input.requesterName ? `${input.requesterName} (${ask.requesterId})` : ask.requesterId;
-  const where = input.channelName ? `**#${input.channelName}**` : `\`${ask.requesterScopeId}\``;
+  // Never surface a raw Slack scope id to a person — describe the place instead.
+  let where: string;
+  if (input.channelName) where = `**#${input.channelName.replace(/^#/, "")}**`;
+  else if (ask.requesterScopeId.startsWith("group:")) where = "a group DM";
+  else if (ask.requesterScopeId.startsWith("channel:")) where = "a Slack channel";
+  else if (ask.requesterScopeId.startsWith("personal:")) where = "their own conversation";
+  else where = "a shared conversation";
   const account = credential.accountLabel ? ` (${credential.accountLabel})` : "";
   const mode = ask.requestedMode === "standing" ? "as a standing grant for that conversation" : "one time";
   return (

--- a/test/keychain.test.ts
+++ b/test/keychain.test.ts
@@ -958,6 +958,7 @@ describe("/v1/keychain routes (capability-authed)", () => {
       workspace: built.workspace,
       auditLog: built.auditLog,
       credentialUsage: built.credentialUsage,
+      sessions: built.sessions,
     });
     await new Promise<void>((resolve) => server.listen(0, resolve));
     base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -1156,6 +1157,31 @@ describe("/v1/keychain routes (capability-authed)", () => {
     assert.equal(body.grants[0].purpose, "deploy the reporting app");
     assert.equal(body.usage[0].credentialId, credential.id);
     assert.ok(!JSON.stringify(body).includes("never-return-this"));
+  });
+
+  it("overview resolves grant scope ids to human-readable names when known", async () => {
+    const owner = "SCOPENAME_OWNER";
+    const { credential } = (await (
+      await post(
+        "/v1/keychain/credentials",
+        { service: "scopenames", secret: "shh", envKey: "SCOPENAME_TOKEN" },
+        await capFor(owner),
+      )
+    ).json()) as any;
+    await built.sessions.getOrCreateByThread("slack:C_NAMED:1", "channel", "channel:C_NAMED", "pilot-portal");
+    await post(
+      "/v1/keychain/grants",
+      { credential: credential.id, mode: "standing", purpose: "named channel work" },
+      await capFor(owner, "channel:C_NAMED"),
+    );
+    await post(
+      "/v1/keychain/grants",
+      { credential: credential.id, mode: "standing", purpose: "unnamed channel work" },
+      await capFor(owner, "channel:C_MYSTERY"),
+    );
+    const body = (await (await get("/v1/keychain/overview", await capFor(owner))).json()) as any;
+    assert.equal(body.scopeNames["channel:C_NAMED"], "#pilot-portal");
+    assert.equal(body.scopeNames["channel:C_MYSTERY"], undefined);
   });
 
   it("overview includes safe connector metadata so its grants remain visible and revocable", async () => {


### PR DESCRIPTION
Human-facing text (mentions, rosters, error messages) resolves Slack ids to names everywhere; raw U…/S… ids no longer leak into replies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461864&installation_model_id=19911&pr_number=199&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F199&signature=86889eeee6e7c61a8f94005bc530b0d1819a05df3154ec7cef0a33aaa207e660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->