### PR TITLE
Persist full runtime defaults per scope

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -292,6 +292,10 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       config.effective,
       config.modelCatalog,
     );
+    composerState.effortLevel =
+      (config.effective.effortLevel as EffortLevel | undefined) ?? defaultEffortForModel(currentModelOption().model);
+    composerState.fastMode =
+      config.effective.fastMode === true && modelSupportsFastMode(scopeKey(), config.effective.modelId);
     if (agent && (!ctx.chat.state.threadRef || !threadModelPicks.has(ctx.chat.state.threadRef)))
       agent.state.model = currentModelOption().model;
     ctx.chat.drawActiveChat(agent);
@@ -299,7 +303,14 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   }
 
   async function changeScopeRuntime(
-    change: { harnessId?: string; modelId?: string; inherit?: boolean; keep?: boolean },
+    change: {
+      harnessId?: string;
+      modelId?: string;
+      effortLevel?: string;
+      fastMode?: boolean;
+      inherit?: boolean;
+      keep?: boolean;
+    },
     agent: Agent,
   ): Promise<void> {
     const request = ++runtimeRequest;
@@ -308,19 +319,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       const config = await updateRuntimeConfig(scopeId, change);
       if (request !== runtimeRequest || scopeId !== ctx.chat.state.scopeId) return;
       seededRuntime = null;
-      activeRuntimeConfig = config;
-      setFastModeModelIds(scopeKey(), config.fastModeModelIds);
-      orgFastModeDefault = config.interactiveFastMode === true;
-      applyRuntimeOptions(
-        scopeKey(),
-        config.approvedHarnesses,
-        config.modelsByHarness,
-        config.effective,
-        config.modelCatalog,
-      );
-      if (!ctx.chat.state.threadRef || !threadModelPicks.has(ctx.chat.state.threadRef))
-        agent.state.model = currentModelOption().model;
-      composerState.error = "";
+      applySelectedRuntime(config, agent);
     } catch (e) {
       if (request !== runtimeRequest || scopeId !== ctx.chat.state.scopeId) return;
       composerState.error = errMessage(e, "Could not update the scope default.");
@@ -339,7 +338,15 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     if (fastAvailable) fastTitle = fastOn ? "Fast mode active" : "Fast mode";
     const approvalPauses = ctx.chat.activePendingApprovals();
     const runtimePending = activeRuntimeConfig === null;
-    const modelToggled = !runtimePending && selectedModel.value !== defaultModelValue(scopeKey());
+    const effectiveEffort =
+      (activeRuntimeConfig?.effective.effortLevel as EffortLevel | undefined) ??
+      defaultEffortForModel(selectedModel.model);
+    const effectiveFast = activeRuntimeConfig?.effective.fastMode === true && fastAvailable;
+    const runtimeToggled =
+      !runtimePending &&
+      (selectedModel.value !== defaultModelValue(scopeKey()) ||
+        composerState.effortLevel !== effectiveEffort ||
+        fastOn !== effectiveFast);
     const inputBlocked = runtimePending || ctx.chat.state.resolvingApprovals.size > 0 || approvalPauses.length > 0;
     const attachingDisabled = inputBlocked;
     let placeholder = "Ask anything";
@@ -513,22 +520,22 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                 ? settingsControl(agent, selectedModel, inputBlocked)
                 : html`
                     ${
-                      modelToggled
+                      runtimeToggled
                         ? html`<button
                             class="runtime-default-btn"
                             type="button"
                             aria-label="Make default"
                             data-mobile-label="Default"
-                            title="Use this harness and model as the default for this scope"
+                            title="Use this harness, model, effort, and fast setting as the default for this scope"
                             ?disabled=${inputBlocked}
-                            @click=${() => changeScopeRuntime({ harnessId: selectedModel.harnessId, modelId: selectedModel.model.id }, agent)}
+                            @click=${() => changeScopeRuntime({ harnessId: selectedModel.harnessId, modelId: selectedModel.model.id, effortLevel: composerState.effortLevel, fastMode: fastOn }, agent)}
                           >
                             Make default
                           </button>`
                         : nothing
                     }
                     ${
-                      modelToggled && activeRuntimeConfig?.scopeOverride
+                      runtimeToggled && activeRuntimeConfig?.scopeOverride
                         ? html`<button
                             class="runtime-default-btn"
                             type="button"

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -412,9 +412,15 @@ export interface RuntimeConfig {
   approvedHarnesses: string[];
   modelsByHarness: Record<string, string[]>;
   modelCatalog: Record<string, { name: string; provider: string }>;
-  orgDefault: { harnessId: string; modelId: string; revision: number };
-  scopeOverride: { harnessId: string; modelId: string; orgRevision: number } | null;
-  effective: { harnessId: string; modelId: string };
+  orgDefault: { harnessId: string; modelId: string; effortLevel?: string; fastMode?: boolean; revision: number };
+  scopeOverride: {
+    harnessId: string;
+    modelId: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    orgRevision: number;
+  } | null;
+  effective: { harnessId: string; modelId: string; effortLevel?: string; fastMode?: boolean };
   upgradeAvailable: boolean;
   fastModeModelIds?: string[];
   interactiveFastMode?: boolean;
@@ -432,7 +438,14 @@ export async function fetchRuntimeConfig(scopeId?: string | null): Promise<Runti
 
 export async function updateRuntimeConfig(
   scopeId: string | null,
-  change: { harnessId?: string; modelId?: string; inherit?: boolean; keep?: boolean },
+  change: {
+    harnessId?: string;
+    modelId?: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    inherit?: boolean;
+    keep?: boolean;
+  },
 ): Promise<RuntimeConfig> {
   return api<RuntimeConfig>("/api/runtime-config", {
     method: "PUT",

--- a/plugins/web-ui/test/composer-source.test.ts
+++ b/plugins/web-ui/test/composer-source.test.ts
@@ -4,13 +4,12 @@ import test from "node:test";
 
 const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
 
-test("scope-default buttons render only after the model selection is toggled off the default", () => {
-  assert.match(
-    composer,
-    /const modelToggled = !runtimePending && selectedModel\.value !== defaultModelValue\(scopeKey\(\)\)/,
-  );
-  assert.match(composer, /\$\{\s*modelToggled\s*\? html`[\s\S]{0,800}?>\s*Make default\s*<\/button>/);
-  assert.match(composer, /\$\{\s*modelToggled && activeRuntimeConfig\?\.scopeOverride/);
+test("scope-default buttons render when any runtime setting differs from the scope default", () => {
+  assert.match(composer, /const runtimeToggled =\s*!runtimePending/);
+  assert.match(composer, /composerState\.effortLevel !== effectiveEffort/);
+  assert.match(composer, /fastOn !== effectiveFast/);
+  assert.match(composer, /\$\{\s*runtimeToggled\s*\? html`[\s\S]{0,800}?>\s*Make default\s*<\/button>/);
+  assert.match(composer, /\$\{\s*runtimeToggled && activeRuntimeConfig\?\.scopeOverride/);
 });
 
 test("composer-right keeps its control order: make default, use org default, model, harness, send", () => {
@@ -69,4 +68,11 @@ test("a steer whose run already ended is recovered, never silently dropped", () 
   // Not stored anywhere → the text goes back through a normal send.
   assert.match(composer, /resendWhenIdle\(agent, text, 0\);/);
   assert.match(composer, /if \(composerState\.draft === text\) void sendPrompt\(agent\);/);
+});
+
+test("scope runtime defaults include effort and fast mode", () => {
+  assert.match(composer, /effortLevel: composerState\.effortLevel/);
+  assert.match(composer, /fastMode: fastOn/);
+  assert.match(composer, /config\.effective\.effortLevel/);
+  assert.match(composer, /config\.effective\.fastMode === true/);
 });

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -11,6 +11,7 @@ import {
   serviceableModelIds,
   ALL_PROVIDERS_AVAILABLE,
   FAST_MODE_MODEL_IDS,
+  THINKING_LEVELS,
   type HarnessId,
 } from "../../model/pi-models.ts";
 import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../../model/model-catalog.ts";
@@ -1044,14 +1045,26 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
       : builtInModelCatalog();
   const orgStored = await config.getRuntimeSelectionDurable(org);
   const orgLegacyModel = orgStored ? null : await config.getBaseModelOwnDurable(org);
-  let orgDefault = { ...safeFallback, revision: orgStored?.revision ?? 0 };
+  let orgDefault: {
+    harnessId: HarnessId;
+    modelId: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    revision: number;
+  } = { ...safeFallback, revision: orgStored?.revision ?? 0 };
   if (
     orgStored &&
     isHarnessId(orgStored.harnessId) &&
     approvedHarnesses.includes(orgStored.harnessId) &&
     modelSupportedByHarness(orgStored.modelId, orgStored.harnessId)
   ) {
-    orgDefault = { harnessId: orgStored.harnessId, modelId: orgStored.modelId, revision: orgStored.revision ?? 0 };
+    orgDefault = {
+      harnessId: orgStored.harnessId,
+      modelId: orgStored.modelId,
+      ...(orgStored.effortLevel ? { effortLevel: orgStored.effortLevel } : {}),
+      ...(typeof orgStored.fastMode === "boolean" ? { fastMode: orgStored.fastMode } : {}),
+      revision: orgStored.revision ?? 0,
+    };
   } else if (
     orgLegacyModel &&
     approvedHarnesses.includes(fallback.harnessId) &&
@@ -1061,14 +1074,26 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   }
   const stored = scope === org ? orgStored : await config.getRuntimeSelectionDurable(scope);
   const legacyModel = scope === org ? null : await config.getBaseModelOwnDurable(scope);
-  let scopeOverride: { harnessId: HarnessId; modelId: string; orgRevision?: number } | null = null;
+  let scopeOverride: {
+    harnessId: HarnessId;
+    modelId: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    orgRevision?: number;
+  } | null = null;
   if (
     stored &&
     isHarnessId(stored.harnessId) &&
     approvedHarnesses.includes(stored.harnessId) &&
     modelSupportedByHarness(stored.modelId, stored.harnessId)
   ) {
-    scopeOverride = { harnessId: stored.harnessId, modelId: stored.modelId, orgRevision: stored.orgRevision };
+    scopeOverride = {
+      harnessId: stored.harnessId,
+      modelId: stored.modelId,
+      ...(stored.effortLevel ? { effortLevel: stored.effortLevel } : {}),
+      ...(typeof stored.fastMode === "boolean" ? { fastMode: stored.fastMode } : {}),
+      orgRevision: stored.orgRevision,
+    };
   } else if (
     legacyModel &&
     approvedHarnesses.includes(fallback.harnessId) &&
@@ -1111,7 +1136,12 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
     modelCatalog,
     orgDefault,
     scopeOverride,
-    effective: { harnessId: effective.harnessId, modelId: effective.modelId },
+    effective: {
+      harnessId: effective.harnessId,
+      modelId: effective.modelId,
+      ...(effective.effortLevel ? { effortLevel: effective.effortLevel } : {}),
+      ...(typeof effective.fastMode === "boolean" ? { fastMode: effective.fastMode } : {}),
+    },
     upgradeAvailable: Boolean(scopeOverride && scopeOverride.orgRevision !== orgDefault.revision),
     fastModeModelIds: FAST_MODE_MODEL_IDS,
     interactiveFastMode: await config.getInteractiveFastModeDurable(),
@@ -1169,7 +1199,17 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
     if (typeof modelId !== "string" || !modelSupportedByHarness(modelId, harnessId))
       return sendJson(ctx.res, 400, { error: "model_not_supported" });
     if (!(await webuiModelEnabled(ctx, modelId))) return sendJson(ctx.res, 400, { error: "model_not_enabled" });
-    await config.setRuntimeSelectionLatest(target.scope, { harnessId, modelId });
+    const effortLevel = ctx.body.effortLevel ?? "auto";
+    if (typeof effortLevel !== "string" || !(THINKING_LEVELS as readonly string[]).includes(effortLevel))
+      return sendJson(ctx.res, 400, { error: "effort_not_supported" });
+    const fastMode = ctx.body.fastMode ?? false;
+    if (typeof fastMode !== "boolean") return sendJson(ctx.res, 400, { error: "fast_mode_invalid" });
+    await config.setRuntimeSelectionLatest(target.scope, {
+      harnessId,
+      modelId,
+      effortLevel,
+      fastMode: fastMode && FAST_MODE_MODEL_IDS.includes(modelId),
+    });
   }
   audit(ctx.deps, {
     principalId: target.actorId,

--- a/src/resolution/config-store.ts
+++ b/src/resolution/config-store.ts
@@ -63,10 +63,14 @@ export interface PersistedBaseModel {
   harnessId?: string;
   orgRevision?: number;
   revision?: number;
+  effortLevel?: string;
+  fastMode?: boolean;
 }
 interface RuntimeSelection {
   harnessId: string;
   modelId: string;
+  effortLevel?: string;
+  fastMode?: boolean;
 }
 interface ScopedRuntimeSelection extends RuntimeSelection {
   orgRevision: number;
@@ -652,6 +656,8 @@ export function createMemoryConfigStore(
         modelId: row.modelId,
         orgRevision: row.orgRevision ?? 0,
         ...(row.revision !== undefined ? { revision: row.revision } : {}),
+        ...(row.effortLevel !== undefined ? { effortLevel: row.effortLevel } : {}),
+        ...(row.fastMode !== undefined ? { fastMode: row.fastMode } : {}),
       };
     },
     setRuntimeSelection(id, selection) {
@@ -718,6 +724,8 @@ export function createMemoryConfigStore(
         modelId: row.modelId,
         orgRevision: row.orgRevision ?? 0,
         ...(row.revision !== undefined ? { revision: row.revision } : {}),
+        ...(row.effortLevel !== undefined ? { effortLevel: row.effortLevel } : {}),
+        ...(row.fastMode !== undefined ? { fastMode: row.fastMode } : {}),
       };
     },
     getApprovedHarnesses: () => (approvedHarnesses ? [...approvedHarnesses] : null),

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -259,10 +259,25 @@ test("runtime-config lets a person set, keep, and inherit an approved personal r
     const set = await fetch(`${srv.base}/v1/runtime-config`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ principalId: "alice", scopeId: "personal:alice", harnessId: "codex", modelId: "gpt-5.5" }),
+      body: JSON.stringify({
+        principalId: "alice",
+        scopeId: "personal:alice",
+        harnessId: "codex",
+        modelId: "gpt-5.5",
+        effortLevel: "low",
+        fastMode: true,
+      }),
     });
     assert.equal(set.status, 200);
-    assert.equal(((await set.json()) as { effective: { harnessId: string } }).effective.harnessId, "codex");
+    const selected = (await set.json()) as {
+      effective: { harnessId: string; effortLevel: string; fastMode: boolean };
+    };
+    assert.deepEqual(selected.effective, {
+      harnessId: "codex",
+      modelId: "gpt-5.5",
+      effortLevel: "low",
+      fastMode: false,
+    });
 
     srv.built.config.setRuntimeSelection("org:default-org", { harnessId: "claude", modelId: "claude-opus-4-8" });
     await srv.built.config.flushScope("org:default-org");


### PR DESCRIPTION
Model, reasoning effort, and harness defaults persist per scope instead of resetting per session.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461872&installation_model_id=19911&pr_number=203&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F203&signature=3e24598fadb0011a083d9c4f0866160a59b2b0045d13148748e3e61027db5255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->