### PR TITLE
Expose read-only budget usage to trusted surfaces

### DIFF
--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -45,6 +45,7 @@ import type { AmbientJudgmentStore } from "../surface-cache/ambient-judgment-sto
 import type { AckEmojiPickStore } from "../surface-cache/ack-emoji-pick-store.ts";
 import type { ChannelPolicyStore } from "../surface-cache/channel-policy-store.ts";
 import type { RateLimiter } from "../ratelimit/rate-limiter.ts";
+import type { BudgetTracker } from "../ratelimit/budget.ts";
 import type { AdvisoryLock } from "../persistence/advisory-lock.ts";
 import type { SlackInstallationStore, SlackSocketAppIdReader } from "../surfaces/slack-installation.ts";
 
@@ -85,6 +86,7 @@ export interface ServerDeps {
   harnessId?: string;
   admin?: AdminService;
   rateLimiter?: RateLimiter;
+  budget?: BudgetTracker;
   sessions?: SessionStore;
   auditLog?: AuditLog;
   errors?: ErrorLog;

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -7,7 +7,7 @@ import {
   retention,
   whoami,
 } from "./admin/scope-config.ts";
-import { egress, listAdminAudit, listAdminErrors, listAdminRuns, metrics } from "./admin/observability.ts";
+import { budgetUsage, egress, listAdminAudit, listAdminErrors, listAdminRuns, metrics } from "./admin/observability.ts";
 import { getAdminSession, getAdminSessionLlm, listAdminSessions, listAdminShadowDeliveries } from "./admin/sessions.ts";
 import { downloadAdminFile, listAdminFiles, readAdminFile, uploadAdminFile } from "./admin/files.ts";
 import { archiveAdminSkill, getAdminSkill, listAdminArtifacts, putAdminCronDestination } from "./admin/artifacts.ts";
@@ -65,6 +65,7 @@ const routes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "GET", path: "/v1/admin/resources", auth: "either", handle: getAdminResources },
   { method: "GET", path: "/v1/admin/retention", auth: "either", handle: retention },
   { method: "GET", path: "/v1/admin/metrics", auth: "either", handle: metrics },
+  { method: "GET", path: "/v1/budget-usage", auth: "source", handle: budgetUsage },
   { method: "GET", path: "/v1/admin/egress", auth: "either", handle: egress },
   { method: "GET", path: "/v1/admin/sessions", auth: "either", handle: listAdminSessions },
   { method: "GET", path: "/v1/admin/sessions/:id/llm", auth: "either", handle: getAdminSessionLlm },

--- a/src/api/routes/admin/observability.ts
+++ b/src/api/routes/admin/observability.ts
@@ -1,7 +1,7 @@
 import { parseScopeId, type ScopeId } from "../../../types.ts";
 import { cacheHitRatio, isStablePrefixMiss, type TurnMetricSample } from "../../../admin/metrics-sink.ts";
 import { sendJson } from "../../http.ts";
-import { audit, requireScopedAdmin } from "../shared.ts";
+import { audit, orgScope, requireScopedAdmin } from "../shared.ts";
 import { type ApiCtx } from "../route.ts";
 
 const METRICS_SCAN_LIMIT = 10000;
@@ -226,6 +226,36 @@ export async function metrics(ctx: ApiCtx): Promise<void> {
     anatomy,
     cache,
     phases,
+  });
+}
+
+export async function budgetUsage(ctx: ApiCtx): Promise<void> {
+  const { res, deps, url } = ctx;
+  const authz = await requireScopedAdmin(ctx);
+  if (!authz) return;
+  if (parseScopeId(authz.scope).kind !== "org" || authz.scope !== orgScope(deps)) {
+    return sendJson(res, 400, { error: "bad_request", message: "organization scope required" });
+  }
+  if (!deps.budget) return sendJson(res, 404, { error: "not_found" });
+  const principalId = url.searchParams.get("principalId")?.trim() ?? "";
+  if (!principalId || principalId.length > 512) {
+    return sendJson(res, 400, { error: "bad_request", message: "principalId required" });
+  }
+  audit(deps, {
+    principalId: authz.actor.id,
+    action: "budget-usage.read",
+    resource: principalId,
+    scopeLabel: authz.scope,
+  });
+  const usage = await deps.budget.snapshot(principalId);
+  const finite = (value: number): number | null => (Number.isFinite(value) ? value : null);
+  return sendJson(res, 200, {
+    scopeId: authz.scope,
+    principalId,
+    windowMs: usage.windowMs,
+    member: { spentUsd: usage.member.spentUsd, limitUsd: finite(usage.member.limitUsd) },
+    organization: { spentUsd: usage.organization.spentUsd, limitUsd: finite(usage.organization.limitUsd) },
+    approximate: true,
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const server = createServer(built.app, {
   ...(config.publicWebUrl ? { portalUrl: config.publicWebUrl } : {}),
   admin: built.admin,
   rateLimiter: built.rateLimiter,
+  budget: built.budget,
   acl: built.acl,
   credentialUsage: built.credentialUsage,
   deviceFlowCutover: built.deviceFlowCutover,

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -1,13 +1,20 @@
 import { DEFAULT_AGENT_INPUT_USD_PER_MTOK } from "../model/pi-models.ts";
-interface BudgetCheck {
+export interface BudgetCheck {
   allowed: boolean;
   spentUsd: number;
   limitUsd: number;
 }
 
+export interface BudgetUsageSnapshot {
+  windowMs: number;
+  member: Omit<BudgetCheck, "allowed">;
+  organization: Omit<BudgetCheck, "allowed">;
+}
+
 export interface BudgetTracker {
   check(principalId: string, now?: number): Promise<BudgetCheck>;
   record(principalId: string, costUsd: number, now?: number): Promise<void>;
+  snapshot(principalId: string, now?: number): Promise<BudgetUsageSnapshot>;
 }
 
 export const DEFAULT_BUDGET_WINDOW_MS = 86_400_000;
@@ -32,12 +39,21 @@ export function createBudgetTracker(
     return kept.reduce((s, e) => s + e.usd, 0);
   }
 
+  async function snapshot(principalId: string, now = Date.now()): Promise<BudgetUsageSnapshot> {
+    return {
+      windowMs,
+      member: { spentUsd: spentIn(principalId, now), limitUsd },
+      organization: { spentUsd: spentIn(orgKey, now), limitUsd: orgLimitUsd },
+    };
+  }
+
   return {
     async check(principalId, now = Date.now()) {
-      const spentUsd = spentIn(principalId, now);
-      if (spentUsd >= limitUsd) return { allowed: false, spentUsd, limitUsd };
-      const orgSpent = spentIn(orgKey, now);
-      return { allowed: orgSpent < orgLimitUsd, spentUsd: orgSpent, limitUsd: orgLimitUsd };
+      const usage = await snapshot(principalId, now);
+      if (usage.member.spentUsd >= usage.member.limitUsd) {
+        return { allowed: false, ...usage.member };
+      }
+      return { allowed: usage.organization.spentUsd < usage.organization.limitUsd, ...usage.organization };
     },
     async record(principalId, costUsd, now = Date.now()) {
       for (const key of [principalId, orgKey]) {
@@ -46,5 +62,6 @@ export function createBudgetTracker(
         spend.set(key, list);
       }
     },
+    snapshot,
   };
 }

--- a/src/ratelimit/postgres-budget.ts
+++ b/src/ratelimit/postgres-budget.ts
@@ -20,6 +20,22 @@ export function createPostgresBudgetTracker(
     `CREATE INDEX IF NOT EXISTS budget_spend_by_principal_at ON budget_spend(principal_id, at)`,
   ]);
 
+  async function snapshot(principalId: string, now = Date.now()) {
+    const rows = await q(
+      `SELECT principal_id, COALESCE(SUM(usd), 0) AS spent
+       FROM budget_spend
+       WHERE principal_id = ANY($1) AND at >= $2
+       GROUP BY principal_id`,
+      [[principalId, orgKey], now - windowMs],
+    );
+    const spent = new Map(rows.map((row) => [String(row.principal_id), Number(row.spent)]));
+    return {
+      windowMs,
+      member: { spentUsd: spent.get(principalId) ?? 0, limitUsd },
+      organization: { spentUsd: spent.get(orgKey) ?? 0, limitUsd: orgLimitUsd },
+    };
+  }
+
   return {
     async check(principalId, now = Date.now()) {
       const rows = await q(
@@ -48,5 +64,6 @@ export function createPostgresBudgetTracker(
         console.error("[budget] failed to persist spend:", err);
       }
     },
+    snapshot,
   };
 }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -52,6 +52,7 @@ import { createPostgresAuditLog } from "./admin/postgres-audit-log.ts";
 import { createRateLimiter, type RateLimiter } from "./ratelimit/rate-limiter.ts";
 import { createPostgresRateLimiter } from "./ratelimit/postgres-rate-limiter.ts";
 import { createBudgetTracker } from "./ratelimit/budget.ts";
+import type { BudgetTracker } from "./ratelimit/budget.ts";
 import { createPostgresBudgetTracker } from "./ratelimit/postgres-budget.ts";
 import { createCronStore, type CronStore } from "./cron/cron-store.ts";
 import { createDeliveryStore, type DeliveryStore } from "./delivery/delivery-store.ts";
@@ -326,6 +327,7 @@ export interface BuiltApp {
   scheduler: Scheduler;
   admin: AdminService;
   rateLimiter: RateLimiter;
+  budget: BudgetTracker;
   errors: ErrorLog;
   metrics: MetricsSink;
   crons: CronStore;
@@ -1391,6 +1393,7 @@ export function buildApp(
     scheduler,
     admin,
     rateLimiter,
+    budget,
     errors,
     metrics,
     crons,

--- a/test/admin-budget.test.ts
+++ b/test/admin-budget.test.ts
@@ -1,0 +1,157 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { test } from "node:test";
+import { createInsecureTestServer, createServer } from "../src/api/server.ts";
+import { signedHeaders } from "../plugins/chassis/src/core-client.ts";
+import { createBudgetTracker } from "../src/ratelimit/budget.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+test("budget usage is current, org-admin gated, and audited", async () => {
+  const built = buildApp(testConfig());
+  const budget = createBudgetTracker({ limitUsd: 5, orgLimitUsd: 20, windowMs: 86_400_000 });
+  const now = Date.now();
+  await budget.record("U1", 2, now - 1_000);
+  await budget.record("U2", 3, now - 1_000);
+  const server = createInsecureTestServer(built.app, {
+    admin: built.admin,
+    auditLog: built.auditLog,
+    budget,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    const response = await fetch(
+      `${base}/v1/budget-usage?scope=org:default-org&principalId=U1`,
+      { headers: { "x-admin-actor": "admin-alice@default-org" } },
+    );
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      scopeId: "org:default-org",
+      principalId: "U1",
+      windowMs: 86_400_000,
+      member: { spentUsd: 2, limitUsd: 5 },
+      organization: { spentUsd: 5, limitUsd: 20 },
+      approximate: true,
+    });
+    assert.equal(
+      (
+        await fetch(`${base}/v1/budget-usage?scope=org:default-org&principalId=U1`, {
+          headers: { "x-admin-actor": "user-uma@default-org" },
+        })
+      ).status,
+      403,
+    );
+    assert.equal(
+      (
+        await fetch(`${base}/v1/budget-usage?scope=org:other&principalId=U1`, {
+          headers: { "x-admin-actor": "admin-alice@default-org" },
+        })
+      ).status,
+      400,
+    );
+    assert.ok((await built.auditLog.events()).some((event) => event.action === "budget-usage.read"));
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("budget usage drops spend outside the configured window", async () => {
+  const budget = createBudgetTracker({ limitUsd: 5, orgLimitUsd: 20, windowMs: 1_000 });
+  await budget.record("U1", 2, 1_000);
+  assert.deepEqual(await budget.snapshot("U1", 2_001), {
+    windowMs: 1_000,
+    member: { spentUsd: 0, limitUsd: 5 },
+    organization: { spentUsd: 0, limitUsd: 20 },
+  });
+});
+
+test("budget usage requires source authentication and an organization administrator", async () => {
+  const secret = "budget-usage-source-secret".repeat(3);
+  const capabilitySecret = "budget-usage-capability-secret".repeat(3);
+  const portalIdentitySecret = "budget-usage-portal-secret".repeat(3);
+  const built = buildApp(testConfig({ signingSecret: secret }));
+  const budget = createBudgetTracker({ limitUsd: 5, orgLimitUsd: 20 });
+  const server = createServer(built.app, {
+    production: true,
+    signingSecret: secret,
+    capabilitySecret,
+    portalIdentitySecret,
+    admin: built.admin,
+    auditLog: built.auditLog,
+    budget,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  const path = "/v1/budget-usage?scope=org:default-org&principalId=U1";
+  try {
+    assert.equal((await fetch(base + path)).status, 401);
+    assert.equal(
+      (
+        await fetch(base + path, {
+          headers: { ...signedHeaders(secret, "GET", path, ""), "x-admin-actor": "user-uma@default-org" },
+        })
+      ).status,
+      403,
+    );
+    assert.equal(
+      (
+        await fetch(base + path, {
+          headers: { ...signedHeaders(secret, "GET", path, ""), "x-admin-actor": "admin-alice@default-org" },
+        })
+      ).status,
+      200,
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test("unconfigured limits are explicit and failed reads remain audited", async () => {
+  const built = buildApp(testConfig());
+  const unbounded = createBudgetTracker();
+  const first = createInsecureTestServer(built.app, {
+    admin: built.admin,
+    auditLog: built.auditLog,
+    budget: unbounded,
+  });
+  first.listen(0);
+  const path = "/v1/budget-usage?scope=org:default-org&principalId=U1";
+  try {
+    const response = await fetch(`http://localhost:${(first.address() as AddressInfo).port}${path}`, {
+      headers: { "x-admin-actor": "admin-alice@default-org" },
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      member: { limitUsd: number | null };
+      organization: { limitUsd: number | null };
+    };
+    assert.equal(body.member.limitUsd, null);
+    assert.equal(body.organization.limitUsd, null);
+  } finally {
+    await new Promise<void>((resolve) => first.close(() => resolve()));
+  }
+
+  const failing = createInsecureTestServer(built.app, {
+    admin: built.admin,
+    auditLog: built.auditLog,
+    budget: {
+      check: () => Promise.reject(new Error("unused")),
+      record: () => Promise.reject(new Error("unused")),
+      snapshot: () => Promise.reject(new Error("database unavailable")),
+    },
+  });
+  failing.listen(0);
+  try {
+    const response = await fetch(`http://localhost:${(failing.address() as AddressInfo).port}${path}`, {
+      headers: { "x-admin-actor": "admin-alice@default-org" },
+    });
+    assert.equal(response.status, 500);
+    const reads = (await built.auditLog.events()).filter((event) => event.action === "budget-usage.read");
+    assert.equal(reads.length, 2);
+  } finally {
+    await new Promise<void>((resolve) => failing.close(() => resolve()));
+  }
+});

--- a/test/postgres-budget.test.ts
+++ b/test/postgres-budget.test.ts
@@ -17,8 +17,8 @@ test(
   "pg budget: spend is shared across trackers (instances), trips at the limit, and expires out of the window",
   { skip },
   async () => {
-    const a = createPostgresBudgetTracker(URL!, { limitUsd: 1, windowMs: 60_000 });
-    const b = createPostgresBudgetTracker(URL!, { limitUsd: 1, windowMs: 60_000 });
+    const a = createPostgresBudgetTracker(URL!, { limitUsd: 1, orgLimitUsd: 10, windowMs: 60_000 });
+    const b = createPostgresBudgetTracker(URL!, { limitUsd: 1, orgLimitUsd: 10, windowMs: 60_000 });
 
     assert.equal((await a.check("U1", 1000)).allowed, true);
     await a.record("U1", 0.6, 1000);
@@ -28,9 +28,19 @@ test(
     const tripped = await a.check("U1", 1000);
     assert.equal(tripped.allowed, false, "the cap holds fleet-wide, not per instance");
     assert.equal(tripped.spentUsd > 1, true);
+    assert.deepEqual(await b.snapshot("U1", 1000), {
+      windowMs: 60_000,
+      member: { spentUsd: 1.2, limitUsd: 1 },
+      organization: { spentUsd: 1.2, limitUsd: 10 },
+    });
 
     assert.equal((await a.check("U2", 1000)).allowed, true, "budgets are per-principal");
     assert.equal((await a.check("U1", 1000 + 61_000)).allowed, true, "spend outside the window no longer counts");
+    assert.deepEqual(await a.snapshot("U1", 1000 + 61_000), {
+      windowMs: 60_000,
+      member: { spentUsd: 0, limitUsd: 1 },
+      organization: { spentUsd: 0, limitUsd: 10 },
+    });
   },
 );
 


### PR DESCRIPTION
## Summary

- add a read-only snapshot to the existing member and organization budget tracker
- expose approximate usage through a source-authenticated, organization-admin-gated endpoint
- preserve the PostgreSQL rejection hot path while reporting member and organization spend in one query

## Verification

- targeted in-memory and HTTP tests
- PostgreSQL budget tests against PostgreSQL 16
- typecheck
- scoped lint
- independent specification and standards review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788462006&installation_model_id=19911&pr_number=207&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F207&signature=9bf9f17f9df4ce9cd2a41a2823e44692388340315aaafb7e8ef5620907a431fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->