### PR TITLE
feat(slack): add allowlist controls for agent access

### DIFF
--- a/src/slack/config.ts
+++ b/src/slack/config.ts
@@ -19,8 +19,29 @@ export interface SlackPluginConfig {
   maxPrivateChannels?: number;
   recentMessages?: number;
   userCacheTtlMs?: number;
+  allow_dms: boolean;
+  user_allowlist: string[];
+  channel_allowlist: string[];
   botIdentity?: { username?: string; icon_emoji?: string };
   devIntrospection?: { port: number };
+}
+
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const value = raw.trim().toLowerCase();
+  if (value === "1" || value === "true" || value === "yes" || value === "on") return true;
+  if (value === "0" || value === "false" || value === "no" || value === "off") return false;
+  return undefined;
+}
+
+function parseCsv(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const values: string[] = [];
+  for (const part of raw.split(",")) {
+    const value = part.replace(/^\s+|\s+$/g, "");
+    if (value) values.push(value);
+  }
+  return values;
 }
 
 export function slackPluginConfigFromEnv(env: Record<string, string | undefined>): SlackPluginConfig | null {
@@ -53,6 +74,9 @@ export function slackPluginConfigFromEnv(env: Record<string, string | undefined>
     ...opt("maxPrivateChannels", num(env.SLACK_MAX_PRIVATE_CHANNELS)),
     ...opt("recentMessages", num(env.SLACK_RECENT_MESSAGES)),
     ...opt("userCacheTtlMs", num(env.SLACK_USER_CACHE_TTL_MS)),
+    allow_dms: parseBool(env.SLACK_ALLOW_DMS) ?? true,
+    user_allowlist: parseCsv(env.SLACK_USER_ALLOWLIST),
+    channel_allowlist: parseCsv(env.SLACK_CHANNEL_ALLOWLIST),
     ...(() => {
       const identity = botIdentityFromEnv(env);
       return Object.keys(identity).length ? { botIdentity: identity } : {};

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -13,7 +13,25 @@ import {
 import type { AckGate } from "./deferred-ack.ts";
 import type { BotIdentity, Directory } from "./directory.ts";
 import type { Mirror } from "./mirror.ts";
+import type { SlackPluginConfig } from "./config.ts";
 import type { SlackReactionEvent, TurnHandler } from "./turn-handler.ts";
+
+function canProcessSlackEvent(
+  config: SlackPluginConfig,
+  channelType: string | undefined,
+  userId: string | undefined,
+  channelId: string | undefined,
+): boolean {
+  if (channelType === "im") {
+    if (!config.allow_dms) return false;
+    if (config.user_allowlist.length > 0 && (!userId || !config.user_allowlist.includes(userId))) return false;
+    return true;
+  }
+  if (channelType === "channel" || channelType === "group" || channelType === "mpim") {
+    if (config.channel_allowlist.length > 0 && (!channelId || !config.channel_allowlist.includes(channelId))) return false;
+  }
+  return true;
+}
 
 export function registerSlackEvents(
   app: {
@@ -28,15 +46,17 @@ export function registerSlackEvents(
     deduper: ReturnType<typeof createDeduper>;
     webUiPublicUrl?: string;
     ensureHeader?: (client: SurfaceHeaderClient, channel: string, scopeId: string, kind: "dm" | "channel") => void;
+    config: SlackPluginConfig;
   },
 ): void {
-  const { handler, mirror, directory, ids, deduper } = deps;
+  const { handler, mirror, directory, ids, deduper, config } = deps;
   const { dispatch, handleReactionEvent, botHasStakeInThread } = handler;
   const { mirrorMessageEvent, pushSurfaceEvents } = mirror;
   const { knownPublicChannels, syncForUnseenGroup, forceDirectorySync } = directory;
 
   app.event("app_mention", async ({ event, body, client, context }: any) => {
     const e = event as any;
+    if (!canProcessSlackEvent(config, e.channel_type ?? "channel", e.user, e.channel)) return;
     const key = dedupeKey({
       event_id: (body as any)?.event_id,
       client_msg_id: e.client_msg_id,
@@ -101,6 +121,7 @@ export function registerSlackEvents(
     if (!shouldProcessMessage(m, ids.botUserId, ids.ownBotId)) return;
 
     if (m.channel_type === "im") {
+      if (!canProcessSlackEvent(config, m.channel_type, m.user, m.channel)) return;
       const key = dedupeKey({
         event_id: (body as any)?.event_id,
         client_msg_id: m.client_msg_id,
@@ -126,6 +147,7 @@ export function registerSlackEvents(
     }
 
     if (m.channel_type === "channel" || m.channel_type === "group" || m.channel_type === "mpim") {
+      if (!canProcessSlackEvent(config, m.channel_type, m.user, m.channel)) return;
       if (m.channel_type === "mpim" && m.channel) syncForUnseenGroup(client, String(m.channel));
       const threadReply = isThreadReply(m);
       const isMention = mentionsBot(m.text ?? "", ids.botUserId);

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -161,6 +161,7 @@ export async function startSlackPlugin(
     directory,
     ids,
     deduper,
+    config: cfg,
     ...(cfg.webUiPublicUrl ? { webUiPublicUrl: cfg.webUiPublicUrl } : {}),
     ensureHeader,
   });

--- a/test/slack-http-events.test.ts
+++ b/test/slack-http-events.test.ts
@@ -12,8 +12,14 @@ test("HTTP events mode trims the configured enum like the deployment secret gate
     SLACK_EVENTS_MODE: "  http  ",
     SLACK_BOT_TOKEN: "xoxb-test",
     SLACK_SIGNING_SECRET: SECRET,
+    SLACK_ALLOW_DMS: "false",
+    SLACK_USER_ALLOWLIST: "U1, U2 ",
+    SLACK_CHANNEL_ALLOWLIST: "C1,C2",
   });
   assert.equal(config?.eventsMode, "http");
+  assert.equal(config?.allow_dms, false);
+  assert.deepEqual(config?.user_allowlist, ["U1", "U2"]);
+  assert.deepEqual(config?.channel_allowlist, ["C1", "C2"]);
 });
 
 function sign(body: string, ts = Math.floor(Date.now() / 1000)): { signature: string; timestamp: string } {

--- a/test/slack-index.integration.test.ts
+++ b/test/slack-index.integration.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { mock, test } from "node:test";
 import type { SlackCoreClient } from "../src/slack/index.ts";
+import type { SlackPluginConfig } from "../src/slack/config.ts";
 import type { TurnResult } from "../src/types.ts";
 
 type Handler = (args: any) => Promise<void>;
@@ -301,16 +302,23 @@ async function waitFor(cond: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
-async function fixture(options: { externalParticipants?: boolean; webUiPublicUrl?: string } = {}) {
+async function fixture(
+  options: { externalParticipants?: boolean; webUiPublicUrl?: string; slackConfig?: Partial<SlackPluginConfig> } = {},
+) {
   const core = new FakeCore();
   core.externalParticipants = options.externalParticipants ?? false;
+  const slackConfig: SlackPluginConfig = {
+    botToken: "xoxb-test",
+    appToken: "xapp-test",
+    identityEmail: "0",
+    allow_dms: true,
+    user_allowlist: [],
+    channel_allowlist: [],
+    ...(options.slackConfig ?? {}),
+    ...(options.webUiPublicUrl ? { webUiPublicUrl: options.webUiPublicUrl } : {}),
+  };
   const started = startSlackPlugin(
-    {
-      botToken: "xoxb-test",
-      appToken: "xapp-test",
-      identityEmail: "0",
-      ...(options.webUiPublicUrl ? { webUiPublicUrl: options.webUiPublicUrl } : {}),
-    },
+    slackConfig,
     core,
   );
   const app = FakeApp.instances.at(-1)!;
@@ -342,7 +350,14 @@ test("config is all-or-nothing and numeric tuning fails closed", () => {
     SLACK_CHANNEL_MEMBERS_TTL_MS: "NaN",
     SLACK_MAX_PRIVATE_CHANNELS: "10",
   });
-  assert.deepEqual(config, { botToken: "xoxb", appToken: "xapp", maxPrivateChannels: 10 });
+  assert.deepEqual(config, {
+    botToken: "xoxb",
+    appToken: "xapp",
+    maxPrivateChannels: 10,
+    allow_dms: true,
+    user_allowlist: [],
+    channel_allowlist: [],
+  });
 });
 
 test("a mid-turn message that STEERS the live run does not post the reply twice", async () => {
@@ -538,6 +553,30 @@ test("an external principal is refused in a DM before core sees the text", async
   }
 });
 
+test("a DM allowlist blocks non-pilot users before core sees the text", async () => {
+  const f = await fixture({ slackConfig: { user_allowlist: ["U2"] } });
+  try {
+    await f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "let me in", ts: "102.2" });
+    assert.equal(f.core.turns.length, 0);
+    assert.equal(f.client.posts.length, 0);
+    assert.equal(f.core.ingests.flat().some((event) => event.text === "let me in"), false);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("allow_dms=false blocks direct messages before core sees the text", async () => {
+  const f = await fixture({ slackConfig: { allow_dms: false } });
+  try {
+    await f.app.emitMessage({ channel: "D1", channel_type: "im", user: "U1", text: "hello?", ts: "102.3" });
+    assert.equal(f.core.turns.length, 0);
+    assert.equal(f.client.posts.length, 0);
+    assert.equal(f.core.ingests.flat().some((event) => event.text === "hello?"), false);
+  } finally {
+    await f.stop();
+  }
+});
+
 test("a Slack Connect mention is refused ephemerally and never mirrored", async () => {
   const f = await fixture();
   try {
@@ -548,6 +587,34 @@ test("a Slack Connect mention is refused ephemerally and never mirrored", async 
     assert.equal(f.client.posts.length, 0);
     assert.equal(f.client.ephemerals.length, 1);
     assert.match(f.client.ephemerals[0].text, /isn't fully internal/);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a channel allowlist blocks mentions before orchestration starts", async () => {
+  const f = await fixture({ slackConfig: { channel_allowlist: ["C9"] } });
+  try {
+    const event = { channel: "C1", channel_type: "channel", user: "U1", text: "<@UBOT> hello", ts: "103.15" };
+    await f.app.emitEvent("app_mention", event);
+    assert.equal(f.core.turns.length, 0);
+    assert.equal(f.core.ingests.length, 0);
+    assert.equal(f.client.posts.length, 0);
+    assert.equal(f.client.ephemerals.length, 0);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a channel allowlist blocks mpim thread-follow before directory sync or orchestration", async () => {
+  const f = await fixture({ slackConfig: { channel_allowlist: ["C1"] } });
+  try {
+    f.client.channelsById.set("G9", { id: "G9", name: "", is_member: true, is_private: true, is_mpim: true });
+    const listedBefore = f.client.groupListings;
+    await f.app.emitMessage({ channel: "G9", channel_type: "mpim", user: "U1", text: "also update", ts: "400.1", thread_ts: "300.1" });
+    assert.equal(f.core.turns.length, 0);
+    assert.equal(f.client.groupListings, listedBefore);
+    assert.equal(f.core.ingests.length, 0);
   } finally {
     await f.stop();
   }


### PR DESCRIPTION
this pull request introduces new configuration options to control which users and channels the slack plugin will process events from, adding support for allowlists and direct message restrictions. these changes enhance security and flexibility by enabling administrators to restrict access to specific users and channels, and to disable direct message handling if desired. the implementation includes environment variable parsing, enforcement in event handlers, and comprehensive tests

configuration and environment parsing:

* added `allow_dms`, `user_allowlist`, and `channel_allowlist` options to the `SlackPluginConfig` interface, with parsing functions to interpret environment variables (`SLACK_ALLOW_DMS`, `SLACK_USER_ALLOWLIST`, `SLACK_CHANNEL_ALLOWLIST`). [[1]](diffhunk://#diff-3d669132bf1f7642a0f6acbc23e9ffdcdd9e17477e7aec6ec7539704a42f4b4dR22-R46) [[2]](diffhunk://#diff-3d669132bf1f7642a0f6acbc23e9ffdcdd9e17477e7aec6ec7539704a42f4b4dR77-R79)
* updated `slackPluginConfigFromEnv` to set defaults and parse the new configuration options

event handling and enforcement:

* implemented the `canProcessSlackEvent` function to enforce allowlist and DM restrictions, and integrated it into Slack event handlers to prevent unauthorized events from being processed [[1]](diffhunk://#diff-f82c4ce2a308ee0d0a95a153338d16bb2cbfe3117ffca7294e237b55187bac5bR16-R35) [[2]](diffhunk://#diff-f82c4ce2a308ee0d0a95a153338d16bb2cbfe3117ffca7294e237b55187bac5bR49-R59) [[3]](diffhunk://#diff-f82c4ce2a308ee0d0a95a153338d16bb2cbfe3117ffca7294e237b55187bac5bR124) [[4]](diffhunk://#diff-f82c4ce2a308ee0d0a95a153338d16bb2cbfe3117ffca7294e237b55187bac5bR150)
* updated the plugin startup and dependency injection to pass the new configuration to event handlers

testing:

* added and updated tests to verify that allowlists and DM restrictions are correctly enforced, including cases for user/channel allowlists and DM blocking [[1]](diffhunk://#diff-b0a2411746b37b2b1a96a3b13e0147f6e402dc48f661af16adb24bec14ac6e2aR15-R22) [[2]](diffhunk://#diff-14fceeb73d0b2239b7d9809a1b435a8533fe0044cdfc5377c31696b2365f2bd0L345-R360) [[3]](diffhunk://#diff-14fceeb73d0b2239b7d9809a1b435a8533fe0044cdfc5377c31696b2365f2bd0R556-R579) [[4]](diffhunk://#diff-14fceeb73d0b2239b7d9809a1b435a8533fe0044cdfc5377c31696b2365f2bd0R595-R622)
* extended the test fixture and integration tests to support and validate the new configuration options [[1]](diffhunk://#diff-14fceeb73d0b2239b7d9809a1b435a8533fe0044cdfc5377c31696b2365f2bd0R4) [[2]](diffhunk://#diff-14fceeb73d0b2239b7d9809a1b435a8533fe0044cdfc5377c31696b2365f2bd0L304-R321)

these changes provide fine-grained control over which slack events are handled, improving security and compliance for deployments

issue #146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788468771&installation_model_id=19911&pr_number=211&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F211&signature=fcae05d0bbb16af032f99dedda21f6d19be2ad7573fe1907fef0486584262a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->