### PR TITLE
Make channel policy updates atomic

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -199,19 +199,22 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       if ("error" in parsed) return { error: parsed.error };
       if (b.ambientEnabled !== undefined && b.ambientEnabled !== null && typeof b.ambientEnabled !== "boolean")
         return { error: "ambientEnabled must be a boolean or null (null = default rule)" };
-      const current = await deps.channelPolicy.get(ref);
-      if (typeof b.baseUpdatedAt === "number" && (current?.updatedAt ?? 0) !== b.baseUpdatedAt) {
+      const opts = {
+        setBy: actor.id,
+        bots: parsed.bots,
+        ambientEnabled: b.ambientEnabled as boolean | null | undefined,
+      };
+      const saved =
+        typeof b.baseUpdatedAt === "number"
+          ? await deps.channelPolicy.compareAndSet(ref, b.baseUpdatedAt, b.orders, opts)
+          : await deps.channelPolicy.set(ref, b.orders, opts);
+      if (!saved) {
         return {
           error: "this channel's policy changed since you loaded it — reload and re-apply your edit",
           code: "conflict",
           status: 409,
         };
       }
-      await deps.channelPolicy.set(ref, b.orders, {
-        setBy: actor.id,
-        bots: parsed.bots,
-        ambientEnabled: b.ambientEnabled as boolean | null | undefined,
-      });
       audit(ctx.deps, { principalId: actor.id, action: "surface.policy.set", resource: ref, scopeLabel: scope });
       return { ok: true };
     },

--- a/src/api/routes/context-policy.ts
+++ b/src/api/routes/context-policy.ts
@@ -72,18 +72,21 @@ export async function setContextPolicy(ctx: ApiCtx): Promise<void> {
       error: "bad_request",
       message: "ambientEnabled must be a boolean or null (null = default rule)",
     });
-  const current = await deps.channelPolicy.get(container);
-  if (typeof b.baseUpdatedAt === "number" && (current?.updatedAt ?? 0) !== b.baseUpdatedAt) {
+  const opts = {
+    setBy: principalId,
+    bots: parsed.bots,
+    ambientEnabled: b.ambientEnabled as boolean | null | undefined,
+  };
+  const p =
+    typeof b.baseUpdatedAt === "number"
+      ? await deps.channelPolicy.compareAndSet(container, b.baseUpdatedAt, b.orders, opts)
+      : await deps.channelPolicy.set(container, b.orders, opts);
+  if (!p) {
     return sendJson(res, 409, {
       error: "conflict",
       message: "this channel's policy changed since you loaded it — reload and re-apply your edit",
     });
   }
-  const p = await deps.channelPolicy.set(container, b.orders, {
-    setBy: principalId,
-    bots: parsed.bots,
-    ambientEnabled: b.ambientEnabled as boolean | null | undefined,
-  });
   audit(deps, { principalId, action: "surface.policy.set", resource: container, scopeLabel: scope });
   return sendJson(res, 200, {
     policy: { orders: p.orders, bots: p.bots, ambientEnabled: p.ambientEnabled ?? null, updatedAt: p.updatedAt },

--- a/src/surface-cache/channel-policy-store.ts
+++ b/src/surface-cache/channel-policy-store.ts
@@ -63,6 +63,12 @@ export interface ChannelPolicyStore {
     orders: string,
     opts?: { setBy?: string; bots?: Record<string, BotPolicy>; sessionId?: string; ambientEnabled?: boolean | null },
   ): Promise<ChannelPolicy>;
+  compareAndSet(
+    container: string,
+    expectedUpdatedAt: number,
+    orders: string,
+    opts?: { setBy?: string; bots?: Record<string, BotPolicy>; sessionId?: string; ambientEnabled?: boolean | null },
+  ): Promise<ChannelPolicy | null>;
   history(container: string, limit?: number): Promise<ChannelPolicyRevision[]>;
   list(): Promise<ChannelPolicy[]>;
   close(): Promise<void>;
@@ -111,40 +117,60 @@ export function createPostgresChannelPolicyStore(connectionString: string): Chan
     ...(r.session_id != null ? { sessionId: r.session_id as string } : {}),
     createdAt: Number(r.created_at),
   });
+  const write = async (
+    container: string,
+    orders: string,
+    opts:
+      | { setBy?: string; bots?: Record<string, BotPolicy>; sessionId?: string; ambientEnabled?: boolean | null }
+      | undefined,
+    expectedUpdatedAt: number | null,
+  ): Promise<ChannelPolicy | null> => {
+    const now = Date.now();
+    const rows = await q(
+      `WITH up AS (
+         INSERT INTO channel_policy(org_id, container, orders, bots, ambient_enabled, set_by, updated_at)
+         SELECT $1,$2,$3,COALESCE($4::jsonb,'{}'::jsonb),CASE WHEN $9 THEN $8::boolean END,$5,$6
+         WHERE $10::bigint IS NULL OR $10::bigint = 0 OR EXISTS (
+           SELECT 1 FROM channel_policy WHERE org_id = $1 AND container = $2
+         )
+         ON CONFLICT (org_id, container) DO UPDATE SET orders = EXCLUDED.orders,
+           bots = COALESCE($4::jsonb, channel_policy.bots),
+           ambient_enabled = CASE WHEN $9 THEN $8::boolean ELSE channel_policy.ambient_enabled END,
+           set_by = EXCLUDED.set_by,
+           updated_at = GREATEST(EXCLUDED.updated_at, channel_policy.updated_at + 1)
+         WHERE $10::bigint IS NULL OR channel_policy.updated_at = $10::bigint
+         RETURNING *
+       ), hist AS (
+         INSERT INTO channel_policy_history(org_id, container, orders, bots, ambient_enabled, set_by, session_id, created_at)
+         SELECT $1, $2, up.orders, up.bots, up.ambient_enabled, up.set_by, $7, up.updated_at FROM up
+       )
+       SELECT * FROM up`,
+      [
+        orgId,
+        container,
+        orders,
+        opts?.bots ? JSON.stringify(opts.bots) : null,
+        opts?.setBy ?? null,
+        now,
+        opts?.sessionId ?? null,
+        opts?.ambientEnabled ?? null,
+        opts?.ambientEnabled !== undefined,
+        expectedUpdatedAt,
+      ],
+    );
+    return rows[0] ? row(rows[0]) : null;
+  };
   return {
     async get(container) {
       const rows = await q("SELECT * FROM channel_policy WHERE org_id = $1 AND container = $2", [orgId, container]);
       return rows[0] ? row(rows[0]) : null;
     },
     async set(container, orders, opts) {
-      const now = Date.now();
-      const rows = await q(
-        `WITH up AS (
-           INSERT INTO channel_policy(org_id, container, orders, bots, ambient_enabled, set_by, updated_at)
-           VALUES ($1,$2,$3,COALESCE($4::jsonb,'{}'::jsonb),CASE WHEN $9 THEN $8::boolean END,$5,$6)
-           ON CONFLICT (org_id, container) DO UPDATE SET orders = EXCLUDED.orders,
-             bots = COALESCE($4::jsonb, channel_policy.bots),
-             ambient_enabled = CASE WHEN $9 THEN $8::boolean ELSE channel_policy.ambient_enabled END,
-             set_by = EXCLUDED.set_by, updated_at = EXCLUDED.updated_at
-           RETURNING *
-         ), hist AS (
-           INSERT INTO channel_policy_history(org_id, container, orders, bots, ambient_enabled, set_by, session_id, created_at)
-           SELECT $1, $2, $3, up.bots, up.ambient_enabled, $5, $7, $6 FROM up
-         )
-         SELECT * FROM up`,
-        [
-          orgId,
-          container,
-          orders,
-          opts?.bots ? JSON.stringify(opts.bots) : null,
-          opts?.setBy ?? null,
-          now,
-          opts?.sessionId ?? null,
-          opts?.ambientEnabled ?? null,
-          opts?.ambientEnabled !== undefined,
-        ],
-      );
-      return row(rows[0]!);
+      return (await write(container, orders, opts, null))!;
+    },
+    async compareAndSet(container, expectedUpdatedAt, orders, opts) {
+      if (!Number.isSafeInteger(expectedUpdatedAt) || expectedUpdatedAt < 0) return null;
+      return write(container, orders, opts, expectedUpdatedAt);
     },
     async history(container, limit = HISTORY_DEFAULT_LIMIT) {
       const rows = await q(
@@ -164,34 +190,49 @@ export function createPostgresChannelPolicyStore(connectionString: string): Chan
 export function createMemoryChannelPolicyStore(): ChannelPolicyStore {
   const policies = new Map<string, ChannelPolicy>();
   const history: ChannelPolicyRevision[] = [];
+  const write = (
+    container: string,
+    orders: string,
+    opts:
+      | { setBy?: string; bots?: Record<string, BotPolicy>; sessionId?: string; ambientEnabled?: boolean | null }
+      | undefined,
+    expectedUpdatedAt?: number,
+  ): ChannelPolicy | null => {
+    const existing = policies.get(container);
+    if (expectedUpdatedAt !== undefined && (existing?.updatedAt ?? 0) !== expectedUpdatedAt) return null;
+    const updatedAt = Math.max(Date.now(), (existing?.updatedAt ?? 0) + 1);
+    const ambientEnabled =
+      opts?.ambientEnabled === undefined ? existing?.ambientEnabled : (opts.ambientEnabled ?? undefined);
+    const p: ChannelPolicy = {
+      container,
+      orders,
+      bots: opts?.bots ?? existing?.bots ?? {},
+      ...(ambientEnabled !== undefined ? { ambientEnabled } : {}),
+      ...(opts?.setBy ? { setBy: opts.setBy } : {}),
+      updatedAt,
+    };
+    policies.set(container, p);
+    history.push({
+      container,
+      orders,
+      bots: p.bots,
+      ...(p.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
+      ...(opts?.setBy ? { setBy: opts.setBy } : {}),
+      ...(opts?.sessionId ? { sessionId: opts.sessionId } : {}),
+      createdAt: updatedAt,
+    });
+    return p;
+  };
   return {
     async get(container) {
       return policies.get(container) ?? null;
     },
     async set(container, orders, opts) {
-      const existing = policies.get(container);
-      const now = Date.now();
-      const ambientEnabled =
-        opts?.ambientEnabled === undefined ? existing?.ambientEnabled : (opts.ambientEnabled ?? undefined);
-      const p: ChannelPolicy = {
-        container,
-        orders,
-        bots: opts?.bots ?? existing?.bots ?? {},
-        ...(ambientEnabled !== undefined ? { ambientEnabled } : {}),
-        ...(opts?.setBy ? { setBy: opts.setBy } : {}),
-        updatedAt: now,
-      };
-      policies.set(container, p);
-      history.push({
-        container,
-        orders,
-        bots: p.bots,
-        ...(p.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
-        ...(opts?.setBy ? { setBy: opts.setBy } : {}),
-        ...(opts?.sessionId ? { sessionId: opts.sessionId } : {}),
-        createdAt: now,
-      });
-      return p;
+      return write(container, orders, opts)!;
+    },
+    async compareAndSet(container, expectedUpdatedAt, orders, opts) {
+      if (!Number.isSafeInteger(expectedUpdatedAt) || expectedUpdatedAt < 0) return null;
+      return write(container, orders, opts, expectedUpdatedAt);
     },
     async history(container, limit = HISTORY_DEFAULT_LIMIT) {
       return history

--- a/test/context-policy-routes.test.ts
+++ b/test/context-policy-routes.test.ts
@@ -172,3 +172,25 @@ test("a stale baseUpdatedAt bounces instead of reverting a concurrent edit", asy
   assert.equal(fresh.out.status, 200);
   assert.equal((await store.get("C3"))?.orders, "v2");
 });
+
+test("simultaneous policy writes from the same revision have exactly one winner", async () => {
+  const store = createMemoryChannelPolicyStore();
+  await store.set("C6", "v1", { setBy: "agent" });
+  const revision = (await store.get("C6"))!.updatedAt;
+  const first = makeCtx({
+    contexts: ["channel:C6"],
+    store,
+    body: { principalId: "alice", scope: "channel:C6", orders: "v2-a", bots: {}, baseUpdatedAt: revision },
+  });
+  const second = makeCtx({
+    contexts: ["channel:C6"],
+    store,
+    body: { principalId: "bob", scope: "channel:C6", orders: "v2-b", bots: {}, baseUpdatedAt: revision },
+  });
+
+  await Promise.all([setContextPolicy(first.ctx), setContextPolicy(second.ctx)]);
+
+  assert.deepEqual([first.out.status, second.out.status].sort(), [200, 409]);
+  assert.ok(["v2-a", "v2-b"].includes((await store.get("C6"))!.orders));
+  assert.equal((await store.history("C6")).length, 2);
+});

--- a/test/postgres-surface-cache.test.ts
+++ b/test/postgres-surface-cache.test.ts
@@ -174,6 +174,40 @@ test("pg channel-policy: history appends a revision per set with provenance", { 
   }
 });
 
+test("pg channel-policy: compare-and-set admits one writer across store instances", { skip }, async () => {
+  const first = createPostgresChannelPolicyStore(URL!);
+  const second = createPostgresChannelPolicyStore(URL!);
+  try {
+    const initial = await first.set("CPCAS1", "v1", { setBy: "U-initial" });
+    const [left, right] = await Promise.all([
+      first.compareAndSet("CPCAS1", initial.updatedAt, "v2-left", { setBy: "U-left" }),
+      second.compareAndSet("CPCAS1", initial.updatedAt, "v2-right", { setBy: "U-right" }),
+    ]);
+    assert.equal([left, right].filter(Boolean).length, 1);
+    assert.ok(["v2-left", "v2-right"].includes((await first.get("CPCAS1"))!.orders));
+    assert.equal((await first.history("CPCAS1")).length, 2);
+  } finally {
+    await Promise.all([first.close(), second.close()]);
+  }
+});
+
+test("pg channel-policy: compare-and-set creates only from revision zero", { skip }, async () => {
+  const first = createPostgresChannelPolicyStore(URL!);
+  const second = createPostgresChannelPolicyStore(URL!);
+  try {
+    assert.equal(await first.compareAndSet("CPCAS2", 42, "invalid"), null);
+    const created = await Promise.all([
+      first.compareAndSet("CPCAS2", 0, "created-left", { setBy: "U-left" }),
+      second.compareAndSet("CPCAS2", 0, "created-right", { setBy: "U-right" }),
+    ]);
+    assert.equal(created.filter(Boolean).length, 1);
+    assert.ok(["created-left", "created-right"].includes((await first.get("CPCAS2"))!.orders));
+    assert.equal((await first.history("CPCAS2")).length, 1);
+  } finally {
+    await Promise.all([first.close(), second.close()]);
+  }
+});
+
 test("pg surface-cache: mentions JSONB round-trips and survives a mention-less edit", { skip }, async () => {
   const cache = createPostgresSurfaceCache(URL!);
   try {


### PR DESCRIPTION
## Summary

- add atomic compare-and-set support to channel policy stores
- use the shared CAS path for both member context-policy and admin ambient-policy writes
- keep policy history consistent when concurrent writers race

## Verification

- affected context, admin, and real-PostgreSQL tests: 29 passed
- typecheck and targeted ESLint passed
- fresh independent review passed
- production-shaped local instance with real PostgreSQL returned exactly one `200` and one `409` for simultaneous admin writes from the same revision

No rendered frontend changed, so no screenshot is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788468925&installation_model_id=19911&pr_number=212&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F212&signature=56e557838650d8b1ae169211fe0ed3d11a9a73950dc7b5c1d69e769d2a428307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->