### PR TITLE
Constrain internal OIDC broker endpoints

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -13,6 +13,7 @@ import {
   type DeclaredServiceName,
   type ServiceName,
 } from "./services.ts";
+import { validHttpsOidcUrl, validOidcServerEndpoint, type OidcServerEndpointKind } from "./oidc-url.ts";
 import { hostingProviderChoices, isTarget, type Target } from "./providers.ts";
 import { envNum, isEnvVarName, isMissingOrPlaceholder } from "./util.ts";
 
@@ -805,11 +806,31 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
   if (issuer !== "https://slack.com" && isMissingOrPlaceholder(jwksUri)) {
     throw new CliError(`${path}: portal requires env.portal.OIDC_JWKS_URI when using a non-Slack OIDC issuer`);
   }
-  if (jwksUri !== undefined) {
-    try {
-      if (new URL(jwksUri).protocol !== "https:") throw new Error("protocol");
-    } catch {
-      throw new CliError(`${path}: env.portal.OIDC_JWKS_URI must be a non-placeholder HTTPS URL`);
+  const configuredServiceHost = env.AUTH_BROKER_SERVICE_HOST?.trim().toLowerCase() ?? "";
+  const declaredServiceHost = config.plugins.some((plugin) => plugin.name.toLowerCase() === configuredServiceHost)
+    ? configuredServiceHost
+    : "";
+  const broker = env.AUTH_BROKER_UPSTREAM
+    ? { upstream: env.AUTH_BROKER_UPSTREAM, ...(declaredServiceHost ? { declaredServiceHost } : {}) }
+    : null;
+  if (env.OIDC_AUTH_ENDPOINT !== undefined && !validHttpsOidcUrl(env.OIDC_AUTH_ENDPOINT)) {
+    throw new CliError(`${path}: env.portal.OIDC_AUTH_ENDPOINT must be an HTTPS URL without credentials`);
+  }
+  const endpoints: Array<[OidcServerEndpointKind, string | undefined]> = [
+    ["token", env.OIDC_TOKEN_ENDPOINT],
+    ["userinfo", env.OIDC_USERINFO_ENDPOINT],
+    ["jwks", jwksUri],
+  ];
+  const endpointKeys: Record<OidcServerEndpointKind, string> = {
+    token: "OIDC_TOKEN_ENDPOINT",
+    userinfo: "OIDC_USERINFO_ENDPOINT",
+    jwks: "OIDC_JWKS_URI",
+  };
+  for (const [kind, endpoint] of endpoints) {
+    if (endpoint !== undefined && !validOidcServerEndpoint(endpoint, kind, broker)) {
+      throw new CliError(
+        `${path}: env.portal.${endpointKeys[kind]} must be a non-placeholder HTTPS URL without credentials or the exact service-local AUTH_BROKER_UPSTREAM endpoint`,
+      );
     }
   }
   if (env.OIDC_CLIENT_ID !== undefined && isMissingOrPlaceholder(env.OIDC_CLIENT_ID)) {

--- a/cli/src/oidc-url.ts
+++ b/cli/src/oidc-url.ts
@@ -1,0 +1,97 @@
+import { isIP } from "node:net";
+
+export type OidcServerEndpointKind = "token" | "userinfo" | "jwks";
+
+const brokerPaths: Record<OidcServerEndpointKind, string> = {
+  token: "/token",
+  userinfo: "/userinfo",
+  jwks: "/.well-known/jwks.json",
+};
+
+function privateIp(hostname: string): boolean {
+  if (isIP(hostname) === 4) {
+    const octets = hostname.split(".").map(Number);
+    return (
+      octets[0] === 127 ||
+      octets[0] === 10 ||
+      (octets[0] === 192 && octets[1] === 168) ||
+      (octets[0] === 172 && octets[1] !== undefined && octets[1] >= 16 && octets[1] <= 31)
+    );
+  }
+  if (isIP(hostname) === 6) {
+    const normalized = hostname.toLowerCase();
+    return (
+      normalized === "::1" ||
+      normalized === "0:0:0:0:0:0:0:1" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd")
+    );
+  }
+  return false;
+}
+
+export function isServiceLocalHostname(hostname: string, declaredServiceHost = ""): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const declared = declaredServiceHost.trim().toLowerCase();
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".flycast") ||
+    host.endsWith(".local") ||
+    privateIp(host) ||
+    Boolean(declared && !host.includes(".") && host === declared)
+  );
+}
+
+export function brokerOrigin(raw: string, declaredServiceHost = ""): string {
+  try {
+    const url = new URL(raw);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !isServiceLocalHostname(url.hostname, declaredServiceHost) ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    )
+      return "";
+    return url.origin;
+  } catch {
+    return "";
+  }
+}
+
+export function validHttpsOidcUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" && !url.username && !url.password && !url.hash;
+  } catch {
+    return false;
+  }
+}
+
+export function sameOidcUrl(left: string, right: string): boolean {
+  try {
+    return new URL(left).href === new URL(right).href;
+  } catch {
+    return false;
+  }
+}
+
+export function validOidcServerEndpoint(
+  raw: string,
+  kind: OidcServerEndpointKind,
+  broker: { upstream: string; declaredServiceHost?: string } | null,
+): boolean {
+  try {
+    const url = new URL(raw);
+    if (!broker) return validHttpsOidcUrl(raw);
+    if (url.username || url.password || url.hash || url.search) return false;
+    const expectedOrigin = brokerOrigin(broker.upstream, broker.declaredServiceHost);
+    return Boolean(expectedOrigin && url.origin === expectedOrigin && url.pathname === brokerPaths[kind]);
+  } catch {
+    return false;
+  }
+}

--- a/cli/src/services.ts
+++ b/cli/src/services.ts
@@ -90,6 +90,7 @@ const AUTH_CLIENT_ID = "qm-portal";
 
 export const AUTH_BROKER_ENV_KEYS = [
   "AUTH_BROKER_UPSTREAM",
+  "AUTH_BROKER_SERVICE_HOST",
   "AUTH_BROKER_PREFIX",
   "OIDC_CLIENT_ID",
   "OIDC_ISSUER",
@@ -110,8 +111,10 @@ export function brokerWiring(
   const internal = o.authBaseUrl.replace(/\/$/, "");
   const issuer = `${base}${AUTH_PATH_PREFIX}`;
   if (service === "portal") {
+    const serviceHost = new URL(internal).hostname;
     return {
       AUTH_BROKER_UPSTREAM: internal,
+      AUTH_BROKER_SERVICE_HOST: serviceHost,
       AUTH_BROKER_PREFIX: AUTH_PATH_PREFIX,
       OIDC_CLIENT_ID: AUTH_CLIENT_ID,
       OIDC_ISSUER: issuer,
@@ -230,6 +233,7 @@ const CATALOG: Record<ServiceName, ServiceDef> = {
         "OIDC_SCOPES",
         "OIDC_PRINCIPAL_CLAIM",
         "AUTH_BROKER_UPSTREAM",
+        "AUTH_BROKER_SERVICE_HOST",
         "AUTH_BROKER_PREFIX",
       ],
       deployFlags: ["--ha=false"],

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -124,6 +124,145 @@ test("env (per-service) and imageOverrides validate by service name", () => {
   });
 });
 
+test("a private OIDC broker may serve JWKS over its matching service-local HTTP origin", () => {
+  for (const upstream of ["http://dingtalk:8080", "http://dingtalk.acme.internal:8080", "http://dingtalk.flycast"]) {
+    withConfig(
+      {
+        services: ["core", "web-ui", "portal"],
+        plugins: [{ name: "dingtalk" }],
+        env: {
+          portal: {
+            AUTH_BROKER_UPSTREAM: upstream,
+            AUTH_BROKER_SERVICE_HOST: "dingtalk",
+            OIDC_CLIENT_ID: "client",
+            OIDC_ISSUER: "https://agent.acme.example/idp",
+            OIDC_JWKS_URI: `${upstream}/.well-known/jwks.json`,
+            PORTAL_EXPECTED_TEAM_ID: "corp-a",
+          },
+        },
+      },
+      ({ path }) => assert.doesNotThrow(() => loadConfigAt(path)),
+    );
+  }
+});
+
+test("an HTTP OIDC JWKS endpoint must match a service-local broker origin", () => {
+  for (const [upstream, jwks] of [
+    ["http://auth.example.com", "http://auth.example.com/.well-known/jwks.json"],
+    ["http://dingtalk:8080", "http://other:8080/.well-known/jwks.json"],
+  ]) {
+    withConfig(
+      {
+        services: ["core", "web-ui", "portal"],
+        env: {
+          portal: {
+            AUTH_BROKER_UPSTREAM: upstream,
+            OIDC_CLIENT_ID: "client",
+            OIDC_ISSUER: "https://agent.acme.example/idp",
+            OIDC_JWKS_URI: jwks,
+            PORTAL_EXPECTED_TEAM_ID: "corp-a",
+          },
+        },
+      },
+      ({ path }) => assert.throws(() => loadConfigAt(path), /service-local AUTH_BROKER_UPSTREAM endpoint/),
+    );
+  }
+});
+
+test("a Docker OIDC broker must name a declared plugin and use the exact JWKS endpoint", () => {
+  for (const portal of [
+    {
+      AUTH_BROKER_UPSTREAM: "http://ws:8080",
+      AUTH_BROKER_SERVICE_HOST: "ws",
+      OIDC_JWKS_URI: "http://ws:8080/.well-known/jwks.json",
+    },
+    {
+      AUTH_BROKER_UPSTREAM: "http://dingtalk:8080",
+      AUTH_BROKER_SERVICE_HOST: "dingtalk",
+      OIDC_JWKS_URI: "http://dingtalk:8080/token",
+    },
+    {
+      AUTH_BROKER_UPSTREAM: "http://dingtalk:8080",
+      AUTH_BROKER_SERVICE_HOST: "dingtalk",
+      OIDC_JWKS_URI: "http://dingtalk:8080/.well-known/jwks.json?key=1",
+    },
+  ]) {
+    withConfig(
+      {
+        services: ["core", "web-ui", "portal"],
+        plugins: [{ name: "dingtalk" }],
+        env: {
+          portal: {
+            ...portal,
+            OIDC_CLIENT_ID: "client",
+            OIDC_ISSUER: "https://agent.acme.example/idp",
+            PORTAL_EXPECTED_TEAM_ID: "corp-a",
+          },
+        },
+      },
+      ({ path }) => assert.throws(() => loadConfigAt(path), /service-local AUTH_BROKER_UPSTREAM endpoint/),
+    );
+  }
+});
+
+test("CLI and Portal share exact server-side OIDC endpoint trust rules", () => {
+  const accepted = ["http://10.0.0.5:8080", "http://[fd00::1]:8080", "http://auth.local:8080"];
+  for (const upstream of accepted) {
+    withConfig(
+      {
+        services: ["core", "web-ui", "portal"],
+        env: {
+          portal: {
+            AUTH_BROKER_UPSTREAM: upstream,
+            OIDC_CLIENT_ID: "client",
+            OIDC_ISSUER: "https://agent.acme.example/idp",
+            OIDC_AUTH_ENDPOINT: "HTTPS://AGENT.ACME.EXAMPLE/idp/authorize",
+            OIDC_TOKEN_ENDPOINT: `${upstream}/token`,
+            OIDC_USERINFO_ENDPOINT: `${upstream}/userinfo`,
+            OIDC_JWKS_URI: `${upstream}/.well-known/jwks.json`,
+            PORTAL_EXPECTED_TEAM_ID: "corp-a",
+          },
+        },
+      },
+      ({ path }) => assert.doesNotThrow(() => loadConfigAt(path)),
+    );
+  }
+
+  for (const override of [
+    { OIDC_TOKEN_ENDPOINT: "http://dingtalk:8080/admin" },
+    { OIDC_USERINFO_ENDPOINT: "http://dingtalk:8080/userinfo?leak=1" },
+    { OIDC_TOKEN_ENDPOINT: "http://user:pass@dingtalk:8080/token" },
+    { OIDC_TOKEN_ENDPOINT: "https://attacker.example/collect" },
+    { OIDC_USERINFO_ENDPOINT: "https://attacker.example/collect" },
+    { OIDC_JWKS_URI: "https://attacker.example/keys" },
+    { OIDC_TOKEN_ENDPOINT: "https://user:pass@auth.example.com/token" },
+    { OIDC_AUTH_ENDPOINT: "https://user:pass@auth.example.com/authorize" },
+  ]) {
+    withConfig(
+      {
+        services: ["core", "web-ui", "portal"],
+        plugins: [{ name: "dingtalk" }],
+        env: {
+          portal: {
+            AUTH_BROKER_UPSTREAM: "http://dingtalk:8080",
+            AUTH_BROKER_SERVICE_HOST: "dingtalk",
+            OIDC_CLIENT_ID: "client",
+            OIDC_ISSUER: "https://agent.acme.example/idp",
+            OIDC_AUTH_ENDPOINT: "https://agent.acme.example/idp/authorize",
+            OIDC_TOKEN_ENDPOINT: "http://dingtalk:8080/token",
+            OIDC_USERINFO_ENDPOINT: "http://dingtalk:8080/userinfo",
+            OIDC_JWKS_URI: "http://dingtalk:8080/.well-known/jwks.json",
+            PORTAL_EXPECTED_TEAM_ID: "corp-a",
+            ...override,
+          },
+        },
+      },
+      ({ path }) =>
+        assert.throws(() => loadConfigAt(path), /HTTPS URL without credentials|service-local AUTH_BROKER_UPSTREAM/),
+    );
+  }
+});
+
 test("listen ports are managed consistently across deployment targets", () => {
   withConfig({ env: { core: { PORT: "9000" } } }, ({ path }) => {
     assert.throws(() => loadConfigAt(path), /env\.core\.PORT.*managed/);

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -41,6 +41,7 @@ import { coreClaimStore, withinRateLimit } from "../../chassis/src/claims.ts";
 import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
 import { errMessage } from "../../chassis/src/errors.ts";
 import { json, escapeHtml, serveEmojiFavicon } from "../../chassis/src/http.ts";
+import { brokerOrigin, sameOidcUrl, validHttpsOidcUrl, validOidcServerEndpoint } from "./oidc-url.ts";
 import {
   CORE_API_URL as CORE,
   CORE_ORG_ID as ORG,
@@ -133,6 +134,7 @@ const OIDC: OidcConfig = {
 const OIDC_JWKS_CONFIGURED = Boolean(process.env.OIDC_JWKS_URI?.trim());
 
 const AUTH_BROKER_UPSTREAM = (process.env.AUTH_BROKER_UPSTREAM ?? "").replace(/\/$/, "");
+const AUTH_BROKER_SERVICE_HOST = process.env.AUTH_BROKER_SERVICE_HOST?.trim().toLowerCase() ?? "";
 const AUTH_BROKER_PREFIX = (process.env.AUTH_BROKER_PREFIX ?? "/idp").replace(/\/$/, "");
 const BROKER_PUBLIC_ROUTES: ReadonlyArray<{ method: string; path: string }> = [
   { method: "GET", path: "/authorize" },
@@ -288,31 +290,8 @@ function isLocalPortalUrl(raw: string): boolean {
   }
 }
 
-function originOf(raw: string): string {
-  try {
-    return new URL(raw).origin;
-  } catch {
-    return "";
-  }
-}
-
 export function isPrivateNetworkUrl(raw: string): boolean {
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return false;
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
-  if (host.endsWith(".internal") || host.endsWith(".flycast") || host.endsWith(".local")) return true;
-  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
-  if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
-  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
-  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
-  return false;
+  return Boolean(brokerOrigin(raw));
 }
 
 export function isLoopbackAddress(address: string | null | undefined): boolean {
@@ -1267,26 +1246,36 @@ export function bootChecks(): void {
       problems.push("PORTAL_SESSION_SECRET must differ from CORE_SIGNING_SECRET");
     }
     if (!PUBLIC_URL.startsWith("https://")) problems.push("PORTAL_PUBLIC_URL must be https in production");
-    if (!OIDC.authEndpoint.startsWith("https://")) {
+    if (!validHttpsOidcUrl(OIDC.authEndpoint)) {
       problems.push(`OIDC_AUTH_ENDPOINT must be https — the browser is sent there: ${OIDC.authEndpoint}`);
     }
-    const brokerOrigin =
-      AUTH_BROKER_UPSTREAM && isPrivateNetworkUrl(AUTH_BROKER_UPSTREAM) ? originOf(AUTH_BROKER_UPSTREAM) : "";
-    for (const ep of [OIDC.tokenEndpoint, OIDC.userinfoEndpoint, OIDC.jwksUri]) {
-      if (!ep.startsWith("https://") && !(brokerOrigin && originOf(ep) === brokerOrigin)) {
-        problems.push(`OIDC endpoint must be https unless it is the built-in broker on the private network: ${ep}`);
+    const broker = AUTH_BROKER_UPSTREAM
+      ? {
+          upstream: AUTH_BROKER_UPSTREAM,
+          ...(AUTH_BROKER_SERVICE_HOST ? { declaredServiceHost: AUTH_BROKER_SERVICE_HOST } : {}),
+        }
+      : null;
+    for (const [kind, endpoint] of [
+      ["token", OIDC.tokenEndpoint],
+      ["userinfo", OIDC.userinfoEndpoint],
+      ["jwks", OIDC.jwksUri],
+    ] as const) {
+      if (!validOidcServerEndpoint(endpoint, kind, broker)) {
+        problems.push(
+          `OIDC endpoint must be https unless it is the built-in broker on the private network: ${endpoint}`,
+        );
       }
     }
     if (AUTH_BROKER_UPSTREAM) {
-      if (!isPrivateNetworkUrl(AUTH_BROKER_UPSTREAM)) {
+      if (!brokerOrigin(AUTH_BROKER_UPSTREAM, AUTH_BROKER_SERVICE_HOST)) {
         problems.push(
           "AUTH_BROKER_UPSTREAM must address a private-network host — the broker is never exposed directly",
         );
       }
-      if (OIDC.issuer !== `${PUBLIC_URL}${AUTH_BROKER_PREFIX}`) {
+      if (!sameOidcUrl(OIDC.issuer, `${PUBLIC_URL}${AUTH_BROKER_PREFIX}`)) {
         problems.push(`OIDC_ISSUER must be ${PUBLIC_URL}${AUTH_BROKER_PREFIX} when the built-in broker is wired`);
       }
-      if (OIDC.authEndpoint !== `${PUBLIC_URL}${AUTH_BROKER_PREFIX}/authorize`) {
+      if (!sameOidcUrl(OIDC.authEndpoint, `${PUBLIC_URL}${AUTH_BROKER_PREFIX}/authorize`)) {
         problems.push(
           `OIDC_AUTH_ENDPOINT must be ${PUBLIC_URL}${AUTH_BROKER_PREFIX}/authorize when the built-in broker is wired`,
         );

--- a/plugins/portal/src/oidc-url.ts
+++ b/plugins/portal/src/oidc-url.ts
@@ -1,0 +1,97 @@
+import { isIP } from "node:net";
+
+export type OidcServerEndpointKind = "token" | "userinfo" | "jwks";
+
+const brokerPaths: Record<OidcServerEndpointKind, string> = {
+  token: "/token",
+  userinfo: "/userinfo",
+  jwks: "/.well-known/jwks.json",
+};
+
+function privateIp(hostname: string): boolean {
+  if (isIP(hostname) === 4) {
+    const octets = hostname.split(".").map(Number);
+    return (
+      octets[0] === 127 ||
+      octets[0] === 10 ||
+      (octets[0] === 192 && octets[1] === 168) ||
+      (octets[0] === 172 && octets[1] !== undefined && octets[1] >= 16 && octets[1] <= 31)
+    );
+  }
+  if (isIP(hostname) === 6) {
+    const normalized = hostname.toLowerCase();
+    return (
+      normalized === "::1" ||
+      normalized === "0:0:0:0:0:0:0:1" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd")
+    );
+  }
+  return false;
+}
+
+export function isServiceLocalHostname(hostname: string, declaredServiceHost = ""): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const declared = declaredServiceHost.trim().toLowerCase();
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".flycast") ||
+    host.endsWith(".local") ||
+    privateIp(host) ||
+    Boolean(declared && !host.includes(".") && host === declared)
+  );
+}
+
+export function brokerOrigin(raw: string, declaredServiceHost = ""): string {
+  try {
+    const url = new URL(raw);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !isServiceLocalHostname(url.hostname, declaredServiceHost) ||
+      url.pathname !== "/" ||
+      url.search ||
+      url.hash ||
+      url.username ||
+      url.password
+    )
+      return "";
+    return url.origin;
+  } catch {
+    return "";
+  }
+}
+
+export function validHttpsOidcUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "https:" && !url.username && !url.password && !url.hash;
+  } catch {
+    return false;
+  }
+}
+
+export function sameOidcUrl(left: string, right: string): boolean {
+  try {
+    return new URL(left).href === new URL(right).href;
+  } catch {
+    return false;
+  }
+}
+
+export function validOidcServerEndpoint(
+  raw: string,
+  kind: OidcServerEndpointKind,
+  broker: { upstream: string; declaredServiceHost?: string } | null,
+): boolean {
+  try {
+    const url = new URL(raw);
+    if (!broker) return validHttpsOidcUrl(raw);
+    if (url.username || url.password || url.hash || url.search) return false;
+    const expectedOrigin = brokerOrigin(broker.upstream, broker.declaredServiceHost);
+    return Boolean(expectedOrigin && url.origin === expectedOrigin && url.pathname === brokerPaths[kind]);
+  } catch {
+    return false;
+  }
+}

--- a/plugins/portal/test/entry.test.ts
+++ b/plugins/portal/test/entry.test.ts
@@ -161,6 +161,29 @@ test("production accepts cleartext OIDC only on private-network hosts, and only 
   const wired = boot(brokerEnv);
   assert.equal(wired.status, 0, wired.stderr);
 
+  const dockerWired = boot({
+    ...brokerEnv,
+    OIDC_TOKEN_ENDPOINT: "http://dingtalk:8080/token",
+    OIDC_USERINFO_ENDPOINT: "http://dingtalk:8080/userinfo",
+    OIDC_JWKS_URI: "http://dingtalk:8080/.well-known/jwks.json",
+    AUTH_BROKER_UPSTREAM: "http://dingtalk:8080",
+    AUTH_BROKER_SERVICE_HOST: "dingtalk",
+  });
+  assert.equal(dockerWired.status, 0, dockerWired.stderr);
+
+  for (const host of ["10.0.0.5", "[fd00::1]", "auth.local"]) {
+    const origin = `http://${host}:8080`;
+    const privateWired = boot({
+      ...brokerEnv,
+      OIDC_AUTH_ENDPOINT: "HTTPS://AGENT.EXAMPLE.COM/idp/authorize",
+      OIDC_TOKEN_ENDPOINT: `${origin}/token`,
+      OIDC_USERINFO_ENDPOINT: `${origin}/userinfo`,
+      OIDC_JWKS_URI: `${origin}/.well-known/jwks.json`,
+      AUTH_BROKER_UPSTREAM: origin,
+    });
+    assert.equal(privateWired.status, 0, privateWired.stderr);
+  }
+
   for (const [override, pattern] of [
     [
       { OIDC_TOKEN_ENDPOINT: "http://tokens.example.com/token" },
@@ -169,6 +192,48 @@ test("production accepts cleartext OIDC only on private-network hosts, and only 
     [{ OIDC_JWKS_URI: "http://10.0.0.5/keys" }, /OIDC endpoint must be https unless it is the built-in broker/],
     [{ OIDC_AUTH_ENDPOINT: "http://agent.example.com/idp/authorize" }, /OIDC_AUTH_ENDPOINT must be https/],
     [{ AUTH_BROKER_UPSTREAM: "https://auth.example.com" }, /AUTH_BROKER_UPSTREAM must address a private-network host/],
+    [
+      {
+        AUTH_BROKER_UPSTREAM: "http://ws:8080",
+        AUTH_BROKER_SERVICE_HOST: "dingtalk",
+        OIDC_TOKEN_ENDPOINT: "http://ws:8080/token",
+        OIDC_USERINFO_ENDPOINT: "http://ws:8080/userinfo",
+        OIDC_JWKS_URI: "http://ws:8080/.well-known/jwks.json",
+      },
+      /AUTH_BROKER_UPSTREAM must address a private-network host/,
+    ],
+    [
+      { OIDC_JWKS_URI: "http://acme-auth.internal:8080/token" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_JWKS_URI: "http://acme-auth.internal:8080/.well-known/jwks.json?key=1" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_TOKEN_ENDPOINT: "http://acme-auth.internal:8080/admin" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_USERINFO_ENDPOINT: "http://acme-auth.internal:8080/userinfo?leak=1" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_TOKEN_ENDPOINT: "https://attacker.example/collect" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_USERINFO_ENDPOINT: "https://attacker.example/collect" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_JWKS_URI: "https://attacker.example/keys" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
+    [
+      { OIDC_TOKEN_ENDPOINT: "https://user:pass@auth.example.com/token" },
+      /OIDC endpoint must be https unless it is the built-in broker/,
+    ],
     [
       { OIDC_AUTH_ENDPOINT: "https://elsewhere.example.com/idp/authorize" },
       /OIDC_AUTH_ENDPOINT must be https:\/\/agent\.example\.com\/idp\/authorize/,


### PR DESCRIPTION
## Summary

- allow service-local HTTP or HTTPS only for the configured internal OIDC broker
- require token, userinfo, and JWKS endpoints to match the broker origin and exact endpoint paths
- keep browser authorization and external identity-provider endpoints HTTPS-only
- derive and validate the declared broker service host consistently across Docker, Fly, and AWS

## Validation

- CLI config, auth-broker, and doctor tests (70 passing)
- Portal broker and entry tests (15 passing)
- CLI and Portal typechecks
- changed-file ESLint and Prettier checks
- independent security-focused review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788471589&installation_model_id=19911&pr_number=213&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F213&signature=4a4ecca2dc6594990890721bab156f59c2c87966306f1aa87a8c79dbbe269993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->