### PR TITLE
Build source plugins with the shared chassis context

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -7,7 +7,13 @@
     "": {
       "name": "@yc-software/qm",
       "version": "0.1.4",
+      "bundleDependencies": [
+        "@balena/dockerignore"
+      ],
       "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2"
+      },
       "bin": {
         "qm": "dist/bin/qm.js"
       },
@@ -18,6 +24,13 @@
       "engines": {
         "node": ">=24.0.0"
       }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "inBundle": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@types/node": {
       "version": "24.13.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -33,9 +33,12 @@
     "manifest.json",
     "README.md"
   ],
+  "bundleDependencies": [
+    "@balena/dockerignore"
+  ],
   "scripts": {
     "qm": "node -- bin/qm.ts",
-    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json && node -e \"require('node:fs').cpSync('../plugins/chassis','dist/plugin-chassis',{recursive:true})\"",
     "prepack": "npm run build",
     "typecheck": "tsc -p tsconfig.json",
     "test": "node --test test/*.test.ts",
@@ -46,5 +49,8 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "typescript": "^5.8.2"
+  },
+  "dependencies": {
+    "@balena/dockerignore": "^1.0.2"
   }
 }

--- a/cli/src/aws-lease.ts
+++ b/cli/src/aws-lease.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { AwsConfig } from "./config.ts";
 import { CliError, errMessage, warn } from "./log.ts";
+import { registerProcessCleanup } from "./process-cleanup.ts";
 import { capture, envNum } from "./util.ts";
 
 const LEASE_SECONDS = 60 * 60;
@@ -9,7 +10,7 @@ export interface AwsLease {
   table: string;
   key: string;
   holder: string;
-  releaseOnSignal?: () => void;
+  unregisterCleanup?: () => void;
   renewTimer?: ReturnType<typeof setInterval>;
 }
 
@@ -47,16 +48,7 @@ export function acquireAwsLease(aws: AwsConfig, key = "deploy"): AwsLease {
     throw error;
   }
   const lease: AwsLease = { table, key, holder };
-  const onSignal = (): void => {
-    releaseAwsLease(aws, lease);
-    process.exit(130);
-  };
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
-  lease.releaseOnSignal = () => {
-    process.removeListener("SIGINT", onSignal);
-    process.removeListener("SIGTERM", onSignal);
-  };
+  lease.unregisterCleanup = registerProcessCleanup(() => releaseAwsLease(aws, lease));
   lease.renewTimer = setInterval(
     () => renewAwsLease(aws, lease),
     envNum("QM_AWS_LEASE_RENEW_MS", (LEASE_SECONDS / 3) * 1000),
@@ -98,8 +90,8 @@ function renewAwsLease(aws: AwsConfig, lease: AwsLease): void {
 export function releaseAwsLease(aws: AwsConfig, lease: AwsLease): void {
   if (lease.renewTimer) clearInterval(lease.renewTimer);
   lease.renewTimer = undefined;
-  lease.releaseOnSignal?.();
-  lease.releaseOnSignal = undefined;
+  lease.unregisterCleanup?.();
+  lease.unregisterCleanup = undefined;
   try {
     awsText(aws, [
       "dynamodb",

--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -45,6 +45,7 @@ import {
   readEnvFile,
   resolveBuildRepoRoot,
   runInherit,
+  runInheritAsync,
   sleep,
   streamLabeled,
 } from "../util.ts";
@@ -56,6 +57,7 @@ import {
   syncDeploymentLayerBody,
   type DeploymentLayerSyncResult,
 } from "../deployment-layer.ts";
+import { withSourcePluginBuildContextAsync } from "../plugin-build-context.ts";
 
 export interface AwsUpOpts {
   dryRun?: boolean;
@@ -485,34 +487,36 @@ export function imageTransferArgs(source: string, tagged: string): string[] {
   return ["buildx", "imagetools", "create", "--prefer-index=false", "--tag", tagged, source];
 }
 
-function publishWorkloadImage(
+async function publishWorkloadImage(
   config: QmConfig,
   workload: string,
   plugin: ResolvedPlugin | undefined,
   label: string,
   opts: AwsUpOpts,
-): string {
+): Promise<string> {
   const aws = requireAws(config);
   const spec = aws.services[workload]!;
   const tagged = `${ecrHost(aws)}/${spec.ecrRepository}:${label}`;
   const platform = `linux/${workloadArchitecture(config, workload)}`;
   if (plugin?.kind === "source") {
-    const args = [
-      "buildx",
-      "build",
-      "--platform",
-      platform,
-      "--provenance=false",
-      "--push",
-      "-f",
-      plugin.dockerfile!,
-      "-t",
-      tagged,
-    ];
-    for (const [name, value] of Object.entries(workloadBuildArgs(config, workload)))
-      args.push("--build-arg", `${name}=${value}`);
-    args.push(plugin.sourceDir!);
-    runInherit("docker", args);
+    await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+      const args = [
+        "buildx",
+        "build",
+        "--platform",
+        platform,
+        "--provenance=false",
+        "--push",
+        "-f",
+        prepared.dockerfile,
+        "-t",
+        tagged,
+      ];
+      for (const [name, value] of Object.entries(workloadBuildArgs(config, workload)))
+        args.push("--build-arg", `${name}=${value}`);
+      args.push(prepared.directory);
+      await runInheritAsync("docker", args);
+    });
   } else if (opts.buildFrom && isServiceName(workload)) {
     const root = resolveBuildRepoRoot(opts.buildFromPath, [workload]);
     const dockerfile = join(root, spec.dockerfile ?? join("deploy", workload, "Dockerfile"));
@@ -1715,7 +1719,7 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
     for (const service of services) {
       staged.add(service);
       selectedImageProvenance[service] = workloadImageProvenance(config, service, plugins.get(service), opts);
-      images[service] = publishWorkloadImage(config, service, plugins.get(service), stagingLabel, opts);
+      images[service] = await publishWorkloadImage(config, service, plugins.get(service), stagingLabel, opts);
     }
     const desired = reportTaskChanges(config, services, images, arns);
     const targets: Record<string, string> = {};

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -11,6 +11,7 @@ import {
   readEnvFile,
   resolveBuildRepoRoot,
   runInherit,
+  runInheritAsync,
   sleep,
   streamLabeled,
   tailString,
@@ -32,6 +33,7 @@ import { dockerBasePort, sandboxCoreEnv, securityScreenEnv, type QmConfig } from
 import { discoverPlugins, type ResolvedPlugin } from "../plugins.ts";
 import { computedSecrets, runtimeSecretNames, secretsForService } from "../secrets.ts";
 import { readDeploymentState, withDeploymentLock, writeDeploymentState, type DeploymentState } from "../state.ts";
+import { withSourcePluginBuildContextAsync } from "../plugin-build-context.ts";
 
 const safe = (s: string): string => s.replace(/[^A-Za-z0-9_.-]/g, "-");
 const ORG_LABEL_KEY = "qm.org";
@@ -151,11 +153,17 @@ function resolveImage(ctx: DockerCtx, service: ServiceName): string {
   return ref;
 }
 
-function resolvePluginImage(ctx: DockerCtx, p: ResolvedPlugin): string {
+async function resolvePluginImage(ctx: DockerCtx, p: ResolvedPlugin): Promise<string> {
   if (p.kind === "source") {
     const tag = `${ctx.prefix}-${p.name}:local`;
     step(`building plugin ${p.name} from ${p.dockerfile}`);
-    dockerInherit(["build", "-f", p.dockerfile!, "-t", tag, p.sourceDir!]);
+    await withSourcePluginBuildContextAsync(p, async (prepared) => {
+      try {
+        await runInheritAsync("docker", ["build", "-f", prepared.dockerfile, "-t", tag, prepared.directory]);
+      } catch {
+        throw new CliError("docker build failed.");
+      }
+    });
     return tag;
   }
   step(`pulling plugin ${p.name} (${p.image})`);
@@ -590,7 +598,7 @@ export async function dockerUp(
   }
 
   for (const p of plugins) {
-    const image = resolvePluginImage(ctx, p);
+    const image = await resolvePluginImage(ctx, p);
     docker(["rm", "-f", cname(ctx, p.name)], /No such container|is not running/);
     step(`starting plugin ${p.name} (${image})`);
     const args = [

--- a/cli/src/backends/fly.ts
+++ b/cli/src/backends/fly.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -39,6 +39,8 @@ import { computedSecrets, runtimeSecretNames, secretDestinations, secretsForServ
 import { flySandboxRepository, imageRepository, pinnedByDigest, recordSandboxPin } from "../commands/sandbox.ts";
 import { manifestRef } from "../manifest.ts";
 import { doctorCommon, localDoctorSecrets, requireFlyAuth } from "./doctor.ts";
+import { withSourcePluginBuildContextAsync } from "../plugin-build-context.ts";
+import { runTrackedChild } from "../process-cleanup.ts";
 
 export interface FlyUpOpts {
   dryRun?: boolean;
@@ -874,23 +876,27 @@ async function buildPluginImage(
   const app = pluginApp(ctx, plugin.name);
   note(`\n=== building plugin image ${flyTaggedImage(ctx.appPrefix, plugin.name, label)} ===`);
   const cfgPath = pluginCfgPath(ctx, plugin.name);
-  const args = [
-    "deploy",
-    "--yes",
-    "--build-only",
-    "--push",
-    "--image-label",
-    label,
-    "-c",
-    cfgPath,
-    "--ha=false",
-    "--remote-only",
-    "--dockerfile",
-    plugin.dockerfile!,
-    plugin.sourceDir!,
-  ];
-  step(`fly ${args.join(" ")}`);
-  await timing.timeAsync(plugin.name, "image build", () => runFlyDeploy(args, ctx.commandCwd));
+  await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+    const args = [
+      "deploy",
+      "--yes",
+      "--build-only",
+      "--push",
+      "--image-label",
+      label,
+      "-c",
+      cfgPath,
+      "--ha=false",
+      "--remote-only",
+      "--dockerfile",
+      prepared.dockerfile,
+      "--ignorefile",
+      prepared.ignorefile,
+      prepared.directory,
+    ];
+    step(`fly ${args.join(" ")}`);
+    await timing.timeAsync(plugin.name, "image build", () => runFlyDeploy(args, ctx.commandCwd));
+  });
   note(`image: ${app} -> ${flyTaggedImage(ctx.appPrefix, plugin.name, label)}`);
 }
 
@@ -914,7 +920,19 @@ async function deployPlugin(
   } else if (plugin.kind === "image") {
     args.push("--image", plugin.image!);
   } else {
-    args.push("--remote-only", "--dockerfile", plugin.dockerfile!, plugin.sourceDir!);
+    await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+      args.push(
+        "--remote-only",
+        "--dockerfile",
+        prepared.dockerfile,
+        "--ignorefile",
+        prepared.ignorefile,
+        prepared.directory,
+      );
+      step(`fly ${args.join(" ")}`);
+      await timing.timeAsync(plugin.name, "fly deploy", () => runFlyDeploy(args, ctx.commandCwd));
+    });
+    return;
   }
   step(`fly ${args.join(" ")}`);
   await timing.timeAsync(plugin.name, "fly deploy", () => runFlyDeploy(args, ctx.commandCwd));
@@ -932,17 +950,17 @@ async function deployPlugins(
 }
 
 function runFlyDeploy(args: string[], cwd: string): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const child = spawn(flyBin(), args, { stdio: "inherit", cwd });
-    child.on("error", (err) => reject(new CliError(`fly ${args.join(" ")} failed:\n${err.message}`)));
-    child.on("close", (code, signal) => {
-      if (code === 0) resolve();
-      else
-        reject(
-          new CliError(`fly ${args.join(" ")} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`),
+  return runTrackedChild(flyBin(), args, { stdio: "inherit", cwd })
+    .catch((error) => {
+      throw new CliError(`fly ${args.join(" ")} failed:\n${(error as Error).message}`);
+    })
+    .then(({ code, signal }) => {
+      if (code !== 0) {
+        throw new CliError(
+          `fly ${args.join(" ")} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
         );
+      }
     });
-  });
 }
 
 function unsetDisabledSecurityScreenToken(config: QmConfig, appPrefix: string): void {

--- a/cli/src/plugin-build-context.ts
+++ b/cli/src/plugin-build-context.ts
@@ -1,0 +1,223 @@
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, sep } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { CliError } from "./log.ts";
+import type { ResolvedPlugin } from "./plugins.ts";
+import { registerProcessCleanup } from "./process-cleanup.ts";
+
+export interface SourcePluginBuildContext {
+  directory: string;
+  dockerfile: string;
+  ignorefile: string;
+}
+
+interface DockerIgnoreMatcher {
+  add(pattern: string): DockerIgnoreMatcher;
+  ignores(path: string): boolean;
+}
+
+type DockerIgnoreFactory = (options: { ignorecase: boolean }) => DockerIgnoreMatcher;
+
+const dockerIgnore = createRequire(import.meta.url)("@balena/dockerignore") as DockerIgnoreFactory;
+
+function removeContext(directory: string): void {
+  if (!existsSync(directory)) return;
+  const makeRemovable = (path: string): void => {
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return;
+    chmodSync(path, stat.mode | 0o700);
+    for (const entry of readdirSync(path)) makeRemovable(join(path, entry));
+  };
+  makeRemovable(directory);
+  rmSync(directory, { recursive: true, force: true });
+}
+
+function trackContext(directory: string): () => void {
+  let removed = false;
+  const remove = (): void => {
+    if (removed) return;
+    removed = true;
+    removeContext(directory);
+  };
+  const unregister = registerProcessCleanup(remove);
+  return () => {
+    unregister();
+    remove();
+  };
+}
+
+function chassisDirectory(): string {
+  const candidates = [
+    fileURLToPath(new URL("../plugin-chassis", import.meta.url)),
+    fileURLToPath(new URL("../../plugins/chassis", import.meta.url)),
+  ];
+  const found = candidates.find((candidate) => existsSync(join(candidate, "package.json")));
+  if (!found) throw new CliError("the packaged source plugin chassis is missing");
+  return found;
+}
+
+function contextPath(root: string, path: string, pluginName: string, label: string): string {
+  const resolved = relative(root, path);
+  if (!resolved || isAbsolute(resolved) || resolved === ".." || resolved.startsWith(`..${sep}`)) {
+    throw new CliError(`plugin ${pluginName} ${label} must be inside its source directory`);
+  }
+  return resolved;
+}
+
+function exclusionPatterns(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .flatMap((line) => {
+      if (line.startsWith("!")) return [line];
+      if (line.startsWith("/!")) return [line.slice(1)];
+      return [];
+    });
+}
+
+function exclusionCouldMatchWithin(directory: string, patterns: string[]): boolean {
+  return patterns.some((raw) => {
+    const pattern = raw.slice(1).replace(/^\/+/, "").replace(/\/+$/, "");
+    if (!pattern || pattern.includes("\\")) return true;
+    const wildcard = pattern.search(/[?*[]/);
+    const prefix = (wildcard === -1 ? pattern : pattern.slice(0, wildcard)).replace(/\/+$/, "");
+    if (!prefix) return true;
+    return prefix === directory || prefix.startsWith(`${directory}/`) || directory.startsWith(prefix);
+  });
+}
+
+function portablePath(path: string): string {
+  return sep === "/" ? path : path.split(sep).join("/");
+}
+
+function copyFilteredContext(
+  sourceRoot: string,
+  destinationRoot: string,
+  ignoreContent: string,
+  mandatoryPaths: Set<string>,
+): void {
+  const matcher = dockerIgnore({ ignorecase: false }).add(ignoreContent);
+  const exclusions = exclusionPatterns(ignoreContent);
+  const copyDirectory = (source: string, destination: string): void => {
+    for (const entry of readdirSync(source, { withFileTypes: true })) {
+      const sourcePath = join(source, entry.name);
+      const destinationPath = join(destination, entry.name);
+      const relativePath = portablePath(relative(sourceRoot, sourcePath));
+      if (relativePath === "plugins/chassis" || relativePath.startsWith("plugins/chassis/")) continue;
+      const mandatory = mandatoryPaths.has(relativePath);
+      const ignored = !mandatory && matcher.ignores(relativePath);
+      if (entry.isSymbolicLink()) {
+        if (!ignored) symlinkSync(readlinkSync(sourcePath), destinationPath);
+        continue;
+      }
+      if (entry.isDirectory()) {
+        const mandatoryDescendant = [...mandatoryPaths].some((path) => path.startsWith(`${relativePath}/`));
+        if (ignored && !mandatoryDescendant && !exclusionCouldMatchWithin(relativePath, exclusions)) continue;
+        mkdirSync(destinationPath);
+        copyDirectory(sourcePath, destinationPath);
+        chmodSync(destinationPath, lstatSync(sourcePath).mode);
+        continue;
+      }
+      if (ignored) continue;
+      cpSync(sourcePath, destinationPath, { preserveTimestamps: true, verbatimSymlinks: true });
+    }
+  };
+  copyDirectory(sourceRoot, destinationRoot);
+}
+
+function injectChassis(directory: string, pluginName: string): void {
+  const plugins = join(directory, "plugins");
+  let pluginsMode: number | undefined;
+  if (existsSync(plugins)) {
+    const stat = lstatSync(plugins);
+    if (stat.isSymbolicLink()) throw new CliError(`plugin ${pluginName} plugins path cannot be a symbolic link`);
+    if (!stat.isDirectory()) throw new CliError(`plugin ${pluginName} plugins path must be a directory`);
+    pluginsMode = stat.mode;
+    chmodSync(plugins, stat.mode | 0o700);
+  } else {
+    mkdirSync(plugins);
+  }
+  const chassis = join(plugins, "chassis");
+  if (existsSync(chassis)) throw new CliError(`plugin ${pluginName} plugins/chassis path is reserved`);
+  try {
+    cpSync(chassisDirectory(), chassis, { recursive: true, verbatimSymlinks: true });
+  } finally {
+    if (pluginsMode !== undefined) chmodSync(plugins, pluginsMode);
+  }
+}
+
+function prepareSourcePluginBuildContext(plugin: ResolvedPlugin): SourcePluginBuildContext & { cleanup: () => void } {
+  if (plugin.kind !== "source" || !plugin.sourceDir || !plugin.dockerfile) {
+    throw new CliError(`plugin ${plugin.name} is not a source plugin`);
+  }
+  const dockerfile = contextPath(plugin.sourceDir, plugin.dockerfile, plugin.name, "Dockerfile");
+  const dockerfileIgnore = `${plugin.dockerfile}.dockerignore`;
+  const rootIgnore = join(plugin.sourceDir, ".dockerignore");
+  const ignoreFile = existsSync(dockerfileIgnore) ? dockerfileIgnore : existsSync(rootIgnore) ? rootIgnore : undefined;
+  const ignoreContent = ignoreFile ? readFileSync(ignoreFile, "utf8") : "";
+  const ignorePath = ignoreFile ? contextPath(plugin.sourceDir, ignoreFile, plugin.name, "ignore file") : undefined;
+  const mandatoryPaths = new Set([portablePath(dockerfile), ...(ignorePath ? [portablePath(ignorePath)] : [])]);
+  const directory = mkdtempSync(join(tmpdir(), "qm-plugin-build-"));
+  const cleanup = trackContext(directory);
+  try {
+    copyFilteredContext(plugin.sourceDir, directory, ignoreContent, mandatoryPaths);
+    injectChassis(directory, plugin.name);
+    const buildDockerfile = `.qm-plugin-${randomUUID()}.Dockerfile`;
+    const buildIgnore = `${buildDockerfile}.dockerignore`;
+    cpSync(plugin.dockerfile, join(directory, buildDockerfile), { dereference: true, preserveTimestamps: true });
+    const separator = ignoreContent.endsWith("\n") || ignoreContent.length === 0 ? "" : "\n";
+    writeFileSync(
+      join(directory, buildIgnore),
+      `${ignoreContent}${separator}${buildDockerfile}\n${buildIgnore}\n!plugins\n!plugins/chassis\n!plugins/chassis/**\n`,
+    );
+    return {
+      directory,
+      dockerfile: join(directory, buildDockerfile),
+      ignorefile: join(directory, buildIgnore),
+      cleanup,
+    };
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}
+
+export function withSourcePluginBuildContext<T>(
+  plugin: ResolvedPlugin,
+  build: (context: SourcePluginBuildContext) => T,
+): T {
+  const { cleanup, ...context } = prepareSourcePluginBuildContext(plugin);
+  try {
+    return build(context);
+  } finally {
+    cleanup();
+  }
+}
+
+export async function withSourcePluginBuildContextAsync<T>(
+  plugin: ResolvedPlugin,
+  build: (context: SourcePluginBuildContext) => Promise<T>,
+): Promise<T> {
+  const { cleanup, ...context } = prepareSourcePluginBuildContext(plugin);
+  try {
+    return await build(context);
+  } finally {
+    cleanup();
+  }
+}

--- a/cli/src/process-cleanup.ts
+++ b/cli/src/process-cleanup.ts
@@ -1,0 +1,142 @@
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+export type ProcessCleanup = () => void | Promise<void>;
+
+export interface TrackedChildResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+const cleanups = new Set<ProcessCleanup>();
+const signals = ["SIGINT", "SIGTERM"] as const;
+const handlers = new Map<NodeJS.Signals, () => void>(signals.map((signal) => [signal, () => terminate(signal)]));
+let terminating: Promise<void> | undefined;
+
+function removeHandlers(): void {
+  for (const [signal, handler] of handlers) process.removeListener(signal, handler);
+}
+
+async function terminateCleanups(signal: NodeJS.Signals): Promise<void> {
+  const pending = [...cleanups].reverse();
+  cleanups.clear();
+  removeHandlers();
+  for (const cleanup of pending) {
+    try {
+      await cleanup();
+    } catch {
+      void 0;
+    }
+  }
+  process.kill(process.pid, signal);
+}
+
+function terminate(signal: NodeJS.Signals): void {
+  terminating ??= terminateCleanups(signal);
+}
+
+export function registerProcessCleanup(cleanup: ProcessCleanup): () => void {
+  if (cleanups.size === 0) {
+    for (const [signal, handler] of handlers) process.on(signal, handler);
+  }
+  cleanups.add(cleanup);
+  return () => {
+    cleanups.delete(cleanup);
+    if (cleanups.size === 0) removeHandlers();
+  };
+}
+
+const wait = (milliseconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function processGroupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessGroup(pid: number, timeout?: number): Promise<boolean> {
+  const deadline = timeout === undefined ? undefined : Date.now() + timeout;
+  while (processGroupAlive(pid)) {
+    if (deadline !== undefined && Date.now() >= deadline) return false;
+    await wait(25);
+  }
+  return true;
+}
+
+async function terminateChildProcessTree(child: ChildProcess, exited: Promise<void>): Promise<void> {
+  const pid = child.pid;
+  if (pid === undefined) {
+    await exited;
+    return;
+  }
+  if (child.exitCode !== null || child.signalCode !== null) {
+    await exited;
+    return;
+  }
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore" });
+    await exited;
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    void 0;
+  }
+  if (!(await waitForProcessGroup(pid, 5000))) {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      void 0;
+    }
+    await waitForProcessGroup(pid);
+  }
+  await exited;
+}
+
+export function runTrackedChild(command: string, args: string[], options: SpawnOptions): Promise<TrackedChildResult> {
+  const child = spawn(command, args, {
+    ...options,
+    ...(process.platform === "win32" ? {} : { detached: true }),
+  });
+  let childError: Error | undefined;
+  let childResult: TrackedChildResult | undefined;
+  let cleanupRunning = false;
+  let settled = false;
+  let resolveResult: (result: TrackedChildResult) => void;
+  let rejectResult: (error: Error) => void;
+  const result = new Promise<TrackedChildResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+  let resolveExited: () => void;
+  const exited = new Promise<void>((resolve) => {
+    resolveExited = resolve;
+  });
+  const settle = (): void => {
+    if (cleanupRunning || settled || (!childError && !childResult)) return;
+    settled = true;
+    unregister();
+    if (childError) rejectResult(childError);
+    else resolveResult(childResult!);
+  };
+  child.once("error", (error) => {
+    childError = error;
+    resolveExited();
+    settle();
+  });
+  child.once("exit", (code, signal) => {
+    childResult = { code, signal };
+    resolveExited();
+    settle();
+  });
+  const unregister = registerProcessCleanup(async () => {
+    cleanupRunning = true;
+    await terminateChildProcessTree(child, exited);
+    cleanupRunning = false;
+    settle();
+  });
+  return result;
+}

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -2,6 +2,7 @@ import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, openSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { CliError, errMessage } from "./log.ts";
+import { runTrackedChild } from "./process-cleanup.ts";
 
 export const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -61,6 +62,16 @@ export function runInherit(cmd: string, args: string[], opts: { cwd?: string; en
   execFileSync(cmd, args, {
     stdio: "inherit",
     ...procOpts(opts),
+  });
+}
+
+export function runInheritAsync(
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<void> {
+  return runTrackedChild(cmd, args, { stdio: "inherit", ...procOpts(opts) }).then(({ code, signal }) => {
+    if (code !== 0) throw new Error(`${cmd} failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`);
   });
 }
 

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   assertAwsDeploymentStorage,
   assertAwsPublicListener,
@@ -1878,13 +1878,42 @@ test("AWS source-plugin provenance records the build source and detects source-m
     },
   };
   const dockerBin = join(dir, "docker");
-  writeFileSync(dockerBin, `#!/bin/sh\necho 'Digest: sha256:${"a".repeat(64)}'\n`);
+  const contextLog = join(dir, "plugin-context.json");
+  writeFileSync(
+    dockerBin,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "buildx" && args[1] === "build") {
+  const context = args.at(-1);
+  const dockerfile = args[args.indexOf("-f") + 1];
+  fs.writeFileSync(${JSON.stringify(contextLog)}, JSON.stringify({
+    context,
+    dockerfile,
+    pluginSource: fs.readFileSync(context + "/handler.js", "utf8"),
+    chassis: fs.existsSync(context + "/plugins/chassis/src/core-client.ts"),
+  }));
+}
+console.log("Digest: sha256:${"a".repeat(64)}");
+`,
+  );
   chmodSync(dockerBin, 0o755);
   const priorPath = process.env.PATH;
   process.env.PATH = `${dir}:${priorPath}`;
   const fake = statefulAws(dir, sourceConfig);
   try {
     await awsUp(sourceConfig, dir, { yes: true });
+    const recorded = JSON.parse(readFileSync(contextLog, "utf8")) as {
+      context: string;
+      dockerfile: string;
+      pluginSource: string;
+      chassis: boolean;
+    };
+    assert.equal(dirname(recorded.dockerfile), recorded.context);
+    assert.match(basename(recorded.dockerfile), /^\.qm-plugin-.+\.Dockerfile$/);
+    assert.equal(recorded.pluginSource, "export const version = 1;\n");
+    assert.equal(recorded.chassis, true);
+    assert.equal(existsSync(recorded.context), false);
     const state = JSON.parse(readFileSync(fake.state, "utf8"));
     const manifestId = state.dynamo["deployment/current"].manifestId.S;
     const manifest = JSON.parse(state.dynamo[`deployment/manifest/${manifestId}`].manifest.S);

--- a/cli/test/fly-timing.test.ts
+++ b/cli/test/fly-timing.test.ts
@@ -1,14 +1,23 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const cliDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = join(cliDir, "..");
 const bin = join(cliDir, "bin", "qm.ts");
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
 
 function fakeFlyBin(dir: string): string {
   const binPath = join(dir, "fake-fly.cjs");
@@ -19,6 +28,35 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 const cmd = args.join(" ");
 if (process.env.FAKE_FLY_LOG) fs.appendFileSync(process.env.FAKE_FLY_LOG, JSON.stringify(args) + "\\n");
+if (process.env.FAKE_FLY_BLOCK && args[0] === "deploy") {
+  const { spawn } = require("node:child_process");
+  const grandchild = spawn(process.execPath, ["--eval", ${JSON.stringify(
+    `setTimeout(() => require("node:fs").writeFileSync(process.env.FAKE_FLY_SIDE_EFFECT, "late\n"), 750); setInterval(() => undefined, 1000);`,
+  )}], { stdio: "ignore", env: process.env });
+  fs.writeFileSync(process.env.FAKE_FLY_PROCESS_IDS, process.pid + " " + grandchild.pid);
+  fs.writeFileSync(process.env.FAKE_FLY_READY, JSON.stringify(args));
+  setTimeout(() => fs.writeFileSync(process.env.FAKE_FLY_SIDE_EFFECT, "late\\n"), 750);
+  setInterval(() => undefined, 1000);
+}
+if (process.env.FAKE_FLY_CONTEXT_LOG && args[0] === "deploy" && args.includes("--dockerfile")) {
+  const context = args.at(-1);
+  const dockerfile = args[args.indexOf("--dockerfile") + 1];
+  const ignorefile = args[args.indexOf("--ignorefile") + 1];
+  if (!args.includes("--ignorefile") || !ignorefile) process.exit(43);
+  const dockerIgnore = require(${JSON.stringify(join(cliDir, "node_modules", "@balena", "dockerignore"))});
+  const matcher = dockerIgnore({ ignorecase: false }).add(fs.readFileSync(ignorefile, "utf8"));
+  const archived = (path) => fs.existsSync(context + "/" + path) && !matcher.ignores(path);
+  fs.writeFileSync(process.env.FAKE_FLY_CONTEXT_LOG, JSON.stringify({
+    context,
+    dockerfile,
+    ignorefile,
+    pluginSource: archived("src/index.mjs") ? fs.readFileSync(context + "/src/index.mjs", "utf8") : null,
+    chassis: archived("plugins/chassis/src/core-client.ts"),
+    ignoredSecret: archived("ignored-secret"),
+    rootSecret: archived("root-secret"),
+    specificSecret: archived("specific-secret"),
+  }));
+}
 if (args[0] === "apps" && args[1] === "create") {
   console.log("created");
 } else if (args[0] === "secrets" && args[1] === "set") {
@@ -51,10 +89,242 @@ if (args[0] === "apps" && args[1] === "create") {
   console.error("unexpected fake fly command: " + cmd);
   process.exit(42);
 }
+
 `,
   );
   chmodSync(binPath, 0o755);
   return binPath;
+}
+
+test("Fly source plugin deploys use a prepared root context and remove it after flyctl exits", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-fly-plugin-context-"));
+  const pluginDir = join(dir, "plugins", "example");
+  const contextLog = join(dir, "context.json");
+  mkdirSync(join(pluginDir, "src"), { recursive: true });
+  writeFileSync(
+    join(pluginDir, "Dockerfile"),
+    "FROM scratch\nCOPY src /app/src\nCOPY plugins/chassis /plugins/chassis\n",
+  );
+  writeFileSync(join(pluginDir, "src", "index.mjs"), 'export const plugin = "example";\n');
+  writeFileSync(join(pluginDir, ".dockerignore"), "plugins/*\nignored-secret\n");
+  writeFileSync(join(pluginDir, "ignored-secret"), "secret\n");
+  const configPath = join(dir, "qm.config.jsonc");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      contract: 1,
+      orgId: "plugin-context",
+      publicUrl: "https://example.invalid",
+      target: "fly",
+      flyOrg: "personal",
+      region: "sjc",
+      services: ["core"],
+      plugins: [{ name: "example" }],
+      skills: [],
+      env: {
+        core: {
+          SNAPSHOT_STORE: "s3",
+          TRANSFER_STORE: "s3",
+          S3_BUCKET: "plugin-context-data",
+          S3_REGION: "auto",
+        },
+      },
+      imageOverrides: {},
+      sandbox: { app: "plugin-context-sandboxes" },
+    }),
+  );
+  try {
+    const result = spawnSync(process.execPath, [bin, "up", "--config", configPath, "--only", "example"], {
+      encoding: "utf8",
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        FLY_BIN: fakeFlyBin(dir),
+        FAKE_FLY_CONTEXT_LOG: contextLog,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const recorded = JSON.parse(readFileSync(contextLog, "utf8")) as {
+      context: string;
+      dockerfile: string;
+      ignorefile: string;
+      pluginSource: string;
+      chassis: boolean;
+      ignoredSecret: boolean;
+    };
+    assert.equal(dirname(recorded.dockerfile), recorded.context);
+    assert.match(basename(recorded.dockerfile), /^\.qm-plugin-.+\.Dockerfile$/);
+    assert.equal(recorded.ignorefile, `${recorded.dockerfile}.dockerignore`);
+    assert.equal(recorded.pluginSource, 'export const plugin = "example";\n');
+    assert.equal(recorded.chassis, true);
+    assert.equal(recorded.ignoredSecret, false);
+    assert.equal(existsSync(recorded.context), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Fly source plugin build-only uses Dockerfile-specific ignore precedence", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-fly-plugin-build-context-"));
+  const pluginDir = join(dir, "plugins", "example");
+  const contextLog = join(dir, "context.json");
+  mkdirSync(join(pluginDir, "src"), { recursive: true });
+  writeFileSync(
+    join(pluginDir, "Dockerfile"),
+    "FROM scratch\nCOPY src /app/src\nCOPY plugins/chassis /plugins/chassis\nCOPY root-secret /app/root-secret\n",
+  );
+  writeFileSync(join(pluginDir, "src", "index.mjs"), 'export const plugin = "example";\n');
+  writeFileSync(join(pluginDir, ".dockerignore"), "root-secret\n");
+  writeFileSync(join(pluginDir, "Dockerfile.dockerignore"), "plugins/*\nspecific-secret\n");
+  writeFileSync(join(pluginDir, "root-secret"), "included\n");
+  writeFileSync(join(pluginDir, "specific-secret"), "excluded\n");
+  const configPath = join(dir, "qm.config.jsonc");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      contract: 1,
+      orgId: "plugin-build-context",
+      publicUrl: "https://example.invalid",
+      target: "fly",
+      flyOrg: "personal",
+      region: "sjc",
+      services: ["core"],
+      plugins: [{ name: "example" }],
+      skills: [],
+      env: {
+        core: {
+          SNAPSHOT_STORE: "s3",
+          TRANSFER_STORE: "s3",
+          S3_BUCKET: "plugin-build-context-data",
+          S3_REGION: "auto",
+        },
+      },
+      imageOverrides: {},
+      sandbox: { app: "plugin-build-context-sandboxes" },
+    }),
+  );
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [bin, "up", "--config", configPath, "--only", "example", "--build-only", "--image-label", "test"],
+      {
+        encoding: "utf8",
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          FLY_BIN: fakeFlyBin(dir),
+          FAKE_FLY_CONTEXT_LOG: contextLog,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const recorded = JSON.parse(readFileSync(contextLog, "utf8")) as {
+      context: string;
+      dockerfile: string;
+      ignorefile: string;
+      chassis: boolean;
+      rootSecret: boolean;
+      specificSecret: boolean;
+    };
+    assert.equal(recorded.ignorefile, `${recorded.dockerfile}.dockerignore`);
+    assert.equal(recorded.chassis, true);
+    assert.equal(recorded.rootSecret, true);
+    assert.equal(recorded.specificSecret, false);
+    assert.equal(existsSync(recorded.context), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+for (const scenario of [
+  { name: "ordinary deploy", signal: "SIGTERM", extraArgs: [] },
+  { name: "build-only deploy", signal: "SIGINT", extraArgs: ["--build-only", "--image-label", "test"] },
+] as const) {
+  test(`${scenario.signal} stops the Fly source plugin ${scenario.name} process tree`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "qm-fly-plugin-signal-"));
+    const pluginDir = join(dir, "plugins", "example");
+    const ready = join(dir, "ready.json");
+    const sideEffect = join(dir, "side-effect");
+    const processIds = join(dir, "process-ids");
+    mkdirSync(join(pluginDir, "src"), { recursive: true });
+    writeFileSync(join(pluginDir, "Dockerfile"), "FROM scratch\nCOPY plugins/chassis /plugins/chassis\n");
+    writeFileSync(join(pluginDir, "src", "index.mjs"), 'export const plugin = "example";\n');
+    const configPath = join(dir, "qm.config.jsonc");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        contract: 1,
+        orgId: "plugin-signal",
+        publicUrl: "https://example.invalid",
+        target: "fly",
+        flyOrg: "personal",
+        region: "sjc",
+        services: ["core"],
+        plugins: [{ name: "example" }],
+        skills: [],
+        env: {
+          core: {
+            SNAPSHOT_STORE: "s3",
+            TRANSFER_STORE: "s3",
+            S3_BUCKET: "plugin-signal-data",
+            S3_REGION: "auto",
+          },
+        },
+        imageOverrides: {},
+        sandbox: { app: "plugin-signal-sandboxes" },
+      }),
+    );
+    const child = spawn(
+      process.execPath,
+      [bin, "up", "--config", configPath, "--only", "example", ...scenario.extraArgs],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          FLY_BIN: fakeFlyBin(dir),
+          FAKE_FLY_BLOCK: "1",
+          FAKE_FLY_PROCESS_IDS: processIds,
+          FAKE_FLY_READY: ready,
+          FAKE_FLY_SIDE_EFFECT: sideEffect,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+    try {
+      await waitForFile(ready);
+      const args = JSON.parse(readFileSync(ready, "utf8")) as string[];
+      const context = args.at(-1)!;
+      assert.equal(existsSync(context), true);
+      assert.equal(
+        args.includes("--build-only"),
+        scenario.extraArgs.some((arg) => arg === "--build-only"),
+      );
+      child.kill(scenario.signal);
+      const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+      assert.equal(code, null);
+      assert.equal(signal, scenario.signal);
+      assert.equal(existsSync(context), false);
+      await new Promise((resolve) => setTimeout(resolve, 900));
+      assert.equal(existsSync(sideEffect), false);
+      for (const pid of readFileSync(processIds, "utf8").split(" ").map(Number)) {
+        assert.throws(() => process.kill(pid, 0));
+      }
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      if (existsSync(processIds)) {
+        for (const pid of readFileSync(processIds, "utf8").split(" ").map(Number)) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            void 0;
+          }
+        }
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 }
 
 test("fly up emits phase timings and appends a GitHub step summary", () => {

--- a/cli/test/package.test.ts
+++ b/cli/test/package.test.ts
@@ -286,6 +286,9 @@ else if (command === "secretsmanager get-secret-value") {
       assert.ok(packed[0]!.files.some(({ path }) => path === "templates/deployment/deployment.md"));
       assert.ok(packed[0]!.files.some(({ path }) => path === "templates/deployment/references/fly.md"));
       assert.ok(packed[0]!.files.some(({ path }) => path === "templates/fly/core.toml"));
+      assert.ok(packed[0]!.files.some(({ path }) => path === "dist/plugin-chassis/package.json"));
+      assert.ok(packed[0]!.files.some(({ path }) => path === "dist/plugin-chassis/src/errors.ts"));
+      assert.ok(packed[0]!.files.some(({ path }) => path === "node_modules/@balena/dockerignore/ignore.js"));
       assert.ok(!packed[0]!.files.some(({ path }) => path === "src/contract.ts" || path === "bin/qm.ts"));
     } finally {
       if (registry) await new Promise<void>((resolve) => registry!.close(() => resolve()));

--- a/cli/test/plugin-build-context.test.ts
+++ b/cli/test/plugin-build-context.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import {
+  existsSync,
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { test } from "node:test";
+import { withSourcePluginBuildContext, withSourcePluginBuildContextAsync } from "../src/plugin-build-context.ts";
+import type { ResolvedPlugin } from "../src/plugins.ts";
+import { runInheritAsync } from "../src/util.ts";
+
+function sourcePlugin(root: string): ResolvedPlugin {
+  const sourceDir = join(root, "plugins", "example");
+  mkdirSync(join(sourceDir, "src"), { recursive: true });
+  writeFileSync(join(sourceDir, "Dockerfile"), "FROM scratch\nCOPY package.json /app/package.json\n");
+  writeFileSync(join(sourceDir, "package.json"), '{"type":"module"}\n');
+  writeFileSync(join(sourceDir, "src", "index.mjs"), 'export const value = "plugin";\n');
+  writeFileSync(join(sourceDir, ".dockerignore"), "node_modules\n");
+  return {
+    name: "example",
+    kind: "source",
+    sourceDir,
+    dockerfile: join(sourceDir, "Dockerfile"),
+    env: {},
+  };
+}
+
+function dockerAvailable(): boolean {
+  return spawnSync("docker", ["version", "-f", "{{.Server.Version}}"], { stdio: "ignore" }).status === 0;
+}
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+test("source plugin build contexts preserve the plugin root and add the packaged chassis", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-test-"));
+  try {
+    const plugin = sourcePlugin(root);
+    let preparedDir = "";
+    const result = withSourcePluginBuildContext(plugin, (prepared) => {
+      preparedDir = prepared.directory;
+      assert.notEqual(prepared.directory, plugin.sourceDir);
+      assert.equal(dirname(prepared.dockerfile), prepared.directory);
+      assert.match(basename(prepared.dockerfile), /^\.qm-plugin-.+\.Dockerfile$/);
+      assert.equal(readFileSync(join(prepared.directory, "package.json"), "utf8"), '{"type":"module"}\n');
+      assert.equal(
+        readFileSync(join(prepared.directory, "src", "index.mjs"), "utf8"),
+        'export const value = "plugin";\n',
+      );
+      assert.equal(readFileSync(join(prepared.directory, ".dockerignore"), "utf8"), "node_modules\n");
+      assert.match(
+        readFileSync(join(prepared.directory, "plugins", "chassis", "src", "errors.ts"), "utf8"),
+        /export function errMessage/,
+      );
+      return "built";
+    });
+    assert.equal(result, "built");
+    assert.equal(existsSync(preparedDir), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source plugin build contexts are removed after synchronous build failures", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-test-"));
+  try {
+    const plugin = sourcePlugin(root);
+    let preparedDir = "";
+    assert.throws(
+      () =>
+        withSourcePluginBuildContext(plugin, (prepared) => {
+          preparedDir = prepared.directory;
+          throw new Error("build failed");
+        }),
+      /build failed/,
+    );
+    assert.equal(existsSync(preparedDir), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("source plugin build contexts are removed after asynchronous builds settle", async () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-test-"));
+  try {
+    const plugin = sourcePlugin(root);
+    let successDir = "";
+    const result = await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+      successDir = prepared.directory;
+      await Promise.resolve();
+      return "deployed";
+    });
+    assert.equal(result, "deployed");
+    assert.equal(existsSync(successDir), false);
+
+    let failureDir = "";
+    await assert.rejects(
+      withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+        failureDir = prepared.directory;
+        await Promise.resolve();
+        throw new Error("deploy failed");
+      }),
+      /deploy failed/,
+    );
+    assert.equal(existsSync(failureDir), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test(
+  "a generic source plugin image can import the chassis copied from its prepared context",
+  { skip: !dockerAvailable() },
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-smoke-"));
+    const image = `qm-plugin-context-smoke:${randomUUID()}`;
+    try {
+      const plugin = sourcePlugin(root);
+      writeFileSync(join(plugin.sourceDir!, ".dockerignore"), "node_modules\nplugins\n");
+      writeFileSync(
+        plugin.dockerfile!,
+        'FROM node:24-alpine\nWORKDIR /app\nCOPY package.json .\nCOPY src ./src\nCOPY plugins/chassis /plugins/chassis\nCMD ["node", "src/index.ts"]\n',
+      );
+      writeFileSync(
+        join(plugin.sourceDir!, "src", "index.ts"),
+        'import { errMessage } from "../../plugins/chassis/src/errors.ts";\nprocess.stdout.write(errMessage(new Error("chassis-loaded")));\n',
+      );
+      await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+        await runInheritAsync("docker", ["build", "-f", prepared.dockerfile, "-t", image, prepared.directory]);
+      });
+      assert.equal(execFileSync("docker", ["run", "--rm", image], { encoding: "utf8" }), "chassis-loaded");
+    } finally {
+      spawnSync("docker", ["image", "rm", "-f", image], { stdio: "ignore" });
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "prepared contexts preserve relative symlinks and build the same runnable image",
+  { skip: !dockerAvailable() },
+  () => {
+    const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-symlink-"));
+    const image = `qm-plugin-context-symlink:${randomUUID()}`;
+    try {
+      const plugin = sourcePlugin(root);
+      mkdirSync(join(plugin.sourceDir!, "shared"));
+      writeFileSync(join(plugin.sourceDir!, "shared", "value.txt"), "relative-link-works\n");
+      symlinkSync("../shared", join(plugin.sourceDir!, "src", "shared"));
+      writeFileSync(plugin.dockerfile!, 'FROM alpine:3.22\nCOPY . /app\nCMD ["cat", "/app/src/shared/value.txt"]\n');
+      withSourcePluginBuildContext(plugin, (prepared) => {
+        assert.equal(readlinkSync(join(prepared.directory, "src", "shared")), "../shared");
+        execFileSync("docker", ["build", "-f", prepared.dockerfile, "-t", image, prepared.directory], {
+          stdio: "pipe",
+        });
+      });
+      assert.equal(execFileSync("docker", ["run", "--rm", image], { encoding: "utf8" }), "relative-link-works\n");
+    } finally {
+      spawnSync("docker", ["image", "rm", "-f", image], { stdio: "ignore" });
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("plugin-controlled symlink ancestors cannot redirect chassis injection", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-escape-"));
+  const outside = mkdtempSync(join(tmpdir(), "qm-plugin-context-outside-"));
+  try {
+    const plugin = sourcePlugin(root);
+    const pluginPlugins = join(plugin.sourceDir!, "plugins");
+    mkdirSync(join(outside, "chassis"));
+    writeFileSync(join(outside, "chassis", "marker"), "untouched\n");
+    symlinkSync(outside, pluginPlugins);
+    assert.throws(() => withSourcePluginBuildContext(plugin, () => undefined), /plugins.*symbolic link/);
+    assert.equal(readFileSync(join(outside, "chassis", "marker"), "utf8"), "untouched\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("prepared contexts never materialize files excluded by the effective Docker ignore rules", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-ignore-"));
+  try {
+    const plugin = sourcePlugin(root);
+    writeFileSync(join(plugin.sourceDir!, ".dockerignore"), ".env\nnode_modules\nignored-cache\n");
+    writeFileSync(join(plugin.sourceDir!, ".env"), "PRIVATE_TOKEN=secret\n");
+    mkdirSync(join(plugin.sourceDir!, "node_modules", "dependency"), { recursive: true });
+    writeFileSync(join(plugin.sourceDir!, "node_modules", "dependency", "index.js"), "secret cache\n");
+    mkdirSync(join(plugin.sourceDir!, "ignored-cache"));
+    writeFileSync(join(plugin.sourceDir!, "ignored-cache", "token"), "secret cache\n");
+    chmodSync(join(plugin.sourceDir!, ".env"), 0o000);
+    chmodSync(join(plugin.sourceDir!, "node_modules"), 0o000);
+    try {
+      withSourcePluginBuildContext(plugin, (prepared) => {
+        assert.equal(existsSync(join(prepared.directory, ".env")), false);
+        assert.equal(existsSync(join(prepared.directory, "node_modules")), false);
+        assert.equal(existsSync(join(prepared.directory, "ignored-cache")), false);
+        assert.equal(existsSync(join(prepared.directory, "package.json")), true);
+        assert.equal(existsSync(join(prepared.directory, "plugins", "chassis", "src", "errors.ts")), true);
+      });
+    } finally {
+      chmodSync(join(plugin.sourceDir!, ".env"), 0o600);
+      chmodSync(join(plugin.sourceDir!, "node_modules"), 0o700);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Dockerfile-specific ignore rules take precedence without changing either source ignore file", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-specific-ignore-"));
+  try {
+    const plugin = sourcePlugin(root);
+    const rootIgnore = "root-secret\n";
+    const dockerfileIgnore = "specific-secret\nplugins\n";
+    writeFileSync(join(plugin.sourceDir!, ".dockerignore"), rootIgnore);
+    writeFileSync(`${plugin.dockerfile!}.dockerignore`, dockerfileIgnore);
+    writeFileSync(join(plugin.sourceDir!, "root-secret"), "included by the effective rules\n");
+    writeFileSync(join(plugin.sourceDir!, "specific-secret"), "excluded by the effective rules\n");
+    withSourcePluginBuildContext(plugin, (prepared) => {
+      assert.equal(existsSync(join(prepared.directory, "root-secret")), true);
+      assert.equal(existsSync(join(prepared.directory, "specific-secret")), false);
+      assert.equal(readFileSync(join(prepared.directory, ".dockerignore"), "utf8"), rootIgnore);
+      assert.equal(readFileSync(join(prepared.directory, "Dockerfile.dockerignore"), "utf8"), dockerfileIgnore);
+      assert.match(readFileSync(`${prepared.dockerfile}.dockerignore`, "utf8"), /!plugins\/chassis\/\*\*/);
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("negated Docker ignore rules can restore descendants without restoring unrelated trees", () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-negated-ignore-"));
+  try {
+    const plugin = sourcePlugin(root);
+    writeFileSync(join(plugin.sourceDir!, ".dockerignore"), "*\n!package.json\n!src/**\n");
+    writeFileSync(join(plugin.sourceDir!, "secret"), "excluded\n");
+    mkdirSync(join(plugin.sourceDir!, "node_modules", "dependency"), { recursive: true });
+    writeFileSync(join(plugin.sourceDir!, "node_modules", "dependency", "index.js"), "excluded\n");
+    withSourcePluginBuildContext(plugin, (prepared) => {
+      assert.equal(existsSync(join(prepared.directory, "secret")), false);
+      assert.equal(existsSync(join(prepared.directory, "node_modules")), false);
+      assert.equal(existsSync(join(prepared.directory, "package.json")), true);
+      assert.equal(existsSync(join(prepared.directory, "src", "index.mjs")), true);
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("SIGTERM removes a prepared context before the process exits", async () => {
+  const root = mkdtempSync(join(tmpdir(), "qm-plugin-context-signal-"));
+  const marker = join(root, "prepared-path");
+  const plugin = sourcePlugin(root);
+  const script = `
+import { writeFileSync } from "node:fs";
+import { withSourcePluginBuildContextAsync } from ${JSON.stringify(new URL("../src/plugin-build-context.ts", import.meta.url).href)};
+import { runInheritAsync } from ${JSON.stringify(new URL("../src/util.ts", import.meta.url).href)};
+const plugin = JSON.parse(process.env.QM_TEST_PLUGIN);
+await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+  writeFileSync(process.env.QM_TEST_MARKER, prepared.directory);
+  await runInheritAsync(process.execPath, ["--eval", "const parent = process.ppid; setInterval(() => { try { process.kill(parent, 0); } catch { process.exit(0); } }, 25)"]);
+});
+`;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+    env: {
+      ...process.env,
+      QM_TEST_MARKER: marker,
+      QM_TEST_PLUGIN: JSON.stringify(plugin),
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  try {
+    await waitForFile(marker);
+    const prepared = readFileSync(marker, "utf8");
+    assert.equal(existsSync(prepared), true);
+    child.kill("SIGTERM");
+    const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+    assert.equal(code, null);
+    assert.equal(signal, "SIGTERM");
+    assert.equal(existsSync(prepared), false);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/cli/test/process-cleanup.test.ts
+++ b/cli/test/process-cleanup.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { test } from "node:test";
+import { runTrackedChild } from "../src/process-cleanup.ts";
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+test("tracked children unregister signal cleanup after normal, failing, and spawn-error exits", async () => {
+  const baseline = [process.listenerCount("SIGINT"), process.listenerCount("SIGTERM")];
+  assert.deepEqual(await runTrackedChild(process.execPath, ["--eval", "process.exit(0)"], { stdio: "ignore" }), {
+    code: 0,
+    signal: null,
+  });
+  assert.deepEqual(await runTrackedChild(process.execPath, ["--eval", "process.exit(7)"], { stdio: "ignore" }), {
+    code: 7,
+    signal: null,
+  });
+  await assert.rejects(
+    () => runTrackedChild(join(tmpdir(), "qm-missing-executable"), [], { stdio: "ignore" }),
+    /ENOENT/,
+  );
+  assert.deepEqual([process.listenerCount("SIGINT"), process.listenerCount("SIGTERM")], baseline);
+});
+
+for (const scenario of [
+  { name: "docker build", signal: "SIGTERM", args: ["build", "--tag", "test", "."] },
+  { name: "docker buildx push", signal: "SIGINT", args: ["buildx", "build", "--push", "."] },
+] as const) {
+  test(`${scenario.signal} stops the ${scenario.name} process tree before contexts and leases are released`, async () => {
+    const root = mkdtempSync(join(tmpdir(), "qm-process-cleanup-"));
+    const pluginDir = join(root, "plugins", "example");
+    const marker = join(root, "prepared-path");
+    const childReady = join(root, "child-ready");
+    const sideEffect = join(root, "side-effect");
+    const processIds = join(root, "process-ids");
+    const awsLog = join(root, "aws.log");
+    const awsBin = join(root, "aws");
+    const dockerBin = join(root, "docker");
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(pluginDir, "Dockerfile"), "FROM scratch\n");
+    writeFileSync(
+      awsBin,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.QM_TEST_AWS_LOG, args.join(" ") + "\\n");
+if (args.includes("delete-item")) {
+  const context = fs.readFileSync(process.env.QM_TEST_MARKER, "utf8");
+  const pids = fs.readFileSync(process.env.QM_TEST_PROCESS_IDS, "utf8").split(" ").map(Number);
+  const alive = pids.some((pid) => { try { process.kill(pid, 0); return true; } catch { return false; } });
+  fs.appendFileSync(process.env.QM_TEST_AWS_LOG, "release-state context=" + fs.existsSync(context) + " children=" + alive + "\\n");
+}
+`,
+    );
+    chmodSync(awsBin, 0o755);
+    writeFileSync(
+      dockerBin,
+      `#!/usr/bin/env node
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const grandchild = spawn(process.execPath, ["--eval", ${JSON.stringify(
+        `setTimeout(() => require("node:fs").writeFileSync(process.env.QM_TEST_SIDE_EFFECT, "late\n"), 750); setInterval(() => undefined, 1000);`,
+      )}], { stdio: "ignore", env: process.env });
+fs.writeFileSync(process.env.QM_TEST_PROCESS_IDS, process.pid + " " + grandchild.pid);
+fs.writeFileSync(process.env.QM_TEST_CHILD_READY, process.argv.slice(2).join(" "));
+setTimeout(() => fs.writeFileSync(process.env.QM_TEST_SIDE_EFFECT, "late\\n"), 750);
+setInterval(() => undefined, 1000);
+`,
+    );
+    chmodSync(dockerBin, 0o755);
+    const script = `
+import { writeFileSync } from "node:fs";
+import { acquireAwsLease } from ${JSON.stringify(new URL("../src/aws-lease.ts", import.meta.url).href)};
+import { withSourcePluginBuildContextAsync } from ${JSON.stringify(new URL("../src/plugin-build-context.ts", import.meta.url).href)};
+import { runInheritAsync } from ${JSON.stringify(new URL("../src/util.ts", import.meta.url).href)};
+const plugin = JSON.parse(process.env.QM_TEST_PLUGIN);
+acquireAwsLease({ accountId: "123456789012", region: "us-west-2", cluster: "cleanup-test", deployRoleArn: "arn:test", imageLabel: "test", secretsPrefix: "test/", networking: { cloudMapNamespace: "test.internal" }, services: {} });
+await withSourcePluginBuildContextAsync(plugin, async (prepared) => {
+  writeFileSync(process.env.QM_TEST_MARKER, prepared.directory);
+  await runInheritAsync(process.env.QM_TEST_DOCKER, JSON.parse(process.env.QM_TEST_DOCKER_ARGS));
+});
+`;
+    const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+      env: {
+        ...process.env,
+        AWS_BIN: awsBin,
+        QM_TEST_CHILD_READY: childReady,
+        QM_TEST_DOCKER: dockerBin,
+        QM_TEST_DOCKER_ARGS: JSON.stringify(scenario.args),
+        QM_TEST_AWS_LOG: awsLog,
+        QM_TEST_MARKER: marker,
+        QM_TEST_PROCESS_IDS: processIds,
+        QM_TEST_SIDE_EFFECT: sideEffect,
+        QM_TEST_PLUGIN: JSON.stringify({
+          name: "example",
+          kind: "source",
+          sourceDir: pluginDir,
+          dockerfile: join(pluginDir, "Dockerfile"),
+          env: {},
+        }),
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    let prepared = "";
+    try {
+      await waitForFile(marker);
+      try {
+        await waitForFile(childReady);
+      } catch (error) {
+        throw new Error(`${(error as Error).message}\n${stderr}`);
+      }
+      prepared = readFileSync(marker, "utf8");
+      assert.equal(existsSync(prepared), true);
+      assert.equal(readFileSync(childReady, "utf8"), scenario.args.join(" "));
+      child.kill(scenario.signal);
+      const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+      assert.equal(code, null);
+      assert.equal(signal, scenario.signal);
+      assert.equal(existsSync(prepared), false);
+      const commands = readFileSync(awsLog, "utf8");
+      assert.match(commands, /dynamodb put-item/);
+      assert.match(commands, /dynamodb delete-item/);
+      assert.match(commands, /release-state context=false children=false/);
+      await new Promise((resolve) => setTimeout(resolve, 900));
+      assert.equal(existsSync(sideEffect), false);
+      for (const pid of readFileSync(processIds, "utf8").split(" ").map(Number)) {
+        assert.throws(() => process.kill(pid, 0));
+      }
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      if (existsSync(processIds)) {
+        for (const pid of readFileSync(processIds, "utf8").split(" ").map(Number)) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            void 0;
+          }
+        }
+      }
+      if (prepared && basename(prepared).startsWith("qm-plugin-build-")) {
+        rmSync(prepared, { recursive: true, force: true });
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,9 +60,15 @@
     },
     "cli": {
       "name": "@yc-software/qm",
-      "version": "0.1.0",
+      "version": "0.1.4",
+      "bundleDependencies": [
+        "@balena/dockerignore"
+      ],
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2"
+      },
       "bin": {
         "qm": "dist/bin/qm.js"
       },
@@ -767,6 +773,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@earendil-works/pi-agent-core": {
       "version": "0.82.1",


### PR DESCRIPTION
Source plugins can import the canonical `plugins/chassis` package in production builds without copying it into each plugin.

This change prepares a filtered temporary Docker context that honors root and Dockerfile-specific ignore rules while forcing the shared chassis source into the archive. Docker, AWS, and both Fly source-build paths use that context.

Process cleanup now tracks spawned build/deploy process trees so SIGINT/SIGTERM stops children before removing the context or releasing an AWS deploy lease.

Validation:
- 28 focused source-context, process-tree, Fly, packaging, and real-Docker tests
- AWS source-plugin provenance test
- CLI typecheck, Prettier, oxlint, and diff check
- independent fresh-context review passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788477256&installation_model_id=19911&pr_number=223&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F223&signature=fa16f585fb3a7b70eb22bb66ae3d35ff9f8abcc0b1636e6c59b6d20eff4db9e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->