### PR TITLE
Expose durable budget usage to administrators

### DIFF
--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -46,6 +46,7 @@ import type { AmbientJudgmentStore } from "../surface-cache/ambient-judgment-sto
 import type { AckEmojiPickStore } from "../surface-cache/ack-emoji-pick-store.ts";
 import type { ChannelPolicyStore } from "../surface-cache/channel-policy-store.ts";
 import type { RateLimiter } from "../ratelimit/rate-limiter.ts";
+import type { BudgetTracker } from "../ratelimit/budget.ts";
 import type { AdvisoryLock } from "../persistence/advisory-lock.ts";
 import type { SlackInstallationStore, SlackSocketAppIdReader } from "../surfaces/slack-installation.ts";
 
@@ -88,6 +89,7 @@ export interface ServerDeps {
   harnessId?: string;
   admin?: AdminService;
   rateLimiter?: RateLimiter;
+  budget?: BudgetTracker;
   sessions?: SessionStore;
   auditLog?: AuditLog;
   errors?: ErrorLog;

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -34,6 +34,7 @@ import {
 import { deleteSlackInstallation, getSlackInstallation, putSlackInstallation } from "./admin/slack-installation.ts";
 import { deleteModelProvider, getModelProviders, putModelProvider } from "./admin/model-providers.ts";
 import { deleteCustomProvider, getCustomProviders, putCustomProvider } from "./admin/custom-providers.ts";
+import { getBudgetUsage } from "./admin/budget-usage.ts";
 
 const timed =
   (handle: (ctx: ApiCtx) => void | Promise<void>) =>
@@ -64,6 +65,7 @@ const routes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "DELETE", path: "/v1/admin/custom-providers/:provider", auth: "either", handle: deleteCustomProvider },
   { method: "PUT", path: "/v1/admin/scopes/:scope/:resource", auth: "either", handle: putScopeConfig },
   { method: "GET", path: "/v1/admin/whoami", auth: "either", handle: whoami },
+  { method: "GET", path: "/v1/admin/budget-usage", auth: "either", handle: getBudgetUsage },
   { method: "GET", path: "/v1/admin/scopes", auth: "either", handle: listAdminScopes },
   { method: "GET", path: "/v1/admin/scopes/:scope", auth: "either", handle: getScopeConfig },
   { method: "GET", path: "/v1/admin/resources", auth: "either", handle: getAdminResources },

--- a/src/api/routes/admin/budget-usage.ts
+++ b/src/api/routes/admin/budget-usage.ts
@@ -1,0 +1,24 @@
+import { sendJson } from "../../http.ts";
+import { audit, authorizeAdmin, orgScope } from "../shared.ts";
+import type { ApiCtx } from "../route.ts";
+
+export async function getBudgetUsage(ctx: ApiCtx): Promise<void> {
+  const { deps, res, url } = ctx;
+  if (!deps.budget) return sendJson(res, 404, { error: "not_found" });
+  const scope = url.searchParams.get("scope") ?? "";
+  const principalId = url.searchParams.get("principalId") ?? "";
+  if (!scope || !principalId || principalId.length > 512 || /[\u0000-\u001f\u007f]/u.test(principalId)) {
+    return sendJson(res, 400, { error: "bad_request" });
+  }
+  if (scope !== orgScope(deps)) return sendJson(res, 403, { error: "forbidden" });
+  const actor = await authorizeAdmin(ctx, scope);
+  if (!actor) return;
+  const usage = await deps.budget.usage(principalId);
+  audit(deps, {
+    principalId: actor.id,
+    action: "budget-usage.read",
+    resource: principalId,
+    scopeLabel: scope,
+  });
+  return sendJson(res, 200, { scopeId: scope, principalId, approximate: true, ...usage });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -73,6 +73,7 @@ function capabilityAdminDenied(method: string, pathname: string, url: URL, claim
 }
 
 function isAdminContentRead(pathname: string): boolean {
+  if (pathname === "/v1/admin/budget-usage") return true;
   if (pathname === "/v1/admin/memory") return true;
   if (pathname === "/v1/admin/keychain") return true;
   if (pathname === "/v1/admin/volumes") return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const server = createServer(built.app, {
   ...(config.publicWebUrl ? { portalUrl: config.publicWebUrl } : {}),
   admin: built.admin,
   rateLimiter: built.rateLimiter,
+  budget: built.budget,
   acl: built.acl,
   credentialUsage: built.credentialUsage,
   deviceFlowCutover: built.deviceFlowCutover,

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -5,9 +5,16 @@ interface BudgetCheck {
   limitUsd: number;
 }
 
+export interface BudgetUsage {
+  windowMs: number;
+  member: { spentUsd: number; limitUsd: number | null };
+  organization: { spentUsd: number; limitUsd: number | null };
+}
+
 export interface BudgetTracker {
   check(principalId: string, now?: number): Promise<BudgetCheck>;
   record(principalId: string, costUsd: number, now?: number): Promise<void>;
+  usage(principalId: string, now?: number): Promise<BudgetUsage>;
 }
 
 export const DEFAULT_BUDGET_WINDOW_MS = 86_400_000;
@@ -22,29 +29,47 @@ export function createBudgetTracker(
   const limitUsd = opts.limitUsd ?? Infinity;
   const orgLimitUsd = opts.orgLimitUsd ?? Infinity;
   const windowMs = opts.windowMs ?? DEFAULT_BUDGET_WINDOW_MS;
-  const spend = new Map<string, Array<{ at: number; usd: number }>>();
-  const orgKey = "@org";
+  const memberSpend = new Map<string, Array<{ at: number; usd: number }>>();
+  let organizationSpend: Array<{ at: number; usd: number }> = [];
 
-  function spentIn(principalId: string, now: number): number {
+  function memberSpentIn(principalId: string, now: number): number {
     const cutoff = now - windowMs;
-    const kept = (spend.get(principalId) ?? []).filter((e) => e.at >= cutoff);
-    spend.set(principalId, kept);
+    const kept = (memberSpend.get(principalId) ?? []).filter((e) => e.at >= cutoff);
+    memberSpend.set(principalId, kept);
     return kept.reduce((s, e) => s + e.usd, 0);
+  }
+
+  function organizationSpentIn(now: number): number {
+    const cutoff = now - windowMs;
+    organizationSpend = organizationSpend.filter((entry) => entry.at >= cutoff);
+    return organizationSpend.reduce((sum, entry) => sum + entry.usd, 0);
   }
 
   return {
     async check(principalId, now = Date.now()) {
-      const spentUsd = spentIn(principalId, now);
+      const spentUsd = memberSpentIn(principalId, now);
       if (spentUsd >= limitUsd) return { allowed: false, spentUsd, limitUsd };
-      const orgSpent = spentIn(orgKey, now);
+      const orgSpent = organizationSpentIn(now);
       return { allowed: orgSpent < orgLimitUsd, spentUsd: orgSpent, limitUsd: orgLimitUsd };
     },
     async record(principalId, costUsd, now = Date.now()) {
-      for (const key of [principalId, orgKey]) {
-        const list = spend.get(key) ?? [];
-        list.push({ at: now, usd: costUsd });
-        spend.set(key, list);
-      }
+      const member = memberSpend.get(principalId) ?? [];
+      member.push({ at: now, usd: costUsd });
+      memberSpend.set(principalId, member);
+      organizationSpend.push({ at: now, usd: costUsd });
+    },
+    async usage(principalId, now = Date.now()) {
+      return {
+        windowMs,
+        member: {
+          spentUsd: memberSpentIn(principalId, now),
+          limitUsd: Number.isFinite(limitUsd) ? limitUsd : null,
+        },
+        organization: {
+          spentUsd: organizationSpentIn(now),
+          limitUsd: Number.isFinite(orgLimitUsd) ? orgLimitUsd : null,
+        },
+      };
     },
   };
 }

--- a/src/ratelimit/postgres-budget.ts
+++ b/src/ratelimit/postgres-budget.ts
@@ -13,40 +13,73 @@ export function createPostgresBudgetTracker(
   const { q } = createPgPool(connectionString, [
     `CREATE TABLE IF NOT EXISTS budget_spend(
         id BIGSERIAL PRIMARY KEY,
+        spend_kind TEXT,
         principal_id TEXT NOT NULL,
         at BIGINT NOT NULL,
         usd DOUBLE PRECISION NOT NULL
       )`,
+    `ALTER TABLE budget_spend ADD COLUMN IF NOT EXISTS spend_kind TEXT`,
+    `UPDATE budget_spend
+       SET spend_kind = CASE WHEN principal_id = '@org' THEN 'organization' ELSE 'member' END
+       WHERE spend_kind IS NULL`,
     `CREATE INDEX IF NOT EXISTS budget_spend_by_principal_at ON budget_spend(principal_id, at)`,
   ]);
 
+  async function spentIn(spendKind: "member" | "organization", principalId: string, now: number): Promise<number> {
+    const legacy = spendKind === "organization" ? "principal_id = '@org'" : "principal_id <> '@org'";
+    const rows = await q(
+      `SELECT COALESCE(SUM(usd), 0) AS spent
+       FROM budget_spend
+       WHERE (spend_kind = $1 OR (spend_kind IS NULL AND ${legacy}))
+         AND principal_id = $2
+         AND at >= $3`,
+      [spendKind, principalId, now - windowMs],
+    );
+    return Number(rows[0]?.spent ?? 0);
+  }
+
   return {
     async check(principalId, now = Date.now()) {
-      const rows = await q(
-        "SELECT COALESCE(SUM(usd), 0) AS spent FROM budget_spend WHERE principal_id = $1 AND at >= $2",
-        [principalId, now - windowMs],
-      );
-      const spentUsd = Number(rows[0]?.spent ?? 0);
+      const spentUsd = await spentIn("member", principalId, now);
       if (spentUsd >= limitUsd) return { allowed: false, spentUsd, limitUsd };
-      const orgRows = await q(
-        "SELECT COALESCE(SUM(usd), 0) AS spent FROM budget_spend WHERE principal_id = $1 AND at >= $2",
-        [orgKey, now - windowMs],
-      );
-      const orgSpent = Number(orgRows[0]?.spent ?? 0);
+      const orgSpent = await spentIn("organization", orgKey, now);
       return { allowed: orgSpent < orgLimitUsd, spentUsd: orgSpent, limitUsd: orgLimitUsd };
     },
     async record(principalId, costUsd, now = Date.now()) {
       try {
-        for (const key of [principalId, orgKey]) {
+        for (const [spendKind, key] of [
+          ["member", principalId],
+          ["organization", orgKey],
+        ] as const) {
+          const legacy = spendKind === "organization" ? "principal_id = '@org'" : "principal_id <> '@org'";
           await q(
-            `WITH ins AS (INSERT INTO budget_spend(principal_id, at, usd) VALUES ($1, $2, $3))
-             DELETE FROM budget_spend WHERE principal_id = $1 AND at < $4`,
-            [key, now, costUsd, now - windowMs],
+            `WITH ins AS (
+               INSERT INTO budget_spend(spend_kind, principal_id, at, usd) VALUES ($1, $2, $3, $4)
+             )
+             DELETE FROM budget_spend
+             WHERE (spend_kind = $1 OR (spend_kind IS NULL AND ${legacy}))
+               AND principal_id = $2
+               AND at < $5`,
+            [spendKind, key, now, costUsd, now - windowMs],
           );
         }
       } catch (err) {
         console.error("[budget] failed to persist spend:", err);
       }
+    },
+    async usage(principalId, now = Date.now()) {
+      const [memberSpent, organizationSpent] = await Promise.all([
+        spentIn("member", principalId, now),
+        spentIn("organization", orgKey, now),
+      ]);
+      return {
+        windowMs,
+        member: { spentUsd: memberSpent, limitUsd: Number.isFinite(limitUsd) ? limitUsd : null },
+        organization: {
+          spentUsd: organizationSpent,
+          limitUsd: Number.isFinite(orgLimitUsd) ? orgLimitUsd : null,
+        },
+      };
     },
   };
 }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -51,7 +51,7 @@ import { createAuditLog, type AuditLog } from "./audit/audit-log.ts";
 import { createPostgresAuditLog } from "./admin/postgres-audit-log.ts";
 import { createRateLimiter, type RateLimiter } from "./ratelimit/rate-limiter.ts";
 import { createPostgresRateLimiter } from "./ratelimit/postgres-rate-limiter.ts";
-import { createBudgetTracker } from "./ratelimit/budget.ts";
+import { createBudgetTracker, type BudgetTracker } from "./ratelimit/budget.ts";
 import { createPostgresBudgetTracker } from "./ratelimit/postgres-budget.ts";
 import { createCronStore, type CronStore } from "./cron/cron-store.ts";
 import { createDeliveryStore, type DeliveryStore } from "./delivery/delivery-store.ts";
@@ -331,6 +331,7 @@ export interface BuiltApp {
   scheduler: Scheduler;
   admin: AdminService;
   rateLimiter: RateLimiter;
+  budget: BudgetTracker;
   errors: ErrorLog;
   metrics: MetricsSink;
   crons: CronStore;
@@ -530,10 +531,9 @@ export function buildApp(
     ...(config.orgBudgetUsdPerWindow !== undefined ? { orgLimitUsd: config.orgBudgetUsdPerWindow } : {}),
     windowMs: config.budgetWindowMs,
   };
-  const budget =
-    config.databaseUrl && (config.budgetUsdPerWindow !== undefined || config.orgBudgetUsdPerWindow !== undefined)
-      ? createPostgresBudgetTracker(config.databaseUrl, budgetOpts)
-      : createBudgetTracker(budgetOpts);
+  const budget = config.databaseUrl
+    ? createPostgresBudgetTracker(config.databaseUrl, budgetOpts)
+    : createBudgetTracker(budgetOpts);
   const resolution = createResolutionService(config.orgId, configStore, acl);
 
   const workspace = createLocalWorkspaceStore(config.dataDir);
@@ -1453,6 +1453,7 @@ export function buildApp(
     scheduler,
     admin,
     rateLimiter,
+    budget,
     errors,
     metrics,
     crons,

--- a/test/admin-budget-usage.test.ts
+++ b/test/admin-budget-usage.test.ts
@@ -1,0 +1,96 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { createInsecureTestServer, createServer } from "../src/api/server.ts";
+import { signRequest } from "../src/auth/source-auth.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+function start(signingSecret?: string) {
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "admin-budget-usage-")),
+      budgetUsdPerWindow: 2,
+      orgBudgetUsdPerWindow: 5,
+      budgetWindowMs: 86_400_000,
+    }),
+  );
+  const dependencies = {
+    admin: built.admin,
+    auditLog: built.auditLog,
+    budget: built.budget,
+  };
+  const server = signingSecret
+    ? createServer(built.app, { ...dependencies, signingSecret })
+    : createInsecureTestServer(built.app, dependencies);
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  return { base, built, close: () => new Promise<void>((resolve) => server.close(() => resolve())) };
+}
+
+test("org admin reads approximate member and organization budget usage", async () => {
+  const s = start();
+  try {
+    await s.built.budget.record("U1", 0.5);
+    await s.built.budget.record("U2", 1.25);
+    const url = new URL("/v1/admin/budget-usage", s.base);
+    url.searchParams.set("scope", "org:default-org");
+    url.searchParams.set("principalId", "U1");
+    const response = await fetch(url, { headers: { "x-admin-actor": "admin-alice@default-org" } });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      scopeId: "org:default-org",
+      principalId: "U1",
+      windowMs: 86_400_000,
+      approximate: true,
+      member: { spentUsd: 0.5, limitUsd: 2 },
+      organization: { spentUsd: 1.75, limitUsd: 5 },
+    });
+  } finally {
+    await s.close();
+  }
+});
+
+test("budget usage requires and accepts signed source authentication", async () => {
+  const secret = "budget-usage-signing-secret".repeat(3);
+  const s = start(secret);
+  try {
+    const path = "/v1/admin/budget-usage?scope=org%3Adefault-org&principalId=U1";
+    const unsigned = await fetch(`${s.base}${path}`, {
+      headers: { "x-admin-actor": "admin-alice@default-org" },
+    });
+    assert.equal(unsigned.status, 401);
+    const timestamp = Math.floor(Date.now() / 1_000);
+    const signature = signRequest(secret, timestamp, `GET\n${path}\n`);
+    const signed = await fetch(`${s.base}${path}`, {
+      headers: {
+        "x-admin-actor": "admin-alice@default-org",
+        "x-timestamp": String(timestamp),
+        "x-signature": signature,
+      },
+    });
+    assert.equal(signed.status, 200);
+  } finally {
+    await s.close();
+  }
+});
+
+test("budget usage rejects non-admins and foreign scopes", async () => {
+  const s = start();
+  try {
+    const own = "/v1/admin/budget-usage?scope=org%3Adefault-org&principalId=U1";
+    const denied = await fetch(`${s.base}${own}`, { headers: { "x-admin-actor": "U1@default-org" } });
+    assert.equal(denied.status, 403);
+    const foreign = await fetch(`${s.base}/v1/admin/budget-usage?scope=org%3Aother-org&principalId=U1`, {
+      headers: { "x-admin-actor": "admin-alice@default-org" },
+    });
+    assert.equal(foreign.status, 403);
+  } finally {
+    await s.close();
+  }
+});

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -22,6 +22,31 @@ test("budget tracker accumulates per-principal and trips at the limit", async ()
   assert.equal((await b.check("U1", 1000 + 61_000)).allowed, true);
 });
 
+test("budget tracker reports member and organization spend for the active window", async () => {
+  const budget = createBudgetTracker({ limitUsd: 2, orgLimitUsd: 5, windowMs: 100 });
+  await budget.record("U1", 0.75, 950);
+  await budget.record("U2", 1.25, 975);
+  await budget.record("U1", 9, 899);
+
+  assert.deepEqual(await budget.usage("U1", 1_000), {
+    windowMs: 100,
+    member: { spentUsd: 0.75, limitUsd: 2 },
+    organization: { spentUsd: 2, limitUsd: 5 },
+  });
+});
+
+test("a member principal matching the legacy organization key is accounted independently", async () => {
+  const budget = createBudgetTracker({ limitUsd: 2, orgLimitUsd: 5, windowMs: 100 });
+  await budget.record("@org", 0.75, 950);
+  await budget.record("U2", 1.25, 975);
+
+  assert.deepEqual(await budget.usage("@org", 1_000), {
+    windowMs: 100,
+    member: { spentUsd: 0.75, limitUsd: 2 },
+    organization: { spentUsd: 2, limitUsd: 5 },
+  });
+});
+
 test("caps are opt-in: an unconfigured tracker never refuses, a configured one does", async () => {
   const unbounded = createBudgetTracker();
   await unbounded.record("U1", 1_000_000);

--- a/test/postgres-budget.test.ts
+++ b/test/postgres-budget.test.ts
@@ -43,3 +43,57 @@ test("pg budget: caps are opt-in — unconfigured allows, configured refuses", {
   assert.equal(c.allowed, false);
   assert.equal(c.spentUsd, 9_999);
 });
+
+test("pg budget: usage reports both durable levels and excludes expired spend", { skip }, async () => {
+  const budget = createPostgresBudgetTracker(URL!, { limitUsd: 2, orgLimitUsd: 5, windowMs: 100 });
+  await budget.record("U1", 0.75, 950);
+  await budget.record("U2", 1.25, 975);
+  await budget.record("U1", 9, 899);
+
+  assert.deepEqual(await budget.usage("U1", 1_000), {
+    windowMs: 100,
+    member: { spentUsd: 0.75, limitUsd: 2 },
+    organization: { spentUsd: 2, limitUsd: 5 },
+  });
+});
+
+test(
+  "pg budget: member and organization namespaces cannot collide and unconfigured limits stay null",
+  { skip },
+  async () => {
+    const first = createPostgresBudgetTracker(URL!, { windowMs: 100 });
+    await first.record("@org", 0.75, 950);
+    await first.record("U2", 1.25, 975);
+    const restarted = createPostgresBudgetTracker(URL!, { windowMs: 100 });
+
+    assert.deepEqual(await restarted.usage("@org", 1_000), {
+      windowMs: 100,
+      member: { spentUsd: 0.75, limitUsd: null },
+      organization: { spentUsd: 2, limitUsd: null },
+    });
+  },
+);
+
+test("pg budget: rolling upgrade accepts and reads legacy writers after the new schema is live", { skip }, async () => {
+  const pg = (await import("pg")).default;
+  const admin = new pg.Pool({ connectionString: URL });
+  await admin.query(`CREATE TABLE budget_spend(
+    id BIGSERIAL PRIMARY KEY,
+    principal_id TEXT NOT NULL,
+    at BIGINT NOT NULL,
+    usd DOUBLE PRECISION NOT NULL
+  )`);
+  await admin.query("INSERT INTO budget_spend(principal_id, at, usd) VALUES ('U1', 950, 0.5), ('@org', 950, 0.5)");
+  const budget = createPostgresBudgetTracker(URL!, { windowMs: 100 });
+  assert.equal((await budget.usage("U1", 1_000)).member.spentUsd, 0.5);
+
+  await admin.query("INSERT INTO budget_spend(principal_id, at, usd) VALUES ('U1', 975, 0.25), ('@org', 975, 0.25)");
+  await budget.record("@org", 1, 990);
+  assert.deepEqual(await budget.usage("U1", 1_000), {
+    windowMs: 100,
+    member: { spentUsd: 0.75, limitUsd: null },
+    organization: { spentUsd: 1.75, limitUsd: null },
+  });
+  assert.equal((await budget.usage("@org", 1_000)).member.spentUsd, 1);
+  await admin.end();
+});


### PR DESCRIPTION
## Summary

- expose approximate member and organization budget usage to organization administrators
- read both levels from the existing durable 24-hour budget ledger
- preserve rolling-upgrade compatibility while separating member and organization accounting namespaces

## Verification

- `node --test test/admin-budget-usage.test.ts test/budget.test.ts`
- `DATABASE_URL=... node --test test/postgres-budget.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788494660&installation_model_id=19911&pr_number=226&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F226&signature=6840d6c8836c471b912383a36a8533eb7a125fafb7fda4df6047dce9cc39db20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->