### PR TITLE
fix(admin): resolve custom provider routes under subpath and load catalog on onboarding

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -7087,6 +7087,7 @@
         $("onboarding-oauth-summary").textContent = configured.length
           ? configured.map((item) => connectorName(item.provider)).join(", ") + " available in the web UI."
           : "Add Google, GitHub, Notion, or other OAuth clients to make those connectors available.";
+        await loadCustomProviders();
         viewLoadedAt.onboarding = Date.now();
       }
       $("onboarding-model-provider").onchange = () => renderOnboardingModelOptions();
@@ -7228,7 +7229,12 @@
         const saved = await api("PUT", "/api/custom-providers/" + encodeURIComponent(id), body);
         $("custom-provider-save").disabled = false;
         if (!saved.ok) {
-          setStatus("st-custom-provider", saved.data?.message || "Could not save this provider.", "err", true);
+          setStatus(
+            "st-custom-provider",
+            saved.data?.message || (saved.data?.error ? "Error: " + saved.data.error : "Could not save this provider."),
+            "err",
+            true,
+          );
           return;
         }
         $("custom-provider-key").value = "";

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -313,7 +313,10 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   res.setHeader("x-frame-options", "DENY");
   res.setHeader("content-security-policy", ADMIN_CSP);
   const url = new URL(req.url ?? "/", "http://localhost");
-  const { pathname } = url;
+  let pathname = url.pathname;
+  if (ADMIN_BASE_PATH && (pathname === ADMIN_BASE_PATH || pathname.startsWith(ADMIN_BASE_PATH + "/"))) {
+    pathname = pathname.slice(ADMIN_BASE_PATH.length) || "/";
+  }
   const method = req.method ?? "GET";
 
   const serveShell = async (): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const server = createServer(built.app, {
   modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
   providerKeys: providerKeysPresent(config),
   modelCredentials: built.modelCredentials,
+  customProviders: built.customProviders,
+  refreshCustomProviders: built.refreshCustomProviders,
   ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
   harnessId: config.harness,
   connectorTokens: built.connectorTokens,


### PR DESCRIPTION
This commit fixes routing, dependency wiring, and frontend catalog rendering issues for Custom Providers in the Admin plugin:

1. `plugins/admin/src/index.ts`:
   - Strip `ADMIN_BASE_PATH` (e.g. `/admin`) at request entry so `/admin/api/custom-providers` routes correctly without throwing 404 `not_found`.

2. `src/index.ts`:
   - Pass `customProviders` and `refreshCustomProviders` into `createServer()` options so `ctx.deps.customProviders` is properly initialized in Core handlers.

3. `plugins/admin/public/index.html`:
   - Invoke `await loadCustomProviders()` inside `loadOnboarding()` to automatically populate saved custom providers on page refresh and menu navigation.
   - Improve status error reporting to display `saved.data?.error` when `message` is omitted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788499948&installation_model_id=19911&pr_number=227&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F227&signature=ddeb99e47ab1675899172c899d5faaeeb8be4a2f6e0d262c9d8099f1d7f02d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->