### PR TITLE
fix(admin): trigger dirty state check on webui models chip removal and addition

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -6423,6 +6423,7 @@
                 webuiModelIds = webuiModelIds.filter((v) => v !== id);
                 renderChips();
                 syncDefault();
+                updateSectionDirty("webui-models");
               };
               chip.appendChild(label);
               chip.appendChild(x);
@@ -6448,6 +6449,7 @@
             addInput.value = "";
             renderChips();
             syncDefault();
+            updateSectionDirty("webui-models");
           };
           addInput.onchange = addModel;
           addInput.onkeydown = (e) => {
@@ -6456,6 +6458,7 @@
               addModel();
             }
           };
+          $("webui-models-default").onchange = () => updateSectionDirty("webui-models");
           renderChips();
           syncDefault();
         }


### PR DESCRIPTION
This commit fixes a UI form state bug where clearing all allowed model chips in Admin Governance left the Save button disabled:

- `plugins/admin/public/index.html`:
   - Call `updateSectionDirty("webui-models")` inside chip removal (`x.onclick`), chip addition (`addModel`), and default model selection change handlers.
   - Enables administrators to save an empty allowlist to remove model restrictions and restore default catalog visibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788500195&installation_model_id=19911&pr_number=228&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F228&signature=2e9fbf74b20239f20ebd0e5d1592e7816cc322be03db6e18493ae6faf8defd9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->