### PR TITLE
Add BlueNexus integration: 200+ connections via single OAuth grant

### DIFF
--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -111,6 +111,7 @@ const PLAYBOOKS: Readonly<Record<string, readonly string[]>> = {
   GOOGLE_OAUTH_CLIENT_SECRET: ["From your Google Cloud OAuth client (APIs & Services -> Credentials)."],
   DROPBOX_OAUTH_CLIENT_SECRET: ["From your Dropbox app console (https://www.dropbox.com/developers/apps)."],
   LINEAR_OAUTH_CLIENT_SECRET: ["From your Linear OAuth application settings."],
+  BLUENEXUS_OAUTH_CLIENT_SECRET: ["From your BlueNexus OAuth client (Developer -> My Apps)."],
 };
 
 const FORMAT_HINTS: Readonly<Record<string, { prefix: string; label: string }>> = {

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -164,6 +164,12 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
     description: "Linear OAuth client secret.",
   },
   {
+    name: "BLUENEXUS_OAUTH_CLIENT_SECRET",
+    service: "core",
+    required: { when: { kind: "env-present", service: "core", name: "BLUENEXUS_OAUTH_CLIENT_ID" } },
+    description: "BlueNexus OAuth client secret.",
+  },
+  {
     name: "SLACK_BOT_TOKEN",
     service: "slack",
     required: false,

--- a/deploy/stacks/acme/.env.example
+++ b/deploy/stacks/acme/.env.example
@@ -77,6 +77,10 @@ SKILL_SIGNING_SECRET=
 # Needed when env.core.LINEAR_OAUTH_CLIENT_ID is set.
 # LINEAR_OAUTH_CLIENT_SECRET=
 
+# BlueNexus OAuth client secret. (core)
+# Needed when env.core.BLUENEXUS_OAUTH_CLIENT_ID is set.
+# BLUENEXUS_OAUTH_CLIENT_SECRET=
+
 # Slack request-signing secret (from the Slack app's Basic Information page); HTTP events mode only. (slack)
 # Needed when env.slack.SLACK_EVENTS_MODE is "http".
 # SLACK_SIGNING_SECRET=

--- a/plugins/web-ui/src/connector-link.ts
+++ b/plugins/web-ui/src/connector-link.ts
@@ -9,6 +9,7 @@ export const CONNECTOR_NAMES: Record<string, string> = {
   github: "GitHub",
   dropbox: "Dropbox",
   x: "X",
+  bluenexus: "BlueNexus",
 };
 
 export interface ConnectorLink {

--- a/plugins/web-ui/src/connectors.ts
+++ b/plugins/web-ui/src/connectors.ts
@@ -51,6 +51,11 @@ const CONNECTOR_LABELS: Record<string, { name: string; hosts: string; desc?: str
     hosts: "Posts & profile",
     desc: "Lets the agent read X and post, like, and follow as you — used when an action should come from your account rather than the org's.",
   },
+  bluenexus: {
+    name: "BlueNexus",
+    hosts: "Every service you connected there",
+    desc: "Lets the agent reach the services you connected to BlueNexus — Slack, Notion, GitHub, Google Workspace, Telegram and more — through that one account, reading and acting on your behalf.",
+  },
 };
 
 const CONNECTOR_LOGOS: Record<string, string> = {

--- a/skills-seed/bluenexus-connections/SKILL.md
+++ b/skills-seed/bluenexus-connections/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: bluenexus-connections
+description: Reach the user's third-party services (Slack, Notion, GitHub, Google Workspace, Telegram, and more) through their connected BlueNexus account.
+---
+
+## BlueNexus connected services
+
+BlueNexus fronts every service the user has connected to it. One connection, many
+services — you do not need a separate credential per service.
+
+This is an OAuth connector. The user's BlueNexus token already lives on your computer as
+an environment variable, the way a logged-in CLI's cached credential would:
+
+- `$VAULT_TOKEN_BLUENEXUS_AI` — for `bluenexus.ai` and its subdomains
+
+If that variable is empty, the user has not connected BlueNexus. Tell them to connect it
+on the Keychain page. Do not ask them for a token, log it, or use another principal's
+credential.
+
+## How to call it
+
+The endpoint is **`https://api.bluenexus.ai/mcp`** and it speaks **JSON-RPC 2.0 over
+POST**. It is stateless — no session, no handshake, every call is self-contained.
+
+Send `Accept: application/json` and you get a single JSON body back. If you send
+`text/event-stream` you will get SSE instead and have to parse `data:` lines, so don't.
+
+List what the current grant can reach:
+
+```bash
+curl -sS -X POST https://api.bluenexus.ai/mcp \
+  -H "Authorization: Bearer $VAULT_TOKEN_BLUENEXUS_AI" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call a tool:
+
+```bash
+curl -sS -X POST https://api.bluenexus.ai/mcp \
+  -H "Authorization: Bearer $VAULT_TOKEN_BLUENEXUS_AI" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"<tool>","arguments":{...}}}'
+```
+
+The reply is JSON-RPC. The useful text is in `result.content[].text`; `result._meta`
+sometimes carries structured extras. A tool that fails returns `result.isError: true`
+with the reason in the same text field — check for it rather than assuming success.
+
+## The tools
+
+| Tool                    | Arguments        | What it does                                                    |
+| ----------------------- | ---------------- | --------------------------------------------------------------- |
+| `list-connections`      | `{}`             | Which services are connected, and as which account. Start here. |
+| `read-connections`      | `{"prompt":"…"}` | Read-only task across the connected services.                   |
+| `write-connections`     | `{"prompt":"…"}` | Same, but permitted to make changes.                            |
+| `search-knowledge-base` | `{"query":"…"}`  | Search the user's BlueNexus knowledge base.                     |
+| `add-to-knowledge-base` | `{…}`            | Add to it.                                                      |
+| `poll-agent-result`     | `{"jobId":"…"}`  | Collect a deferred long-running result.                         |
+
+`tools/list` is the source of truth for what this grant can actually do. If it returns
+only four tools, the connection was made read-only: BlueNexus filters the list by scope,
+so `write-connections` and `add-to-knowledge-base` are genuinely absent rather than merely
+refused. In that case say the connection is read-only and the user can re-grant with write
+access on the Keychain page — do not keep retrying the missing tool.
+
+## Describe the goal, not the API
+
+`read-connections` and `write-connections` do not take an endpoint or a method. They take
+an instruction in plain words, and a BlueNexus agent picks the tools on the other side —
+GitHub alone exposes 88, Notion 40. So write:
+
+```json
+{ "prompt": "Summarise the unread Slack DMs I got this week" }
+```
+
+not a description of Slack's API. Naming a specific service, account, or time window
+helps it choose well. Asking for something enormous ("audit every message in every
+channel") makes it exhaust its reasoning budget and return an apology — split those up.
+
+Run `list-connections` first when you are not sure a service is actually connected.
+Assuming it is and getting a confusing answer wastes a turn.
+
+## Long-running tasks
+
+A call that runs past about 50 seconds does not hang or fail. It returns text like:
+
+```
+Still working on your request. Call the `poll-agent-result` tool with jobId="…"
+```
+
+That is a normal outcome, not an error. Take the `jobId`, wait a little, then call
+`poll-agent-result` with it. Broad reads and multi-step writes routinely go this way.
+
+## Care
+
+- `write-connections` acts on the user's real accounts — it sends messages, creates
+  issues, publishes posts. Confirm intent before calling it, and say plainly what you are
+  about to do. `read-connections` is safe to use freely.
+- Rate limit is 30 requests per minute. Back off on `429` rather than retrying hard.
+- Agent runs consume the user's credits; a failure mentioning credits means their balance
+  is out, not that you called it wrong.
+- On `401`, the token has expired and core will refresh it on the next turn — say so
+  rather than trying to re-authenticate. You cannot log in from here.

--- a/src/connectors/oauth.ts
+++ b/src/connectors/oauth.ts
@@ -213,6 +213,30 @@ const notionExchange: OAuthExchangeAdapter = async ({ provider, client, code, re
 };
 
 export const PROVIDERS: Record<string, OAuthProviderConfig> = {
+  bluenexus: {
+    hosts: ["bluenexus.ai"],
+    authUrl: "https://app.bluenexus.ai/oauth/authorize",
+    tokenUrl: "https://api.bluenexus.ai/api/v1/auth/token",
+    scopes: ["universal-mcp-read-write"],
+    clientIdEnv: "BLUENEXUS_OAUTH_CLIENT_ID",
+    clientSecretEnv: "BLUENEXUS_OAUTH_CLIENT_SECRET",
+    redirectPath: "bluenexus/callback",
+    consentMode: "standard",
+    egressRule: ["api.bluenexus.ai", "app.bluenexus.ai"],
+    pkce: true,
+    setupGuide: {
+      console: "BlueNexus → Developer → My Apps → Add App",
+      url: "https://app.bluenexus.ai/developer/clients",
+      steps: [
+        "Create an OAuth client in Third-Party Integration mode.",
+        "Add the redirect URI shown below to that client.",
+        "Paste the Client ID + Client secret below.",
+        "Clients can also be registered over the API — the registration_endpoint in https://api.bluenexus.ai/.well-known/oauth-authorization-server accepts RFC 7591 requests.",
+      ],
+      scopesRationale:
+        "universal-mcp-read-write exposes all six Universal MCP tools. The server filters tools/list by scope, so universal-mcp-read yields only the four read tools and cannot write to connected services.",
+    },
+  },
   google: {
     hosts: [
       "gmail.googleapis.com",

--- a/src/credentials/connector-status.ts
+++ b/src/credentials/connector-status.ts
@@ -100,6 +100,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   linear: "Linear",
   github: "GitHub",
   dropbox: "Dropbox",
+  bluenexus: "BlueNexus",
 };
 
 export function connectorLabel(name: string): string {

--- a/src/deployment/secret-schema.ts
+++ b/src/deployment/secret-schema.ts
@@ -11,6 +11,7 @@ type SecretGate =
   | "google-oauth"
   | "dropbox-oauth"
   | "linear-oauth"
+  | "bluenexus-oauth"
   | "model-anthropic"
   | "model-openai"
   | "model-openrouter";
@@ -37,6 +38,7 @@ export const CORE_SECRET_SPECS: readonly RuntimeSecretSpec[] = [
   { name: "GOOGLE_OAUTH_CLIENT_SECRET", requiredWhen: "google-oauth" },
   { name: "DROPBOX_OAUTH_CLIENT_SECRET", requiredWhen: "dropbox-oauth" },
   { name: "LINEAR_OAUTH_CLIENT_SECRET", requiredWhen: "linear-oauth" },
+  { name: "BLUENEXUS_OAUTH_CLIENT_SECRET", requiredWhen: "bluenexus-oauth" },
 ];
 
 const GATE_PREDICATES: Readonly<Record<SecretGate, (env: NodeJS.ProcessEnv) => boolean>> = {
@@ -50,6 +52,7 @@ const GATE_PREDICATES: Readonly<Record<SecretGate, (env: NodeJS.ProcessEnv) => b
   "google-oauth": (env) => Boolean(env.GOOGLE_OAUTH_CLIENT_ID),
   "dropbox-oauth": (env) => Boolean(env.DROPBOX_OAUTH_CLIENT_ID),
   "linear-oauth": (env) => Boolean(env.LINEAR_OAUTH_CLIENT_ID),
+  "bluenexus-oauth": (env) => Boolean(env.BLUENEXUS_OAUTH_CLIENT_ID),
   "model-anthropic": (env) => env.MODEL_PROVIDER?.trim() === "anthropic",
   "model-openai": (env) => env.MODEL_PROVIDER?.trim() === "openai",
   "model-openrouter": (env) => env.MODEL_PROVIDER?.trim() === "openrouter",

--- a/test/connector-byo-route.test.ts
+++ b/test/connector-byo-route.test.ts
@@ -169,7 +169,7 @@ test("the catalog endpoint exposes per-provider setup guidance (no secrets)", as
       catalog: Array<{ provider: string; setupGuide: { url: string; steps: string[] }; consentMode: string }>;
     };
     const names = catalog.map((c) => c.provider).sort();
-    assert.deepEqual(names, ["dropbox", "github", "google", "linear", "notion", "slack", "x"]);
+    assert.deepEqual(names, ["bluenexus", "dropbox", "github", "google", "linear", "notion", "slack", "x"]);
     const google = catalog.find((c) => c.provider === "google")!;
     assert.ok(google.setupGuide.steps.length >= 3);
     assert.match(google.setupGuide.url, /^https:\/\//);

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -27,6 +27,8 @@ const env = {
   GITHUB_OAUTH_CLIENT_SECRET: "ghsecret",
   X_OAUTH_CLIENT_ID: "xid",
   X_OAUTH_CLIENT_SECRET: "xsecret",
+  BLUENEXUS_OAUTH_CLIENT_ID: "bnid",
+  BLUENEXUS_OAUTH_CLIENT_SECRET: "bnsecret",
 } as NodeJS.ProcessEnv;
 
 const resolve = createSecretClientResolver(createEnvSecretSource(env));
@@ -383,9 +385,10 @@ test("authorizeUrl adds code_challenge + S256 only when a challenge is supplied"
   assert.equal(without.searchParams.get("code_challenge_method"), null);
 });
 
-test("only X opts into PKCE; the other providers leave the seam inert (regression guard)", () => {
+test("only X and BlueNexus opt into PKCE; the other providers leave the seam inert (regression guard)", () => {
+  const pkceProviders = new Set(["x", "bluenexus"]);
   for (const [name, p] of Object.entries(PROVIDERS)) {
-    if (name === "x") assert.equal(p.pkce, true, "X requires PKCE");
+    if (pkceProviders.has(name)) assert.equal(p.pkce, true, `${name} requires PKCE`);
     else assert.notEqual(p.pkce, true, `${name} must not enable PKCE`);
   }
 });
@@ -415,6 +418,25 @@ test("OAuth state round-trips the PKCE verifier", async () => {
   );
   const opened = await openOAuthState(sealed, { secret: "state-secret" });
   assert.equal(opened.codeVerifier, "ver-abc");
+});
+
+const bluenexusClient = (): Promise<ResolvedClient> => resolve("bluenexus", {});
+
+test("BlueNexus authorizes on the app host but exchanges on the api host, with PKCE and the read-write MCP scope", async () => {
+  const u = new URL(
+    authorizeUrl("bluenexus", {
+      redirectUri: "https://app/cb",
+      state: "s",
+      client: await bluenexusClient(),
+      codeChallenge: "CH",
+    }),
+  );
+  assert.equal(u.origin + u.pathname, "https://app.bluenexus.ai/oauth/authorize");
+  assert.equal(PROVIDERS.bluenexus!.tokenUrl, "https://api.bluenexus.ai/api/v1/auth/token");
+  assert.equal(u.searchParams.get("client_id"), "bnid");
+  assert.equal(u.searchParams.get("code_challenge"), "CH");
+  assert.equal(u.searchParams.get("code_challenge_method"), "S256");
+  assert.equal(u.searchParams.get("scope"), "universal-mcp-read-write");
 });
 
 const xClient = (): Promise<ResolvedClient> => resolve("x", {});


### PR DESCRIPTION
## What this adds

This PR adds BlueNexus to the connector registry so a QM user can link it from the Keychain page, and adds a seeded skill so the agent knows how to use it. The full, authoritative list of supported connectors lives at https://bluenexus.ai/connectors.

Users can connect all their accounts — Slack, Notion, GitHub, Google Workspace, Telegram and 200+ others, with several thousand tools between them — behind a single OAuth grant. A QM user who links it gets whichever of those services they've already connected.

Users can add custom MCP servers to their BlueNexus account, providing a quick way to support any MCP server until QM natively supports it (see https://github.com/yc-software/qm/pull/75).

Connections can be permissioned as read-only or read + write, which controls what the agent is able to do once connected. This connector defaults to read + write (`universal-mcp-read-write`), exposing all six BlueNexus tools. To run it read-only instead, change `scopes` to `["universal-mcp-read"]` and register the BlueNexus app with that same scope — the two have to match, because BlueNexus rejects an authorization request asking for a scope the app does not allow.

I note the preference in CONTRIBUTING.MD for human `feature` PR's, but since we know our own API it seemed to make sense to do a traditional PR :)

## Demo

**▶️ Demo video:**

https://www.loom.com/share/356ffacf7577440884d3cbf53298dafe

A short walkthrough: Keychain → Connect BlueNexus → consent → the agent listing and calling downstream tools from a single grant.

## How it works

The model gets a small fixed tool surface and everything else runs through `execute` in the scope's sandbox. This connector does not change that. It follows the same shape as the existing Google, Dropbox and Linear connectors: core holds the credential, and a skill teaches the call.

1. Core stores the OAuth token in the keychain, encrypted with AES-256-GCM.
2. Each DM turn, core injects it into the sandbox as `$VAULT_TOKEN_BLUENEXUS_AI`, the same way `$VAULT_TOKEN_WWW_GOOGLEAPIS_COM` already works.
3. `skills-seed/bluenexus-connections/SKILL.md` tells the agent the endpoint, the JSON-RPC shape, the six tools, and the failure modes.
4. The agent calls `https://api.bluenexus.ai/mcp` with `curl`.

**Note: No tools are added to the model's context.** Several hundred downstream tools stay on the far side of one `execute` call, maximizing context window size for actual meaningful work.

## Test changes

Two existing tests needed updating, both because the specification genuinely changed rather than to make them pass.

`only X opts into PKCE (regression guard)` asserted exactly one PKCE provider. BlueNexus is the second deliberate opt-in, so the guard now takes an explicit allowlist of `x` and `bluenexus`. The `else` branch is untouched, so a third accidental opt-in still fails.

`the catalog endpoint exposes per-provider setup guidance` pins the sorted provider list, which gained `bluenexus`.

One test was added: `BlueNexus authorizes on the app host but exchanges on the api host, with PKCE and the read-write MCP scope`. That pins the split-host quirk — authorize on `app.bluenexus.ai`, token exchange on `api.bluenexus.ai` — which is unique among the eight providers and the easiest thing to "tidy" into a single host and silently break.

## Verification

`tsc` (root, cli, contract), `prettier`, `eslint`, `oxlint` and `knip` are clean.

CLI 503/503, web-ui 440/440, deployment stack contracts 1/1. Core is 3579/3713 with two failures in `opencode-harness.test.ts` and `sandbox-noninteractive.test.ts`; both were confirmed pre-existing by running them on unmodified `7f2c916`, and neither file touches anything here.

Exercised end to end against production BlueNexus from a cold start: Keychain → Connect account → consent → callback → grant stored with a refresh token → the agent listing all six tools using the injected env var.

## Setup

Create an OAuth client at BlueNexus → Developers → My Apps → Add App, in Third-Party Integration mode, grant it the same scope this connector requests (`universal-mcp-read-write` by default), and add `<PUBLIC_URL>/v1/connectors/oauth/bluenexus/callback` as its redirect URI. Clients can also be registered over the API; the `registration_endpoint` in `https://api.bluenexus.ai/.well-known/oauth-authorization-server` accepts RFC 7591 requests.

Then set the two secrets and restart:

```bash
BLUENEXUS_OAUTH_CLIENT_ID=client_...
BLUENEXUS_OAUTH_CLIENT_SECRET=...
```

`qm check` now fails when the client ID is set without the secret.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788501076&installation_model_id=19911&pr_number=231&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F231&signature=56de40bc612ceb14bf9d9adedcbe7d0c5460ae02848c168fbe8d3525762d43ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->