### PR TITLE
Limit sandbox tool permission changes

### DIFF
--- a/cli/src/commands/sandbox.ts
+++ b/cli/src/commands/sandbox.ts
@@ -288,9 +288,9 @@ function prepare(opts: SandboxBuildOpts): PreparedBuild {
   } else {
     const copies = layer.tools
       .filter((tool) => tool.executablePath)
-      .map((tool) => `COPY tools/${tool.dir}/${tool.binary} /usr/local/bin/${tool.binary}`)
+      .map((tool) => `COPY --chmod=0755 tools/${tool.dir}/${tool.binary} /usr/local/bin/${tool.binary}`)
       .join("\n");
-    dockerfileBody = `FROM ${base}\n${copies}\nRUN chmod -R a+rx /usr/local/bin\n${presenceCheck}`;
+    dockerfileBody = `FROM ${base}\n${copies}\n${presenceCheck}`;
   }
   const dockerfilePath = join(mkdtempSync(join(tmpdir(), "qm-sandbox-")), "Dockerfile");
   writeFileSync(dockerfilePath, dockerfileBody);

--- a/cli/test/e2e/sandbox-build.e2e.test.ts
+++ b/cli/test/e2e/sandbox-build.e2e.test.ts
@@ -17,7 +17,7 @@ test("sandbox build --dry-run generates the COPY-tools Dockerfile + the fly push
     assert.equal(r.code, 0, r.out);
     assert.match(r.out, /DRY RUN — nothing built/);
     assert.match(r.out, /FROM registry\.invalid\/qm\/qm-sandbox-base@sha256:a{64}/);
-    assert.match(r.out, /COPY tools\/example-tool\/example-tool \/usr\/local\/bin\/example-tool/);
+    assert.match(r.out, /COPY --chmod=0755 tools\/example-tool\/example-tool \/usr\/local\/bin\/example-tool/);
     assert.match(r.out, /command -v "\$b"/);
     assert.match(r.out, /docker buildx build --platform linux\/amd64 --load -t acme-sandbox:local/);
   } finally {

--- a/cli/test/sandbox-build.test.ts
+++ b/cli/test/sandbox-build.test.ts
@@ -56,7 +56,8 @@ test("generates a Dockerfile that COPYs each tool executable onto PATH + bakes t
   try {
     const out = dryRun({ sandboxDir: sb });
     assert.match(out, /FROM registry\.invalid\/qm\/qm-sandbox-base@sha256:a{64}/);
-    assert.match(out, /COPY tools\/example-tool\/example-tool \/usr\/local\/bin\/example-tool/);
+    assert.match(out, /COPY --chmod=0755 tools\/example-tool\/example-tool \/usr\/local\/bin\/example-tool/);
+    assert.doesNotMatch(out, /chmod -R/);
     assert.match(out, /command -v "\$b"/);
     assert.match(out, /'example-tool'/);
     assert.match(out, /acme-sandbox:local/);


### PR DESCRIPTION
## Summary

- set executable mode on each copied sandbox tool with `COPY --chmod=0755`
- stop recursively changing permissions on the base image's `/usr/local/bin`
- cover the generated Dockerfile contract in unit and CLI end-to-end tests

## Verification

- Node 24 sandbox build unit and CLI end-to-end tests: 15 passed
- CLI typecheck, ESLint, Prettier, and diff check
- real Buildx build of a synthetic sandbox layer
- local sandbox image build and live cold-start, warm-restart, persistence, and scratch smoke test

No rendered UI changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788521485&installation_model_id=19911&pr_number=233&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F233&signature=a05670ae2f00c91170d99abc5bb6797ecbf758ccb36cf385e3587e852a3ac23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->