### PR TITLE
Support OpenAI-compatible endpoints in Codex harness

### DIFF
--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -199,6 +199,11 @@ export function codexChildEnv(source: NodeJS.ProcessEnv, jail: string): NodeJS.P
 export function prepareCodexHome(source: NodeJS.ProcessEnv, jail: string): string {
   const target = join(jail, "codex-home");
   mkdirSync(target, { recursive: true });
+  if (source.OPENAI_BASE_URL) {
+    writeFileSync(join(target, "config.toml"), `openai_base_url = ${JSON.stringify(source.OPENAI_BASE_URL)}\n`, {
+      mode: 0o600,
+    });
+  }
   if (source.OPENAI_API_KEY) {
     writeFileSync(
       join(target, "auth.json"),

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -635,11 +635,12 @@ const realCodexBinary = (() => {
 })();
 
 test(
-  "the installed Codex app-server accepts the exact thread/start this adapter sends",
+  "the installed Codex app-server accepts QM's endpoint and exact thread/start request",
   { skip: realCodexBinary && existsSync(realCodexBinary) ? false : "@openai/codex is not resolvable" },
   async (t) => {
     const jail = mkdtempSync(join(tmpdir(), "qm-codex-real-"));
-    prepareCodexHome({ CODEX_HOME: join(jail, "empty-source") }, jail);
+    const endpoint = "https://gateway.example.com/v1";
+    prepareCodexHome({ CODEX_HOME: join(jail, "empty-source"), OPENAI_BASE_URL: endpoint }, jail);
     const requests: string[] = [];
     const server = new CodexAppServer({
       binaryPath: realCodexBinary!,
@@ -657,6 +658,8 @@ test(
     });
 
     await server.initialize();
+    const resolved = await server.request<{ config: { openai_base_url: string | null } }>("config/read", {});
+    assert.equal(resolved.config.openai_base_url, endpoint);
     const started = await server.request<{ thread: { id: string } }>("thread/start", {
       model: DEFAULT_CODEX_MODEL_ID,
       cwd: jail,

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -304,6 +304,13 @@ test("Codex materializes API-key auth into its isolated home, and never an ambie
   assert.equal(existsSync(join(prepareCodexHome({ HOME: homedir() }, bare), "auth.json")), false);
 });
 
+test("Codex materializes an OpenAI-compatible endpoint into its isolated home", (t) => {
+  const jail = mkdtempSync(join(tmpdir(), "qm-codex-endpoint-test-"));
+  t.after(() => rmSync(jail, { recursive: true, force: true }));
+  const home = prepareCodexHome({ OPENAI_BASE_URL: "https://proxy.example.com/v1" }, jail);
+  assert.equal(readFileSync(join(home, "config.toml"), "utf8"), 'openai_base_url = "https://proxy.example.com/v1"\n');
+});
+
 test("Codex children cannot use parent surface, control, or terminal tools", () => {
   assert.equal(codexChildToolAllowed("history"), true);
   assert.equal(codexChildToolAllowed("execute"), true);


### PR DESCRIPTION
## Summary

- materialize `OPENAI_BASE_URL` as Codex's user-level `openai_base_url` setting inside each isolated harness home
- preserve API-key isolation without inheriting ambient Codex configuration
- cover compatible-endpoint configuration with a focused regression test

## Testing

- `node --experimental-test-module-mocks --test test/codex-harness.test.ts`
- `npm run typecheck`
- `npm run lint -- --no-warn-ignored src/harness/codex-harness.ts test/codex-harness.test.ts`
- `npx prettier --check src/harness/codex-harness.ts test/codex-harness.test.ts`
- production-shaped local dev instance completed a real Codex turn through an OpenAI-compatible Responses endpoint, including one `execute` tool call

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788523765&installation_model_id=19911&pr_number=234&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F234&signature=61e39d021b3477f05975270bc0efeb63db95a0f3c6fde7877e9e0d1cd0d33b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->