### PR TITLE
tape-fold: don't synthesize tool results for aborted assistant messages

### DIFF
--- a/src/harness/tape-fold.ts
+++ b/src/harness/tape-fold.ts
@@ -177,6 +177,11 @@ function contextEvent(row: TapeRecord): TapeEvent | null {
 
 type Foldable = { out: unknown[]; boundaries: Array<{ pos: number; entrySeq: number }> };
 
+function assistantDroppedAtReplay(m: unknown): boolean {
+  const msg = m as { role?: string; stopReason?: string };
+  return msg?.role === "assistant" && (msg.stopReason === "aborted" || msg.stopReason === "error");
+}
+
 function healDanglingCalls(out: unknown[], at: number): void {
   const answered = new Set<string>();
   for (const m of out) {
@@ -186,7 +191,7 @@ function healDanglingCalls(out: unknown[], at: number): void {
   const missing: Array<{ id: string; name: string }> = [];
   for (const m of out) {
     const msg = m as { role?: string; content?: unknown };
-    if (msg?.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    if (msg?.role !== "assistant" || !Array.isArray(msg.content) || assistantDroppedAtReplay(m)) continue;
     for (const block of msg.content) {
       const b = block as { type?: string; id?: string; name?: string };
       if (b?.type === "toolCall" && typeof b.id === "string" && !answered.has(b.id)) {
@@ -309,7 +314,7 @@ export function lintFold(messages: readonly unknown[]): FoldLint {
         if (b?.type === "toolCall" && typeof b.id === "string") {
           if (seenCallIds.has(b.id)) problems.push(`#${i}: duplicate tool call id ${b.id}`);
           seenCallIds.add(b.id);
-          openCalls.add(b.id);
+          if (!assistantDroppedAtReplay(m)) openCalls.add(b.id);
         }
       }
     } else if (msg.role === "toolResult") {

--- a/test/tape-fold.test.ts
+++ b/test/tape-fold.test.ts
@@ -157,6 +157,38 @@ test("aborted assistant's dangling tool call is not healed — pi drops the mess
   assert.ok(lintFold(out).ok);
 });
 
+test("a poisoned tape — errored assistants, consecutive users, pre-existing interrupt — serves clean", () => {
+  seq = 0;
+  const erroredAssistant = () =>
+    row({
+      kind: "message",
+      payload: { role: "assistant", content: [], timestamp: 4, stopReason: "error" },
+    });
+  const rows = [
+    user("q"),
+    assistant([{ type: "toolCall", id: "c1", name: "exec", arguments: {} }]),
+    toolResult("c1", "ok"),
+    row({
+      kind: "message",
+      payload: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c9", name: "exec", arguments: {} }],
+        timestamp: 2,
+        stopReason: "aborted",
+      },
+    }),
+    row({ kind: "context_event", payload: { event: "interrupt" } }),
+    user("next turn"),
+    erroredAssistant(),
+    user("retry note"),
+    erroredAssistant(),
+  ];
+  const out = foldTape(rows) as Array<{ role: string; toolCallId?: string }>;
+  assert.ok(!out.some((m) => m.role === "toolResult" && m.toolCallId === "c9"));
+  assert.ok(lintFold(out).ok);
+  assert.ok(!tapeNeedsInterruptHeal(rows));
+});
+
 test("lintFold rejects a toolResult answering an aborted assistant's call", () => {
   seq = 0;
   const rows = [

--- a/test/tape-fold.test.ts
+++ b/test/tape-fold.test.ts
@@ -129,6 +129,52 @@ test("interrupt event heals dangling tool calls with error results", () => {
   assert.ok(lintFold(out).ok);
 });
 
+test("aborted assistant's dangling tool call is not healed — pi drops the message at replay", () => {
+  seq = 0;
+  const abortedAssistant = row({
+    kind: "message",
+    payload: {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "c9", name: "exec", arguments: { cmd: "sleep" } }],
+      timestamp: 2,
+      stopReason: "aborted",
+    },
+  });
+  const rows = [
+    user("q"),
+    assistant([{ type: "toolCall", id: "c1", name: "exec", arguments: {} }]),
+    toolResult("c1", "ok"),
+    abortedAssistant,
+    row({ kind: "context_event", payload: { event: "interrupt" } }),
+    user("next turn"),
+  ];
+  assert.ok(!tapeNeedsInterruptHeal(rows.slice(0, 4)), "aborted dangler needs no heal");
+  const out = foldTape(rows) as Array<{ role: string; toolCallId?: string }>;
+  assert.ok(
+    !out.some((m) => m.role === "toolResult" && m.toolCallId === "c9"),
+    "no synthetic result for a call pi will drop with its aborted message",
+  );
+  assert.ok(lintFold(out).ok);
+});
+
+test("lintFold rejects a toolResult answering an aborted assistant's call", () => {
+  seq = 0;
+  const rows = [
+    user("q"),
+    row({
+      kind: "message",
+      payload: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "c9", name: "exec", arguments: {} }],
+        timestamp: 2,
+        stopReason: "aborted",
+      },
+    }),
+    toolResult("c9", "orphaned on the wire"),
+  ];
+  assert.ok(!lintFold(foldTape(rows)).ok);
+});
+
 test("audience filter withholds message rows the whole room isn't entitled to, never events", () => {
   seq = 0;
   const me = { id: "U1", type: "internal" } as unknown as Principal;


### PR DESCRIPTION
## Problem

When a user aborts a turn while the model is mid-stream, pi commits the partial assistant message with `stopReason: "aborted"`. If the abort landed after a complete `toolCall` block, that message contains a tool call that never executed and has no tool result.

The tape fold treated that call as dangling: `tapeNeedsInterruptHeal` flagged it, an `interrupt` event was appended, and `healDanglingCalls` synthesized an `INTERRUPTED_TOOL_RESULT` for it. But pi's `transformMessages` drops aborted/errored assistant messages entirely when building the provider request, while keeping every `toolResult` message. The healed result therefore reached the provider as a `tool_result` block with no corresponding `tool_use` in the previous message:

```
Model provider API error (invalid_request_error): messages.N.content.1:
unexpected `tool_use_id` found in `tool_result` blocks: toolu_… Each
`tool_result` block must have a corresponding `tool_use` block in the
previous message.
```

Every subsequent step re-serves the same fold, so the session is permanently wedged: each turn fails with the same 400.

## Fix

- `healDanglingCalls` skips assistant messages with `stopReason` `"aborted"`/`"error"` when collecting dangling calls. Those messages are never replayed, so their calls need no results — and synthesizing one is what poisons the request.
- `lintFold` no longer counts such messages' calls as open. A `toolResult` answering one now lints as a problem, so a fold that would orphan a result on the wire falls back to entry-based replay instead of being served.

The interrupted-result heal is unchanged for the case it exists for: a restart mid tool execution, where the assistant message completed normally (`stopReason: "toolUse"`) and is replayed.

## Testing

- New test: an aborted assistant's dangling call is not healed and the fold lints clean.
- New test: `lintFold` rejects a fold where a `toolResult` answers an aborted assistant's call.
- `node --test test/tape-fold.test.ts` — 26/26 pass; `tsc --noEmit` and eslint clean.

Reproduced against a live session: abort a turn while the model is streaming a tool call, then send another message — before this fix every subsequent turn 400s with the error above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788562035&installation_model_id=19911&pr_number=239&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F239&signature=b67ff5db16518814dd4b84cb13acc56ed0fb9239adf52153a5e901712e7688bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->