### PR TITLE
auth: prefer AUTH LOGIN over PLAIN when the server advertises both

### DIFF
--- a/plugins/auth/src/smtp.ts
+++ b/plugins/auth/src/smtp.ts
@@ -159,13 +159,13 @@ async function openSocket(options: SmtpOptions, timeoutMs: number): Promise<Sock
 }
 
 function authSteps(mechanisms: string, username: string, password: string): string[] {
-  if (/\bPLAIN\b/.test(mechanisms))
-    return [`AUTH PLAIN ${Buffer.from(`\0${username}\0${password}`, "utf8").toString("base64")}`];
-  return [
-    "AUTH LOGIN",
-    Buffer.from(username, "utf8").toString("base64"),
-    Buffer.from(password, "utf8").toString("base64"),
-  ];
+  if (/\bLOGIN\b/i.test(mechanisms))
+    return [
+      "AUTH LOGIN",
+      Buffer.from(username, "utf8").toString("base64"),
+      Buffer.from(password, "utf8").toString("base64"),
+    ];
+  return [`AUTH PLAIN ${Buffer.from(`\0${username}\0${password}`, "utf8").toString("base64")}`];
 }
 
 function clientName(host: string): string {

--- a/plugins/auth/test/smtp.test.ts
+++ b/plugins/auth/test/smtp.test.ts
@@ -11,7 +11,7 @@ interface FakeSmtp {
 }
 
 async function fakeSmtp(
-  options: { offerStartTls?: boolean; rejectAuth?: boolean; rejectRecipient?: boolean } = {},
+  options: { offerStartTls?: boolean; rejectAuth?: boolean; rejectRecipient?: boolean; mechanisms?: string } = {},
 ): Promise<FakeSmtp> {
   const transcript: string[] = [];
   const messages: string[] = [];
@@ -19,6 +19,7 @@ async function fakeSmtp(
     let buffer = "";
     let inData = false;
     let message = "";
+    let authStep: "idle" | "user" | "pass" = "idle";
     socket.setEncoding("utf8");
     socket.write("220 fake.smtp.test ESMTP\r\n");
     socket.on("data", (chunk: string) => {
@@ -38,14 +39,27 @@ async function fakeSmtp(
           continue;
         }
         transcript.push(line);
+        if (authStep === "user") {
+          authStep = "pass";
+          socket.write("334 UGFzc3dvcmQ6\r\n");
+          continue;
+        }
+        if (authStep === "pass") {
+          authStep = "idle";
+          socket.write(options.rejectAuth ? "535 5.7.8 bad credentials\r\n" : "235 2.7.0 Accepted\r\n");
+          continue;
+        }
         const verb = line.split(" ")[0]!.toUpperCase();
         if (verb === "EHLO")
           socket.write(
-            `250-fake.smtp.test\r\n${options.offerStartTls ? "250-STARTTLS\r\n" : ""}250 AUTH PLAIN LOGIN\r\n`,
+            `250-fake.smtp.test\r\n${options.offerStartTls ? "250-STARTTLS\r\n" : ""}250 AUTH ${options.mechanisms ?? "PLAIN LOGIN"}\r\n`,
           );
-        else if (verb === "AUTH")
-          socket.write(options.rejectAuth ? "535 5.7.8 bad credentials\r\n" : "235 2.7.0 Accepted\r\n");
-        else if (verb === "MAIL") socket.write("250 2.1.0 Ok\r\n");
+        else if (verb === "AUTH") {
+          if (/^AUTH LOGIN$/i.test(line)) {
+            authStep = "user";
+            socket.write("334 VXNlcm5hbWU6\r\n");
+          } else socket.write(options.rejectAuth ? "535 5.7.8 bad credentials\r\n" : "235 2.7.0 Accepted\r\n");
+        } else if (verb === "MAIL") socket.write("250 2.1.0 Ok\r\n");
         else if (verb === "RCPT")
           socket.write(options.rejectRecipient ? "550 5.1.1 no such user\r\n" : "250 2.1.5 Ok\r\n");
         else if (verb === "DATA") {
@@ -103,14 +117,21 @@ test("a message is delivered over the full SMTP conversation", async (t) => {
   assert.match(receipt, /queued as FAKE1/);
   assert.deepEqual(
     server.transcript.map((line) => line.split(" ")[0]),
-    ["EHLO", "AUTH", "MAIL", "RCPT", "DATA", "QUIT"],
+    ["EHLO", "AUTH", Buffer.from("apikey").toString("base64"), Buffer.from("s3cret").toString("base64"), "MAIL", "RCPT", "DATA", "QUIT"],
   );
+  assert.equal(server.transcript[1]!, "AUTH LOGIN");
+  assert.match(server.messages[0]!, /^\.leading dot survives$/m);
+});
+
+test("AUTH PLAIN is used when the server does not advertise LOGIN", async (t) => {
+  const server = await fakeSmtp({ mechanisms: "PLAIN" });
+  t.after(() => server.close());
+  assert.equal(await smtpDeliver(options(server.port), null), "authenticated");
   assert.match(server.transcript[1]!, /^AUTH PLAIN /);
   assert.equal(
     Buffer.from(server.transcript[1]!.slice("AUTH PLAIN ".length), "base64").toString("utf8"),
     "\0apikey\0s3cret",
   );
-  assert.match(server.messages[0]!, /^\.leading dot survives$/m);
 });
 
 test("a rejected recipient and rejected credentials both surface as errors", async (t) => {
@@ -137,7 +158,7 @@ test("verification authenticates without sending a message", async (t) => {
   assert.equal(await smtpDeliver(options(server.port), null), "authenticated");
   assert.deepEqual(
     server.transcript.map((line) => line.split(" ")[0]),
-    ["EHLO", "AUTH", "QUIT"],
+    ["EHLO", "AUTH", Buffer.from("apikey").toString("base64"), Buffer.from("s3cret").toString("base64"), "QUIT"],
   );
   assert.equal(server.messages.length, 0);
 });


### PR DESCRIPTION
## Problem

`authSteps` prefers AUTH PLAIN whenever the server advertises it. Some servers list PLAIN in their EHLO capabilities but reject it in practice — observed with QQ Mail (`smtp.qq.com`), which answers an `AUTH PLAIN` attempt with `502 Invalid input` / `535 Login fail` yet completes `AUTH LOGIN` with the same credentials. Sign-in email delivery fails with valid credentials and no recourse, because PLAIN is always picked when advertised.

## Change

Try AUTH LOGIN first; fall back to PLAIN only when LOGIN is not advertised. LOGIN is a single extra round trip and is accepted everywhere PLAIN is, so preferring it strictly widens server compatibility.

## Tests

- The fake SMTP server in `smtp.test.ts` now speaks the LOGIN challenge-response (`334` base64 prompts) instead of treating every `AUTH` line as one-shot.
- The delivery and verification tests assert the LOGIN transcript (`AUTH LOGIN`, base64 username, base64 password).
- A new case covers a server advertising only PLAIN, keeping the fallback path covered.

All 8 tests in `plugins/auth/test/smtp.test.ts` pass. The fix was also verified against a live QQ Mail account: `AUTH LOGIN` completes (`235 Authentication successful`) where `AUTH PLAIN` is rejected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788592817&installation_model_id=19911&pr_number=242&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F242&signature=0978336f361d7d3d59e6cc6de304fad74489ac6c15b2642149e2b6379ded2a10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->