### PR TITLE
local-sandbox: allow reaching the exec daemon over a peer network

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -245,12 +245,14 @@ interface LocalSandboxEnv {
   cpus?: number;
   memoryMb?: number;
   defaultTimeoutSec?: number;
+  peerNetwork?: string;
 }
 
 function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
   return {
     ...(env.LOCAL_SANDBOX_IMAGE ? { image: env.LOCAL_SANDBOX_IMAGE } : {}),
     ...(env.LOCAL_SANDBOX_DOCKER_BIN ? { dockerBin: env.LOCAL_SANDBOX_DOCKER_BIN } : {}),
+    ...(env.LOCAL_SANDBOX_PEER_NETWORK ? { peerNetwork: env.LOCAL_SANDBOX_PEER_NETWORK } : {}),
     ...(numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) !== undefined
       ? { cpus: numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) }
       : {}),

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -48,6 +48,7 @@ export interface LocalSandboxOptions {
   repoRoot?: string;
   dockerExec?: DockerExec;
   fetchImpl?: typeof fetch;
+  peerNetwork?: string;
   onError?: (e: { category: string; code: string; message: string; scopeLabel?: string }) => void;
 }
 
@@ -144,6 +145,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
   }
 
   async function resolvePort(name: string): Promise<number> {
+    if (opts.peerNetwork) return AGENT_PORT;
     const cached = portByName.get(name);
     if (cached) return cached;
     const r = await dexec(["port", name, `${AGENT_PORT}/tcp`]);
@@ -167,7 +169,8 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
   ): Promise<{ status: number; text: string }> {
     const port = await resolvePort(name);
     const signals = [AbortSignal.timeout(timeoutMs ?? 30_000), ...(signal ? [signal] : [])];
-    const res = await fetchImpl(`http://127.0.0.1:${port}${path}`, {
+    const host = opts.peerNetwork ? name : "127.0.0.1";
+    const res = await fetchImpl(`http://${host}:${port}${path}`, {
       method: body === undefined ? "GET" : "POST",
       ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
       signal: AbortSignal.any(signals),
@@ -195,6 +198,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     portByName.delete(name);
     const r = await dexec(["start", name]);
     if (r.code !== 0) throw new Error(`docker start ${name} failed: ${r.stderr.trim()}`);
+    await ensurePeerConnected(name);
     await waitDaemon(name);
   }
 
@@ -236,6 +240,14 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     return net;
   }
 
+  async function ensurePeerConnected(name: string): Promise<void> {
+    if (!opts.peerNetwork) return;
+    const r = await dexec(["network", "connect", opts.peerNetwork, name]);
+    if (r.code !== 0 && !/already exists/i.test(r.stderr)) {
+      throw new Error(`docker network connect ${opts.peerNetwork} ${name} failed: ${r.stderr.trim()}`);
+    }
+  }
+
   async function runContainer(name: string, scope: string | undefined, withVolume: boolean): Promise<void> {
     const net = await ensureNetwork(name);
     const args = [
@@ -262,6 +274,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     ];
     const r = await dexec(args, 120_000);
     if (r.code !== 0) throw new Error(`docker run ${name} failed: ${r.stderr.trim()}`);
+    await ensurePeerConnected(name);
     portByName.delete(name);
     await waitDaemon(name);
   }


### PR DESCRIPTION
## Problem

`local-sandbox` reaches the sandbox exec daemon at a hard-coded `http://127.0.0.1:<port>`. That only works when core runs on the docker host itself. When core runs inside a container — the shape `deploy/core/Dockerfile` produces — loopback inside the core container is the container itself, not the host publishing the sandbox's mapped agent port. Every exec/read/write against the sandbox fails with `fetch failed`, and the agent reports its computer backend down.

## Change

With `LOCAL_SANDBOX_PEER_NETWORK` set:

- sandbox containers are attached to that docker network after `docker run` / `docker start` (`docker network connect`, idempotent)
- core reaches the daemon by container name on `AGENT_PORT` instead of via the published loopback port

Unset keeps the loopback behavior used when core runs on the host, so existing single-process setups are unaffected.

The exec daemon is unauthenticated (loopback binding is its access control), so this option is only for a trusted internal network — e.g. the private stack network shared with the core container, never a public one.

## Tests

`test/local-sandbox.test.ts` passes (15/15). The option was also exercised end to end with core in a container: a turn executed in the sandbox container and a file written through the exec daemon was verified from the host volume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788593142&installation_model_id=19911&pr_number=243&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F243&signature=9080298a1ce1f1a2aa34890ccbbe59e993c45763ac6bc24537b29beaccad4d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->