### PR TITLE
feat(web-ui): surface delivered posts in live replies

### DIFF
--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -854,8 +854,10 @@ function applyRun(
     if (paused) work.pendingApprovals = approvals;
     notify?.();
   }
+  const deliveredPost = latestDeliveredPostText(work?.activity ?? []);
   if (res?.stopped) {
     if (res.reply && res.reply.length > st.acc.length) pushDelta(stream, partial, st, res.reply);
+    else if (deliveredPost) replaceText(stream, partial, st, deliveredPost);
     abortStream(stream, partial);
     return "terminal";
   }
@@ -869,7 +871,13 @@ function applyRun(
     return "terminal";
   }
   if (!paused && !quiet && (run.status === "failed" || (res && res.status !== "ok"))) {
+    if (deliveredPost) replaceText(stream, partial, st, deliveredPost);
     fail(stream, partial, res?.reason ?? "The agent run failed.");
+    return "terminal";
+  }
+  if (deliveredPost) {
+    replaceText(stream, partial, st, deliveredPost);
+    finish(stream, partial, st, deliveredPost);
     return "terminal";
   }
   finish(stream, partial, st, st.acc);
@@ -1081,6 +1089,16 @@ function pushDelta(stream: AssistantMessageEventStream, partial: AssistantMessag
   stream.push({ type: "text_delta", contentIndex: 0, delta, partial });
 }
 
+function replaceText(stream: AssistantMessageEventStream, partial: AssistantMessage, st: Acc, next: string): void {
+  if (next.startsWith(st.acc)) {
+    pushDelta(stream, partial, st, next);
+    return;
+  }
+  const block = partial.content[0];
+  if (block?.type === "text") block.text = next;
+  st.acc = next;
+}
+
 function finish(stream: AssistantMessageEventStream, partial: AssistantMessage, st: Acc, reply: string): void {
   const finalText = reply.length >= st.acc.length ? reply : st.acc;
   if (finalText.length > st.acc.length) pushDelta(stream, partial, st, finalText);
@@ -1151,6 +1169,26 @@ function postCallText(payload: unknown): string | null {
 function postResultOk(payload: unknown): boolean {
   const p = (payload ?? {}) as { ok?: unknown; isError?: unknown };
   return p.isError !== true && p.ok !== false;
+}
+
+function latestDeliveredPostText(activity: ToolActivity[]): string | null {
+  const pending = new Map<string, string>();
+  let delivered: string | null = null;
+  for (const item of activity) {
+    const payload = (item.payload ?? {}) as { callId?: unknown };
+    if (typeof payload.callId !== "string") continue;
+    if (item.type === "tool_call") {
+      const text = postCallText(item.payload);
+      if (text) pending.set(payload.callId, text);
+      continue;
+    }
+    if (item.type !== "tool_result") continue;
+    const text = pending.get(payload.callId);
+    if (!text) continue;
+    pending.delete(payload.callId);
+    if (postResultOk(item.payload)) delivered = text;
+  }
+  return delivered;
 }
 
 function userEntryText(payload: unknown): string | null {

--- a/plugins/web-ui/test/core-bridge-idle.test.ts
+++ b/plugins/web-ui/test/core-bridge-idle.test.ts
@@ -332,6 +332,152 @@ test("a reattached background wake that ended silent is a clean stop, never 'The
   assert.equal(work?.status, "complete");
 });
 
+test("a silent terminal run surfaces its latest delivered post as the reply", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("terminal initial snapshot should not poll");
+  }) as typeof fetch;
+
+  const streamFn = makeRunResumeStreamFn(
+    "run-posted",
+    {
+      status: "done",
+      result: { status: "silent" },
+      partial: "",
+      activity: [
+        {
+          seq: 1,
+          type: "tool_call",
+          payload: { tool: "web", action: "post", text: "Still working", callId: "post-1" },
+          createdAt: 100,
+        },
+        {
+          seq: 2,
+          type: "tool_result",
+          payload: { tool: "web", action: "post", ok: true, callId: "post-1", result: "[sent]" },
+          createdAt: 110,
+        },
+        {
+          seq: 3,
+          type: "tool_call",
+          payload: { tool: "web", action: "post", text: "Visible answer", callId: "post-2" },
+          createdAt: 120,
+        },
+        {
+          seq: 4,
+          type: "tool_result",
+          payload: { tool: "web", action: "post", ok: true, callId: "post-2", result: "[sent]" },
+          createdAt: 130,
+        },
+        {
+          seq: 5,
+          type: "tool_call",
+          payload: { tool: "stay_silent", callId: "silent-1" },
+          createdAt: 140,
+        },
+        {
+          seq: 6,
+          type: "tool_result",
+          payload: { tool: "stay_silent", ok: true, callId: "silent-1" },
+          createdAt: 150,
+        },
+      ],
+      startedAt: 100,
+      finishedAt: 200,
+    },
+    undefined,
+    undefined,
+    "Previously restored response that is longer",
+  );
+  const stream = await streamFn(MODEL, { systemPrompt: "", messages: [], tools: [] } as never);
+  const final = await drain(stream);
+  const block = final.content[0];
+
+  assert.equal(final.stopReason, "stop");
+  assert.equal(block?.type === "text" ? block.text : "", "Visible answer");
+});
+
+test("a failed terminal run preserves its error after delivering a post", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("terminal initial snapshot should not poll");
+  }) as typeof fetch;
+
+  const streamFn = makeRunResumeStreamFn(
+    "run-failed-after-post",
+    {
+      status: "failed",
+      result: { status: "error", reason: "The final step failed." },
+      partial: "",
+      activity: [
+        {
+          seq: 1,
+          type: "tool_call",
+          payload: { tool: "web", action: "post", text: "Delivered before failure", callId: "post-1" },
+          createdAt: 100,
+        },
+        {
+          seq: 2,
+          type: "tool_result",
+          payload: { tool: "web", action: "post", ok: true, callId: "post-1", result: "[sent]" },
+          createdAt: 110,
+        },
+      ],
+      startedAt: 100,
+      finishedAt: 200,
+    },
+    undefined,
+    undefined,
+    "Previously restored response that is longer",
+  );
+  const stream = await streamFn(MODEL, { systemPrompt: "", messages: [], tools: [] } as never);
+  const final = await drain(stream);
+  const block = final.content[0];
+
+  assert.equal(final.stopReason, "error");
+  assert.equal(final.errorMessage, "The final step failed.");
+  assert.equal(block?.type === "text" ? block.text : "", "Delivered before failure");
+});
+
+test("a stopped terminal run preserves its delivered post before aborting", async () => {
+  globalThis.fetch = (async () => {
+    throw new Error("terminal initial snapshot should not poll");
+  }) as typeof fetch;
+
+  const streamFn = makeRunResumeStreamFn(
+    "run-stopped-after-post",
+    {
+      status: "done",
+      result: { status: "error", stopped: true },
+      partial: "",
+      activity: [
+        {
+          seq: 1,
+          type: "tool_call",
+          payload: { tool: "web", action: "post", text: "Delivered before stop", callId: "post-1" },
+          createdAt: 100,
+        },
+        {
+          seq: 2,
+          type: "tool_result",
+          payload: { tool: "web", action: "post", ok: true, callId: "post-1", result: "[sent]" },
+          createdAt: 110,
+        },
+      ],
+      startedAt: 100,
+      finishedAt: 200,
+    },
+    undefined,
+    undefined,
+    "Previously restored response that is longer",
+  );
+  const stream = await streamFn(MODEL, { systemPrompt: "", messages: [], tools: [] } as never);
+  const final = await drain(stream);
+  const block = final.content[0];
+
+  assert.equal(final.stopReason, "aborted");
+  assert.equal(final.errorMessage, "aborted");
+  assert.equal(block?.type === "text" ? block.text : "", "Delivered before stop");
+});
+
 test("approval denial is rendered as a normal status, not a stream error", async () => {
   globalThis.fetch = (async () => {
     throw new Error("approval denial terminal snapshot should not poll");


### PR DESCRIPTION
## Problem

Web runs can deliver their final answer through a successful `post` tool call and then terminate without `result.reply`. The live transcript currently renders only the work timeline until the session is reloaded, even though history reconstruction already treats the delivered post as the reply.

## Change

- Promote the latest successfully delivered post to the terminal live reply when no ordinary reply exists.
- Preserve failure and abort semantics while retaining text that was already delivered.
- Replace stale reattach text when the delivered post is not an append-only continuation.

## Verification

- Web UI tests: 502 passed
- Web UI typecheck
- Web UI production build
- Prettier, ESLint, and Oxlint on changed files
- Fresh-context review: no findings

## Screenshot

Synthetic data, rendered without deployment-specific content:

![Before and after: delivered post appears in the live transcript](https://raw.githubusercontent.com/ErciZe/qm-upstream/pr-assets/.github/pr-assets/254-live-delivered-post.png)
