### PR TITLE
Support organization data in deployment layers

### DIFF
--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -60,9 +60,7 @@ export async function runConformance(
   const bundle = deploymentLayerBundle(sandboxDir);
   const expectedHash = createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
   if (live.contentHash !== expectedHash) {
-    throw new CliError(
-      "runtime.layer-resolved: live content hash differs from the directory's complete tools and skills layer",
-    );
+    throw new CliError("runtime.layer-resolved: live content hash differs from the directory's complete layer");
   }
   if (
     live.status === "degraded" ||

--- a/cli/src/commands/sandbox.ts
+++ b/cli/src/commands/sandbox.ts
@@ -254,7 +254,7 @@ function prepare(opts: SandboxBuildOpts): PreparedBuild {
     throw new CliError(`sandbox check failed:\n${layer.errors.map((error) => `  - ${error}`).join("\n")}`);
   }
   const customDockerfile = join(sandboxDir, "Dockerfile");
-  const hasCustom = existsSync(customDockerfile);
+  const hasCustom = layer.hasDockerfile;
   if (!hasCustom && layer.tools.length === 0) {
     die(`nothing to build in ${sandboxDir}: add a tool executable under tools/, or a sandbox/Dockerfile.`);
   }

--- a/cli/src/deployment-layer.ts
+++ b/cli/src/deployment-layer.ts
@@ -16,6 +16,7 @@ export interface DeploymentLayerBundle {
   contract: 1;
   tools: DeploymentLayerFile[];
   skills: DeploymentLayerFile[];
+  data?: DeploymentLayerFile[];
 }
 
 export interface DeploymentLayerState {
@@ -40,7 +41,7 @@ function textFile(root: string, path: string, prefix: string): DeploymentLayerFi
     throw new CliError(`deployment layer file must be a regular file: ${path}`);
   const bytes = readFileSync(path);
   if (bytes.includes(0) || !Buffer.from(bytes.toString("utf8"), "utf8").equals(bytes)) {
-    throw new CliError(`deployment layer API only accepts text skill assets: ${path}`);
+    throw new CliError(`deployment layer API only accepts UTF-8 text assets: ${path}`);
   }
   const rel = relative(root, path).split(sep).join("/");
   return {
@@ -58,8 +59,16 @@ const pathOrder = (a: DeploymentLayerFile, b: DeploymentLayerFile): number => {
 
 export const JUNK_FILE = /^(?:\.DS_Store|Thumbs\.db|\._.*)$/;
 
+function regularDirectoryExists(path: string): boolean {
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (!stat) return false;
+  if (stat.isSymbolicLink() || !stat.isDirectory())
+    throw new CliError(`deployment layer directory must be a regular directory: ${path}`);
+  return true;
+}
+
 function walkText(root: string, prefix: string): DeploymentLayerFile[] {
-  if (!existsSync(root)) return [];
+  if (!regularDirectoryExists(root)) return [];
   const out: DeploymentLayerFile[] = [];
   const walk = (dir: string): void => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -74,32 +83,47 @@ function walkText(root: string, prefix: string): DeploymentLayerFile[] {
 }
 
 export function deploymentLayerBundle(sandboxDir: string): DeploymentLayerBundle {
+  if (!regularDirectoryExists(sandboxDir)) return { contract: 1, tools: [], skills: [] };
   const toolsDir = join(sandboxDir, "tools");
-  const tools = existsSync(toolsDir)
-    ? readdirSync(toolsDir, { withFileTypes: true })
+  const tools: DeploymentLayerFile[] = [];
+  if (regularDirectoryExists(toolsDir)) {
+    tools.push(
+      ...readdirSync(toolsDir, { withFileTypes: true })
         .filter((entry) => !JUNK_FILE.test(entry.name))
         .map((entry) => {
           const path = join(toolsDir, entry.name);
           if (!entry.isDirectory())
             throw new CliError(`deployment layer tools entry must be a directory containing tool.json: ${path}`);
           const descriptor = join(path, "tool.json");
-          if (!existsSync(descriptor))
+          if (!lstatSync(descriptor, { throwIfNoEntry: false }))
             throw new CliError(`deployment layer tool directory is missing tool.json: ${path}`);
           return textFile(toolsDir, descriptor, "tools");
         })
-        .sort(pathOrder)
-    : [];
-  return { contract: 1, tools, skills: walkText(join(sandboxDir, "skills"), "skills") };
+        .sort(pathOrder),
+    );
+  }
+  const data = walkText(join(sandboxDir, "data"), "data");
+  return {
+    contract: 1,
+    tools,
+    skills: walkText(join(sandboxDir, "skills"), "skills"),
+    ...(data.length ? { data } : {}),
+  };
 }
 
 function normalizedLayerBody(value: unknown): string {
   if (!value || typeof value !== "object" || Array.isArray(value))
     throw new CliError("deployment layer bundle must be an object");
   const bundle = value as Record<string, unknown>;
-  if (bundle.contract !== 1 || !Array.isArray(bundle.tools) || !Array.isArray(bundle.skills)) {
+  if (
+    bundle.contract !== 1 ||
+    !Array.isArray(bundle.tools) ||
+    !Array.isArray(bundle.skills) ||
+    (bundle.data !== undefined && !Array.isArray(bundle.data))
+  ) {
     throw new CliError("deployment layer bundle requires contract: 1, tools[], and skills[]");
   }
-  const files = (kind: "tools" | "skills", entries: unknown[]): DeploymentLayerFile[] =>
+  const files = (kind: "tools" | "skills" | "data", entries: unknown[]): DeploymentLayerFile[] =>
     entries
       .map((entry) => {
         if (!entry || typeof entry !== "object" || Array.isArray(entry))
@@ -111,13 +135,17 @@ function normalizedLayerBody(value: unknown): string {
         return { path: file.path, content: file.content, ...(file.executable === true ? { executable: true } : {}) };
       })
       .sort(pathOrder);
-  return JSON.stringify({ contract: 1, tools: files("tools", bundle.tools), skills: files("skills", bundle.skills) });
+  const data = files("data", (bundle.data as unknown[] | undefined) ?? []);
+  return JSON.stringify({
+    contract: 1,
+    tools: files("tools", bundle.tools),
+    skills: files("skills", bundle.skills),
+    ...(data.length ? { data } : {}),
+  });
 }
 
 export function deploymentLayerBody(sandboxDir: string): string {
-  const bundle = existsSync(sandboxDir)
-    ? deploymentLayerBundle(sandboxDir)
-    : { contract: 1 as const, tools: [], skills: [] };
+  const bundle = deploymentLayerBundle(sandboxDir);
   const body = normalizedLayerBody(bundle);
   if (Buffer.byteLength(body) > 1_000_000)
     throw new CliError("deployment layer exceeds the core API's 1 MB request limit");
@@ -251,7 +279,7 @@ export async function syncDeploymentLayer(opts: {
   envFile?: string;
   allowUnavailable?: boolean;
 }): Promise<void> {
-  if (!existsSync(opts.sandboxDir)) {
+  if (!regularDirectoryExists(opts.sandboxDir)) {
     step(`deployment layer: skipped (no sandbox directory at ${opts.sandboxDir})`);
     return;
   }

--- a/cli/src/sandbox-layer.ts
+++ b/cli/src/sandbox-layer.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { JUNK_FILE, deploymentLayerBundle } from "./deployment-layer.ts";
 import { errMessage } from "./log.ts";
@@ -770,7 +770,8 @@ export interface SandboxValidation {
 
 const isFile = (p: string): boolean => {
   try {
-    return statSync(p).isFile();
+    const stat = lstatSync(p);
+    return !stat.isSymbolicLink() && stat.isFile();
   } catch {
     return false;
   }
@@ -788,14 +789,34 @@ const isCidr = (host: string): boolean =>
   /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/.test(host) || /^[0-9A-Fa-f:]+\/\d{1,3}$/.test(host);
 
 export function validateSandboxLayer(sandboxDir: string): SandboxValidation {
+  const root = lstatSync(sandboxDir, { throwIfNoEntry: false });
   const out: SandboxValidation = {
-    exists: existsSync(sandboxDir),
-    hasDockerfile: existsSync(join(sandboxDir, "Dockerfile")),
+    exists: root !== undefined,
+    hasDockerfile: false,
     tools: [],
     skills: [],
     errors: [],
     warnings: [],
   };
+  let bundleBody: string | undefined;
+  try {
+    bundleBody = JSON.stringify(deploymentLayerBundle(sandboxDir));
+    if (out.exists) {
+      const dockerfilePath = join(sandboxDir, "Dockerfile");
+      const dockerfile = lstatSync(dockerfilePath, { throwIfNoEntry: false });
+      if (dockerfile) {
+        if (dockerfile.isSymbolicLink() || !dockerfile.isFile()) {
+          out.errors.push(`sandbox/Dockerfile must be a regular file`);
+          return out;
+        }
+        out.hasDockerfile = true;
+      }
+    }
+  } catch (e) {
+    out.errors.push(errMessage(e));
+    return out;
+  }
+  if (!out.exists) return out;
 
   const toolsDir = join(sandboxDir, "tools");
   const idCounts = new Map<string, number>();
@@ -888,15 +909,8 @@ export function validateSandboxLayer(sandboxDir: string): SandboxValidation {
     }
   }
 
-  if (out.exists && out.errors.length === 0) {
-    try {
-      const body = JSON.stringify(deploymentLayerBundle(sandboxDir));
-      if (Buffer.byteLength(body) > 1_000_000) {
-        out.errors.push("deployment layer (skills/ + tool descriptors) exceeds the core API's 1 MB request limit");
-      }
-    } catch (e) {
-      out.errors.push(errMessage(e));
-    }
+  if (out.errors.length === 0 && bundleBody !== undefined && Buffer.byteLength(bundleBody) > 1_000_000) {
+    out.errors.push("deployment layer exceeds the core API's 1 MB request limit");
   }
 
   return out;

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -7,12 +7,15 @@ import { join } from "node:path";
 import { CONFIG_FILENAME, loadConfigInDir, type QmConfig } from "../src/config.ts";
 import { currentDeploymentLayerState, deploymentLayerBundle, syncDeploymentLayer } from "../src/deployment-layer.ts";
 import { expectedDescriptors, runConformance } from "../src/commands/conformance.ts";
+import { validateSandboxLayer } from "../src/sandbox-layer.ts";
 
 const SECRET = "conformance-test-secret";
 
 const PINNED_SANDBOX_IMAGE = `registry.fly.io/acme-sandboxes@sha256:${"b".repeat(64)}`;
 
 function writeLayer(dir: string): void {
+  mkdirSync(join(dir, "sandbox", "data", "catalogs"), { recursive: true });
+  writeFileSync(join(dir, "sandbox", "data", "catalogs", "materials.json"), '{"version":1}\n');
   mkdirSync(join(dir, "sandbox", "skills", "a"), { recursive: true });
   mkdirSync(join(dir, "sandbox", "skills", "a-b"), { recursive: true });
   writeFileSync(join(dir, "sandbox", "skills", "a", "SKILL.md"), "---\nname: a\ndescription: skill a\n---\nbody a\n");
@@ -37,8 +40,14 @@ function coreNormalizedHash(dir: string): string {
   const tools = [
     { path: "tools/t/tool.json", content: readFileSync(join(dir, "sandbox", "tools", "t", "tool.json"), "utf8") },
   ];
+  const data = [
+    {
+      path: "data/catalogs/materials.json",
+      content: readFileSync(join(dir, "sandbox", "data", "catalogs", "materials.json"), "utf8"),
+    },
+  ];
   const order = (a: { path: string }, b: { path: string }): number => a.path.localeCompare(b.path);
-  const bundle = { contract: 1, tools: tools.sort(order), skills: skillFiles.sort(order) };
+  const bundle = { contract: 1, tools: tools.sort(order), skills: skillFiles.sort(order), data: data.sort(order) };
   return createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
 }
 
@@ -52,6 +61,7 @@ test("the CLI bundle hashes byte-identically to the core's full-path normalizati
       ["skills/a-b/SKILL.md", "skills/a/SKILL.md"],
       "full-path order, not per-directory walk order",
     );
+    assert.deepEqual(bundle.data?.map((file) => file.path), ["data/catalogs/materials.json"]);
     const cliHash = createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
     assert.equal(cliHash, coreNormalizedHash(dir));
   } finally {
@@ -116,6 +126,26 @@ test("a missing sandbox directory skips sync instead of replacing the deployed l
       sandboxDir: join(dir, "sandbox"),
     });
     assert.ok(lines.some((line) => /skipped \(no sandbox directory/.test(line)));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a dangling sandbox link fails sync instead of being treated as missing", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-dangling-sync-"));
+  const sandboxDir = join(dir, "sandbox");
+  try {
+    symlinkSync(join(dir, "missing"), sandboxDir);
+    await assert.rejects(
+      () =>
+        syncDeploymentLayer({
+          config: makeConfig("http://example.invalid"),
+          target: "docker",
+          configDir: dir,
+          sandboxDir,
+        }),
+      /directory must be a regular directory/,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -694,6 +724,97 @@ test("junk files (.DS_Store, Thumbs.db, AppleDouble) are excluded from the bundl
     writeFileSync(join(dir, "sandbox", "skills", "a", "Thumbs.db"), Buffer.from([0xd0, 0xcf, 0x11, 0xe0]));
     writeFileSync(join(dir, "sandbox", "skills", "a", "._SKILL.md"), Buffer.from([0x00, 0x05, 0x16, 0x07]));
     assert.deepEqual(deploymentLayerBundle(join(dir, "sandbox")), clean);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("organization data files must be regular UTF-8 text", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-data-shape-"));
+  try {
+    mkdirSync(join(dir, "sandbox", "data"), { recursive: true });
+    writeFileSync(join(dir, "catalog.json"), "{}\n");
+    symlinkSync(join(dir, "catalog.json"), join(dir, "sandbox", "data", "catalog.json"));
+    assert.throws(
+      () => deploymentLayerBundle(join(dir, "sandbox")),
+      /deployment layer file must be a regular file/,
+    );
+    rmSync(join(dir, "sandbox", "data", "catalog.json"));
+    writeFileSync(join(dir, "sandbox", "data", "catalog.bin"), Buffer.from([0xff]));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /only accepts UTF-8 text assets/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("deployment layer directories must not be symbolic links", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-linked-directory-"));
+  try {
+    mkdirSync(join(dir, "external", "data"), { recursive: true });
+    writeFileSync(join(dir, "external", "data", "catalog.json"), "{}\n");
+    mkdirSync(join(dir, "external", "tools", "external"), { recursive: true });
+    writeFileSync(join(dir, "external", "tools", "external", "tool.json"), JSON.stringify({ id: "external" }));
+    symlinkSync(join(dir, "external"), join(dir, "sandbox"));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+    const validation = validateSandboxLayer(join(dir, "sandbox"));
+    assert.match(validation.errors[0] ?? "", /directory must be a regular directory/);
+    assert.deepEqual(validation.tools, []);
+
+    rmSync(join(dir, "sandbox"));
+    mkdirSync(join(dir, "sandbox"), { recursive: true });
+    symlinkSync(join(dir, "external", "data"), join(dir, "sandbox", "data"));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+
+    rmSync(join(dir, "sandbox", "data"));
+    mkdirSync(join(dir, "external", "tools"), { recursive: true });
+    symlinkSync(join(dir, "external", "tools"), join(dir, "sandbox", "tools"));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+
+    rmSync(join(dir, "sandbox", "tools"));
+    mkdirSync(join(dir, "external", "skills"), { recursive: true });
+    symlinkSync(join(dir, "external", "skills"), join(dir, "sandbox", "skills"));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dangling deployment layer directories fail instead of acting absent", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-dangling-directory-"));
+  try {
+    symlinkSync(join(dir, "missing-sandbox"), join(dir, "sandbox"));
+    assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+    assert.match(validateSandboxLayer(join(dir, "sandbox")).errors[0] ?? "", /directory must be a regular directory/);
+
+    rmSync(join(dir, "sandbox"));
+    mkdirSync(join(dir, "sandbox"));
+    for (const name of ["data", "tools", "skills"]) {
+      symlinkSync(join(dir, `missing-${name}`), join(dir, "sandbox", name));
+      assert.throws(() => deploymentLayerBundle(join(dir, "sandbox")), /directory must be a regular directory/);
+      rmSync(join(dir, "sandbox", name));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("sandbox validation rejects linked descriptors and Dockerfiles before reading them", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-validation-links-"));
+  try {
+    mkdirSync(join(dir, "sandbox", "tools", "linked"), { recursive: true });
+    writeFileSync(join(dir, "private-descriptor.json"), "private-content");
+    symlinkSync(join(dir, "private-descriptor.json"), join(dir, "sandbox", "tools", "linked", "tool.json"));
+    const descriptor = validateSandboxLayer(join(dir, "sandbox"));
+    assert.match(descriptor.errors[0] ?? "", /must be a regular file/);
+    assert.doesNotMatch(descriptor.errors.join("\n"), /private-content/);
+    assert.deepEqual(descriptor.tools, []);
+
+    rmSync(join(dir, "sandbox", "tools"), { recursive: true });
+    writeFileSync(join(dir, "private-Dockerfile"), "FROM private.example/image\n");
+    symlinkSync(join(dir, "private-Dockerfile"), join(dir, "sandbox", "Dockerfile"));
+    const dockerfile = validateSandboxLayer(join(dir, "sandbox"));
+    assert.deepEqual(dockerfile.errors, ["sandbox/Dockerfile must be a regular file"]);
+    assert.equal(dockerfile.hasDockerfile, false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/deploy/layers/README.md
+++ b/deploy/layers/README.md
@@ -28,7 +28,7 @@ deploy/layers/<org>/
   .gitignore               scaffolded; keeps .env and tfstate out of Git
   .env.example             computed secret names, never values
   .env                     local secret values; never committed
-  sandbox/                 org tools and skills for agent computers
+  sandbox/                 org data, agent tools, and skills
   plugins/<name>/          org-specific service images
   infra/                   provider infrastructure and tfvars, on AWS targets
   slack-app-manifest.yml   generated bot manifest

--- a/docs/deploy-directory.md
+++ b/docs/deploy-directory.md
@@ -4,20 +4,21 @@ Contract v1 makes a QM deployment a committed, portable directory. The `qm` CLI 
 
 ## Layout
 
-`package.json` pins the `@yc-software/qm` deployment engine at the exact version that scaffolded the directory, so the directory records which CLI interprets it rather than drifting with whatever version an operator has installed; `contract: 1` remains only the compatibility floor. `package-lock.json` records the installed artifact. `qm.config.jsonc` is the deployment config. `deployment.md` and `.codex/skills/deploy-qm/` are materialized package assets an operator can hand to an agent. `sandbox/` adds tools and skills to agent computers; `plugins/` adds services; `.env.example` documents the computed secret names; `.env` supplies local values and is never committed. `qm init` writes `slack-app-manifest.yml` for the optional Socket Mode bot. It also writes `slack-sso-manifest.yml` only when the portal is configured to use Slack OpenID. `qm slack render` refreshes the applicable manifests after `publicUrl` changes, and `qm outputs` returns their creation links and the web coordinates. `qm init --target aws` also vendors the reference `infra/` Terraform module and its derived `terraform.tfvars`; the copy belongs to the deployment after generation. Init never overwrites an existing deployment config.
+`package.json` pins the `@yc-software/qm` deployment engine at the exact version that scaffolded the directory, so the directory records which CLI interprets it rather than drifting with whatever version an operator has installed; `contract: 1` remains only the compatibility floor. `package-lock.json` records the installed artifact. `qm.config.jsonc` is the deployment config. `deployment.md` and `.codex/skills/deploy-qm/` are materialized package assets an operator can hand to an agent. `sandbox/` adds organization data, tools, and skills; `plugins/` adds services; `.env.example` documents the computed secret names; `.env` supplies local values and is never committed. `qm init` writes `slack-app-manifest.yml` for the optional Socket Mode bot. It also writes `slack-sso-manifest.yml` only when the portal is configured to use Slack OpenID. `qm slack render` refreshes the applicable manifests after `publicUrl` changes, and `qm outputs` returns their creation links and the web coordinates. `qm init --target aws` also vendors the reference `infra/` Terraform module and its derived `terraform.tfvars`; the copy belongs to the deployment after generation. Init never overwrites an existing deployment config.
 
 The sandbox layout is:
 
 ```text
 sandbox/
   Dockerfile
+  data/<path>
   tools/<id>/tool.json
   tools/<id>/<binary>
   skills/<id>/SKILL.md
   skills/<id>/<text assets>
 ```
 
-The Dockerfile is optional when every declared binary is present in its tool directory. Skill assets delivered through the deployment-layer API are text in v1; binaries belong in the sandbox image.
+The Dockerfile is optional when every declared binary is present in its tool directory. Files under `data/` and skill assets delivered through the deployment-layer API are UTF-8 text in v1; binaries belong in the sandbox image. Data files are organization-owned inputs for features that explicitly consume their paths. Merely adding a data file does not expose it to an agent or change runtime behavior.
 
 ## Configuration
 
@@ -96,7 +97,7 @@ Deployment-specific safety belongs here too. For example, an ambiently authentic
 
 ## Delivery and pins
 
-When `sandbox/` exists, every `up` sends its descriptors and complete text skill trees to source-authenticated `PUT /v1/deployment-layer`. Without `sandbox/`, `up` skips layer sync and leaves the deployed layer unchanged. Core validates submitted bundles again, stores them in Postgres table `deployment_layer`, versions them by a canonical SHA-256 content hash, records an audit event, hydrates them before serving, and returns the restorable bundle with its metadata and resolved runtime state from source-authenticated `GET /v1/deployment-layer`. Removed layer-owned skills are archived. Filesystem `DEPLOYMENT_LAYER` remains a bootstrap input for local and recovery use.
+When `sandbox/` exists, every `up` sends its descriptors, data files, and complete text skill trees to source-authenticated `PUT /v1/deployment-layer`. Without `sandbox/`, `up` skips layer sync and leaves the deployed layer unchanged. Core validates submitted bundles again, stores them in Postgres table `deployment_layer`, versions them by a canonical SHA-256 content hash, records an audit event, hydrates them before serving, and returns the restorable bundle with its metadata and resolved runtime state from source-authenticated `GET /v1/deployment-layer`. Removed layer-owned skills are archived. Filesystem `DEPLOYMENT_LAYER` remains a bootstrap input for local and recovery use.
 
 The sandbox handoff is a substrate image pin plus a layer content hash. Docker and Fly use `sandbox publish` to push an OCI image, resolve its immutable digest, and record it in the config. AWS with `sandbox.backend: "aws"` (or no sandbox block) uses `infra build-image` to package the guest agent as a Lambda MicroVM image and records its immutable image version and execution role; with `sandbox.backend: "sprites"`, `sandbox publish` pushes the layer image and records its digest pin in the durable deployment manifest, which `up`, `check --live`, and `rollback` resolve. Service task definitions and sandbox root filesystems use immutable pins, not mutable tags.
 

--- a/src/deployment/deployment-layer-store.ts
+++ b/src/deployment/deployment-layer-store.ts
@@ -23,7 +23,7 @@ import { errMessage } from "../util/errors.ts";
 import { parseToolDescriptor, type ToolDescriptor } from "./deployment-layer.ts";
 import { replaceDeploymentLayer, resolvedDeploymentLayer, type DeploymentLayerRuntime } from "./load-layer.ts";
 
-interface DeploymentLayerFile {
+export interface DeploymentLayerFile {
   path: string;
   content: string;
   executable?: boolean;
@@ -33,6 +33,7 @@ export interface DeploymentLayerBundle {
   contract: 1;
   tools: DeploymentLayerFile[];
   skills: DeploymentLayerFile[];
+  data?: DeploymentLayerFile[];
 }
 
 export interface StoredDeploymentLayer {
@@ -41,7 +42,7 @@ export interface StoredDeploymentLayer {
   updatedAt: number;
   updatedBy: string;
   bundle: DeploymentLayerBundle;
-  resolved: Omit<DeploymentLayerRuntime, "dir">;
+  resolved: Omit<DeploymentLayerRuntime, "dir" | "dataFiles">;
   pendingAudits?: DeploymentLayerAuditRevision[];
 }
 
@@ -61,7 +62,7 @@ export interface DeploymentLayerStore {
   live(): {
     source: "durable" | "filesystem" | "none";
     contentHash: string | null;
-    resolved: Omit<DeploymentLayerRuntime, "dir"> | null;
+    resolved: Omit<DeploymentLayerRuntime, "dir" | "dataFiles"> | null;
   };
 }
 
@@ -100,10 +101,15 @@ function hasLoneSurrogate(value: string): boolean {
 }
 
 function normalizedBundle(input: DeploymentLayerBundle): DeploymentLayerBundle {
-  if (input.contract !== 1 || !Array.isArray(input.tools) || !Array.isArray(input.skills)) {
+  if (
+    input.contract !== 1 ||
+    !Array.isArray(input.tools) ||
+    !Array.isArray(input.skills) ||
+    (input.data !== undefined && !Array.isArray(input.data))
+  ) {
     throw new Error("deployment layer requires contract: 1, tools[], and skills[]");
   }
-  const normalize = (kind: "tools" | "skills", files: DeploymentLayerFile[]): DeploymentLayerFile[] => {
+  const normalize = (kind: "tools" | "skills" | "data", files: DeploymentLayerFile[]): DeploymentLayerFile[] => {
     const seen = new Set<string>();
     return files
       .map((file) => {
@@ -129,7 +135,13 @@ function normalizedBundle(input: DeploymentLayerBundle): DeploymentLayerBundle {
       })
       .sort(pathOrder);
   };
-  return { contract: 1, tools: normalize("tools", input.tools), skills: normalize("skills", input.skills) };
+  const data = normalize("data", input.data ?? []);
+  return {
+    contract: 1,
+    tools: normalize("tools", input.tools),
+    skills: normalize("skills", input.skills),
+    ...(data.length ? { data } : {}),
+  };
 }
 
 function toolDescriptors(files: DeploymentLayerFile[]): ToolDescriptor[] {
@@ -197,8 +209,8 @@ function contentHash(bundle: DeploymentLayerBundle): string {
   return createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
 }
 
-function publicResolved(runtime: DeploymentLayerRuntime): Omit<DeploymentLayerRuntime, "dir"> {
-  const { dir: _dir, ...resolved } = runtime;
+function publicResolved(runtime: DeploymentLayerRuntime): Omit<DeploymentLayerRuntime, "dir" | "dataFiles"> {
+  const { dir: _dir, dataFiles: _dataFiles, ...resolved } = runtime;
   return resolved;
 }
 
@@ -226,7 +238,15 @@ function validateBundle(
   const bundle = normalizedBundle(input);
   const tools = toolDescriptors(bundle.tools);
   const manifests = skillManifests(bundle.skills);
-  return { bundle, manifests, runtime: resolvedDeploymentLayer(dir, tools) };
+  return {
+    bundle,
+    manifests,
+    runtime: resolvedDeploymentLayer(
+      dir,
+      tools,
+      (bundle.data ?? []).map((file) => ({ path: file.path, content: file.content })),
+    ),
+  };
 }
 
 export function createDeploymentLayerStore(opts: {
@@ -312,6 +332,7 @@ export function createDeploymentLayerStore(opts: {
     if (opts.runtime.dir !== `durable:${record.contentHash}`) return false;
     const next = validated ?? validateBundle(record.bundle, `durable:${record.contentHash}`);
     if (JSON.stringify(publicResolved(opts.runtime)) !== JSON.stringify(publicResolved(next.runtime))) return false;
+    if (JSON.stringify(opts.runtime.dataFiles) !== JSON.stringify(next.runtime.dataFiles)) return false;
     const current = layerSkills(await opts.skills.list());
     const wanted = new Set(next.manifests.map((manifest) => manifest.name));
     if (current.some((skill) => skill.status !== "archived" && !wanted.has(skill.manifest.name))) return false;

--- a/src/deployment/load-layer.ts
+++ b/src/deployment/load-layer.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { lstatSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import {
   compileApproval,
@@ -13,6 +13,7 @@ import type { CommandRule } from "../types.ts";
 
 export interface DeploymentLayerRuntime {
   dir: string;
+  dataFiles: DeploymentLayerDataFile[];
   tools: ToolDescriptor[];
   connectors: ResidentAuthConnector[];
   advertisedTools: string[];
@@ -21,6 +22,11 @@ export interface DeploymentLayerRuntime {
   splitEnvTemplates: Record<string, string>[];
   commandRules: CommandRule[];
   brokeredTools: BrokeredLayerTool[];
+}
+
+export interface DeploymentLayerDataFile {
+  path: string;
+  content: string;
 }
 
 export interface BrokeredLayerTool {
@@ -33,6 +39,7 @@ export interface BrokeredLayerTool {
 export function emptyDeploymentLayer(): DeploymentLayerRuntime {
   return {
     dir: "",
+    dataFiles: [],
     tools: [],
     connectors: [],
     advertisedTools: [],
@@ -73,7 +80,11 @@ function toolService(tool: ToolDescriptor, why: string): string {
   );
 }
 
-export function resolvedDeploymentLayer(dir: string, tools: ToolDescriptor[]): DeploymentLayerRuntime {
+export function resolvedDeploymentLayer(
+  dir: string,
+  tools: ToolDescriptor[],
+  dataFiles: DeploymentLayerDataFile[] = [],
+): DeploymentLayerRuntime {
   assertDisjointCredentialLinks(tools);
   const withAuth = tools.filter((t) => t.auth);
   const brokered = withAuth.filter((t) => t.auth!.broker);
@@ -84,6 +95,7 @@ export function resolvedDeploymentLayer(dir: string, tools: ToolDescriptor[]): D
   }
   return {
     dir,
+    dataFiles: dataFiles.map((file) => ({ ...file })),
     tools,
     connectors: withAuth.map((t) => ({
       id: t.id,
@@ -120,6 +132,7 @@ export function resolvedDeploymentLayer(dir: string, tools: ToolDescriptor[]): D
 export function replaceDeploymentLayer(target: DeploymentLayerRuntime, source: DeploymentLayerRuntime): void {
   target.dir = source.dir;
   for (const key of [
+    "dataFiles",
     "tools",
     "connectors",
     "advertisedTools",
@@ -135,15 +148,46 @@ export function replaceDeploymentLayer(target: DeploymentLayerRuntime, source: D
 
 const JUNK_FILE = /^(?:\.DS_Store|Thumbs\.db|\._.*)$/;
 
+function regularDirectoryExists(path: string): boolean {
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (!stat) return false;
+  if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`${path} must be a regular directory`);
+  return true;
+}
+
+function loadTextFiles(root: string, dir: string): DeploymentLayerDataFile[] {
+  if (!regularDirectoryExists(dir)) return [];
+  const files: DeploymentLayerDataFile[] = [];
+  const walk = (current: string, prefix: string): void => {
+    const entries = readdirSync(current, { withFileTypes: true }).filter((entry) => !JUNK_FILE.test(entry.name));
+    for (const entry of entries) {
+      const path = join(current, entry.name);
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(path, relativePath);
+        continue;
+      }
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`${path} must be a regular file`);
+      const bytes = readFileSync(path);
+      if (bytes.includes(0) || !Buffer.from(bytes.toString("utf8"), "utf8").equals(bytes))
+        throw new Error(`deployment layer data must be UTF-8 text: ${path}`);
+      files.push({ path: `${root}/${relativePath}`, content: bytes.toString("utf8") });
+    }
+  };
+  walk(dir, "");
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
 export function loadDeploymentLayer(dir: string): DeploymentLayerRuntime {
-  if (!existsSync(dir)) {
+  if (!regularDirectoryExists(dir)) {
     throw new Error(
       `DEPLOYMENT_LAYER points at ${dir}, which does not exist — a configured layer must be present at boot`,
     );
   }
   const toolsDir = join(dir, "tools");
   const tools: ToolDescriptor[] = [];
-  if (existsSync(toolsDir)) {
+  if (regularDirectoryExists(toolsDir)) {
     const entries = readdirSync(toolsDir, { withFileTypes: true })
       .filter((entry) => !JUNK_FILE.test(entry.name))
       .sort((a, b) => {
@@ -158,13 +202,13 @@ export function loadDeploymentLayer(dir: string): DeploymentLayerRuntime {
         );
       }
       const path = join(toolsDir, entry.name, "tool.json");
-      if (!existsSync(path)) throw new Error(`${join(toolsDir, entry.name)} has no tool.json`);
-      const stat = lstatSync(path);
+      const stat = lstatSync(path, { throwIfNoEntry: false });
+      if (!stat) throw new Error(`${join(toolsDir, entry.name)} has no tool.json`);
       if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`${path} must be a regular file`);
       const desc = parseToolDescriptor(readFileSync(path, "utf8"), path);
       if (tools.some((t) => t.id === desc.id)) throw new Error(`${path}: duplicate tool id "${desc.id}"`);
       tools.push(desc);
     }
   }
-  return resolvedDeploymentLayer(dir, tools);
+  return resolvedDeploymentLayer(dir, tools, loadTextFiles("data", join(dir, "data")));
 }

--- a/test/deployment-layer-load.test.ts
+++ b/test/deployment-layer-load.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { emptyDeploymentLayer, loadDeploymentLayer, replaceDeploymentLayer } from "../src/deployment/load-layer.ts";
@@ -58,6 +58,67 @@ test("loadDeploymentLayer derives the runtime shapes from tool descriptors", () 
   assert.deepEqual(layer.splitEnvTemplates, [
     { ACMECLI_ACTING_SLACK_USER_ID: "{actingSlackUserId}", ACMECLI_PLATFORM: "slack" },
   ]);
+});
+
+test("loadDeploymentLayer includes nested organization data as UTF-8 text", () => {
+  const dir = layerDir({});
+  mkdirSync(join(dir, "data", "catalogs"), { recursive: true });
+  writeFileSync(join(dir, "data", "catalogs", "materials.json"), '{"version":1}\n');
+  const layer = loadDeploymentLayer(dir);
+  assert.deepEqual(layer.dataFiles, [
+    { path: "data/catalogs/materials.json", content: '{"version":1}\n' },
+  ]);
+});
+
+test("loadDeploymentLayer rejects binary and linked organization data", () => {
+  const binary = layerDir({});
+  mkdirSync(join(binary, "data"), { recursive: true });
+  writeFileSync(join(binary, "data", "catalog.bin"), Buffer.from([0xff]));
+  assert.throws(() => loadDeploymentLayer(binary), /must be UTF-8 text/);
+
+  const linked = layerDir({});
+  mkdirSync(join(linked, "data"), { recursive: true });
+  writeFileSync(join(linked, "catalog.json"), "{}\n");
+  symlinkSync(join(linked, "catalog.json"), join(linked, "data", "catalog.json"));
+  assert.throws(() => loadDeploymentLayer(linked), /must be a regular file/);
+
+  const linkedRoot = layerDir({});
+  mkdirSync(join(linkedRoot, "external-data"));
+  writeFileSync(join(linkedRoot, "external-data", "catalog.json"), "{}\n");
+  symlinkSync(join(linkedRoot, "external-data"), join(linkedRoot, "data"));
+  assert.throws(() => loadDeploymentLayer(linkedRoot), /must be a regular directory/);
+});
+
+test("loadDeploymentLayer rejects a linked tools directory", () => {
+  const dir = layerDir({});
+  const toolsDir = join(dir, "tools");
+  const external = join(dir, "external-tools");
+  mkdirSync(external);
+  rmSync(toolsDir, { recursive: true, force: true });
+  symlinkSync(external, toolsDir);
+  assert.throws(() => loadDeploymentLayer(dir), /must be a regular directory/);
+});
+
+test("loadDeploymentLayer rejects a linked layer root", () => {
+  const external = layerDir({});
+  const parent = mkdtempSync(join(tmpdir(), "linked-layer-root-"));
+  const linked = join(parent, "layer");
+  symlinkSync(external, linked);
+  assert.throws(() => loadDeploymentLayer(linked), /must be a regular directory/);
+});
+
+test("loadDeploymentLayer rejects dangling layer directories", () => {
+  const parent = mkdtempSync(join(tmpdir(), "dangling-layer-root-"));
+  const linked = join(parent, "layer");
+  symlinkSync(join(parent, "missing-layer"), linked);
+  assert.throws(() => loadDeploymentLayer(linked), /must be a regular directory/);
+
+  const dir = layerDir({});
+  for (const name of ["data", "tools"]) {
+    symlinkSync(join(dir, `missing-${name}`), join(dir, name));
+    assert.throws(() => loadDeploymentLayer(dir), /must be a regular directory/);
+    rmSync(join(dir, name));
+  }
 });
 
 test("brokered tools resolve to service, binary, and quarantine roots", () => {

--- a/test/deployment-layer-routes.test.ts
+++ b/test/deployment-layer-routes.test.ts
@@ -13,7 +13,10 @@ import { agentApiMatches } from "../src/api/agent-api-catalog.ts";
 import { mintCapabilityToken, CAPABILITY_TTL_MS } from "../src/auth/capability-token.ts";
 import { scopeId } from "../src/types.ts";
 import { testConfig } from "./support/test-config.ts";
-import { DeploymentLayerPersistedError } from "../src/deployment/deployment-layer-store.ts";
+import {
+  DeploymentLayerPersistedError,
+  type DeploymentLayerBundle,
+} from "../src/deployment/deployment-layer-store.ts";
 
 const SECRET = "layer-routes-secret".repeat(3);
 const PATH = "/v1/deployment-layer";
@@ -49,6 +52,7 @@ const bundle = JSON.stringify({
   contract: 1,
   tools: [{ path: "tools/acme/tool.json", content: JSON.stringify({ id: "acme", advertise: "acme CLI" }) }],
   skills: [{ path: "skills/acme/SKILL.md", content: "---\nname: acme\ndescription: Use acme.\n---\nRun acme.\n" }],
+  data: [{ path: "data/catalogs/materials.json", content: '{"version":1}\n' }],
 });
 
 test("an empty layer GETs the version-0 shape with a source discriminator under source auth", async () => {
@@ -133,12 +137,16 @@ test("a correctly signed PUT replaces the layer and a signed GET reads it back",
       status: string;
       runtimeContentHash: string | null;
       source: string;
+      bundle: DeploymentLayerBundle;
     };
     assert.equal(getBody.version, 1);
     assert.equal(getBody.status, "applied");
     assert.equal(getBody.runtimeContentHash, getBody.contentHash);
     assert.equal(getBody.source, "durable");
     assert.ok(getBody.contentHash);
+    assert.deepEqual(getBody.bundle.data, [
+      { path: "data/catalogs/materials.json", content: '{"version":1}\n' },
+    ]);
   } finally {
     await srv.close();
   }

--- a/test/deployment-layer-store.test.ts
+++ b/test/deployment-layer-store.test.ts
@@ -38,7 +38,7 @@ const skill: DeploymentLayerBundle["skills"] = [
 ];
 
 const publicRuntime = (runtime: ReturnType<typeof resolvedDeploymentLayer>) => {
-  const { dir: _dir, ...resolved } = runtime;
+  const { dir: _dir, dataFiles: _dataFiles, ...resolved } = runtime;
   return resolved;
 };
 
@@ -55,20 +55,40 @@ test("the durable deployment layer versions by content, hydrates runtime state, 
     now: () => now++,
   });
 
-  const first = await store.put({ contract: 1, tools: [tool("acme CLI")], skills: skill }, "test");
+  const first = await store.put(
+    {
+      contract: 1,
+      tools: [tool("acme CLI")],
+      skills: skill,
+      data: [{ path: "data/catalogs/materials.json", content: '{"version":1}\n' }],
+    },
+    "test",
+  );
   assert.equal(first.version, 1);
+  assert.deepEqual(runtime.dataFiles, [
+    { path: "data/catalogs/materials.json", content: '{"version":1}\n' },
+  ]);
   assert.equal(runtime.advertisedTools[0], "acme CLI");
   assert.deepEqual(runtime.hints, ["Use acme for company data."]);
   assert.deepEqual(runtime.credentialPaths, [{ path: ".config/acme", kind: "directory" }]);
   assert.equal(runtime.commandRules[0]?.decision, "deny");
   assert.equal((await skills.resolve("acme", [scopeId("org", "default-org")])).skill?.status, "published");
 
-  const unchanged = await store.put({ contract: 1, tools: [tool("acme CLI")], skills: skill }, "other");
+  const unchanged = await store.put(
+    {
+      contract: 1,
+      tools: [tool("acme CLI")],
+      skills: skill,
+      data: [{ path: "data/catalogs/materials.json", content: '{"version":1}\n' }],
+    },
+    "other",
+  );
   assert.equal(unchanged.version, 1);
   assert.equal(unchanged.updatedBy, "test");
 
   const second = await store.put({ contract: 1, tools: [tool("acme v2")], skills: [] }, "test-2");
   assert.equal(second.version, 2);
+  assert.deepEqual(runtime.dataFiles, []);
   assert.equal(runtime.advertisedTools[0], "acme v2");
   assert.equal((await skills.resolve("acme", [scopeId("org", "default-org")])).skill, null);
 
@@ -642,7 +662,12 @@ test("hydrate reparses bundle descriptors instead of trusting stored resolved fi
 
 test("hydrate derives runtime fields from the stored bundle, not the resolved cache", async () => {
   const backing = createMemoryMap<StoredDeploymentLayer>();
-  const bundle = { contract: 1 as const, tools: [tool("bundle truth")], skills: [] };
+  const bundle = {
+    contract: 1 as const,
+    tools: [tool("bundle truth")],
+    skills: [],
+    data: [{ path: "data/catalogs/materials.json", content: '{"version":1}\n' }],
+  };
   const writer = createDeploymentLayerStore({
     backing,
     runtime: emptyDeploymentLayer(),
@@ -663,6 +688,9 @@ test("hydrate derives runtime fields from the stored bundle, not the resolved ca
   });
   await reader.hydrate();
   assert.deepEqual(runtime.advertisedTools, ["bundle truth"]);
+  assert.deepEqual(runtime.dataFiles, [
+    { path: "data/catalogs/materials.json", content: '{"version":1}\n' },
+  ]);
 });
 
 test("a concurrent delete during put surfaces a conflict error, not a TypeError", async () => {
@@ -826,6 +854,33 @@ test("applied status detects and repairs deployment-skill drift", async () => {
   await store.get();
   assert.equal(await store.isApplied(record.contentHash), true);
   assert.equal((await skills.resolve("acme", [org])).skill?.manifest.body, "Run the acme tool.\n");
+});
+
+test("applied status detects and repairs deployment-data drift", async () => {
+  const backing = createMemoryMap<StoredDeploymentLayer>();
+  const runtime = resolvedDeploymentLayer("/fallback", []);
+  const store = createDeploymentLayerStore({
+    backing,
+    runtime,
+    skills: createSkillStore(),
+    scopeId: scopeId("org", "default-org"),
+  });
+  const record = await store.put(
+    {
+      contract: 1,
+      tools: [],
+      skills: [],
+      data: [{ path: "data/catalogs/materials.json", content: '{"version":1}\n' }],
+    },
+    "test",
+  );
+  runtime.dataFiles[0]!.content = '{"version":0}\n';
+  assert.equal(await store.isApplied(record.contentHash), false);
+  await store.get();
+  assert.equal(await store.isApplied(record.contentHash), true);
+  assert.deepEqual(runtime.dataFiles, [
+    { path: "data/catalogs/materials.json", content: '{"version":1}\n' },
+  ]);
 });
 
 test("a later hydrate reconciles a persisted layer audit exactly once", async () => {


### PR DESCRIPTION
## Summary

- carry optional UTF-8 text files from `sandbox/data` through deployment layer bundles
- include data in canonical hashes, durable persistence, hydration, and live runtime replacement
- keep data out of resolved summaries while preserving it in source-authenticated restorable bundles
- reject linked or non-directory deployment roots before reading their contents

## Why

Deployments need organization-owned structured inputs for features that explicitly consume them. Keeping these files in the existing versioned deployment layer gives them the same durability and rollback semantics as tool descriptors and skills without adding feature-specific core behavior.

## Validation

- `node --run typecheck`
- `node --run lint`
- `node --experimental-test-module-mocks --test test/deployment-layer-load.test.ts test/deployment-layer-store.test.ts cli/test/deployment-layer.test.ts cli/test/init.test.ts`
- `node --experimental-test-module-mocks --test test/deployment-layer-routes.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788693102&installation_model_id=19911&pr_number=262&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F262&signature=2c231efaa08e6b6e006268ebca26a0a8763a3e06d0df1a2fd28fa58f4a86013c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->