### PR TITLE
fix: support custom providers across production web surfaces

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -7087,6 +7087,7 @@
         $("onboarding-oauth-summary").textContent = configured.length
           ? configured.map((item) => connectorName(item.provider)).join(", ") + " available in the web UI."
           : "Add Google, GitHub, Notion, or other OAuth clients to make those connectors available.";
+        await loadCustomProviders();
         viewLoadedAt.onboarding = Date.now();
       }
       $("onboarding-model-provider").onchange = () => renderOnboardingModelOptions();
@@ -7228,7 +7229,12 @@
         const saved = await api("PUT", "/api/custom-providers/" + encodeURIComponent(id), body);
         $("custom-provider-save").disabled = false;
         if (!saved.ok) {
-          setStatus("st-custom-provider", saved.data?.message || "Could not save this provider.", "err", true);
+          setStatus(
+            "st-custom-provider",
+            saved.data?.message || (saved.data?.error ? "Error: " + saved.data.error : "Could not save this provider."),
+            "err",
+            true,
+          );
           return;
         }
         $("custom-provider-key").value = "";

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -313,7 +313,10 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
   res.setHeader("x-frame-options", "DENY");
   res.setHeader("content-security-policy", ADMIN_CSP);
   const url = new URL(req.url ?? "/", "http://localhost");
-  const { pathname } = url;
+  let pathname = url.pathname;
+  if (ADMIN_BASE_PATH && (pathname === ADMIN_BASE_PATH || pathname.startsWith(ADMIN_BASE_PATH + "/"))) {
+    pathname = pathname.slice(ADMIN_BASE_PATH.length) || "/";
+  }
   const method = req.method ?? "GET";
 
   const serveShell = async (): Promise<void> => {

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -34,6 +34,10 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
     const template = getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined;
     if (template) return cloneModel(template, id, fallback.name);
   }
+  if (fallback) {
+    const template = getModel("openai", "gpt-4o" as Parameters<typeof getModel>[1]) as PiModel | undefined;
+    if (template) return cloneModel(template, id, fallback.name);
+  }
   throw new Error(`Unsupported model: ${id}`);
 }
 

--- a/plugins/web-ui/test/model-options.test.ts
+++ b/plugins/web-ui/test/model-options.test.ts
@@ -96,6 +96,21 @@ test("runtime options preserve a fetched OpenRouter model as the selected web tu
   assert.equal(defaultModelValue(), "pi:anthropic/claude-sonnet-4.5");
 });
 
+test("runtime options include an OpenAI-compatible custom provider model", () => {
+  applyRuntimeOptions(
+    null,
+    ["pi"],
+    { pi: ["deepseek-v4-flash"] },
+    { harnessId: "pi", modelId: "deepseek-v4-flash" },
+    { "deepseek-v4-flash": { name: "deepseek-v4", provider: "deepseek" } },
+  );
+  const option = getModelOptions()[0]!;
+  assert.equal(option.value, "pi:deepseek-v4-flash");
+  assert.equal(option.label, "deepseek-v4");
+  assert.equal(option.model.id, "deepseek-v4-flash");
+  assert.equal(defaultModelValue(), "pi:deepseek-v4-flash");
+});
+
 test("runtime options hide retired persisted model ids", () => {
   applyRuntimeOptions(
     null,

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1005,6 +1005,9 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
   ]);
   const harnessId = deps.harnessId ?? "pi";
   const managedKeys = deps.modelCredentials ? await deps.modelCredentials.availability() : null;
+  const customProviderConfigured = deps.customProviders
+    ? (await deps.customProviders.statuses()).some((provider) => !provider.disabled && provider.hasKey)
+    : false;
   const catalog = managedKeys?.openrouter
     ? await selectableModelCatalog(deps.modelCredentialFetch)
     : builtInModelCatalog();
@@ -1038,7 +1041,9 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
     webuiModels: configuredPicker.length ? configuredPicker : allowed,
     baseModel: resolvedBase,
     harnessId,
-    ...(managedKeys ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) } : {}),
+    ...(managedKeys
+      ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) || customProviderConfigured }
+      : {}),
     externalSlackParticipants,
     ...(Object.keys(resolvedBranding).length ? { branding: resolvedBranding } : {}),
   });

--- a/src/core/turn-options.ts
+++ b/src/core/turn-options.ts
@@ -1,3 +1,4 @@
+import { customModelCatalog } from "../model/custom-providers.ts";
 import {
   DEFAULT_WEBUI_MODEL_IDS,
   THINKING_LEVELS,
@@ -49,7 +50,8 @@ export function validateWebTurnModelOptions(
   enabledModels: readonly string[] | null,
   providers: ModelProviderAvailability = ALL_PROVIDERS_AVAILABLE,
 ): string | null {
-  const enabled = enabledModels?.length ? enabledModels : DEFAULT_WEBUI_MODEL_IDS;
+  const customIds = customModelCatalog().map((model) => model.id);
+  const enabled = enabledModels?.length ? enabledModels : [...DEFAULT_WEBUI_MODEL_IDS, ...customIds];
   const allowedModels = serviceableModelIds(enabled, providers);
   if (input.model && !allowedModels.includes(input.model)) {
     return resolveModel(input.model) && !modelServiceable(input.model, providers)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const server = createServer(built.app, {
   modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
   providerKeys: providerKeysPresent(config),
   modelCredentials: built.modelCredentials,
+  customProviders: built.customProviders,
+  refreshCustomProviders: built.refreshCustomProviders,
   ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
   harnessId: config.harness,
   connectorTokens: built.connectorTokens,

--- a/test/custom-provider-route.test.ts
+++ b/test/custom-provider-route.test.ts
@@ -59,6 +59,10 @@ test("custom provider lifecycle: register, list, resolve, delete — admin only,
     return new Response(null, { status: 200 });
   });
   try {
+    const before = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(before.status, 200);
+    assert.equal(((await before.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, false);
+
     // Register (validates against the endpoint's /models).
     const put = await fetch(`${srv.base}/v1/admin/custom-providers/acme-gateway`, {
       method: "PUT",
@@ -73,6 +77,9 @@ test("custom provider lifecycle: register, list, resolve, delete — admin only,
 
     // The runtime registry serves the model immediately.
     assert.equal(String(resolveModel("acme-large")?.provider), "acme-gateway");
+    const ready = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(ready.status, 200);
+    assert.equal(((await ready.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, true);
 
     // List never leaks the key.
     const list = await fetch(`${srv.base}/v1/admin/custom-providers`, { headers: ADMIN });
@@ -92,6 +99,9 @@ test("custom provider lifecycle: register, list, resolve, delete — admin only,
     });
     assert.equal(del.status, 200);
     assert.equal(resolveModel("acme-large"), undefined);
+    const after = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(after.status, 200);
+    assert.equal(((await after.json()) as { modelProviderConfigured?: boolean }).modelProviderConfigured, false);
   } finally {
     await srv.close();
   }

--- a/test/public-architecture-docs.test.ts
+++ b/test/public-architecture-docs.test.ts
@@ -39,6 +39,11 @@ test("README describes the shipped Slack topology", () => {
   assert.doesNotMatch(readme, /nothing in the core knows about Slack/);
 });
 
+test("production server receives custom provider dependencies", () => {
+  assert.match(index, /customProviders: built\.customProviders/);
+  assert.match(index, /refreshCustomProviders: built\.refreshCustomProviders/);
+});
+
 test("README names the frameworks the shipped surfaces use", () => {
   assert.ok(rootPackage.dependencies.fastify);
   assert.ok(rootPackage.dependencies["@slack/bolt"]);

--- a/test/turn-options.test.ts
+++ b/test/turn-options.test.ts
@@ -7,6 +7,9 @@ import {
   validateWebTurnModelOptions,
   webTurnRuntimeModelRefusal,
 } from "../src/core/turn-options.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
+
+test.afterEach(() => setCustomProviders([]));
 
 test("triggered turns default to extra-high thinking and non-fast mode", () => {
   assert.deepEqual(turnModelOptions({ triggered: true }), {
@@ -29,6 +32,19 @@ test("web model controls are bounded by admin configuration", () => {
   );
   assert.equal(validateWebTurnModelOptions({ thinkingLevel: "infinite" }, null), "unsupported thinking level");
   assert.equal(validateWebTurnModelOptions({ model: "claude-opus-4-8", thinkingLevel: "high" }, null), null);
+});
+
+test("web model controls allow an active custom provider by default", () => {
+  setCustomProviders([
+    {
+      id: "deepseek",
+      name: "DeepSeek",
+      protocol: "openai",
+      baseUrl: "https://api.deepseek.com",
+      models: [{ id: "deepseek-v4-flash", name: "deepseek-v4" }],
+    },
+  ]);
+  assert.equal(validateWebTurnModelOptions({ model: "deepseek-v4-flash" }, null), null);
 });
 
 test("a resolved scope override outside the configured picker is refused, the org default is not", () => {


### PR DESCRIPTION
## Summary

- wire the custom-provider store and refresh hook into the production core server
- preserve `/admin` subpath routing when the admin UI is served through the portal
- include registered custom models in the web model picker and accept active custom models in web turns
- count an enabled custom provider with a stored key as a configured model provider in `/v1/surface-config`, so non-admin users are not blocked by the portal onboarding gate

## Problem

An admin could successfully register and use an OpenAI-compatible custom provider locally, but a production portal deployment still had several broken handoffs: the core server omitted custom-provider dependencies, the admin proxy lost its subpath, the web picker/turn validator only accepted built-ins, and the portal readiness probe only counted built-in managed keys. The last issue allowed admins with personal overrides to work while ordinary members saw “This deployment isn't set up yet.”

## Tests

```text
node --experimental-test-module-mocks --test \
  test/custom-provider-route.test.ts \
  test/model-credential-route.test.ts \
  test/public-architecture-docs.test.ts \
  test/turn-options.test.ts
```

27 tests passed.

Also validated on a production-style single-host deployment with PostgreSQL, the portal/auth/admin/web processes, and the local Docker sandbox:

- admin custom-provider registration and catalog hydration
- ordinary-member portal access
- organization default/picker selection for the custom model
- a real member-scoped model turn returning successfully

## Screenshots

Pending a clean post-fix capture from the live portal; opening as a draft until that is attached.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788703709&installation_model_id=19911&pr_number=266&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F266&signature=0f7620325cb3a7c842f3d576222e6399ab1fa07e8e7f1212829c8c1ea5de072b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->