### PR TITLE
surface: don't gate the web UI on a provider key when the harness carries its own auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ HARNESS_SECURITY_POSTURE=auto
 #OPENAI_API_KEY=sk-...
 #OPENROUTER_API_KEY=sk-or-...
 
+# HARNESS=claude bills to a Claude subscription instead of a metered provider key.
+# Generate the token with: claude setup-token
+#CLAUDE_CODE_OAUTH_TOKEN=
+
 ORG_ID=acme
 PORT=8080
 

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -4,6 +4,7 @@ import type { Skill, SkillResolution } from "../../skills/skill-store.ts";
 import { ByteSourceTooLargeError } from "../../files/durable-byte-store.ts";
 import {
   defaultModelForHarness,
+  harnessSuppliesOwnModelAuth,
   isHarnessId,
   modelProviderAvailabilityFor,
   modelSupportedByHarness,
@@ -1038,7 +1039,11 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
     webuiModels: configuredPicker.length ? configuredPicker : allowed,
     baseModel: resolvedBase,
     harnessId,
-    ...(managedKeys ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) } : {}),
+    ...(managedKeys
+      ? {
+          modelProviderConfigured: Object.values(managedKeys).some(Boolean) || harnessSuppliesOwnModelAuth(harnessId),
+        }
+      : {}),
     externalSlackParticipants,
     ...(Object.keys(resolvedBranding).length ? { branding: resolvedBranding } : {}),
   });

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -220,6 +220,12 @@ export function serviceableModelIds(ids: readonly string[], providers: ModelProv
 
 export const ALL_PROVIDERS_AVAILABLE: ModelProviderAvailability = { anthropic: true, openai: true, openrouter: true };
 
+export const NO_PROVIDERS_AVAILABLE: ModelProviderAvailability = {
+  anthropic: false,
+  openai: false,
+  openrouter: false,
+};
+
 export function modelProviderAvailabilityFor(
   harness: string,
   configKeys: ModelProviderAvailability,
@@ -231,8 +237,12 @@ export function modelProviderAvailabilityFor(
   return ALL_PROVIDERS_AVAILABLE;
 }
 
+export function harnessSuppliesOwnModelAuth(harness: string): boolean {
+  return Object.values(modelProviderAvailabilityFor(harness, NO_PROVIDERS_AVAILABLE)).some(Boolean);
+}
+
 export function onlyProvider(provider: ModelProvider): ModelProviderAvailability {
-  return { anthropic: false, openai: false, openrouter: false, [provider]: true };
+  return { ...NO_PROVIDERS_AVAILABLE, [provider]: true };
 }
 
 export function defaultModelForProvider(harness: string, provider: ModelProvider): string | undefined {

--- a/test/pi-models.test.ts
+++ b/test/pi-models.test.ts
@@ -5,6 +5,7 @@ import {
   auxiliaryModelForProvider,
   defaultModelForHarness,
   defaultModelForProvider,
+  harnessSuppliesOwnModelAuth,
   modelServiceable,
   modelSupportedByHarness,
   onlyProvider,
@@ -173,5 +174,13 @@ test("context token budget is half of each model's real input room", () => {
   for (const m of SELECTABLE_BASE_MODELS) {
     const budget = contextTokenBudgetForModel(m.id);
     assert.ok(budget !== undefined && budget >= 60_000, `${m.id} budget ${budget} suspiciously small`);
+  }
+});
+
+test("harnesses that carry their own model auth are exactly the ones needing no provider key", () => {
+  assert.equal(harnessSuppliesOwnModelAuth("claude"), true);
+  assert.equal(harnessSuppliesOwnModelAuth("mock"), true);
+  for (const harness of ["pi", "opencode", "codex"]) {
+    assert.equal(harnessSuppliesOwnModelAuth(harness), false, `${harness} bills through a provider key`);
   }
 });


### PR DESCRIPTION
Fixes #268

Heads up: CONTRIBUTING.md asks for text rather than code, so treat this as the report and take or discard the patch as you prefer. Happy to move it to an issue or an `adrs/` note instead.

## What happens

On `HARNESS=claude` with no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` configured, every web navigation 302s to `/admin/onboarding` and the web UI is unreachable. The only action offered there is pasting a provider key that the Claude Code harness never uses.

## Why

`getSurfaceConfig` in `src/api/routes/surface.ts` computes the flag straight off stored credential availability:

```ts
...(managedKeys ? { modelProviderConfigured: Object.values(managedKeys).some(Boolean) } : {}),
```

`plugins/portal/src/index.ts` then redirects on `modelProviderConfigured === false`.

That check is harness-blind, and `modelProviderAvailabilityFor` in `src/model/pi-models.ts` already encodes the opposite for this harness — it returns `ALL_PROVIDERS_AVAILABLE` for `claude` because the CLI authenticates itself and never bills through a provider key. `claude-harness.ts` never reads `providerKeys` at all.

## The change

Names that property once, derived from `modelProviderAvailabilityFor` so there's a single source of truth, and ORs it into the gate.

The gate can only widen. `pi`, `opencode` and `codex` all evaluate exactly as before, and the key-configured path is untouched. `onlyProvider` picks up the new constant to drop a duplicated literal.

## Verification

`npm run typecheck`, `oxlint`, and `prettier` clean. 24 tests pass across `pi-models`, `base-model-serviceability`, `webui-model-allowlist`, and `plugins/portal/test/onboarding-redirect` (all 5 onboarding-redirect cases still pass, including "once a provider is configured, admin HTML navigation proxies to web-ui again").

Against a local dev instance on `HARNESS=claude` with no provider key: before, `/` 302s to `/admin/onboarding`; after, `/` serves the web UI, the composer shows the Claude Code harness with Opus 5, and the turn proceeds to the CLI's own auth (`Not logged in - Please run /login`), which is the expected next step rather than the gate.

I can attach before/after screenshots of the portal if useful.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707505&installation_model_id=19911&pr_number=267&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F267&signature=3dcd1f1646932f19af3d73296e058fa1c50af01ff6b42dd823b0ba43174a0820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
