### PR TITLE
ADR: qm doctor could catch a base model the endpoint no longer serves

### DIFF
--- a/adrs/doctor-verify-base-model.md
+++ b/adrs/doctor-verify-base-model.md
@@ -1,0 +1,56 @@
+# `qm doctor` could catch a base model that the endpoint no longer serves
+
+We run the base model on our own OpenAI-compatible gateway, reached with
+`HARNESS=claude` plus `ANTHROPIC_BASE_URL`, and no `modelProvider` — so `qm doctor`
+correctly refuses to live-check a vendor key against api.anthropic.com. It reports:
+
+```
+· base model: no modelProvider set — an administrator supplies the key from the Admin page
+```
+
+Then someone tidied the gateway's aliases. The model id in our `CLAUDE_MODEL` stopped
+existing, and calls started coming back as:
+
+```
+400 anthropic_messages: Invalid model name passed in model=<id>.
+    Call `/v1/models` to view available models for your key.
+```
+
+Every agent turn failed. `qm check` passed. `qm doctor` passed. `qm up` deployed happily,
+`qm check --live` agreed the live deployment matched the directory — because it does; the
+directory was the thing that was wrong. Nothing in the gate order looks at whether the
+model id resolves, so the deployment was green end to end while being completely dead.
+
+That is the part worth fixing. A wrong model id is not an exotic failure: the id is a
+plain string in config, the gateway that serves it is operated by someone else, and there
+is no signal until a user gets a broken turn.
+
+## The check we'd suggest
+
+When `ANTHROPIC_BASE_URL` is set, have `doctor` ask that endpoint for its model listing
+and confirm `CLAUDE_MODEL` appears in it.
+
+The machinery already exists. `validateKey` in `src/api/routes/admin/custom-providers.ts`
+already talks to `${baseUrl}/v1/models` with the anthropic protocol headers — it just
+discards everything but `response.ok`. Reading the ids out of that same response is the
+whole change.
+
+Two things we'd guard, learned from the code as it stands:
+
+- Not every gateway implements a listing. The custom-provider route already accounts for
+  this with `{"validate": false}`, and the comment there says so. A missing or non-JSON
+  listing should be a skip with a note, not a failure — same posture as the rest of
+  `doctor`.
+- The check belongs to `doctor` rather than `check`: it is an external, read-only probe of
+  someone else's service, which is exactly the line the two commands already draw.
+
+## What we did meanwhile
+
+A shell script in our own deployment layer that reads `CLAUDE_MODEL` and
+`ANTHROPIC_BASE_URL` out of the config, queries `/v1/models`, and exits non-zero when the
+id is absent, printing what the endpoint does offer. It runs first in our gate order. It
+is nine lines of logic and it would have turned a silent outage into a refused deploy, so
+it seems worth having in the tool rather than in every operator's layer.
+
+Happy to test any shape of this against a live third-party gateway — that is the case that
+is awkward to reproduce with a vendor endpoint.


### PR DESCRIPTION
We run the base model on our own OpenAI-compatible gateway — `HARNESS=claude` plus `ANTHROPIC_BASE_URL`, no `modelProvider` — so `doctor` correctly declines to live-check a vendor key and reports `base model: no modelProvider set`.

Then the gateway's aliases were tidied and the id in `CLAUDE_MODEL` stopped existing. Calls came back `400 Invalid model name passed in model=<id>`. Every agent turn failed — while `qm check` passed, `qm doctor` passed, `qm up` deployed, and `qm check --live` confirmed the live deployment matched the directory. It did match; the directory was what was wrong. Nothing in the gate order resolves the model id, so the deploy was green end to end while completely dead.

The suggestion: when `ANTHROPIC_BASE_URL` is set, have `doctor` ask that endpoint for its model listing and confirm `CLAUDE_MODEL` is in it. `validateKey` in `src/api/routes/admin/custom-providers.ts` already talks to `${baseUrl}/v1/models` with the anthropic headers and throws away everything but `response.ok` — reading the ids out of that same response is the whole change.

Two guards we'd suggest from the code as it stands: a gateway may not implement a listing at all (the custom-provider route already handles this with `validate: false`), so a missing or non-JSON listing should skip with a note rather than fail; and this belongs in `doctor` rather than `check`, being an external read-only probe.

Meanwhile we put a nine-line script in our own deployment layer that does exactly this and runs first in our gate order. It turns a silent outage into a refused deploy, which is why it seems worth having in the tool instead of in every operator's layer.

Happy to test any shape of this against a live third-party gateway.

https://claude.ai/code/session_01AnKuftwBchrSLpfQkzBHUE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788753163&installation_model_id=19911&pr_number=280&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F280&signature=3e5d7550e855130f44d79b961b85263b30767d357e98ee8a1baa6be0d47d9ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->