### PR TITLE
fix(portal): align private OIDC broker validation

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -802,14 +802,22 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
   const env = config.env.portal ?? {};
   const issuer = env.OIDC_ISSUER?.trim() || "https://slack.com";
   const jwksUri = env.OIDC_JWKS_URI?.trim();
+  const brokerUpstream = env.AUTH_BROKER_UPSTREAM?.trim();
+  const brokerOrigin = privateNetworkOrigin(brokerUpstream);
+  if (brokerUpstream !== undefined && !brokerOrigin) {
+    throw new CliError(`${path}: env.portal.AUTH_BROKER_UPSTREAM must address a private-network host`);
+  }
   if (issuer !== "https://slack.com" && isMissingOrPlaceholder(jwksUri)) {
     throw new CliError(`${path}: portal requires env.portal.OIDC_JWKS_URI when using a non-Slack OIDC issuer`);
   }
   if (jwksUri !== undefined) {
     try {
-      if (new URL(jwksUri).protocol !== "https:") throw new Error("protocol");
+      const jwks = new URL(jwksUri);
+      if (jwks.protocol !== "https:" && (!brokerOrigin || jwks.origin !== brokerOrigin)) throw new Error("protocol");
     } catch {
-      throw new CliError(`${path}: env.portal.OIDC_JWKS_URI must be a non-placeholder HTTPS URL`);
+      throw new CliError(
+        `${path}: env.portal.OIDC_JWKS_URI must be a non-placeholder HTTPS URL or use the configured private broker origin`,
+      );
     }
   }
   if (env.OIDC_CLIENT_ID !== undefined && isMissingOrPlaceholder(env.OIDC_CLIENT_ID)) {
@@ -854,6 +862,33 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
       `${path}: portal requires OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, or a non-placeholder PORTAL_EXPECTED_TEAM_ID in env.portal or the target secret store`,
     );
   }
+}
+
+function privateNetworkOrigin(raw: string | undefined): string {
+  if (!raw) return "";
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return "";
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const privateHost =
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    !host.includes(".") ||
+    host.endsWith(".internal") ||
+    host.endsWith(".flycast") ||
+    host.endsWith(".local") ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^192\.168\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    host === "::1" ||
+    host === "0:0:0:0:0:0:0:1" ||
+    /^f[cd][0-9a-f]{2}:/.test(host);
+  return privateHost ? url.origin : "";
 }
 
 function validateAwsFrontDoor(config: QmConfig, path: string): void {

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -113,6 +113,41 @@ test("doctor rejects missing and placeholder portal OIDC client ids and tenant g
   );
 });
 
+test("portal trust accepts cleartext JWKS only on the configured private broker origin", () => {
+  const { sandbox: _sandbox, ...withoutSandbox } = config;
+  void _sandbox;
+  const portalConfig: QmConfig = {
+    ...withoutSandbox,
+    services: ["core", "portal"],
+    env: {
+      portal: {
+        OIDC_CLIENT_ID: "real-client-id",
+        OIDC_ISSUER: "https://agent.example.com/idp",
+        OIDC_JWKS_URI: "http://auth:8080/.well-known/jwks.json",
+        AUTH_BROKER_UPSTREAM: "http://auth:8080",
+        PORTAL_EXPECTED_TEAM_ID: "T123",
+      },
+    },
+  };
+
+  assert.doesNotThrow(() => validatePortalTrust(portalConfig));
+  const portal = portalConfig.env.portal!;
+  const { AUTH_BROKER_UPSTREAM: _broker, ...withoutBroker } = portal;
+  void _broker;
+  for (const rejectedPortal of [
+    withoutBroker,
+    { ...portal, AUTH_BROKER_UPSTREAM: "http://other.internal:8080" },
+    { ...portal, AUTH_BROKER_UPSTREAM: "http://auth:8081" },
+    { ...portal, AUTH_BROKER_UPSTREAM: "https://auth:8080" },
+    { ...portal, AUTH_BROKER_UPSTREAM: "https://auth.example.com" },
+  ]) {
+    assert.throws(
+      () => validatePortalTrust({ ...portalConfig, env: { portal: rejectedPortal } }),
+      /private broker|private-network host|HTTPS URL/,
+    );
+  }
+});
+
 test("Fly doctor requires the signing secret for source plugins absent from config", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-fly-doctor-"));
   const bin = join(dir, "fake-fly.cjs");

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -305,7 +305,7 @@ export function isPrivateNetworkUrl(raw: string): boolean {
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") return false;
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "localhost" || host.endsWith(".localhost") || !host.includes(".")) return true;
   if (host.endsWith(".internal") || host.endsWith(".flycast") || host.endsWith(".local")) return true;
   if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
   if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) return true;

--- a/plugins/portal/test/broker-proxy.test.ts
+++ b/plugins/portal/test/broker-proxy.test.ts
@@ -184,6 +184,7 @@ test("isPrivateNetworkUrl admits only unroutable hosts", () => {
   for (const url of [
     "http://qm-auth.internal:8080",
     "http://qm-web-ui.flycast",
+    "http://auth:8080",
     "http://localhost:8099",
     "http://127.0.0.1:8099",
     "http://10.1.2.3:8080",


### PR DESCRIPTION
## Summary

- accept Docker single-label service names as private Portal broker hosts, preserving the original author and commit from #188
- permit cleartext JWKS only when it shares the exact origin of a configured private-network auth broker
- reject missing, cross-origin, different-port, different-scheme, and publicly addressed broker exceptions
- bump the CLI package for the shipped behavior change

This combines the runtime fix from #188 with the matching CLI validation contract so `qm doctor` and Portal startup accept and reject the same deployment shapes.

## Validation

- Portal broker proxy tests: 10 passed
- CLI affected tests: 67 passed
- CLI package tests: 2 passed
- CLI and Portal typechecks
- affected ESLint and Prettier checks
- outgoing-history privacy and binary scan

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788762749&installation_model_id=19911&pr_number=287&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F287&signature=310dc74a865bde9e075ed71d315bbe5506be7bcf38a161bf38c589dfb964a0cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->