### PR TITLE
Surface MicroVM image build failures and pin a current gh package

### DIFF
--- a/aws/microvm-agent/Dockerfile
+++ b/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh-2.97.0-1 \
   && dnf clean all \
   && gh --version
 

--- a/cli/src/commands/infra.ts
+++ b/cli/src/commands/infra.ts
@@ -352,6 +352,35 @@ function getImageVersion(awsBin: string, region: string, imageArn: string, image
   ) as ImageVersionSummary;
 }
 
+function latestMicrovmImageBuildReason(
+  awsBin: string,
+  region: string,
+  imageArn: string,
+  imageVersion: string,
+): string | undefined {
+  try {
+    const parsed = JSON.parse(
+      capture(awsBin, [
+        "lambda-microvms",
+        "list-microvm-image-builds",
+        "--image-identifier",
+        imageArn,
+        "--image-version",
+        imageVersion,
+        "--region",
+        region,
+        "--output",
+        "json",
+        "--no-cli-pager",
+      ]),
+    ) as { items?: Array<{ stateReason?: string; buildState?: string }> };
+    const failed = (parsed.items ?? []).filter((item) => item.buildState === "FAILED" && item.stateReason?.trim());
+    return failed[0]?.stateReason?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function waitForImageVersion(
   awsBin: string,
   region: string,
@@ -369,9 +398,9 @@ async function waitForImageVersion(
     }
     if (version.state === "SUCCESSFUL" && version.status === "ACTIVE") return;
     if (version.state === "FAILED") {
-      throw new CliError(
-        `MicroVM image version ${imageVersion} failed${version.stateReason ? `: ${version.stateReason}` : ""}`,
-      );
+      const buildReason = latestMicrovmImageBuildReason(awsBin, region, imageArn, imageVersion);
+      const reason = buildReason || version.stateReason;
+      throw new CliError(`MicroVM image version ${imageVersion} failed${reason ? `: ${reason}` : ""}`);
     }
     if (["DELETING", "DELETED", "DELETE_FAILED"].includes(version.state)) {
       throw new CliError(`MicroVM image version ${imageVersion} entered unexpected state ${version.state}`);
@@ -484,6 +513,8 @@ async function buildAwsMicrovmImageLocked(
             baseImageArn,
             "--build-role-arn",
             buildRoleArn,
+            "--logging",
+            `cloudWatch={logGroup=/aws/lambda/microvms/${imageName}}`,
             "--client-token",
             `${digest}-${randomUUID()}`,
             "--region",

--- a/cli/templates/aws/microvm-agent/Dockerfile
+++ b/cli/templates/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.96.0-1 \
+  && dnf install -y gh-2.97.0-1 \
   && dnf clean all \
   && gh --version
 


### PR DESCRIPTION
## Summary
- Pin the MicroVM guest image `gh` package to a version present in the GitHub CLI yum repo so image builds do not fail on a stale pin.
- Pass CloudWatch logging on `create-microvm-image` / `update-microvm-image`.
- When an image version fails, surface `stateReason` from `list-microvm-image-builds` in the CLI error instead of only the coarse version-level reason.

## Test plan
- [ ] `qm infra build-image` against an AWS account with the MicroVM build role succeeds (or, on failure, prints the concrete yum/build reason from CloudWatch/`list-microvm-image-builds`).
- [ ] Confirm `/aws/lambda/microvms/<image-name>` receives build log streams when logging is enabled.
- [ ] Confirm `cli/templates/aws/microvm-agent/Dockerfile` and `aws/microvm-agent/Dockerfile` stay identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788800642&installation_model_id=19911&pr_number=291&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F291&signature=7789ea1cd6f82037a8a64781a32d17e642b8bd6d880f6a01ac9f0b5fd4b21b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->