### PR TITLE
api: preserve source auth for source-only routes

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -257,7 +257,7 @@ async function gate(
       await deps.identity.refresh();
       if (deps.identity.classify(actor.p).type !== "internal") actor = null;
     }
-    if (!isPublicRoute && requirePortalIdentity) {
+    if (!isPublicRoute && routeAuth !== "source" && requirePortalIdentity) {
       const webTurn =
         method === "POST" &&
         pathname === "/v1/turns" &&

--- a/test/auth-gate.test.ts
+++ b/test/auth-gate.test.ts
@@ -227,3 +227,23 @@ test("egress-audit ingest requires source auth: unsigned is 401, signed lands â€
     await srv.close();
   }
 });
+
+test("source-only run reads remain available under portal-identity enforcement", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "auth-run-read-")) }));
+  const server = createServer(built.app, {
+    signingSecret: SECRET,
+    runs: built.runs,
+    requireSignedPortalIdentity: true,
+    capabilitySecret: `${SECRET}-cap`,
+    portalIdentitySecret: `${SECRET}-portal`,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    const path = "/v1/runs/missing";
+    const response = await fetch(`${base}${path}`, { headers: sign("GET", path, "") });
+    assert.equal(response.status, 404);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
## Summary

- keep explicitly source-authenticated routes available when portal identity enforcement is enabled
- add a regression test for signed run reads under production-shaped identity enforcement

## Why

Routes declared as source-only already verify their service-to-service signature. Applying the portal identity gate afterward rejects valid surface polling and can make a completed run appear failed to the caller.

## Verification

- `node --experimental-test-module-mocks --test test/auth-gate.test.ts`
- `npm run typecheck`
- `npx eslint src/api/server.ts test/auth-gate.test.ts`
- `npx prettier --check src/api/server.ts test/auth-gate.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788805559&installation_model_id=19911&pr_number=292&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F292&signature=0e13da59d970030eaa82841011020fc677ed13c0df3581a63c11fb5366fcbf9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->