### PR TITLE
adrs: orchestrator-side relaunch of background watcher jobs

### DIFF
--- a/adrs/background-watcher-restart.md
+++ b/adrs/background-watcher-restart.md
@@ -1,0 +1,22 @@
+# Let the orchestrator relaunch background watcher jobs without a model turn
+
+We run a background job in the sandbox that polls an external API and exits when there is
+work for the agent (a monitor on the job wakes the model). It has two other exits that
+carry no work at all: the injected connector token expired (roughly hourly), or its time
+budget ran out. Today every one of those exits still costs a full model turn whose only
+job is to relaunch the watcher and re-arm the monitor — that is ~24 no-op turns per day
+per account, and the growing conversation makes each one dearer than the last. Worse, if
+one of those relaunch turns ever fails (model error, sandbox recycled), watching stops
+silently and nobody finds out until a user asks why the agent ignored them. We had both
+happen; the no-op turns were most of a surprising token bill, and the silent stop cost us
+a stranded user request.
+
+The idea: let a job declare, when it is started, that certain exit codes mean "relaunch me
+with a freshly minted connector token, no model needed" — the orchestrator does the
+relaunch and re-arms the monitor itself, and only the exit that carries actual work wakes
+the model. A natural extension is a declared "keep one of these running" flag so the
+watcher survives sandbox recycling too. With that, model spend for a doc-watching agent
+collapses to exactly the turns where a human actually wrote something.
+
+Happy to talk through the exit-code contract we converged on (0 = work on stdout, 3 =
+token stale, 4 = budget/wedged) if useful.


### PR DESCRIPTION
Feature pitch per CONTRIBUTING — one markdown file under adrs/. Short version: watcher jobs whose exit means "nothing happened, relaunch me with a fresh token" currently cost a full model turn per relaunch (~hourly per account) and stop silently if that turn ever fails; letting the orchestrator own declared relaunch exit codes confines model spend to exits that carry actual work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788832642&installation_model_id=19911&pr_number=294&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F294&signature=966733851cd239abcef1d793f6bda2a276aaeffc6abf2abc253bf633e572afef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->