### PR TITLE
adrs: configurable scope list for the Google OAuth keychain provider

### DIFF
--- a/adrs/google-oauth-scope-config.md
+++ b/adrs/google-oauth-scope-config.md
@@ -1,0 +1,14 @@
+# Configurable scope list for the Google OAuth keychain provider
+
+The Google keychain provider ships a fixed scope list. Our deployment wants two extra
+read-only scopes on the same grant — `drive.activity.readonly` and `directory.readonly` —
+because together they let a tool verify which account actually wrote a Drive comment
+(activity's legacyCommentId joins the comments API id, and People resolves the actor to an
+email). Without them, comment authorship is just display-name text that anyone can fake,
+and we currently run that feature degraded. There is no way to add scopes today short of
+patching core.
+
+The ask: let deployment config extend (or replace) a keychain provider's scope list, with
+the usual re-consent flow when the list changes. Fine if additions are gated somehow —
+scope creep on a shared grant is worth being deliberate about — but the list being
+compiled in means any deployment with a slightly different need has to fork the provider.


### PR DESCRIPTION
Feature pitch per CONTRIBUTING — one markdown file under adrs/. Short version: the Google keychain provider's compiled-in scope list means a deployment wanting two extra read-only scopes (comment-authorship verification via Drive Activity + People) has to patch core; asking for a config-extendable scope list with the normal re-consent flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788832644&installation_model_id=19911&pr_number=295&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F295&signature=1de6e17531d0eaf578f670c41bdcc5ecff60012688c9ba7b90bc2fef16d2dc2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->