### PR TITLE
index: pass the custom provider store to createServer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const server = createServer(built.app, {
   modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
   providerKeys: providerKeysPresent(config),
   modelCredentials: built.modelCredentials,
+  customProviders: built.customProviders,
+  refreshCustomProviders: built.refreshCustomProviders,
   ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
   harnessId: config.harness,
   connectorTokens: built.connectorTokens,


### PR DESCRIPTION
## Problem

Every `/v1/admin/custom-providers` route answers 404, so a custom model provider can never be registered through the admin API.

`buildApp` creates the custom provider store and returns it (`src/wiring.ts`), and the route guard falls back to 404 when the dep is absent (`src/api/routes/admin/custom-providers.ts:58`), but the boot entry (`src/index.ts`) never passes `customProviders` / `refreshCustomProviders` to `createServer`. `ctx.deps.customProviders` is therefore always `undefined` in a real deployment, while the sibling `model-providers` admin endpoints work fine — which makes the 404 look like a routing or auth problem when it is a missing dep.

## Why tests didn't catch it

`test/custom-provider-route.test.ts` and `test/custom-provider-e2e.test.ts` construct their servers with the deps injected directly, so the production assembly path in `src/index.ts` is never exercised. A follow-up could extract the options assembly from `src/index.ts` into a testable helper, but that refactor is beyond this fix.

## Change

Pass the two fields `buildApp` already returns to `createServer`. Two lines.

## Verification

- `npm run typecheck` clean
- `node --test test/custom-provider-route.test.ts test/custom-provider-e2e.test.ts` — 7/7 pass
- Reproduced live before the fix: `PUT /v1/admin/custom-providers/<slug>` → 404 with the request reaching core; after the fix the route reaches the store logic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788841352&installation_model_id=19911&pr_number=298&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F298&signature=69e12f03f51643482852218c2bf950bb2602ad32e74e746127a141753b6010da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->