### PR TITLE
web-ui: render custom-provider models instead of dropping them

### DIFF
--- a/plugins/web-ui/src/model-options.ts
+++ b/plugins/web-ui/src/model-options.ts
@@ -78,7 +78,7 @@ function buildOption(
   id: string,
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, { name: string; provider: string; api?: string }>> = {},
 ): ModelOption | null {
   try {
     const dynamic = catalog[id];
@@ -101,7 +101,7 @@ function buildOptions(
   ids: readonly string[],
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, { name: string; provider: string; api?: string }>> = {},
 ): ModelOption[] {
   const seen = new Set<string>();
   const out: ModelOption[] = [];
@@ -154,7 +154,7 @@ export function applyPickerModelIds(ids: readonly string[] | null | undefined, b
 export function runtimeModelOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, { name: string; provider: string; api?: string }>> = {},
 ): ModelOption[] {
   const options = approvedHarnesses.flatMap((harnessId) => {
     const configured = buildOptions(modelsByHarness[harnessId] ?? [], harnessId, true, catalog);
@@ -170,7 +170,7 @@ export function applyRuntimeOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
   effective: { harnessId: string; modelId: string },
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, { name: string; provider: string; api?: string }>> = {},
 ): void {
   const options = runtimeModelOptions(approvedHarnesses, modelsByHarness, catalog);
   const applied = { options, defaultValue: `${effective.harnessId}:${effective.modelId}` };

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -22,7 +22,7 @@ function builtinModel(id: string): PiModel | undefined {
   return undefined;
 }
 
-export function getBaseModel(id: string, fallback?: { name: string; provider: string }): PiModel {
+export function getBaseModel(id: string, fallback?: { name: string; provider: string; api?: string }): PiModel {
   const builtin = builtinModel(id);
   if (builtin) return builtin;
   const clone = CLONE_TEMPLATES[id];
@@ -30,9 +30,16 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
     const template = builtinModel(clone.template);
     if (template) return cloneModel(template, id, clone.name);
   }
-  if (fallback?.provider === "openrouter") {
-    const template = getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined;
-    if (template) return cloneModel(template, id, fallback.name);
+  if (fallback) {
+    const templateId = fallback.api === "anthropic-messages" ? "claude-sonnet-4-6" : "gpt-5.5";
+    const template =
+      fallback.provider === "openrouter"
+        ? (getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined)
+        : builtinModel(templateId);
+    if (template) {
+      const cloned = cloneModel(template, id, fallback.name);
+      return { ...cloned, provider: fallback.provider, ...(fallback.api ? { api: fallback.api } : {}) } as PiModel;
+    }
   }
   throw new Error(`Unsupported model: ${id}`);
 }

--- a/plugins/web-ui/test/pi-models.test.ts
+++ b/plugins/web-ui/test/pi-models.test.ts
@@ -40,3 +40,25 @@ test("fast-mode support is fed from core's runtime config, not a hardcoded clien
   assert.equal(modelSupportsFastMode(null, "claude-haiku-4-5"), false);
   assert.equal(modelSupportsFastMode(null, undefined), false);
 });
+
+test("web UI resolves custom-provider models regardless of provider id", () => {
+  const openaiProtocol = getBaseModel("acme-large", {
+    name: "Acme Large",
+    provider: "acme",
+    api: "openai-completions",
+  });
+  assert.equal(openaiProtocol.id, "acme-large");
+  assert.equal(openaiProtocol.name, "Acme Large");
+  assert.equal(openaiProtocol.provider, "acme");
+  assert.equal(openaiProtocol.api, "openai-completions");
+
+  const anthropicProtocol = getBaseModel("vendor-messages-model", {
+    name: "Vendor Messages Model",
+    provider: "vendor",
+    api: "anthropic-messages",
+  });
+  assert.equal(anthropicProtocol.provider, "vendor");
+  assert.equal(anthropicProtocol.api, "anthropic-messages");
+
+  assert.throws(() => getBaseModel("still-unknown"), /Unsupported/);
+});

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1164,10 +1164,12 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   const advertisedModelIds = new Set(Object.values(modelsByHarness).flat());
   const modelCatalog = Object.fromEntries(
     [...advertisedModelIds].flatMap((id) => {
-      const model = catalog.find((candidate) => candidate.id === id);
-      if (model) return [[id, { name: model.name, provider: model.provider }]];
       const resolved = resolveModel(id);
-      return resolved ? [[id, { name: resolved.name, provider: resolved.provider }]] : [];
+      const model = catalog.find((candidate) => candidate.id === id);
+      const name = model?.name ?? resolved?.name;
+      const provider = model?.provider ?? resolved?.provider;
+      if (!name || !provider) return [];
+      return [[id, { name, provider, ...(resolved?.api ? { api: resolved.api } : {}) }]];
     }),
   );
   return {


### PR DESCRIPTION
## Problem

Registering a custom model provider promises "the models join the picker" (the admin surface's Custom providers copy), and `/v1/surface-config` does advertise them — but the web-ui model picker never shows them.

## Root cause

`plugins/web-ui/src/pi-models.ts` `getBaseModel()` resolves unknown model ids through a fallback that only accepts `provider === "openrouter"`. Any other custom provider throws `Unsupported model`, and the `catch` in `model-options.ts` silently drops the entry. The file's own leading test is named "resolves models from the shared catalog **without privileging a provider**" — the implementation privileged one.

## Change

Two halves, 4 files:

- `src/api/routes/surface.ts` — surface-config's `modelCatalog` entries now carry the model's `api` protocol alongside `name`/`provider`. `resolveModel()` already resolves custom models and knows their protocol; the route just never shipped it.
- `plugins/web-ui/src/pi-models.ts` — the fallback clones a template picked by that `api` protocol (`anthropic-messages` → the anthropic template, otherwise the openai one; openrouter keeps its existing template) instead of gating on the provider id, and keeps the entry's own `provider`/`api` on the clone so downstream logic doesn't see the template's.
- `plugins/web-ui/src/model-options.ts` — catalog entry type gains the optional `api`.
- `plugins/web-ui/test/pi-models.test.ts` — regression test with a neutral custom provider for both protocols, plus the existing "unknown id still throws" case.

## Verification

- `npm run typecheck` clean
- `node --test plugins/web-ui/test/pi-models.test.ts plugins/web-ui/test/model-options.test.ts` — 18/18 pass
- Reproduced live before the fix: registered custom provider's models advertised by surface-config, absent from the picker; present with the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788862266&installation_model_id=19911&pr_number=303&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F303&signature=273a3bab62f071f0156150cd306fde0572e9d3ad8a92fc8a97bf87b34820e00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->