### PR TITLE
fix: add charset to text file responses

### DIFF
--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -29,6 +29,14 @@ import {
   SHARED_SKILL_TRIGGER_REFUSAL,
 } from "../artifact-share.ts";
 
+function contentTypeForFile(mimetype?: string): string {
+  const contentType = mimetype || "application/octet-stream";
+  if (/^(?:text\/|application\/(?:json|xml)(?:;|$))/i.test(contentType) && !/;\s*charset\s*=/i.test(contentType)) {
+    return `${contentType}; charset=utf-8`;
+  }
+  return contentType;
+}
+
 function isGrant(b: unknown): b is Grant {
   return (
     isObj(b) &&
@@ -252,7 +260,7 @@ async function getFileContent(ctx: ApiCtx): Promise<void> {
   const opened = await app.openFileForViewer(id, viewer);
   if (!opened) return sendJson(res, 404, { error: "not_found" });
   res.writeHead(200, {
-    "content-type": opened.mimetype || "application/octet-stream",
+    "content-type": contentTypeForFile(opened.mimetype),
     "content-length": String(opened.sizeBytes),
     "content-disposition": `inline; filename*=UTF-8''${encodeURIComponent(opened.name)}`,
   });

--- a/test/agent-files-route.test.ts
+++ b/test/agent-files-route.test.ts
@@ -82,6 +82,27 @@ describe("agent files self-API", async () => {
     assert.deepEqual(page.shared, []);
   });
 
+  it("adds UTF-8 to text file content responses", async () => {
+    const res = await get(`/v1/files/${mineId}/content`, await capFor("U1"));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("content-type"), "text/plain; charset=utf-8");
+    assert.equal(Buffer.from(await res.arrayBuffer()).toString("utf8"), "mine");
+
+    await built.files.put({
+      id: "parameterized-text",
+      ownerScopeId: scopeId("personal", "U1"),
+      createdBy: "U1",
+      name: "parameterized.txt",
+      path: "parameterized.txt",
+      mimetype: "text/plain; charset=iso-8859-1",
+      data: Buffer.from("bytes"),
+      direction: "out",
+    });
+    const parameterized = await get("/v1/files/parameterized-text/content", await capFor("U1"));
+    assert.equal(parameterized.status, 200);
+    assert.equal(parameterized.headers.get("content-type"), "text/plain; charset=iso-8859-1");
+  });
+
   it("returns 404 for another principal's file content", async () => {
     const res = await get(`/v1/files/${theirsId}/content`, await capFor("U1"));
     assert.equal(res.status, 404);


### PR DESCRIPTION
## Summary

- add UTF-8 to text, JSON, and XML file content responses when no charset is provided
- preserve explicit charset parameters
- cover the response headers and body with an API regression test

Fixes #305

## Validation

- `node --experimental-test-module-mocks --test test/agent-files-route.test.ts`
- `prettier --check src/api/routes/surface.ts test/agent-files-route.test.ts`
- `eslint src/api/routes/surface.ts test/agent-files-route.test.ts`
- `tsc --noEmit`

`npm ci` completed with the repository lockfile. The local Node.js runtime is v24.11.1 while the repository declares >=24.15.0; the affected test and typecheck passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788869673&installation_model_id=19911&pr_number=306&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F306&signature=0c3c45ae4195742abeab3fde23978599931d0687cb507b1e4eae6ea2723e0ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->