### PR TITLE
Expand ambient judgment backdrop to 30 messages

### DIFF
--- a/src/api/app-ambient.ts
+++ b/src/api/app-ambient.ts
@@ -52,7 +52,7 @@ export function createAmbientHelpers(deps: AppDeps, app: App) {
     const cursor = deps.ambientCursors ? await deps.ambientCursors.get(cursorKey) : null;
     const after = cursor?.lastJudgedTs;
     const all = await deps.surfaceCache.readMessages(container, { limit: 60, noFallback: true });
-    const backdrop = after ? all.filter((m) => m.ts <= after).slice(-10) : [];
+    const backdrop = after ? all.filter((m) => m.ts <= after).slice(-30) : [];
     const rawDelta = (after ? all.filter((m) => m.ts > after) : all).filter((m) => !m.self);
     const ledger = new Map<string, BotPolicy>();
     for (const [name, b] of Object.entries(policy?.bots ?? {})) ledger.set(name.toLowerCase(), b);

--- a/test/surface-cache-ambient.test.ts
+++ b/test/surface-cache-ambient.test.ts
@@ -477,14 +477,14 @@ test("ambient judge: backdrop renders before NEW MESSAGES, absent on the first j
   }
 });
 
-test("ambient judge: backdrop is capped at the last 10 (§2.1)", async () => {
+test("ambient judge: backdrop is capped at the last 30 (§2.1)", async () => {
   const built = freshApp();
   built.runtime.start();
   try {
     const container = "C-bdcap";
     await built.app.setChannelPolicy(container, "watch", "U-admin");
     await built.app.ingestSurfaceEvents(
-      Array.from({ length: 12 }, (_v, i) => ({
+      Array.from({ length: 32 }, (_v, i) => ({
         container,
         ts: `${1000 + i}.0`,
         authorId: `U${i + 1}`,
@@ -493,13 +493,13 @@ test("ambient judge: backdrop is capped at the last 10 (§2.1)", async () => {
       })),
     );
     await sleep(300);
-    await built.app.ingestSurfaceEvents([{ container, ts: "1013.0", authorId: "U13", text: "m13", createdAt: 13 }]);
+    await built.app.ingestSurfaceEvents([{ container, ts: "1033.0", authorId: "U33", text: "m33", createdAt: 33 }]);
     await sleep(300);
     const rows = await listFull(built.ambientJudgments!, { container });
-    const last = rows.find((r: any) => r.prompt?.includes("m13") && r.prompt?.includes("EARLIER CONTEXT"))!;
+    const last = rows.find((r: any) => r.prompt?.includes("m33") && r.prompt?.includes("EARLIER CONTEXT"))!;
     const backdrop = last.prompt!.slice(last.prompt!.indexOf("EARLIER CONTEXT"), last.prompt!.indexOf("NEW MESSAGES"));
     const backdropCount = (backdrop.match(/^U\d+: m\d+$/gm) ?? []).length;
-    assert.equal(backdropCount, 10, "backdrop capped at the last 10");
+    assert.equal(backdropCount, 30, "backdrop capped at the last 30");
     assert.ok(!/: m1$/m.test(backdrop) && !/: m2$/m.test(backdrop), "the oldest messages fell off the cap");
   } finally {
     await built.runtime.stop();


### PR DESCRIPTION
Ambient decisions currently receive only ten already-seen messages even though the surface cache reads a larger batch. Expand the backdrop to the latest thirty messages and lock the cap with the focused ambient integration test.\n\nVerified: the 39 focused surface-cache ambient tests pass, TypeScript typecheck passes, and the diff check is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916895&installation_model_id=19911&pr_number=308&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F308&signature=384c15371115edf3a46f0c62bfe89f80c5eb7d4872cda806884dbc71230c9557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->