### PR TITLE
adr: Mattermost as another agent surface

### DIFF
--- a/adrs/mattermost.md
+++ b/adrs/mattermost.md
@@ -1,0 +1,26 @@
+# Mattermost as another agent surface
+
+We'd like Mattermost alongside Slack and the web UI.
+
+Mattermost is the self-hosted alternative to Slack: free, runs on your own servers,
+and it covers the orgs that can't or won't put their chat in someone else's cloud. We
+self-host everything we run, and a Mattermost bot is how our team would actually talk
+to QM.
+
+The integration surface is close to Slack's: a bot account authenticated with a
+personal access token, an outbound WebSocket for real-time events, and webhooks for
+messages. Like Slack's Socket Mode, there's no public URL, domain or TLS to set up —
+which matters even more for deployments on VPNs or air-gapped networks, where the web
+UI isn't always reachable either.
+
+A few points that came up thinking it through:
+
+- threads are sessions: when a thread is archived or deleted, the sessions bound to it
+  need to close with a reason;
+- Mattermost renders standard markdown, so most of the existing message formatting
+  should carry over as-is;
+- long messages should chunk on paragraph boundaries, never inside a code fence;
+- replies should mention whoever asked, with mentionable roles coming from config.
+
+Same shape as the Discord proposal: a separate service on the chassis, talking to core
+over the HTTP API the way web-ui does, keeps Mattermost opt-in behind a bot token.


### PR DESCRIPTION
Adds a short ADR proposing Mattermost as a surface.

We self-host everything we run, and Mattermost is the natural self-hosted chat surface — it covers the orgs that can't or won't put chat in a third-party cloud. The ADR keeps it short: the integration surface is close to Slack's (bot token, outbound WebSocket, markdown), so hopefully not much new machinery in core.

Happy to help with the surface if there's interest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788934042&installation_model_id=19911&pr_number=309&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F309&signature=68531c7f32d4b2cb4f5ec80d9e93da7c9a0669ba024f8a5e45857481f4ca9945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->