### PR TITLE
Issue run-scoped capabilities for async polling

### DIFF
--- a/src/api/routes/route.ts
+++ b/src/api/routes/route.ts
@@ -25,7 +25,7 @@ export interface ApiCtx extends BaseCtx {
   actor?: PortalIdentity | null;
 }
 
-export type RouteAuth = "either" | "source" | "public" | { aud: string };
+export type RouteAuth = "either" | "source" | "public" | { aud: string; source?: boolean };
 
 export type Route<C extends BaseCtx = ApiCtx> = {
   handle: (ctx: C) => void | Promise<void>;

--- a/src/api/routes/turns.ts
+++ b/src/api/routes/turns.ts
@@ -1,4 +1,6 @@
-import type { TurnOrigin, TurnRequest } from "../../types.ts";
+import { scopeId, type TurnOrigin, type TurnRequest } from "../../types.ts";
+import { CAPABILITY_TTL_MS, mintCapabilityToken, RUN_READ_AUD } from "../../auth/capability-token.ts";
+import { CAPABILITY_HEADER } from "../contract.ts";
 import { resolveTurnOrigin } from "../../core/turn-origin.ts";
 import { sendJson } from "../http.ts";
 import { isObj } from "./shared.ts";
@@ -34,12 +36,30 @@ async function postTurn(ctx: ApiCtx): Promise<void> {
     return sendJson(res, 400, { error: "bad_request", message: "expected a TurnRequest" });
   }
   const wantAsync = url.searchParams.get("async") === "1" || body.async === true;
+  const wantRunCapability = url.searchParams.get("runAccess") === "capability";
   const { ownerKeychainUnion: _ownerKeychainUnion, spawned: _spawned, ...safeBody } = body;
   const resolvedOrigin = publicTurnOrigin(safeBody);
   if (resolvedOrigin.error) return sendJson(res, 400, { error: "bad_request", message: resolvedOrigin.error });
   const origin = resolvedOrigin.origin;
   const result = await app.turn({ ...safeBody, ...(origin ? { origin } : {}), async: wantAsync });
-  if (result.status === "queued") return sendJson(res, 202, result);
+  if (result.status === "queued") {
+    if (!wantRunCapability) return sendJson(res, 202, result);
+    if (!result.runId) return sendJson(res, 500, { error: "internal_error", message: "queued run has no id" });
+    const secret = ctx.deps.capabilitySecret ?? ctx.secret;
+    if (!secret) return sendJson(res, 202, result);
+    const runAccessToken = await mintCapabilityToken(
+      {
+        actorId: safeBody.actor.externalId,
+        scopeId: scopeId("personal", safeBody.actor.externalId),
+        aud: RUN_READ_AUD,
+        runId: result.runId,
+        exp: Date.now() + CAPABILITY_TTL_MS,
+      },
+      secret,
+    );
+    res.setHeader(CAPABILITY_HEADER, runAccessToken);
+    return sendJson(res, 202, result);
+  }
   const status = result.status === "refused" ? 403 : 200;
   return sendJson(res, status, result);
 }
@@ -86,9 +106,12 @@ async function postRunSignal(ctx: ApiCtx): Promise<void> {
 }
 
 async function getRun(ctx: ApiCtx): Promise<void> {
-  const { res, app, actor } = ctx;
+  const { res, app, actor, capability } = ctx;
   const id = ctx.params.id!;
-  const run = await app.getRun(id, actor?.p);
+  if (capability && capability.runId !== id) {
+    return sendJson(res, 404, { error: "not_found" });
+  }
+  const run = await app.getRun(id, actor?.p ?? capability?.actorId);
   if (!run) return sendJson(res, 404, { error: "not_found" });
   return sendJson(res, 200, run);
 }
@@ -157,7 +180,7 @@ export const turnRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "GET", path: "/v1/approvals/:id", auth: "source", handle: getApproval },
   { method: "POST", path: "/v1/runs/:id/delivery-state", auth: "source", handle: postRunDeliveryState },
   { method: "POST", path: "/v1/runs/:id/signal", auth: "source", handle: postRunSignal },
-  { method: "GET", path: "/v1/runs/:id", auth: "source", handle: getRun },
+  { method: "GET", path: "/v1/runs/:id", auth: { aud: RUN_READ_AUD, source: true }, handle: getRun },
   { method: "GET", path: "/v1/runs", auth: "source", handle: getActiveRunForThread },
   { method: "GET", path: "/v1/deliveries", auth: "source", handle: listDeliveries },
   { method: "POST", path: "/v1/deliveries/:id/ack", auth: "source", handle: ackDelivery },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -126,6 +126,15 @@ interface GateResult {
   actor: PortalIdentity | null;
 }
 
+function acceptsSourceAuth(routeAuth: RouteAuth | undefined): boolean {
+  return (
+    routeAuth === undefined ||
+    routeAuth === "source" ||
+    routeAuth === "either" ||
+    (typeof routeAuth === "object" && routeAuth.source === true)
+  );
+}
+
 interface Wiring {
   app: App;
   deps: ServerDeps;
@@ -210,7 +219,7 @@ async function gate(
       sendJson(res, 403, { error: "forbidden", message: "capability token not valid for this route" });
       return null;
     }
-  } else if (requiredAud) {
+  } else if (requiredAud && !acceptsSourceAuth(routeAuth)) {
     sendJson(res, 401, { error: "unauthorized", message: `${requiredAud} capability token required` });
     return null;
   } else if (
@@ -463,8 +472,7 @@ function buildServer(app: App, deps: ServerOptions, allowUnsignedSourceAuth: boo
     if (await dispatch(rawRoutes, base)) return;
     const matched = findRoute(apiRoutes, base.method, base.pathname);
     const routeAuth = matched?.route.auth;
-    const acceptsSourceAuth = !matched || routeAuth === "source" || routeAuth === "either";
-    if (wiring.secret && !capabilityFromHeaders(req) && routeAuth !== "public" && acceptsSourceAuth) {
+    if (wiring.secret && !capabilityFromHeaders(req) && routeAuth !== "public" && acceptsSourceAuth(routeAuth)) {
       const timestamp = Number(req.headers["x-timestamp"] ?? 0);
       if (
         !Number.isFinite(timestamp) ||

--- a/src/auth/capability-token.ts
+++ b/src/auth/capability-token.ts
@@ -10,6 +10,7 @@ export const CREDENTIAL_BROKER_AUD = "credential-broker";
 export const EGRESS_PROXY_AUD = "egress-proxy";
 export const BLOB_TRANSFER_AUD = "blob-transfer";
 export const SECRET_DROP_AUD = "secret-drop";
+export const RUN_READ_AUD = "run-read";
 
 interface BlobGrant {
   dir: "read" | "write";
@@ -34,6 +35,7 @@ export interface CapabilityClaims {
   egress?: EgressPolicy;
   blob?: BlobGrant;
   drop?: string;
+  runId?: string;
   memory?: { write?: ScopeId; orgWrite?: ScopeId; read: ScopeId[] };
   liveActor?: boolean;
   liveAuthor?: boolean;
@@ -81,6 +83,8 @@ export async function verifyCapabilityToken(
   if (claims.liveAuthor !== undefined && typeof claims.liveAuthor !== "boolean") return null;
   if (claims.blob !== undefined && claims.blob?.dir !== "read" && claims.blob?.dir !== "write") return null;
   if (claims.drop !== undefined && typeof claims.drop !== "string") return null;
+  if (claims.runId !== undefined && typeof claims.runId !== "string") return null;
+  if (claims.aud === RUN_READ_AUD && typeof claims.runId !== "string") return null;
   if (now >= claims.exp) return null;
   return claims;
 }

--- a/test/capability-token.test.ts
+++ b/test/capability-token.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   BLOB_TRANSFER_AUD,
   CAPABILITY_TTL_MS,
+  RUN_READ_AUD,
   mintCapabilityToken,
   verifyBlobTransferCapability,
   verifyCapabilityToken,
@@ -73,6 +74,29 @@ test("the wrong secret fails verification", async () => {
 test("an expired token fails closed", async () => {
   assert.equal(
     await verifyCapabilityToken(await mintCapabilityToken(claims({ exp: Date.now() - 1 }), SECRET), SECRET),
+    null,
+  );
+});
+
+test("run-read capabilities require a string run id", async () => {
+  assert.ok(
+    await verifyCapabilityToken(
+      await mintCapabilityToken(claims({ aud: RUN_READ_AUD, runId: "run-1" }), SECRET),
+      SECRET,
+    ),
+  );
+  assert.equal(
+    await verifyCapabilityToken(await mintCapabilityToken(claims({ aud: RUN_READ_AUD }), SECRET), SECRET),
+    null,
+  );
+  assert.equal(
+    await verifyCapabilityToken(
+      await mintCapabilityToken(
+        claims({ aud: RUN_READ_AUD, runId: 1 } as unknown as Partial<CapabilityClaims>),
+        SECRET,
+      ),
+      SECRET,
+    ),
     null,
   );
 });

--- a/test/portal-identity-gate.test.ts
+++ b/test/portal-identity-gate.test.ts
@@ -6,13 +6,15 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildApp, type BuiltApp } from "../src/wiring.ts";
-import { createInsecureTestServer } from "../src/api/server.ts";
+import { createInsecureTestServer, createServer } from "../src/api/server.ts";
 import { mintSignedPayload } from "../src/auth/signed-token.ts";
+import { signedRequestHeaders } from "../src/auth/source-auth-sign.ts";
 import { verifyCapabilityToken } from "../src/auth/capability-token.ts";
 import { testConfig } from "./support/test-config.ts";
 import { scopeId } from "../src/types.ts";
 import { isUnclassifiedWrite } from "../src/api/user-scoped-routes.ts";
 import { authBrokerRoutes } from "../src/api/routes/auth-broker.ts";
+import { CAPABILITY_HEADER } from "../src/api/contract.ts";
 
 const SOURCE = "shared-source-auth-secret-for-tests-0001";
 const CAP = "core-only-capability-secret-for-tests-01";
@@ -65,6 +67,100 @@ describe("user-scoped routes require a portal-verified actor when enforcement is
     try {
       const prodBase = `http://localhost:${(prodServer.address() as AddressInfo).port}`;
       assert.equal((await fetch(`${prodBase}/d/missing/`)).status, 403);
+    } finally {
+      await new Promise<void>((resolve) => prodServer.close(() => resolve()));
+    }
+  });
+
+  it("production issues a run-bound capability for a service to read its queued run", async () => {
+    const prodServer = createServer(built.app, {
+      production: true,
+      signingSecret: SOURCE,
+      capabilitySecret: CAP,
+      portalIdentitySecret: PID,
+    });
+    await new Promise<void>((resolve) => prodServer.listen(0, resolve));
+    try {
+      const prodBase = `http://localhost:${(prodServer.address() as AddressInfo).port}`;
+      const turnPath = "/v1/turns?async=1&runAccess=capability";
+      const turnBody = JSON.stringify({
+        surface: "slack",
+        text: "run capability probe",
+        async: true,
+        actor: { externalId: "U9" },
+        conversation: { kind: "dm", threadRef: "dm:run-capability-probe" },
+      });
+      const queued = await fetch(`${prodBase}${turnPath}`, {
+        method: "POST",
+        headers: signedRequestHeaders(SOURCE, "POST", turnPath, turnBody),
+        body: turnBody,
+      });
+      assert.equal(queued.status, 202);
+      const queuedBody = (await queued.json()) as { runId?: unknown };
+      const runAccessToken = queued.headers.get(CAPABILITY_HEADER);
+      assert.equal(typeof queuedBody.runId, "string");
+      assert.equal(typeof runAccessToken, "string");
+      const ordinaryPath = "/v1/turns?async=1";
+      const ordinaryBody = JSON.stringify({
+        surface: "slack",
+        text: "ordinary async turn",
+        async: true,
+        actor: { externalId: "U9" },
+        conversation: { kind: "dm", threadRef: "dm:ordinary-async-turn" },
+      });
+      const ordinary = await fetch(`${prodBase}${ordinaryPath}`, {
+        method: "POST",
+        headers: signedRequestHeaders(SOURCE, "POST", ordinaryPath, ordinaryBody),
+        body: ordinaryBody,
+      });
+      assert.equal(ordinary.status, 202);
+      assert.equal(ordinary.headers.get(CAPABILITY_HEADER), null);
+      const path = `/v1/runs/${encodeURIComponent(queuedBody.runId as string)}`;
+      assert.equal(
+        (
+          await fetch(`${prodBase}${path}`, {
+            headers: { [CAPABILITY_HEADER]: runAccessToken as string },
+          })
+        ).status,
+        200,
+      );
+      assert.equal(
+        (
+          await fetch(`${prodBase}/v1/runs/another-run`, {
+            headers: { [CAPABILITY_HEADER]: runAccessToken as string },
+          })
+        ).status,
+        404,
+      );
+      assert.equal(
+        (
+          await fetch(`${prodBase}${path}`, {
+            headers: signedRequestHeaders(SOURCE, "GET", path),
+          })
+        ).status,
+        401,
+      );
+      assert.equal(
+        (
+          await fetch(`${prodBase}${path}`, {
+            headers: {
+              ...signedRequestHeaders(SOURCE, "GET", path),
+              "x-portal-identity": await token("U2"),
+            },
+          })
+        ).status,
+        404,
+      );
+      const userPath = "/v1/sessions/missing?viewer=U1";
+      assert.equal(
+        (
+          await fetch(`${prodBase}${userPath}`, {
+            headers: signedRequestHeaders(SOURCE, "GET", userPath),
+          })
+        ).status,
+        401,
+      );
+      assert.equal((await fetch(`${prodBase}${path}`)).status, 401);
     } finally {
       await new Promise<void>((resolve) => prodServer.close(() => resolve()));
     }

--- a/test/route-auth-conformance.test.ts
+++ b/test/route-auth-conformance.test.ts
@@ -3,15 +3,18 @@ import assert from "node:assert/strict";
 import { apiRoutes, rawRoutes } from "../src/api/routes/index.ts";
 import { findRoute, type RouteAuth } from "../src/api/routes/route.ts";
 import { agentApiMatches } from "../src/api/agent-api-catalog.ts";
-import { OAUTH_CONSENT_AUD, CREDENTIAL_BROKER_AUD } from "../src/auth/capability-token.ts";
+import { OAUTH_CONSENT_AUD, CREDENTIAL_BROKER_AUD, RUN_READ_AUD } from "../src/auth/capability-token.ts";
 
 const PUBLIC_ROUTES = new Set<string>();
+const SOURCE_AUD_ROUTES = new Map<string, string>([["GET /v1/runs/sample", RUN_READ_AUD]]);
 const AUD_ROUTES = new Map<string, string>([
   ["POST /v1/connectors/oauth/consent/mint", OAUTH_CONSENT_AUD],
   ["POST /v1/credentials/broker", CREDENTIAL_BROKER_AUD],
 ]);
 function expectedAuth(method: string, pathname: string): RouteAuth {
   if (PUBLIC_ROUTES.has(`${method} ${pathname}`)) return "public";
+  const sourceAud = SOURCE_AUD_ROUTES.get(`${method} ${pathname}`);
+  if (sourceAud) return { aud: sourceAud, source: true };
   const aud = AUD_ROUTES.get(`${method} ${pathname}`);
   if (aud) return { aud };
   if (agentApiMatches(method, pathname)) return "either";


### PR DESCRIPTION
## Summary

- let source-authenticated async callers explicitly request a run polling capability with `runAccess=capability`
- return an audience-, actor-, and run-bound capability in the existing capability response header
- allow that capability to read only its exact run while preserving the Portal identity path for normal source-authenticated reads

## Security properties

- source authentication alone still cannot bypass the Portal identity gate
- production tokens use the isolated capability secret and expire after one hour
- ordinary async turn requests receive no capability
- a capability for one run returns not found for every other run

## Verification

- 96 affected tests pass
- TypeScript typecheck passes
- ESLint, Oxlint, Prettier, and `git diff --check` pass
- independent spec and standards/security reviews report no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788949271&installation_model_id=19911&pr_number=313&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F313&signature=26b3c97d306898ca33e671be98df799c1b2efb660ef6eae069bdbf5302afc588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->