### PR TITLE
adrs: warn on duplicate project names at creation

### DIFF
--- a/adrs/duplicate-project-names.md
+++ b/adrs/duplicate-project-names.md
@@ -1,0 +1,13 @@
+I ran into this while writing up naming conventions for projects.
+
+I understand why project names aren't strictly checked for uniqueness — the project
+list is per-member, so "unique" doesn't really apply.
+
+But it does get awkward. If I forget I already made a project with a name, or someone
+adds me to a project that happens to have the same name as one of mine, I end up with
+two identically named cards in my list.
+
+Duplicate names might be deliberate sometimes, but they're definitely harder to manage.
+
+Would it be better if creating a project checked the list you can already see for a
+matching name, and warned you if there was one? A warning, not a rejection.


### PR DESCRIPTION
A short note for `adrs/` about duplicate project names.

Creating a project doesn't check the list you can already see for a matching name, so
you can end up with two identically named cards — either by forgetting you already made
one, or by being added to someone else's project that happens to share the name.

The note suggests a warning at creation time rather than a block, since a duplicate name
is sometimes deliberate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788973226&installation_model_id=19911&pr_number=320&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F320&signature=6969e74509eff643860f330924c08fcff9ff97d7230edca738ef2fc2754dacc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->