### PR TITLE
adr for named environment labeling in the admin panel

### DIFF
--- a/adrs/named-environment-labeling.md
+++ b/adrs/named-environment-labeling.md
@@ -1,0 +1,17 @@
+Currently the agent has the ability to promote an environment to a named environment, allowing multiple slack channels to essentially share the same VM (super useful if conversations with the same privileged group groups happen across multiple channels).
+
+So I can:
+1. create two channels: #A, and #B
+2. promote #A's channel to a named environment A-permanent
+3. attach #B to A-permanent
+4. now the filesystem and information between #A and #B is shared.
+
+Once this happens however, #B's original scope is fully orphaned, and in the admin panel, editing anything under #B doesn't edit any live information.
+There's also no indication anywhere in the UI that #B is now attached to a different scope.
+
+It would be super helpful if in the admin environment:
+1. there was a list of shared/named environments.
+2. if a an existing channel has been aliased, there is a link to the correct shared environment.
+3. we lock or show a warning if an admin is attempting to edit or debug an orphaned environment.
+
+Nice-to-have as well would be a skill to help with merging or combining two environments together. It's simple enough to prompt the agent into creating handoff docs prior to a detach & reattach, but it's a nice-to-have for teams like ours who started using qm before completely understanding the channel isolation semantics.


### PR DESCRIPTION
Short proposal for being able to view & browse named environments in the admin panel, as well as a warning for when an admin is editing an orphaned environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994078&installation_model_id=19911&pr_number=326&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F326&signature=c4fe90f11e66b391d7dfacaded81519652aebe9bb5ae100c2f86a650854d9aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->