### PR TITLE
Recover local sandboxes when Docker networks are replaced

### DIFF
--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -136,11 +136,23 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     return preflightDone;
   }
 
-  async function containerState(name: string): Promise<{ running: boolean; imageId: string } | null> {
-    const r = await dexec(["inspect", "-f", "{{.State.Running}} {{.Image}}", name]);
+  async function containerState(
+    name: string,
+  ): Promise<{ running: boolean; imageId: string; networkId: string } | null> {
+    const r = await dexec([
+      "inspect",
+      "-f",
+      "{{.State.Running}} {{.Image}} {{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}",
+      name,
+    ]);
     if (r.code !== 0) return null;
-    const [running = "", imageId = ""] = r.stdout.trim().split(/\s+/);
-    return { running: running === "true", imageId };
+    const [running = "", imageId = "", networkId = ""] = r.stdout.trim().split(/\s+/);
+    return { running: running === "true", imageId, networkId };
+  }
+
+  async function containerNetworkIsCurrent(name: string, networkId: string): Promise<boolean> {
+    const r = await dexec(["network", "inspect", "-f", "{{.Id}}", localNetworkName(name)]);
+    return r.code === 0 && !!networkId && r.stdout.trim() === networkId;
   }
 
   async function resolvePort(name: string): Promise<number> {
@@ -272,7 +284,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localContainerName(scope);
       scopeByContainer.set(name, scope);
       const state = await containerState(name);
-      if (state && state.imageId === imageId) {
+      if (state && state.imageId === imageId && (await containerNetworkIsCurrent(name, state.networkId))) {
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
@@ -296,11 +308,12 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localScratchName(key);
       scratchByKey.set(key, name);
       const state = await containerState(name);
-      if (state) {
+      if (state && (await containerNetworkIsCurrent(name, state.networkId))) {
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
       }
+      if (state) await dexec(["rm", "-f", name]);
       await runContainer(name, undefined, false);
       activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
       return { name, coldStart: true };

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -148,6 +148,41 @@ test("a stale-image container is recreated while its home volume survives", asyn
   assert.equal(h2.coldStart, false, "existing volume means a warm home");
 });
 
+test("a container with a missing network is recreated while its home volume survives", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const layers = rw(scopeId("personal", "U-network"));
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(layers);
+  const volume = fake.containers.get(h1.id)!.volume!;
+  await firstSandbox.teardown(h1);
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await makeSandbox(fake).provision(layers);
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "container recreated after its network disappeared");
+  assert.equal(fake.volumes.has(volume), true, "volume survived the recreate");
+  assert.equal(fake.networks.has(localNetworkName(h2.id)), true, "network recreated");
+  assert.equal(h2.coldStart, false, "existing volume means a warm home");
+});
+
+test("a container attached to a replaced network is recreated", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const layers = rw(scopeId("personal", "U-replaced-network"));
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(layers);
+  const network = localNetworkName(h1.id);
+  const originalNetworkId = fake.containers.get(h1.id)!.networkId;
+  await firstSandbox.teardown(h1);
+  fake.networks.delete(network);
+  await fake.dockerExec(["network", "create", network]);
+
+  const h2 = await makeSandbox(fake).provision(layers);
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "container recreated after its network was replaced");
+  assert.notEqual(fake.containers.get(h2.id)!.networkId, originalNetworkId);
+  assert.equal(h2.coldStart, false, "existing volume means a warm home");
+});
+
 test("a scratch box has no volume and is removed on teardown", async () => {
   const fake = installFakeDocker(daemonPort);
   const sb = makeSandbox(fake);
@@ -157,6 +192,24 @@ test("a scratch box has no volume and is removed on teardown", async () => {
   assert.equal(fake.containers.get(h.id)!.volume, undefined);
   await sb.teardown(h);
   assert.equal(fake.containers.has(h.id), false, "scratch container destroyed");
+});
+
+test("a scratch box with a missing network is recreated", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(rw(scopeId("personal", "U-scratch-network")), {
+    scratch: { key: "missing-network" },
+  });
+  fake.containers.get(h1.id)!.running = false;
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await makeSandbox(fake).provision(rw(scopeId("personal", "U-scratch-network")), {
+    scratch: { key: "missing-network" },
+  });
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "scratch container recreated after its network disappeared");
+  assert.equal(fake.networks.has(localNetworkName(h2.id)), true, "scratch network recreated");
+  assert.equal(h2.coldStart, true);
 });
 
 test("teardown destroy removes both the container and its volume", async () => {

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -6,6 +6,8 @@ export interface FakeContainer {
   running: boolean;
   labels: Record<string, string>;
   volume?: string;
+  network?: string;
+  networkId?: string;
 }
 
 export interface FakeDocker {
@@ -24,6 +26,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const containers = new Map<string, FakeContainer>();
   const volumes = new Set<string>();
   const networks = new Set<string>();
+  const networkIds = new Map<string, string>();
+  let networkGeneration = 0;
   const self: FakeDocker = {
     containers,
     volumes,
@@ -48,6 +52,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const [k = "", v = ""] = args[++i]!.split("=");
         c.labels[k] = v;
       } else if (a === "-v") c.volume = args[++i]!.split(":")[0]!;
+      else if (a === "--network") c.network = args[++i]!;
       else if (a === "-p" || a === "--cpus" || a === "--memory") i++;
     }
     return c;
@@ -67,17 +72,24 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const name = rest[rest.length - 1]!;
         const c = containers.get(name);
         if (!c) return fail(`Error: No such object: ${name}`);
-        return ok(`${c.running} ${c.imageId}`);
+        return ok(`${c.running} ${c.imageId} ${c.networkId ?? ""}`);
       }
       case "network": {
-        const [sub, name] = rest as [string, string];
-        if (sub === "inspect") return networks.has(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        const [sub] = rest;
+        const name = rest[rest.length - 1]!;
+        if (sub === "inspect")
+          return networks.has(name) ? ok(networkIds.get(name)!) : fail(`Error: No such network: ${name}`);
         if (sub === "create") {
           if (networks.has(name)) return fail(`network with name ${name} already exists`);
           networks.add(name);
+          networkIds.set(name, `network:${++networkGeneration}:${name}`);
           return ok(name);
         }
-        if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        if (sub === "rm") {
+          if (!networks.delete(name)) return fail(`Error: No such network: ${name}`);
+          networkIds.delete(name);
+          return ok(name);
+        }
         return fail(`unknown network subcommand ${sub}`);
       }
       case "volume": {
@@ -98,6 +110,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const c = parseRun(rest);
         if (self.imageMissing) return fail("Unable to find image");
         if (containers.has(c.name)) return fail(`Conflict. The container name "/${c.name}" is already in use`);
+        if (c.network) c.networkId = networkIds.get(c.network);
         containers.set(c.name, c);
         self.runCount++;
         return ok("deadbeef");
@@ -105,6 +118,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
       case "start": {
         const c = containers.get(rest[0]!);
         if (!c) return fail("Error: No such container");
+        if (c.network && !networks.has(c.network))
+          return fail(`failed to set up container networking: network network:${c.network} not found`);
         c.running = true;
         return ok(rest[0]!);
       }


### PR DESCRIPTION
## Summary

- validate the current Docker network identity before reusing a local sandbox container
- recreate stale persistent containers without deleting their named home volumes
- recreate stale scratch containers and their per-container networks
- model immutable Docker network IDs in the fake runtime and cover missing and replaced networks

## Testing

- `node --experimental-test-module-mocks --test test/local-sandbox.test.ts` (18 passed)
- `npm run typecheck`
- targeted ESLint and Oxlint checks
- Prettier and `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789021837&installation_model_id=19911&pr_number=329&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F329&signature=10d3e581cb9a6014201876affea34b30f79e62b16b249808a3fa712ef5812dad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->