### PR TITLE
fix(api): let source-auth callers read runs under portal enforcement

### DIFF
--- a/src/api/user-scoped-routes.ts
+++ b/src/api/user-scoped-routes.ts
@@ -69,8 +69,6 @@ const USER_SCOPED: Rule[] = [
   pat("POST", "/v1/environments"),
   pat("POST", "/v1/environments/attach"),
   pat("POST", "/v1/emoji"),
-  pat("GET", "/v1/runs/:id"),
-  pat("GET", "/v1/runs"),
   pat("POST", "/v1/runs/:id/signal"),
 ];
 

--- a/test/run-query-source-auth.test.ts
+++ b/test/run-query-source-auth.test.ts
@@ -13,6 +13,7 @@ import { testConfig } from "./support/test-config.ts";
 import { isUserScoped } from "../src/api/user-scoped-routes.ts";
 
 const SECRET = "source-auth-secret-for-run-query-tests-01";
+const CAP = "core-only-capability-secret-for-tests-01";
 const PID = "portal-only-identity-secret-for-tests-01";
 
 describe("run queries authenticate with source auth under production portal enforcement", () => {
@@ -23,6 +24,7 @@ describe("run queries authenticate with source auth under production portal enfo
     const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "run-query-auth-")) }));
     server = createServer(built.app, {
       signingSecret: SECRET,
+      capabilitySecret: CAP,
       portalIdentitySecret: PID,
       requireSignedPortalIdentity: true,
       scheduler: built.scheduler,

--- a/test/run-query-source-auth.test.ts
+++ b/test/run-query-source-auth.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createServer } from "../src/api/server.ts";
+import { signRequest } from "../src/auth/source-auth.ts";
+import { mintSignedPayload } from "../src/auth/signed-token.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+import { isUserScoped } from "../src/api/user-scoped-routes.ts";
+
+const SECRET = "source-auth-secret-for-run-query-tests-01";
+const PID = "portal-only-identity-secret-for-tests-01";
+
+describe("run queries authenticate with source auth under production portal enforcement", () => {
+  let server: Server;
+  let base: string;
+
+  before(async () => {
+    const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "run-query-auth-")) }));
+    server = createServer(built.app, {
+      signingSecret: SECRET,
+      portalIdentitySecret: PID,
+      requireSignedPortalIdentity: true,
+      scheduler: built.scheduler,
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  const signed = (method: string, pathWithQuery: string, body = "", secret = SECRET): Record<string, string> => {
+    const ts = Math.floor(Date.now() / 1000);
+    return {
+      "content-type": "application/json",
+      "x-timestamp": String(ts),
+      "x-signature": signRequest(secret, ts, `${method}\n${pathWithQuery}\n${body}`),
+    };
+  };
+
+  const get = (pathWithQuery: string, headers?: Record<string, string>): Promise<Response> =>
+    fetch(`${base}${pathWithQuery}`, { headers: headers ?? signed("GET", pathWithQuery) });
+
+  it("reaches the handler for a single run instead of failing the portal gate", async () => {
+    const res = await get("/v1/runs/run-that-does-not-exist");
+    assert.notEqual(res.status, 401);
+    assert.equal(res.status, 404);
+  });
+
+  it("reaches the handler for a thread lookup instead of failing the portal gate", async () => {
+    const res = await get("/v1/runs?threadRef=surface%3Atenant%3Achat");
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { runId: null });
+  });
+
+  it("still admits the system turn submission that surfaces already rely on", async () => {
+    const path = "/v1/turns";
+    const body = JSON.stringify({});
+    const res = await fetch(`${base}${path}`, { method: "POST", headers: signed("POST", path, body), body });
+    assert.notEqual(res.status, 401);
+  });
+
+  it("stays closed to an unsigned run query", async () => {
+    assert.equal((await get("/v1/runs/any", { "content-type": "application/json" })).status, 401);
+    assert.equal((await get("/v1/runs?threadRef=t", { "content-type": "application/json" })).status, 401);
+  });
+
+  it("stays closed to a run query signed with the wrong secret", async () => {
+    const path = "/v1/runs/any";
+    assert.equal((await get(path, signed("GET", path, "", PID))).status, 401);
+  });
+
+  it("keeps requiring a portal identity on routes that really are user scoped", async () => {
+    const path = "/v1/sessions/nope?viewer=U1";
+    assert.equal((await get(path)).status, 401);
+    const token = await mintSignedPayload({ p: "U1", exp: Date.now() + 60_000 }, PID);
+    assert.equal((await get(path, { ...signed("GET", path), "x-portal-identity": token })).status, 404);
+  });
+
+  it("classifies run queries as system rather than user scoped", () => {
+    assert.equal(isUserScoped("GET", "/v1/runs/run-1"), false);
+    assert.equal(isUserScoped("GET", "/v1/runs"), false);
+    assert.equal(isUserScoped("GET", "/v1/sessions/s-1"), true);
+    assert.equal(isUserScoped("GET", "/v1/memory"), true);
+  });
+});


### PR DESCRIPTION
## Problem

The run read routes declare source authentication, but they were also classified as user-scoped. When signed portal identity enforcement is enabled, a correctly source-signed caller without a portal identity is rejected before the run handler executes.

These read routes do not carry a caller-provided actor field, so the user-scoped classification adds a second authentication requirement without binding the request to a user.

## Change

- Remove `GET /v1/runs/:id` and `GET /v1/runs` from the user-scoped route table.
- Add an integration regression covering source-signed reads, unsigned and incorrectly signed requests, a system turn submission, and a route that must remain user-scoped.

The write route `POST /v1/runs/:id/signal` keeps its existing classification.

## Security

The read routes remain fail-closed. A request without a capability token still has to pass source-auth verification before it reaches the portal identity gate. The regression also provisions distinct source, capability, and portal identity secrets to exercise the production isolation contract.

## Verification

- `node --test test/run-query-source-auth.test.ts` — 7 passed, 0 failed
- `npm run typecheck`
- `npm run lint`
- `npm run lint:ox`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789033566&installation_model_id=19911&pr_number=332&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F332&signature=cf7a1233ef469b5da5efc9f54ba3525ad307fa9fc8acd36c1226d2bcc804ea1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->