### PR TITLE
Custom model providers are unreachable: wire the store, and stop the picker discarding their models

### DIFF
--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -473,7 +473,7 @@ export interface RuntimeConfig {
   scopeId: string;
   approvedHarnesses: string[];
   modelsByHarness: Record<string, string[]>;
-  modelCatalog: Record<string, { name: string; provider: string }>;
+  modelCatalog: Record<string, { name: string; provider: string; api?: "openai-completions" | "anthropic-messages"; baseUrl?: string }>;
   orgDefault: { harnessId: string; modelId: string; effortLevel?: string; fastMode?: boolean; revision: number };
   scopeOverride: {
     harnessId: string;

--- a/plugins/web-ui/src/model-options.ts
+++ b/plugins/web-ui/src/model-options.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getBaseModel } from "./pi-models.ts";
+import { getBaseModel, type CatalogEntry } from "./pi-models.ts";
 
 export type ModelOptionValue = string;
 export interface ModelOption {
@@ -78,7 +78,7 @@ function buildOption(
   id: string,
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, CatalogEntry>> = {},
 ): ModelOption | null {
   try {
     const dynamic = catalog[id];
@@ -101,7 +101,7 @@ function buildOptions(
   ids: readonly string[],
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, CatalogEntry>> = {},
 ): ModelOption[] {
   const seen = new Set<string>();
   const out: ModelOption[] = [];
@@ -154,7 +154,7 @@ export function applyPickerModelIds(ids: readonly string[] | null | undefined, b
 export function runtimeModelOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, CatalogEntry>> = {},
 ): ModelOption[] {
   const options = approvedHarnesses.flatMap((harnessId) => {
     const configured = buildOptions(modelsByHarness[harnessId] ?? [], harnessId, true, catalog);
@@ -170,7 +170,7 @@ export function applyRuntimeOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
   effective: { harnessId: string; modelId: string },
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, CatalogEntry>> = {},
 ): void {
   const options = runtimeModelOptions(approvedHarnesses, modelsByHarness, catalog);
   const applied = { options, defaultValue: `${effective.harnessId}:${effective.modelId}` };

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -22,7 +22,19 @@ function builtinModel(id: string): PiModel | undefined {
   return undefined;
 }
 
-export function getBaseModel(id: string, fallback?: { name: string; provider: string }): PiModel {
+export interface CatalogEntry {
+  name: string;
+  provider: string;
+  api?: "openai-completions" | "anthropic-messages";
+  baseUrl?: string;
+}
+
+const PROTOCOL_TEMPLATES: Readonly<Record<NonNullable<CatalogEntry["api"]>, { provider: string; id: string }>> = {
+  "openai-completions": { provider: "openrouter", id: "openrouter/auto" },
+  "anthropic-messages": { provider: "anthropic", id: "claude-opus-4-8" },
+};
+
+export function getBaseModel(id: string, fallback?: CatalogEntry): PiModel {
   const builtin = builtinModel(id);
   if (builtin) return builtin;
   const clone = CLONE_TEMPLATES[id];
@@ -31,14 +43,25 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
     if (template) return cloneModel(template, id, clone.name);
   }
   if (fallback) {
-    const template = getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined;
-    if (template) return cloneModel(template, id, fallback.name);
+    const protocol = PROTOCOL_TEMPLATES[fallback.api ?? "openai-completions"];
+    const template = getModel(
+      protocol.provider as Parameters<typeof getModel>[0],
+      protocol.id as Parameters<typeof getModel>[1],
+    ) as PiModel | undefined;
+    if (template) return cloneModel(template, id, fallback.name, fallback);
   }
   throw new Error(`Unsupported model: ${id}`);
 }
 
-function cloneModel(model: PiModel, id: string, name: string): PiModel {
-  return { ...structuredClone(model), id, name };
+function cloneModel(model: PiModel, id: string, name: string, identity?: CatalogEntry): PiModel {
+  const clone = { ...structuredClone(model), id, name };
+  if (!identity) return clone;
+  return {
+    ...clone,
+    provider: identity.provider,
+    ...(identity.api ? { api: identity.api } : {}),
+    ...(identity.baseUrl ? { baseUrl: identity.baseUrl } : {}),
+  } as PiModel;
 }
 
 const fastModeByScope = new Map<string, Set<string>>();

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -30,7 +30,7 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
     const template = builtinModel(clone.template);
     if (template) return cloneModel(template, id, clone.name);
   }
-  if (fallback?.provider === "openrouter") {
+  if (fallback) {
     const template = getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined;
     if (template) return cloneModel(template, id, fallback.name);
   }

--- a/plugins/web-ui/test/pi-models.test.ts
+++ b/plugins/web-ui/test/pi-models.test.ts
@@ -40,3 +40,38 @@ test("fast-mode support is fed from core's runtime config, not a hardcoded clien
   assert.equal(modelSupportsFastMode(null, "claude-haiku-4-5"), false);
   assert.equal(modelSupportsFastMode(null, undefined), false);
 });
+
+test("a custom-provider model keeps its own provider, protocol and endpoint", () => {
+  const openaiStyle = getBaseModel("vendor/some-model", {
+    name: "Some Model",
+    provider: "my-gateway",
+    api: "openai-completions",
+    baseUrl: "https://gateway.example/v1",
+  });
+  assert.equal(openaiStyle.id, "vendor/some-model");
+  assert.equal(openaiStyle.name, "Some Model");
+  assert.equal(openaiStyle.provider, "my-gateway", "the custom provider slug survives, not the template's");
+  assert.equal(openaiStyle.api, "openai-completions");
+  assert.equal(openaiStyle.baseUrl, "https://gateway.example/v1");
+
+  const anthropicStyle = getBaseModel("vendor/claude-ish", {
+    name: "Claude Ish",
+    provider: "my-anthropic-gateway",
+    api: "anthropic-messages",
+    baseUrl: "https://anthropic.example",
+  });
+  assert.equal(anthropicStyle.provider, "my-anthropic-gateway");
+  assert.equal(
+    anthropicStyle.api,
+    "anthropic-messages",
+    "an Anthropic-protocol custom model must not be attributed to an OpenAI-completions transport",
+  );
+  assert.equal(anthropicStyle.baseUrl, "https://anthropic.example");
+  assert.notEqual(anthropicStyle.provider, "openrouter");
+});
+
+test("a catalogued model with no declared protocol defaults to OpenAI-completions", () => {
+  const model = getBaseModel("vendor/unspecified", { name: "Unspecified", provider: "my-gateway" });
+  assert.equal(model.provider, "my-gateway");
+  assert.equal(model.api, "openai-completions");
+});

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1165,7 +1165,18 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   const modelCatalog = Object.fromEntries(
     [...advertisedModelIds].flatMap((id) => {
       const model = catalog.find((candidate) => candidate.id === id);
-      if (model) return [[id, { name: model.name, provider: model.provider }]];
+      if (model)
+        return [
+          [
+            id,
+            {
+              name: model.name,
+              provider: model.provider,
+              ...(model.api ? { api: model.api } : {}),
+              ...(model.baseUrl ? { baseUrl: model.baseUrl } : {}),
+            },
+          ],
+        ];
       const resolved = resolveModel(id);
       return resolved ? [[id, { name: resolved.name, provider: resolved.provider }]] : [];
     }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ const server = createServer(built.app, {
   modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
   providerKeys: providerKeysPresent(config),
   modelCredentials: built.modelCredentials,
+  customProviders: built.customProviders,
+  refreshCustomProviders: built.refreshCustomProviders,
   ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
   harnessId: config.harness,
   connectorTokens: built.connectorTokens,

--- a/src/model/custom-providers.ts
+++ b/src/model/custom-providers.ts
@@ -147,8 +147,20 @@ export function isCustomModelId(id: string): boolean {
   return registry.has(id);
 }
 
-export function customModelCatalog(): Array<{ id: string; name: string; provider: string }> {
-  return [...registry.values()].map((m) => ({ id: m.id, name: m.name, provider: m.provider }));
+export function customModelCatalog(): Array<{
+  id: string;
+  name: string;
+  provider: string;
+  api: CustomRuntimeModel["api"];
+  baseUrl: string;
+}> {
+  return [...registry.values()].map((m) => ({
+    id: m.id,
+    name: m.name,
+    provider: m.provider,
+    api: m.api,
+    baseUrl: m.baseUrl,
+  }));
 }
 
 /**

--- a/src/model/model-catalog.ts
+++ b/src/model/model-catalog.ts
@@ -6,6 +6,9 @@ export interface ModelCatalogEntry {
   name: string;
   /** A built-in provider or the slug of an admin-registered custom provider. */
   provider: string;
+  /** Set for custom-provider models: the wire protocol and endpoint the client must attribute the model to. */
+  api?: "openai-completions" | "anthropic-messages";
+  baseUrl?: string;
 }
 
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models?supported_parameters=tools&sort=most-popular";

--- a/test/custom-providers.test.ts
+++ b/test/custom-providers.test.ts
@@ -74,7 +74,15 @@ test("a registered custom model is serviceable regardless of built-in key availa
 
 test("catalog lists custom models; clearing the registry removes them", () => {
   setCustomProviders([GATEWAY]);
-  assert.deepEqual(customModelCatalog(), [{ id: "acme-large", name: "Acme Large", provider: "acme-gateway" }]);
+  assert.deepEqual(customModelCatalog(), [
+    {
+      id: "acme-large",
+      name: "Acme Large",
+      provider: "acme-gateway",
+      api: "openai-completions",
+      baseUrl: "https://llm.acme.internal/v1",
+    },
+  ]);
   setCustomProviders([]);
   assert.equal(isCustomModelId("acme-large"), false);
   assert.equal(resolveModel("acme-large"), undefined);


### PR DESCRIPTION
Custom model providers cannot be used at all. Two independent defects sit between a registered provider and a usable model, and neither reports an error.

## 1. The store never reaches the routes

`putCustomProvider`, `getCustomProviders` and `deleteCustomProvider` all begin with

```ts
if (!ctx.deps.customProviders) return sendJson(ctx.res, 404, { error: "not_found" });
```

`ctx.deps` is `ServerOptions`. `createCustomProviderStore` is built in `wiring.ts`, returned on the built object, and declared on both `ApiDeps` and the `createApp` options — but `index.ts` passes it only to `createApp`, never to `createServer`. So `ctx.deps.customProviders` is always `undefined` and every request 404s.

`refreshCustomProviders` has the same gap and matters just as much: the handlers call it after a successful upsert to rehydrate the in-process registry, so without it a saved provider would not resolve until the next restart.

**Reproduce:** `PUT /v1/admin/custom-providers/<id>` with a valid spec. Returns 404 on any deployment.

## 2. The picker discards models it was told about

With the store wired, a provider saves, the row persists, and `/api/runtime-config` correctly returns the model in both `modelsByHarness` and `modelCatalog` — but the model is still absent from the web UI picker.

`getBaseModel` clones a template only when the catalogue entry's provider is the literal string `"openrouter"`:

```ts
if (fallback?.provider === "openrouter") { ... }
throw new Error(`Unsupported model: ${id}`);
```

A custom provider's slug cannot be `"openrouter"` — `validateCustomProviderSpec` rejects the built-in provider ids as reserved. So `getBaseModel` throws, `buildOption`'s `catch { return null }` swallows it, and the option is dropped with no error in the console or the server log.

The catalogue is the server's statement of which models this deployment may use. This honours it for any entry rather than for one hardcoded provider name. The change is strictly more permissive and affects only models the server already advertised.

**Reproduce:** register a custom provider, add its model id to the scope's picker list, and observe it missing from the composer while `runtime-config` lists it.

## Verification

Both fixes applied to a running instance: the `PUT` returns 200, the provider persists, the model resolves through `resolveModel`, passes `modelSupportedByHarness`, appears in `selectableCatalogForHarness`, and the model is then selectable in the composer and serves turns.

No screenshot is attached. The surface in question is a model name appearing in the composer's picker, and a capture of a working instance would show organization data.

`npx tsc --noEmit` is clean on both changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789041687&installation_model_id=19911&pr_number=333&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F333&signature=4212ffbc75f67d127ea0eaf9135cd20555560714a58e05c89364b8538663acbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->