### PR TITLE
Improve mobile web layouts

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -201,6 +201,9 @@ body.resizing-sidebar {
 .sidebar-collapse-toggle:hover {
   opacity: 1;
 }
+.mobile-sidebar-toggle {
+  display: none;
+}
 .icon {
   display: block;
   flex-shrink: 0;
@@ -4078,18 +4081,30 @@ a.chat-row-open {
     z-index: 10;
     box-shadow: 18px 0 40px color-mix(in srgb, var(--foreground) 12%, transparent);
   }
-  .layout {
-    /* left safe-area inset + the 44px touch-size toggle + its 8px right padding */
-    --rail-w: calc(max(8px, env(safe-area-inset-left)) + 52px);
-  }
   .sidebar {
-    /* Open is an absolute overlay, closed is a static rail — animating width across
-       that position flip would squeeze the main pane mid-transition. Snap instead. */
-    transition: none;
+    transform: translateX(0);
+    transition: transform 0.18s ease;
   }
   .layout.sidebar-closed .sidebar {
-    position: static;
+    width: min(var(--sidebar-w), calc(100vw - 48px));
+    transform: translateX(-100%);
     box-shadow: none;
+  }
+  .mobile-sidebar-toggle {
+    position: absolute;
+    top: calc(10px + var(--surface-safe-top));
+    left: max(10px, env(safe-area-inset-left));
+    z-index: 8;
+    display: inline-flex;
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--background) 92%, var(--secondary));
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--foreground) 12%, transparent);
+  }
+  .layout:not(.sidebar-closed) .mobile-sidebar-toggle {
+    display: none;
   }
   .sidebar-resize-handle {
     display: none;
@@ -4135,9 +4150,14 @@ a.chat-row-open {
     height: 44px;
     margin-top: 0;
   }
-  .chat-topbar {
+  .main > .custom-chat .chat-topbar {
     height: calc(54px + var(--surface-safe-top));
-    padding: var(--surface-safe-top) max(10px, env(safe-area-inset-right)) 0 max(10px, env(safe-area-inset-left));
+    padding: var(--surface-safe-top) max(10px, env(safe-area-inset-right)) 0
+      max(64px, calc(env(safe-area-inset-left) + 54px));
+  }
+  .main > .split-canvas > .split-dock {
+    padding: calc(64px + var(--surface-safe-top)) max(5px, env(safe-area-inset-right))
+      max(5px, env(safe-area-inset-bottom)) max(5px, env(safe-area-inset-left));
   }
   .message-stack {
     gap: 6px;
@@ -4147,8 +4167,13 @@ a.chat-row-open {
     padding-left: max(var(--chat-pad), env(safe-area-inset-left));
   }
   .pane {
-    padding: calc(28px + var(--surface-safe-top)) max(28px, env(safe-area-inset-right))
+    padding: calc(70px + var(--surface-safe-top)) max(28px, env(safe-area-inset-right))
       calc(40px + env(safe-area-inset-bottom)) max(28px, env(safe-area-inset-left));
+  }
+  .resource-pane {
+    padding-top: calc(70px + var(--surface-safe-top));
+    padding-right: max(24px, env(safe-area-inset-right));
+    padding-left: max(24px, env(safe-area-inset-left));
   }
   .message-bubble {
     max-width: 88%;
@@ -4222,7 +4247,11 @@ a.chat-row-open {
 
 @media (max-width: 560px) {
   .pane {
-    padding: calc(20px + var(--surface-safe-top)) max(14px, env(safe-area-inset-right))
+    padding: calc(70px + var(--surface-safe-top)) max(14px, env(safe-area-inset-right))
+      calc(32px + env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
+  }
+  .resource-pane {
+    padding: calc(70px + var(--surface-safe-top)) max(14px, env(safe-area-inset-right))
       calc(32px + env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
   }
   .composer-approval .approval-actions {
@@ -6858,4 +6887,276 @@ h3.ambient-field-label {
 }
 .qm-tooltip.visible {
   opacity: 1;
+}
+
+@media (max-width: 860px) and (prefers-reduced-motion: reduce) {
+  .sidebar {
+    transition: none;
+  }
+}
+
+@media (max-width: 620px) {
+  .pane-head,
+  .resource-heading,
+  .deploy-detail-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .pane-head > div:first-child,
+  .resource-heading > div:first-child {
+    min-width: 0;
+  }
+  .pane-head-actions,
+  .deploy-detail-heading > .actions,
+  .resource-detail > .actions {
+    width: 100%;
+    box-sizing: border-box;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .deploy-detail-heading > .actions > .btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+  .project-grid,
+  .grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .list-toolbar {
+    align-items: stretch;
+  }
+  .list-toolbar .list-search {
+    flex-basis: 100%;
+  }
+  .file-drop {
+    flex-wrap: wrap;
+    text-align: center;
+  }
+  .file-drop > span:not(.scope-chip) {
+    flex: 1 1 150px;
+  }
+  .file-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 6px 10px;
+    cursor: default;
+  }
+  .file-row .list-row-title,
+  .file-row .list-row-meta {
+    grid-column: 2;
+  }
+  .file-row .list-row-title {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .file-row .list-row-meta {
+    min-width: 0;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    row-gap: 6px;
+  }
+  .resource-tabs,
+  .cron-list-controls {
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+  }
+  .resource-tabs::-webkit-scrollbar,
+  .cron-list-controls::-webkit-scrollbar {
+    display: none;
+  }
+  .resource-tabs button,
+  .cron-filter-chip {
+    flex: 0 0 auto;
+  }
+  .chat-row {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 0;
+  }
+  .chat-row-open {
+    width: 100%;
+    box-sizing: border-box;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .chat-row-open .list-row-title,
+  .chat-row-open .list-row-meta {
+    width: 100%;
+    min-width: 0;
+  }
+  .chat-row-open .list-row-meta {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .chat-row-actions {
+    width: 100%;
+    box-sizing: border-box;
+    justify-content: flex-end;
+    padding: 0 8px 8px;
+  }
+  .deploy-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 0;
+  }
+  .deploy-row-main {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "title"
+      "url"
+      "meta";
+  }
+  .deploy-row-title {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .deploy-row-title .list-row-title {
+    flex: 1 1 180px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .deploy-row .deploy-row-meta {
+    grid-column: 1;
+    min-width: 0;
+    justify-content: flex-start;
+  }
+  .deploy-row-actions {
+    grid-column: 1;
+    width: 100%;
+    box-sizing: border-box;
+    justify-content: flex-start;
+    padding: 10px 0 0;
+  }
+  .deploy-detail {
+    width: 100%;
+  }
+  .deploy-heading-title {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+  .deploy-git-field .value,
+  .deploy-setting-value,
+  .deploy-edit-form {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+  .deploy-git-field code,
+  .deploy-setting-value > span,
+  .deploy-setting-value > code {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .deploy-slug-input,
+  .deploy-slug-input input,
+  .deploy-slug-input.name input {
+    width: 100%;
+  }
+  .kc-access-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .kc-resource-actions,
+  .kc-form-actions {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+  .ambient-enabled-select {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+  .context-session-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .context-session-title {
+    width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .context-session-meta,
+  .context-resource-row .context-session-meta {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+  .skill-form-heading {
+    flex-wrap: wrap;
+  }
+  .project-dialog-actions {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 430px) {
+  .skill-filter-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .skill-variant-description,
+  .skill-variant-meta {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .scope-filter {
+    flex: 1 1 150px;
+    min-width: 0;
+  }
+  .scope-filter .menu-button {
+    width: 100%;
+    max-width: 100%;
+  }
+  .project-dialog-actions .btn,
+  .kc-form-actions .btn,
+  .kc-form-actions a.btn {
+    flex: 1 1 100%;
+  }
+}
+
+@media (max-width: 860px) and (hover: none) {
+  .main .icon-btn,
+  .cron-action-btn,
+  .project-icon-button {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+  }
+  .context-resource-action,
+  .kc-text-action,
+  .resource-tabs button,
+  .cron-filter-chip,
+  .context-back,
+  .list-select select,
+  .deploy-sort select,
+  .skill-variant-details summary {
+    min-height: 44px;
+  }
+  .context-resource-action,
+  .kc-text-action {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+  .skill-variant-details summary {
+    display: inline-flex;
+    align-items: center;
+  }
+  .split-canvas .split-pane-actions .icon-btn {
+    width: 26px;
+    height: 26px;
+    min-width: 26px;
+  }
+  .split-canvas .split-tab-close {
+    width: 18px;
+    height: 18px;
+    min-width: 18px;
+  }
 }

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -425,6 +425,15 @@ export function mountShell(): void {
     html`
       ${banner ?? nothing}
       <div class="layout ${sidebarOpen ? "" : "sidebar-closed"} ${banner ? "bannered" : ""}">
+        <button
+          class="icon-btn subtle sidebar-toggle mobile-sidebar-toggle"
+          type="button"
+          title="Show sidebar"
+          aria-label="Show sidebar"
+          @click=${toggleSidebar}
+        >
+          ${icon(PanelLeft, 17)}
+        </button>
         <aside class="sidebar" aria-label="Navigation" @keydown=${onSidebarKeydown}>
           <div class="brand">
             <div class="brand-lockup">${brandMark()}<span class="brand-name">${brandName()}</span></div>
@@ -667,8 +676,16 @@ export function closeSidebarOnNarrowView(): void {
 }
 
 narrowViewport.addEventListener("change", (event) => {
+  const root = appEl as HTMLElement;
+  const sidebar = root.querySelector<HTMLElement>(".sidebar");
+  const launcher = root.querySelector<HTMLElement>(".mobile-sidebar-toggle");
+  const focusedInside = sidebar?.contains(document.activeElement) === true;
+  const focusedLauncher = document.activeElement === launcher;
   if (event.matches && sidebarOpen) setSidebarOpen(false, false);
   else syncSidebarAccessibility(false);
+  if (event.matches && focusedInside) requestAnimationFrame(() => launcher?.focus());
+  else if (!event.matches && focusedLauncher)
+    requestAnimationFrame(() => sidebar?.querySelector<HTMLElement>(".sidebar-collapse-toggle")?.focus());
 });
 
 function setSidebarOpen(open: boolean, moveFocus = true): void {
@@ -684,14 +701,23 @@ function syncSidebarAccessibility(moveFocus: boolean): void {
   const main = root.querySelector<HTMLElement>(".main");
   const scrim = root.querySelector<HTMLButtonElement>(".sidebar-scrim");
   const modal = narrowViewport.matches && sidebarOpen;
+  const hiddenDrawer = narrowViewport.matches && !sidebarOpen;
   if (!sidebar || !main || !scrim) return;
   main.inert = modal;
+  sidebar.inert = hiddenDrawer;
   sidebar.setAttribute("role", modal ? "dialog" : "navigation");
   if (modal) sidebar.setAttribute("aria-modal", "true");
   else sidebar.removeAttribute("aria-modal");
+  if (hiddenDrawer) sidebar.setAttribute("aria-hidden", "true");
+  else sidebar.removeAttribute("aria-hidden");
   scrim.hidden = !modal;
   if (!moveFocus || !narrowViewport.matches) return;
-  requestAnimationFrame(() => sidebar.querySelector<HTMLElement>(".sidebar-collapse-toggle")?.focus());
+  requestAnimationFrame(() => {
+    const target = modal
+      ? sidebar.querySelector<HTMLElement>(".sidebar-collapse-toggle")
+      : root.querySelector<HTMLElement>(".mobile-sidebar-toggle");
+    target?.focus();
+  });
 }
 
 function onSidebarKeydown(event: KeyboardEvent): void {

--- a/plugins/web-ui/test/responsive-source.test.ts
+++ b/plugins/web-ui/test/responsive-source.test.ts
@@ -21,6 +21,8 @@ test("mobile sidebar is modal, dismissible, and sized for touch", () => {
   assert.match(shell, /class="new-chat[\s\S]{0,200}closeSidebarOnNarrowView\(\);/);
   assert.match(shell, /class="sidebar-scrim"[^>]+aria-label="Close sidebar"[^>]+@click=\$\{toggleSidebar\}/);
   assert.match(shell, /main\.inert = modal/);
+  assert.match(shell, /sidebar\.inert = hiddenDrawer/);
+  assert.match(shell, /if \(hiddenDrawer\) sidebar\.setAttribute\("aria-hidden", "true"\)/);
   assert.match(
     css,
     /\.layout\.sidebar-closed \.sidebar > :not\(\.brand\):not\(#sidebar-top\),\s*\.layout\.sidebar-closed \.brand-lockup \{[^}]*opacity: 0;\s*visibility: hidden;/,
@@ -36,7 +38,20 @@ test("mobile sidebar is modal, dismissible, and sized for touch", () => {
   assert.match(sessions, /data-menu-id=\$\{s\.id\}/);
   assert.match(sessions, /focusSessionMenuButton\(menuKey\)/);
   assert.match(shell, /trapDialogFocus\(event, \(\) => setSidebarOpen\(false\)\)/);
-  assert.match(css, /\.layout\.sidebar-closed \.sidebar \{\s*position: static;\s*box-shadow: none;/);
+  assert.match(
+    shell,
+    /modal[\s\S]*sidebar\.querySelector<HTMLElement>\("\.sidebar-collapse-toggle"\)[\s\S]*root\.querySelector<HTMLElement>\("\.mobile-sidebar-toggle"\)/,
+  );
+  assert.match(
+    shell,
+    /const focusedInside[\s\S]*const focusedLauncher[\s\S]*if \(event\.matches && sidebarOpen\) setSidebarOpen\(false, false\)[\s\S]*if \(event\.matches && focusedInside\)[\s\S]*else if \(!event\.matches && focusedLauncher\)[\s\S]*\.sidebar-collapse-toggle/,
+  );
+  assert.match(shell, /class="icon-btn subtle sidebar-toggle mobile-sidebar-toggle"/);
+  assert.match(
+    css,
+    /\.layout\.sidebar-closed \.sidebar \{\s*width: min\(var\(--sidebar-w\), calc\(100vw - 48px\)\);\s*transform: translateX\(-100%\);/,
+  );
+  assert.match(css, /\.mobile-sidebar-toggle \{[\s\S]*display: inline-flex;[\s\S]*width: 44px;\s*height: 44px;/);
   assert.match(
     shell,
     /setSidebarOpen\(false, false\);\s*requestAnimationFrame\(\(\) => appState\.mainEl\?\.focus\(\{ preventScroll: true \}\)\)/,
@@ -104,11 +119,11 @@ test("touch layouts expose row actions and preserve readable composer choices", 
   );
   assert.match(
     compactCss,
-    /\.pane \{\s*padding: calc\(28px \+ var\(--surface-safe-top\)\) max\(28px, env\(safe-area-inset-right\)\) calc\(40px \+ env\(safe-area-inset-bottom\)\) max\(28px, env\(safe-area-inset-left\)\)/,
+    /\.pane \{\s*padding: calc\(70px \+ var\(--surface-safe-top\)\) max\(28px, env\(safe-area-inset-right\)\) calc\(40px \+ env\(safe-area-inset-bottom\)\) max\(28px, env\(safe-area-inset-left\)\)/,
   );
   assert.match(
     compactCss,
-    /padding: calc\(20px \+ var\(--surface-safe-top\)\) max\(14px, env\(safe-area-inset-right\)\) calc\(32px \+ env\(safe-area-inset-bottom\)\) max\(14px, env\(safe-area-inset-left\)\)/,
+    /padding: calc\(70px \+ var\(--surface-safe-top\)\) max\(14px, env\(safe-area-inset-right\)\) calc\(32px \+ env\(safe-area-inset-bottom\)\) max\(14px, env\(safe-area-inset-left\)\)/,
   );
   assert.match(
     compactCss,
@@ -118,4 +133,30 @@ test("touch layouts expose row actions and preserve readable composer choices", 
     compactCss,
     /\.live-work-dock \{\s*width: auto;\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
   );
+});
+
+test("mobile browse pages stack dense rows and keep controls reachable", () => {
+  assert.match(
+    compactCss,
+    /\.pane-head, \.resource-heading, \.deploy-detail-heading \{ align-items: flex-start; flex-direction: column;/,
+  );
+  assert.match(compactCss, /\.file-row \{ display: grid; grid-template-columns: auto minmax\(0, 1fr\);/);
+  assert.match(compactCss, /\.chat-row \{ display: flex; flex-direction: column;/);
+  assert.match(compactCss, /\.deploy-row-meta \{ grid-column: 1;/);
+  assert.match(compactCss, /\.deploy-detail \{ width: 100%;/);
+  assert.match(compactCss, /\.context-session-row \{ align-items: flex-start; flex-direction: column;/);
+  assert.match(compactCss, /\.skill-filter-fields \{ grid-template-columns: minmax\(0, 1fr\);/);
+  assert.match(
+    compactCss,
+    /\.resource-tabs, \.cron-list-controls \{ max-width: 100%; overflow-x: auto; overscroll-behavior-x: contain;/,
+  );
+  assert.match(
+    compactCss,
+    /\.context-resource-action, \.kc-text-action, \.resource-tabs button,[\s\S]*\.skill-variant-details summary \{ min-height: 44px;/,
+  );
+  assert.match(
+    compactCss,
+    /\.split-canvas \.split-pane-actions \.icon-btn \{ width: 26px; height: 26px; min-width: 26px;/,
+  );
+  assert.match(compactCss, /\.split-canvas \.split-tab-close \{ width: 18px; height: 18px; min-width: 18px;/);
 });

--- a/plugins/web-ui/test/sidebar-rail-source.test.ts
+++ b/plugins/web-ui/test/sidebar-rail-source.test.ts
@@ -22,7 +22,8 @@ test("hidden sidebar innards are out of the focus order and keep their layout wh
     /\.layout\.sidebar-closed \.sidebar > :not\(\.brand\):not\(#sidebar-top\),\s*\.layout\.sidebar-closed \.brand-lockup \{[^}]*opacity: 0;\s*visibility: hidden;\s*\}/,
   );
   assert.doesNotMatch(css, /transition:[^;}]*visibility/);
-  assert.doesNotMatch(shell, /sidebar\.inert/);
+  assert.match(shell, /sidebar\.inert = hiddenDrawer/);
+  assert.match(shell, /if \(hiddenDrawer\) sidebar\.setAttribute\("aria-hidden", "true"\)/);
 });
 
 test("the collapsed rail keeps icon-only navigation instead of going empty", () => {
@@ -43,11 +44,31 @@ test("the collapsed rail keeps icon-only navigation instead of going empty", () 
   assert.match(shell, /class="navrow[^`]*title=\$\{label\}/);
 });
 
-test("narrow viewports keep the rail in flow and size it for touch + safe area", () => {
+test("narrow viewports use an off-canvas drawer and a safe-area-aware touch launcher", () => {
   const narrow = css.slice(css.indexOf("@media (max-width: 860px)"));
-  assert.match(narrow, /--rail-w: calc\(max\(8px, env\(safe-area-inset-left\)\) \+ 52px\)/);
-  assert.match(narrow, /\.layout\.sidebar-closed \.sidebar \{\s*position: static;\s*box-shadow: none;/);
-  assert.match(narrow, /\.sidebar \{[^}]*transition: none;/);
+  assert.match(shell, /class="icon-btn subtle sidebar-toggle mobile-sidebar-toggle"/);
+  assert.match(
+    narrow,
+    /\.layout\.sidebar-closed \.sidebar \{\s*width: min\(var\(--sidebar-w\), calc\(100vw - 48px\)\);\s*transform: translateX\(-100%\);/,
+  );
+  assert.match(
+    narrow,
+    /\.mobile-sidebar-toggle \{[^}]*left: max\(10px, env\(safe-area-inset-left\)\);[^}]*width: 44px;[^}]*height: 44px;/,
+  );
+  assert.match(narrow, /\.pane \{\s*padding: calc\(70px \+ var\(--surface-safe-top\)\)/);
+  assert.match(
+    narrow,
+    /\.main > \.custom-chat \.chat-topbar \{[^}]*max\(64px, calc\(env\(safe-area-inset-left\) \+ 54px\)\)/,
+  );
+  assert.match(
+    narrow,
+    /\.main > \.split-canvas > \.split-dock \{\s*padding: calc\(64px \+ var\(--surface-safe-top\)\) max\(5px, env\(safe-area-inset-right\)\)\s*max\(5px, env\(safe-area-inset-bottom\)\) max\(5px, env\(safe-area-inset-left\)\)/,
+  );
+  assert.match(
+    narrow,
+    /\.resource-pane \{[^}]*padding-right: max\(24px, env\(safe-area-inset-right\)\);[^}]*padding-left: max\(24px, env\(safe-area-inset-left\)\)/,
+  );
+  assert.match(shell, /focusedLauncher[\s\S]*\.sidebar-collapse-toggle/);
 });
 
 test("per-view clearance hacks for the old floating button are gone", () => {


### PR DESCRIPTION
## Summary

- replace the narrow sidebar rail with an accessible off-canvas drawer, including focus transfer, `inert` state, scrim dismissal, and breakpoint-safe behavior
- improve safe-area spacing, wrapping, stacking, overflow handling, and touch targets across Projects, Chats, Files, Crons, Keychain, Apps, Memory, and Skills
- add responsive source regressions for the mobile drawer and dense resource layouts

## Screenshots

All screenshots use synthetic data at a 390px viewport.

### Projects

| Before | After |
| --- | --- |
| ![projects-before.png](https://github.com/user-attachments/assets/01f9a804-f3f3-4a07-adf9-322482f86796) | ![projects-after.png](https://github.com/user-attachments/assets/a3894f4d-70c8-4f88-9d57-5668e3ae714c) |

### Project detail

| Before | After |
| --- | --- |
| ![project-detail-before.png](https://github.com/user-attachments/assets/dfc8a923-fbd7-4159-b1a5-3edaec6d6667) | ![project-detail-after.png](https://github.com/user-attachments/assets/2bec942f-3f47-4a39-9320-c8e296912a82) |

### Apps

| Before | After |
| --- | --- |
| ![apps-before.png](https://github.com/user-attachments/assets/4b01d33d-ed8e-46b1-90fc-f7059815a4cb) | ![apps-after.png](https://github.com/user-attachments/assets/ac1527d8-e583-4a02-bbbc-76fda0229e46) |

### Files

| Before | After |
| --- | --- |
| ![files-before.png](https://github.com/user-attachments/assets/641d355d-b7d1-4c95-85fb-5ef90091a4ac) | ![files-after.png](https://github.com/user-attachments/assets/20e09d5c-30db-4e8a-b2f6-42355eaa1b89) |

### Mobile navigation drawer

![sidebar-after.png](https://github.com/user-attachments/assets/f7038ccc-e031-404f-8dde-ec75d0f415f0)

## Testing

- `cd plugins/web-ui && npm test`
- `cd plugins/web-ui && npm run typecheck`
- `cd plugins/web-ui && npm run build`
- ESLint and Prettier checks for the changed files
- manual synthetic-data checks at 320px, 390px, and 430px across every web UI page, including project, cron, and app detail views

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056616&installation_model_id=19911&pr_number=335&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F335&signature=cd4119720ef21dd8a88494bde7b2ec69909ea5c8f577fca823097689bae39de8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->