### PR TITLE
Support OIDC group trust boundaries

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -825,6 +825,11 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
     env.OIDC_ALLOWED_EMAILS?.split(",")
       .map((email) => email.trim())
       .filter(Boolean) ?? [];
+  const allowedGroups =
+    env.OIDC_ALLOWED_GROUPS?.split(",")
+      .map((group) => group.trim())
+      .filter(Boolean) ?? [];
+  const groupsClaim = env.OIDC_GROUPS_CLAIM;
   const configuredTeam = env.PORTAL_EXPECTED_TEAM_ID?.trim();
   if (domain !== undefined && (isMissingOrPlaceholder(domain) || !validEmailDomain(domain))) {
     throw new CliError(
@@ -833,6 +838,15 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
   }
   if (allowedEmails.some((email) => isMissingOrPlaceholder(email) || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email))) {
     throw new CliError(`${path}: env.portal.OIDC_ALLOWED_EMAILS must contain valid, non-placeholder email addresses`);
+  }
+  if (
+    env.OIDC_ALLOWED_GROUPS !== undefined &&
+    !allowedGroups.length
+  ) {
+    throw new CliError(`${path}: env.portal.OIDC_ALLOWED_GROUPS must contain non-empty group values`);
+  }
+  if (groupsClaim !== undefined && !groupsClaim.trim()) {
+    throw new CliError(`${path}: env.portal.OIDC_GROUPS_CLAIM must be a non-empty claim name when set`);
   }
   if ((domain || allowedEmails.length) && (env.OIDC_PRINCIPAL_CLAIM ?? "email") !== "email") {
     throw new CliError(
@@ -848,10 +862,11 @@ export function validatePortalTrust(config: QmConfig, path = "config", secrets?:
     secrets &&
     !domain &&
     !allowedEmails.length &&
+    !allowedGroups.length &&
     isMissingOrPlaceholder(configuredTeam ?? secrets.get("PORTAL_EXPECTED_TEAM_ID"))
   ) {
     throw new CliError(
-      `${path}: portal requires OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, or a non-placeholder PORTAL_EXPECTED_TEAM_ID in env.portal or the target secret store`,
+      `${path}: portal requires OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, OIDC_ALLOWED_GROUPS, or a non-placeholder PORTAL_EXPECTED_TEAM_ID in env.portal or the target secret store`,
     );
   }
 }

--- a/cli/src/provider-scaffold.ts
+++ b/cli/src/provider-scaffold.ts
@@ -116,7 +116,8 @@ const AWS_AGENTS_APPENDIX = `
    portal's client credentials and wires \`OIDC_*\` itself. To use an external
    identity provider instead, drop \`"auth"\` from \`services\`, configure
    \`env.portal\` with the provider's OIDC endpoints and an \`OIDC_ALLOWED_EMAILS\`
-   or \`OIDC_ALLOWED_EMAIL_DOMAIN\` tenant gate, and register
+   or \`OIDC_ALLOWED_EMAIL_DOMAIN\` tenant gate, or exact \`OIDC_ALLOWED_GROUPS\`
+   with optional \`OIDC_GROUPS_CLAIM\` (default \`groups\`), and register
    \`<publicUrl>/auth/callback\` with the provider. Add optional services and their
    ECS/ECR entries now, then render and apply once more.
 4. Run \`npm exec qm -- infra build-image\` to build the Lambda MicroVM guest image

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -234,7 +234,7 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
           {
             kind: "env-all-absent",
             service: "portal",
-            names: ["OIDC_ALLOWED_EMAILS", "OIDC_ALLOWED_EMAIL_DOMAIN", "PORTAL_EXPECTED_TEAM_ID"],
+            names: ["OIDC_ALLOWED_EMAILS", "OIDC_ALLOWED_EMAIL_DOMAIN", "OIDC_ALLOWED_GROUPS", "PORTAL_EXPECTED_TEAM_ID"],
           },
         ],
       },

--- a/cli/src/services.ts
+++ b/cli/src/services.ts
@@ -221,6 +221,8 @@ const CATALOG: Record<ServiceName, ServiceDef> = {
         "OIDC_CLIENT_ID",
         "OIDC_ALLOWED_EMAILS",
         "OIDC_ALLOWED_EMAIL_DOMAIN",
+        "OIDC_ALLOWED_GROUPS",
+        "OIDC_GROUPS_CLAIM",
         "PORTAL_EXPECTED_TEAM_ID",
         "OIDC_AUTH_ENDPOINT",
         "OIDC_TOKEN_ENDPOINT",

--- a/cli/templates/deployment/deployment.md
+++ b/cli/templates/deployment/deployment.md
@@ -130,9 +130,11 @@ require Slack sign-in.
 
 ### Another OIDC provider
 
-To use a different work-email OIDC provider, drop `"auth"` from
-`services`, register `<publicUrl>/auth/callback` with the provider, and put its
-endpoints and the email gate in `env.portal`. For Google Workspace:
+To use a different OIDC provider, drop `"auth"` from `services`, register
+`<publicUrl>/auth/callback` with the provider, and put its endpoints plus an identity
+provider trust boundary in `env.portal`. That boundary can be an email allowlist or
+domain, a Slack team, or an exact group allowlist with `OIDC_ALLOWED_GROUPS` and an
+optional `OIDC_GROUPS_CLAIM` (default `groups`). For Google Workspace:
 
 ```json
 {

--- a/cli/templates/deployment/references/slack.md
+++ b/cli/templates/deployment/references/slack.md
@@ -54,9 +54,11 @@ silently skip the SSO manifest and its links when the values are left implicit.
 
 Every deployment needs one tenant trust boundary or the portal refuses to start:
 `PORTAL_EXPECTED_TEAM_ID` (the workspace id, and Slack-only),
-`OIDC_ALLOWED_EMAIL_DOMAIN`, or `OIDC_ALLOWED_EMAILS`. Copy the workspace id from
-the Slack About dialog. `PORTAL_EXPECTED_TEAM_ID` is refused while `"auth"` is
-enabled — the two sign-in paths are mutually exclusive, so switch fully.
+`OIDC_ALLOWED_EMAIL_DOMAIN`, `OIDC_ALLOWED_EMAILS`, or exact groups through
+`OIDC_ALLOWED_GROUPS` with an optional `OIDC_GROUPS_CLAIM` (default `groups`). Copy
+the workspace id from the Slack About dialog. `PORTAL_EXPECTED_TEAM_ID` is refused
+while `"auth"` is enabled — the two sign-in paths are mutually exclusive, so switch
+fully.
 
 `qm outputs` requires the `slack` service even when only the SSO app is wanted.
 Keep `"slack"` in `services` and leave its bot tokens unset if the operator does

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -89,6 +89,8 @@ test("doctor rejects missing and placeholder portal OIDC client ids and tenant g
   }
   const acceptedGates: Array<Record<string, string>> = [
     { OIDC_ALLOWED_EMAIL_DOMAIN: "example.com" },
+    { OIDC_ALLOWED_GROUPS: "qm-users" },
+    { OIDC_ALLOWED_GROUPS: "qm-users", OIDC_GROUPS_CLAIM: "  memberships  " },
     { PORTAL_EXPECTED_TEAM_ID: "T123" },
     { OIDC_ALLOWED_EMAIL_DOMAIN: "example.com", PORTAL_EXPECTED_TEAM_ID: "T123" },
   ];

--- a/cli/test/secrets.test.ts
+++ b/cli/test/secrets.test.ts
@@ -94,7 +94,7 @@ test("portal deployment coordinates can come from the target secret store", () =
 
   const configured = makeConfig({
     services: ["core", "portal"],
-    env: { portal: { OIDC_CLIENT_ID: "client", OIDC_ALLOWED_EMAIL_DOMAIN: "example.com" } },
+    env: { portal: { OIDC_CLIENT_ID: "client", OIDC_ALLOWED_GROUPS: "qm-users" } },
   });
   assert.ok(!computedSecrets(configured).some((secret) => secret.name === "OIDC_CLIENT_ID"));
   assert.ok(!computedSecrets(configured).some((secret) => secret.name === "PORTAL_EXPECTED_TEAM_ID"));

--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -137,6 +137,15 @@ verified work email, lowercased; sign-in fails unless the IdP marks the email ve
 `OIDC_ALLOWED_EMAIL_DOMAIN` — with `email`, additionally reject any account outside this domain
 (checked against the email suffix and Google's `hd` claim).
 
+`OIDC_ALLOWED_GROUPS` — a comma-separated exact group allowlist. `OIDC_GROUPS_CLAIM`
+selects the claim name and defaults to `groups`. A group claim may be a string or a
+string array in either the verified `id_token` or the verified `userinfo` response.
+If both responses provide it, their sets must match exactly; a disagreement, malformed
+claim, or an absent claim rejects sign-in. Whitespace around CSV separators is ignored;
+claim values are case-sensitive and otherwise not normalized.
+This check is independent of the email and Slack workspace gates, so configured gates
+all must pass.
+
 ### Google Workspace SSO with the email principal
 
 The OIDC client is generic, so Google is pure config. One-time setup:

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -22,8 +22,11 @@ import {
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserinfo,
+  normalizeGroupClaim,
+  requireAllowedGroup,
   resolvePrincipal,
   verifyIdToken,
+  type GroupRule,
   type OidcConfig,
   type PrincipalRule,
 } from "./oidc.ts";
@@ -170,6 +173,13 @@ const PRINCIPAL_RULE: PrincipalRule = {
   allowedEmailDomain: process.env.OIDC_ALLOWED_EMAIL_DOMAIN || undefined,
   allowedEmails: process.env.OIDC_ALLOWED_EMAILS?.split(",")
     .map((email) => email.trim())
+    .filter(Boolean),
+};
+const OIDC_GROUPS_CLAIM = process.env.OIDC_GROUPS_CLAIM;
+const GROUP_RULE: GroupRule = {
+  claim: normalizeGroupClaim(OIDC_GROUPS_CLAIM),
+  allowedGroups: process.env.OIDC_ALLOWED_GROUPS?.split(",")
+    .map((group) => group.trim())
     .filter(Boolean),
 };
 
@@ -1138,6 +1148,7 @@ async function authCallback(req: IncomingMessage, res: ServerResponse, url: URL)
     const infoSub = typeof info.sub === "string" ? info.sub : "";
     if (!infoSub) throw new Error("userinfo missing sub");
     if (typeof claims.sub === "string" && claims.sub !== infoSub) throw new Error("subject mismatch");
+    requireAllowedGroup(GROUP_RULE, { claims, userinfo: info });
     sub = resolvePrincipal(PRINCIPAL_RULE, { sub: infoSub, claims, userinfo: info });
     const rawName = info.name ?? claims.name;
     if (typeof rawName === "string") name = rawName.trim().slice(0, 200);
@@ -1225,6 +1236,9 @@ export function bootChecks(): void {
   if ((PRINCIPAL_RULE.allowedEmailDomain || PRINCIPAL_RULE.allowedEmails?.length) && PRINCIPAL_RULE.claim !== "email") {
     problems.push("OIDC_ALLOWED_EMAIL_DOMAIN and OIDC_ALLOWED_EMAILS require OIDC_PRINCIPAL_CLAIM=email");
   }
+  if (OIDC_GROUPS_CLAIM !== undefined && !OIDC_GROUPS_CLAIM.trim()) {
+    problems.push("OIDC_GROUPS_CLAIM must be a non-empty claim name when set");
+  }
   if (IS_PROD) {
     if (isMissingOrPlaceholder(SESSION_SECRET))
       problems.push("PORTAL_SESSION_SECRET is required and may not be a placeholder in production");
@@ -1249,12 +1263,19 @@ export function bootChecks(): void {
       problems.push("OIDC_ALLOWED_EMAILS must be a comma-separated list of valid, non-placeholder email addresses");
     }
     if (
+      process.env.OIDC_ALLOWED_GROUPS !== undefined &&
+      !GROUP_RULE.allowedGroups?.length
+    ) {
+      problems.push("OIDC_ALLOWED_GROUPS must be a comma-separated list of non-empty group values");
+    }
+    if (
       !PRINCIPAL_RULE.allowedEmailDomain &&
       !PRINCIPAL_RULE.allowedEmails?.length &&
+      !GROUP_RULE.allowedGroups?.length &&
       isMissingOrPlaceholder(OIDC.expectedTeamId)
     ) {
       problems.push(
-        "production requires OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, or PORTAL_EXPECTED_TEAM_ID as an identity-provider trust boundary",
+        "production requires OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, OIDC_ALLOWED_GROUPS, or PORTAL_EXPECTED_TEAM_ID as an identity-provider trust boundary",
       );
     }
     if (OIDC.expectedTeamId !== undefined && isMissingOrPlaceholder(OIDC.expectedTeamId)) {

--- a/plugins/portal/src/oidc.ts
+++ b/plugins/portal/src/oidc.ts
@@ -125,6 +125,15 @@ export interface PrincipalRule {
   allowedEmails?: readonly string[];
 }
 
+export interface GroupRule {
+  claim: string;
+  allowedGroups?: readonly string[];
+}
+
+export function normalizeGroupClaim(claim: string | undefined): string {
+  return claim?.trim() || "groups";
+}
+
 export function resolvePrincipal(
   rule: PrincipalRule,
   args: { sub: string; claims: Record<string, unknown>; userinfo: Record<string, unknown> },
@@ -149,6 +158,34 @@ export function resolvePrincipal(
       throw new Error("account is outside the permitted domain");
   }
   return email;
+}
+
+export function requireAllowedGroup(
+  rule: GroupRule,
+  args: { claims: Record<string, unknown>; userinfo: Record<string, unknown> },
+): void {
+  if (!rule.allowedGroups?.length) return;
+  const tokenGroups = groupsFrom(args.claims[rule.claim], "id_token", rule.claim);
+  const userinfoGroups = groupsFrom(args.userinfo[rule.claim], "userinfo", rule.claim);
+  if (tokenGroups && userinfoGroups && !sameGroups(tokenGroups, userinfoGroups)) {
+    throw new Error("group claim differs between id_token and userinfo");
+  }
+  const groups = tokenGroups ?? userinfoGroups;
+  if (!groups) throw new Error(`identity provider returned no ${rule.claim} group claim`);
+  if (!rule.allowedGroups.some((allowed) => groups.has(allowed))) {
+    throw new Error("account is not in a permitted group");
+  }
+}
+
+function groupsFrom(value: unknown, source: string, claim: string): Set<string> | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return new Set([value]);
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) return new Set(value);
+  throw new Error(`${source} ${claim} group claim must be a string or string array`);
+}
+
+function sameGroups(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && [...left].every((group) => right.has(group));
 }
 
 async function readJson(r: Response, what: string): Promise<Record<string, unknown>> {

--- a/plugins/portal/test/entry.test.ts
+++ b/plugins/portal/test/entry.test.ts
@@ -45,6 +45,7 @@ test("production boot requires an explicit OIDC tenant trust boundary", () => {
   delete baseEnv.PORTAL_EXPECTED_TEAM_ID;
   delete baseEnv.OIDC_ALLOWED_EMAIL_DOMAIN;
   delete baseEnv.OIDC_ALLOWED_EMAILS;
+  delete baseEnv.OIDC_ALLOWED_GROUPS;
   for (const value of [undefined, "", " ", "replace-me"]) {
     const env = { ...baseEnv };
     if (value !== undefined) env.PORTAL_EXPECTED_TEAM_ID = value;
@@ -54,11 +55,15 @@ test("production boot requires an explicit OIDC tenant trust boundary", () => {
       encoding: "utf8",
     });
     assert.notEqual(missing.status, 0);
-    assert.match(missing.stderr, /OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, or PORTAL_EXPECTED_TEAM_ID/);
+    assert.match(
+      missing.stderr,
+      /OIDC_ALLOWED_EMAILS, OIDC_ALLOWED_EMAIL_DOMAIN, OIDC_ALLOWED_GROUPS, or PORTAL_EXPECTED_TEAM_ID/,
+    );
   }
   for (const gate of [
     { OIDC_ALLOWED_EMAILS: "admin@example.com" },
     { OIDC_ALLOWED_EMAIL_DOMAIN: "example.com" },
+    { OIDC_ALLOWED_GROUPS: "qm-users" },
     { PORTAL_EXPECTED_TEAM_ID: "T123" },
     { OIDC_ALLOWED_EMAIL_DOMAIN: "example.com", PORTAL_EXPECTED_TEAM_ID: "T123" },
   ]) {
@@ -69,6 +74,34 @@ test("production boot requires an explicit OIDC tenant trust boundary", () => {
     });
     assert.equal(accepted.status, 0, accepted.stderr);
   }
+});
+
+test("production boot validates a configured OIDC group gate", () => {
+  const command = "import('./src/index.ts').then(m => m.bootChecks())";
+  const baseEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: "production",
+    PORTAL_PUBLIC_URL: "https://agent.example.com",
+    PORTAL_SESSION_SECRET: "portal-session-secret",
+    CORE_SIGNING_SECRET: "core-signing-secret",
+    SKILL_SIGNING_SECRET: "skill-signing-secret",
+    SANDBOX_BACKEND: "local",
+    OIDC_CLIENT_ID: "client-id",
+    OIDC_CLIENT_SECRET: "client-secret",
+    OIDC_ALLOWED_GROUPS: "qm-users",
+  };
+  const boot = (env: NodeJS.ProcessEnv): { status: number | null; stderr: string } =>
+    spawnSync(process.execPath, ["--input-type=module", "-e", command], { cwd: process.cwd(), env, encoding: "utf8" });
+
+  assert.equal(boot(baseEnv).status, 0);
+  assert.equal(boot({ ...baseEnv, OIDC_ALLOWED_GROUPS: "todo" }).status, 0);
+  assert.equal(boot({ ...baseEnv, OIDC_GROUPS_CLAIM: "  memberships  " }).status, 0);
+  const emptyGroups = boot({ ...baseEnv, OIDC_ALLOWED_GROUPS: " " });
+  assert.notEqual(emptyGroups.status, 0);
+  assert.match(emptyGroups.stderr, /OIDC_ALLOWED_GROUPS must be a comma-separated list of non-empty group values/);
+  const emptyClaim = boot({ ...baseEnv, OIDC_GROUPS_CLAIM: " " });
+  assert.notEqual(emptyClaim.status, 0);
+  assert.match(emptyClaim.stderr, /OIDC_GROUPS_CLAIM must be a non-empty claim name/);
 });
 
 test("production boot requires an explicit JWKS URI for custom issuers", () => {

--- a/plugins/portal/test/oidc.test.ts
+++ b/plugins/portal/test/oidc.test.ts
@@ -7,6 +7,8 @@ import {
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserinfo,
+  normalizeGroupClaim,
+  requireAllowedGroup,
   resolvePrincipal,
   verifyIdToken,
   type OidcConfig,
@@ -230,5 +232,39 @@ test("resolvePrincipal allowedEmails permits only the seeded verified addresses"
     () =>
       resolvePrincipal(rule, { sub: "g", claims: {}, userinfo: { email: "other@example.com", email_verified: true } }),
     /permitted email list/,
+  );
+});
+
+test("requireAllowedGroup accepts exact matching groups from either verified response", () => {
+  const rule = { claim: "groups", allowedGroups: ["engineering", "operations"] };
+  assert.doesNotThrow(() =>
+    requireAllowedGroup(rule, {
+      claims: { groups: ["engineering", "other"] },
+      userinfo: { groups: ["other", "engineering"] },
+    }),
+  );
+  assert.doesNotThrow(() => requireAllowedGroup(rule, { claims: { groups: "operations" }, userinfo: {} }));
+  assert.doesNotThrow(() => requireAllowedGroup(rule, { claims: {}, userinfo: { groups: ["operations"] } }));
+});
+
+test("normalizeGroupClaim trims configured claim names and defaults to groups", () => {
+  assert.equal(normalizeGroupClaim(undefined), "groups");
+  assert.equal(normalizeGroupClaim("  memberships  "), "memberships");
+});
+
+test("requireAllowedGroup rejects missing, malformed, mismatched, and non-matching group claims", () => {
+  const rule = { claim: "groups", allowedGroups: ["engineering"] };
+  assert.throws(() => requireAllowedGroup(rule, { claims: {}, userinfo: {} }), /no groups group claim/);
+  assert.throws(
+    () => requireAllowedGroup(rule, { claims: { groups: ["engineering", 1] }, userinfo: {} }),
+    /must be a string or string array/,
+  );
+  assert.throws(
+    () => requireAllowedGroup(rule, { claims: { groups: ["engineering"] }, userinfo: { groups: ["other"] } }),
+    /differs/,
+  );
+  assert.throws(
+    () => requireAllowedGroup(rule, { claims: { groups: "Engineering" }, userinfo: {} }),
+    /not in a permitted group/,
   );
 });


### PR DESCRIPTION
## Summary

- add an exact, case-sensitive OIDC group allowlist as a production trust boundary
- support a configurable group claim from the verified ID token or userinfo response
- fail closed when both verified responses disagree, or when the claim is absent or malformed
- route the new environment settings through CLI deployment paths and document the configuration

Configured email, Slack workspace, and group restrictions remain independent and all must pass.

## Verification

- `npm --prefix plugins/portal test` (109 passing)
- `node --test test/doctor.test.ts test/secrets.test.ts` from the CLI package (54 passing)
- `npm run typecheck`
- `npm run lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789067054&installation_model_id=19911&pr_number=337&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F337&signature=85b9d7df54268d30afb212e6e7db9b10055520c40da2397902250cc3ac2f3779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->