### PR TITLE
adrs: suggestion for per user claude creds

### DIFF
--- a/adrs/claude-auth-and-per-user-model-creds.txt
+++ b/adrs/claude-auth-and-per-user-model-creds.txt
@@ -1,0 +1,26 @@
+Two related thoughts from running a small self-hosted deployment, one tiny
+and concrete, one bigger that I'd mostly like your read on.
+
+I want my personal scope running on my Claude subscription token
+(CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`) while org work bills an
+API key. Per-scope harness/model selection plus custom providers already gets
+me surprisingly close.
+
+(a) The concrete one: when both ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN
+are set, the claude harness passes both into the Claude Code child
+(claude-harness.ts, the CLAUDE_ENV_PASSTHROUGH list), and which credential
+actually gets used is decided by Claude Code's internal precedence. The
+operator has no say, and the answer silently decides whether a turn bills a
+subscription or an API account. An explicit knob (CLAUDE_AUTH=token|api-key or
+similar) that filters the passthrough would make mixed-credential deployments
+deterministic. Happy to have this be the whole ask if (b) doesn't land.
+
+(b) The bigger thought: model credentials are the one credential class that
+bypasses the keychain entirely and lives in process env. Everything else a
+person authenticates with is owner-scoped, encrypted, grantable, auditable,
+but the thing that bills money is global. What I'd love: let a person connect
+their own Claude subscription token as a keychain credential, and have
+personal-scope turns on the claude harness use *their* token, with shared/org
+scopes and the utility-harness calls (screener, titles, judge) always on the
+deployment credential. That gives per-person cost attribution.
+


### PR DESCRIPTION
Adds an ADR suggestion per CONTRIBUTING's process: two related thoughts on model credentials in mixed-credential deployments (personal scope on a Claude subscription token, org work on an API key).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789068282&installation_model_id=19911&pr_number=338&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F338&signature=04b7908f88aff60a2eb31cb730c52891ff42425dadc242cc2832da98b626d1a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->