### PR TITLE
adr: Feishu as another agent surface

### DIFF
--- a/adrs/feishu.md
+++ b/adrs/feishu.md
@@ -1,0 +1,16 @@
+# Feishu as another way to talk to QM
+
+My company uses Feishu for day-to-day communication, so Slack isn't where we'd
+actually use QM. We'd like to add QM to our existing Feishu chats instead of asking
+everyone to move to another tool.
+
+A useful first version for us would be pretty small: DMs, mentioning the bot in a
+group, replies in the same thread, and scheduled updates back to that chat. Text is
+enough to start; files and interactive cards can come later.
+
+Feishu has an official Node SDK and a WebSocket event mode, which sounds close to
+the way QM connects to Slack without needing a public callback URL. I'm happy to
+test this in our real Feishu tenant.
+
+Would Feishu be in scope as another agent surface? If so, would you rather keep it
+as its own deployment plugin or support it alongside Slack in the main project?


### PR DESCRIPTION
My company uses Feishu for internal communication, so this proposes a small Feishu surface for QM.

The first version we would actually use is DMs, group @mentions, thread replies, and scheduled updates. I can test it in our real Feishu tenant.

This PR only adds the short proposal in `adrs/feishu.md`; there is no implementation code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789142953&installation_model_id=19911&pr_number=358&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F358&signature=e58bc193211ff71c00f80df61a918915b310a6cdb8e5267944fb3597f6fe7bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->