### PR TITLE
[codex] Accept Resend sending-only API keys

### DIFF
--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -259,8 +259,11 @@ async function resendCheck(apiKey: string): Promise<void> {
       `could not reach the Resend API: ${errMessage(e)} — check network access (and any proxy) and retry`,
     );
   }
-  if (res.status === 401 || res.status === 403)
+  if (res.status === 401 || res.status === 403) {
+    const body = (await res.json().catch(() => ({}))) as { name?: string };
+    if (body.name === "restricted_api_key") return;
     throw new CliError("Resend rejected RESEND_API_KEY — mint a key with send access at https://resend.com/api-keys");
+  }
   if (!res.ok) throw new CliError(`the Resend API returned HTTP ${res.status}; retry when it recovers`);
 }
 

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -63,6 +63,31 @@ test("doctor allows deferred Slack setup but rejects a partial token pair", asyn
   );
 });
 
+test("doctor accepts a Resend sending-only API key", async () => {
+  const { sandbox: _sandbox, ...withoutSandbox } = config;
+  void _sandbox;
+  const priorFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        statusCode: 401,
+        message: "This API key is restricted to only send emails",
+        name: "restricted_api_key",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    await assert.doesNotReject(
+      doctorCommon(
+        { ...withoutSandbox, services: ["auth"], env: { auth: { AUTH_EMAIL_TRANSPORT: "resend" } } },
+        new Map([["RESEND_API_KEY", "re_sending_only"]]),
+      ),
+    );
+  } finally {
+    globalThis.fetch = priorFetch;
+  }
+});
+
 test("doctor rejects missing and placeholder portal OIDC client ids and tenant gates", async () => {
   const { sandbox: _sandbox, ...withoutSandbox } = config;
   void _sandbox;

--- a/plugins/auth/src/email.ts
+++ b/plugins/auth/src/email.ts
@@ -45,7 +45,11 @@ export function resendMailer(cfg: AuthConfig, fetchImpl: typeof fetch = fetch): 
         headers: { authorization },
         signal: AbortSignal.timeout(RESEND_TIMEOUT_MS),
       });
-      if (r.status === 401 || r.status === 403) throw new Error("Resend rejected RESEND_API_KEY");
+      if (r.status === 401 || r.status === 403) {
+        const body = (await r.json().catch(() => ({}))) as { name?: string };
+        if (body.name === "restricted_api_key") return "Resend API key accepted";
+        throw new Error("Resend rejected RESEND_API_KEY");
+      }
       if (!r.ok) throw new Error(`Resend API returned HTTP ${r.status}`);
       return "Resend API key accepted";
     },

--- a/plugins/auth/test/email.test.ts
+++ b/plugins/auth/test/email.test.ts
@@ -102,4 +102,18 @@ test("the Resend transport reports the provider's message id and surfaces refusa
 
   const badKey = resendMailer(cfg, (async () => new Response("{}", { status: 401 })) as unknown as typeof fetch);
   await assert.rejects(() => badKey.verify(), /rejected RESEND_API_KEY/);
+
+  const sendingOnlyKey = resendMailer(
+    cfg,
+    (async () =>
+      new Response(
+        JSON.stringify({
+          statusCode: 401,
+          message: "This API key is restricted to only send emails",
+          name: "restricted_api_key",
+        }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch,
+  );
+  assert.equal(await sendingOnlyKey.verify(), "Resend API key accepted");
 });


### PR DESCRIPTION
## What changed

- accept Resend's `restricted_api_key` response as proof that a sending-only API key is valid
- apply the behavior to both `qm doctor` and the auth plugin's mailer verification
- add regression coverage using Resend's exact restricted-key response

## Why

`qm doctor` probes `GET /domains`, but correctly scoped sending-only keys cannot list domains. Resend returns a structured 401 identifying these keys as `restricted_api_key`; treating every 401 as an invalid credential rejected working keys and advised operators to broaden their permissions.

Other 401 and 403 responses still fail as invalid credentials.

Closes #353.

## Validation

- `node --test test/doctor.test.ts` in `cli/` (24 tests)
- `npm test` in `plugins/auth/` (52 tests)
- root `npm run typecheck`
- CLI `npm run typecheck`
- root `npm run lint`
- Prettier check on all four changed files
- independent fresh-context review: no findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789170076&installation_model_id=19911&pr_number=361&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F361&signature=545d82b080365f79e6cb1f986909357173e038865cc900b39e3676c612d250a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->