### PR TITLE
[codex] Preserve auth email allowlist with domain

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -316,7 +316,10 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
   {
     name: "AUTH_ALLOWED_EMAILS",
     service: "auth",
-    required: { when: { kind: "env-absent", service: "auth", name: "AUTH_ALLOWED_EMAIL_DOMAIN" } },
+    required: {
+      when: { kind: "env-absent", service: "auth", name: "AUTH_ALLOWED_EMAIL_DOMAIN" },
+      optionalOtherwise: true,
+    },
     description: "Comma-separated email addresses allowed to sign in through the built-in broker.",
   },
   {
@@ -331,6 +334,7 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
           { kind: "env-absent", service: "auth", name: "AUTH_ALLOWED_EMAIL_DOMAIN" },
         ],
       },
+      optionalOtherwise: true,
     },
     description: "Email addresses allowed to sign in; the portal enforces the same list the broker does.",
   },

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -137,7 +137,10 @@ test("the broker's generated secrets reach both sides under the right names", ()
   assert.ok(!names.has("OIDC_CLIENT_SECRET"), "the operator is never asked for an OIDC client secret in broker mode");
   assert.ok(!names.has("OIDC_CLIENT_ID"));
   assert.ok(!names.has("PORTAL_EXPECTED_TEAM_ID"));
-  assert.ok(!names.has("AUTH_ALLOWED_EMAILS"), "a configured domain removes the per-address allowlist requirement");
+  const allowed = secrets.find((secret) => secret.name === "AUTH_ALLOWED_EMAILS")!;
+  assert.equal(allowed.required, false);
+  assert.deepEqual(runtimeSecretNames("auth", allowed), ["AUTH_ALLOWED_EMAILS"]);
+  assert.deepEqual(runtimeSecretNames("portal", allowed), ["OIDC_ALLOWED_EMAILS"]);
   assert.ok(names.has("RESEND_API_KEY"));
   assert.ok(!names.has("SMTP_HOST"), "only the configured transport's credentials are collected");
   assert.ok(secretsForService(config, "auth").some((secret) => secret.name === "CORE_SIGNING_SECRET"));

--- a/plugins/portal/src/oidc.ts
+++ b/plugins/portal/src/oidc.ts
@@ -135,19 +135,16 @@ export function resolvePrincipal(
   const verified = args.userinfo.email_verified;
   if (verified !== true && verified !== "true") throw new Error("email is not verified by the identity provider");
   const email = rawEmail.trim().toLowerCase();
-  if (
-    rule.allowedEmails?.length &&
-    !rule.allowedEmails.map((allowed) => allowed.trim().toLowerCase()).includes(email)
-  ) {
-    throw new Error("account is not on the permitted email list");
-  }
+  if (rule.allowedEmails?.map((allowed) => allowed.trim().toLowerCase()).includes(email)) return email;
   if (rule.allowedEmailDomain) {
     const domain = rule.allowedEmailDomain.toLowerCase();
     if (!email.endsWith(`@${domain}`)) throw new Error("account is outside the permitted domain");
     const hd = args.userinfo.hd ?? args.claims.hd;
     if (typeof hd === "string" && hd.toLowerCase() !== domain)
       throw new Error("account is outside the permitted domain");
+    return email;
   }
+  if (rule.allowedEmails?.length) throw new Error("account is not on the permitted email list");
   return email;
 }
 

--- a/plugins/portal/test/oidc.test.ts
+++ b/plugins/portal/test/oidc.test.ts
@@ -232,3 +232,19 @@ test("resolvePrincipal allowedEmails permits only the seeded verified addresses"
     /permitted email list/,
   );
 });
+
+test("resolvePrincipal permits an email matching either the list or domain", () => {
+  const rule = {
+    claim: "email" as const,
+    allowedEmails: ["admin@gmail.com"],
+    allowedEmailDomain: "example.com",
+  };
+  for (const email of ["admin@gmail.com", "member@example.com"]) {
+    assert.equal(resolvePrincipal(rule, { sub: "g", claims: {}, userinfo: { email, email_verified: true } }), email);
+  }
+  assert.throws(
+    () =>
+      resolvePrincipal(rule, { sub: "g", claims: {}, userinfo: { email: "other@gmail.com", email_verified: true } }),
+    /permitted domain/,
+  );
+});


### PR DESCRIPTION
Fixes #328.

## What changed

- keep `AUTH_ALLOWED_EMAILS` optional when `AUTH_ALLOWED_EMAIL_DOMAIN` is configured, so the CLI still sends it to auth and portal
- make portal authorization accept an address matching either the explicit list or the configured domain, matching the auth broker
- cover optional secret routing and combined list/domain authorization with focused regressions

## Root cause

The conditional secret specs had no `optionalOtherwise`, so a configured domain removed `AUTH_ALLOWED_EMAILS` from `computedSecrets` instead of making it optional. The portal also evaluated simultaneous list and domain rules as an intersection while the broker evaluated them as a union.

## Validation

- `node --test test/auth-broker.test.ts` in `cli` (8 passed)
- `node --test test/oidc.test.ts` in `plugins/portal` (14 passed)
- `npm run typecheck`
- `npm run lint`
- Prettier check on changed files
- independent fresh-context review: no findings

Live dev-instance QA was attempted, but no Slack pool app became available during the launcher's bounded wait, so no live instance was created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789171146&installation_model_id=19911&pr_number=362&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F362&signature=2a652fcdfadb9f9350b60d29ad491b48bde114f2ee18fb118e44461f7c4fe3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->