### PR TITLE
Recover local sandboxes from stale Docker networks

### DIFF
--- a/src/sandbox/docker-exec.ts
+++ b/src/sandbox/docker-exec.ts
@@ -8,19 +8,33 @@ export type DockerExec = (
 export function spawnDockerExec(dockerBin: string): DockerExec {
   return (args, timeoutMs = 60_000) =>
     new Promise((res) => {
-      const child = spawn(dockerBin, args, { timeout: timeoutMs, killSignal: "SIGKILL" });
+      const child = spawn(dockerBin, args);
       let stdout = "";
       let stderr = "";
       let settled = false;
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, timeoutMs);
       const done = (r: { code: number; stdout: string; stderr: string }) => {
         if (!settled) {
           settled = true;
+          clearTimeout(timer);
           res(r);
         }
       };
       child.stdout.on("data", (d) => (stdout += d.toString()));
       child.stderr.on("data", (d) => (stderr += d.toString()));
       child.on("error", (e) => done({ code: -1, stdout, stderr: `${stderr}\n${e.message}` }));
-      child.on("close", (code) => done({ code: code ?? -1, stdout, stderr }));
+      child.on("close", (code, signal) => {
+        let termination = "";
+        if (timedOut) termination = `docker command timed out after ${timeoutMs}ms${signal ? ` (${signal})` : ""}`;
+        else if (signal) termination = `docker command terminated by ${signal}`;
+        const diagnostic = termination
+          ? `${stderr}${stderr && !stderr.endsWith("\n") ? "\n" : ""}${termination}`
+          : stderr;
+        done({ code: code ?? -1, stdout, stderr: diagnostic });
+      });
     });
 }

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -136,11 +136,23 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     return preflightDone;
   }
 
-  async function containerState(name: string): Promise<{ running: boolean; imageId: string } | null> {
-    const r = await dexec(["inspect", "-f", "{{.State.Running}} {{.Image}}", name]);
+  async function containerState(
+    name: string,
+  ): Promise<{ running: boolean; imageId: string; networkId: string } | null> {
+    const r = await dexec([
+      "inspect",
+      "-f",
+      "{{.State.Running}} {{.Image}} {{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}",
+      name,
+    ]);
     if (r.code !== 0) return null;
-    const [running = "", imageId = ""] = r.stdout.trim().split(/\s+/);
-    return { running: running === "true", imageId };
+    const [running = "", imageId = "", networkId = ""] = r.stdout.trim().split(/\s+/);
+    return { running: running === "true", imageId, networkId };
+  }
+
+  async function containerNetworkIsCurrent(name: string, networkId: string): Promise<boolean> {
+    const r = await dexec(["network", "inspect", "-f", "{{.Id}}", localNetworkName(name)]);
+    return r.code === 0 && !!networkId && r.stdout.trim() === networkId;
   }
 
   async function resolvePort(name: string): Promise<number> {
@@ -272,7 +284,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localContainerName(scope);
       scopeByContainer.set(name, scope);
       const state = await containerState(name);
-      if (state && state.imageId === imageId) {
+      if (state && state.imageId === imageId && (await containerNetworkIsCurrent(name, state.networkId))) {
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
@@ -296,11 +308,12 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localScratchName(key);
       scratchByKey.set(key, name);
       const state = await containerState(name);
-      if (state) {
+      if (state && (await containerNetworkIsCurrent(name, state.networkId))) {
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
       }
+      if (state) await dexec(["rm", "-f", name]);
       await runContainer(name, undefined, false);
       activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
       return { name, coldStart: true };

--- a/test/docker-exec.test.ts
+++ b/test/docker-exec.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { spawnDockerExec } from "../src/sandbox/docker-exec.ts";
+
+test("docker execution reports a bounded timeout when the daemon command hangs", async () => {
+  const dockerExec = spawnDockerExec(process.execPath);
+  const result = await dockerExec(["-e", "setTimeout(() => {}, 60_000)"], 20);
+  assert.equal(result.code, -1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /docker command timed out after 20ms \(SIGKILL\)/);
+});
+
+test("docker execution preserves daemon stderr on ordinary failures", async () => {
+  const dockerExec = spawnDockerExec(process.execPath);
+  const result = await dockerExec(["-e", "process.stderr.write('daemon failed\\n'); process.exit(7)"], 1_000);
+  assert.equal(result.code, 7);
+  assert.equal(result.stderr, "daemon failed\n");
+});

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -148,6 +148,41 @@ test("a stale-image container is recreated while its home volume survives", asyn
   assert.equal(h2.coldStart, false, "existing volume means a warm home");
 });
 
+test("a container with a missing network is recreated while its home volume survives", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const layers = rw(scopeId("personal", "U-network"));
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(layers);
+  const volume = fake.containers.get(h1.id)!.volume!;
+  await firstSandbox.teardown(h1);
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await makeSandbox(fake).provision(layers);
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "container recreated after its network disappeared");
+  assert.equal(fake.volumes.has(volume), true, "volume survived the recreate");
+  assert.equal(fake.networks.has(localNetworkName(h2.id)), true, "network recreated");
+  assert.equal(h2.coldStart, false, "existing volume means a warm home");
+});
+
+test("a container attached to a replaced network is recreated", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const layers = rw(scopeId("personal", "U-replaced-network"));
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(layers);
+  const network = localNetworkName(h1.id);
+  const originalNetworkId = fake.containers.get(h1.id)!.networkId;
+  await firstSandbox.teardown(h1);
+  fake.networks.delete(network);
+  await fake.dockerExec(["network", "create", network]);
+
+  const h2 = await makeSandbox(fake).provision(layers);
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "container recreated after its network was replaced");
+  assert.notEqual(fake.containers.get(h2.id)!.networkId, originalNetworkId);
+  assert.equal(h2.coldStart, false, "existing volume means a warm home");
+});
+
 test("a scratch box has no volume and is removed on teardown", async () => {
   const fake = installFakeDocker(daemonPort);
   const sb = makeSandbox(fake);
@@ -157,6 +192,24 @@ test("a scratch box has no volume and is removed on teardown", async () => {
   assert.equal(fake.containers.get(h.id)!.volume, undefined);
   await sb.teardown(h);
   assert.equal(fake.containers.has(h.id), false, "scratch container destroyed");
+});
+
+test("a scratch box with a missing network is recreated", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const firstSandbox = makeSandbox(fake);
+  const h1 = await firstSandbox.provision(rw(scopeId("personal", "U-scratch-network")), {
+    scratch: { key: "missing-network" },
+  });
+  fake.containers.get(h1.id)!.running = false;
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await makeSandbox(fake).provision(rw(scopeId("personal", "U-scratch-network")), {
+    scratch: { key: "missing-network" },
+  });
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "scratch container recreated after its network disappeared");
+  assert.equal(fake.networks.has(localNetworkName(h2.id)), true, "scratch network recreated");
+  assert.equal(h2.coldStart, true);
 });
 
 test("teardown destroy removes both the container and its volume", async () => {

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -6,6 +6,8 @@ export interface FakeContainer {
   running: boolean;
   labels: Record<string, string>;
   volume?: string;
+  network?: string;
+  networkId?: string;
 }
 
 export interface FakeDocker {
@@ -24,6 +26,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const containers = new Map<string, FakeContainer>();
   const volumes = new Set<string>();
   const networks = new Set<string>();
+  const networkIds = new Map<string, string>();
+  let networkGeneration = 0;
   const self: FakeDocker = {
     containers,
     volumes,
@@ -48,6 +52,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const [k = "", v = ""] = args[++i]!.split("=");
         c.labels[k] = v;
       } else if (a === "-v") c.volume = args[++i]!.split(":")[0]!;
+      else if (a === "--network") c.network = args[++i]!;
       else if (a === "-p" || a === "--cpus" || a === "--memory") i++;
     }
     return c;
@@ -67,17 +72,24 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const name = rest[rest.length - 1]!;
         const c = containers.get(name);
         if (!c) return fail(`Error: No such object: ${name}`);
-        return ok(`${c.running} ${c.imageId}`);
+        return ok(`${c.running} ${c.imageId} ${c.networkId ?? ""}`);
       }
       case "network": {
-        const [sub, name] = rest as [string, string];
-        if (sub === "inspect") return networks.has(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        const [sub] = rest;
+        const name = rest[rest.length - 1]!;
+        if (sub === "inspect")
+          return networks.has(name) ? ok(networkIds.get(name)!) : fail(`Error: No such network: ${name}`);
         if (sub === "create") {
           if (networks.has(name)) return fail(`network with name ${name} already exists`);
           networks.add(name);
+          networkIds.set(name, `network:${++networkGeneration}:${name}`);
           return ok(name);
         }
-        if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        if (sub === "rm") {
+          if (!networks.delete(name)) return fail(`Error: No such network: ${name}`);
+          networkIds.delete(name);
+          return ok(name);
+        }
         return fail(`unknown network subcommand ${sub}`);
       }
       case "volume": {
@@ -98,6 +110,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const c = parseRun(rest);
         if (self.imageMissing) return fail("Unable to find image");
         if (containers.has(c.name)) return fail(`Conflict. The container name "/${c.name}" is already in use`);
+        if (c.network) c.networkId = networkIds.get(c.network);
         containers.set(c.name, c);
         self.runCount++;
         return ok("deadbeef");
@@ -105,6 +118,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
       case "start": {
         const c = containers.get(rest[0]!);
         if (!c) return fail("Error: No such container");
+        if (c.network && !networks.has(c.network))
+          return fail(`failed to set up container networking: network network:${c.network} not found`);
         c.running = true;
         return ok(rest[0]!);
       }


### PR DESCRIPTION
## Summary
- recreate sandbox containers when their per-sandbox Docker network is missing or replaced
- preserve the sandbox home volume during recovery
- bound hung Docker commands and return a clear timeout diagnostic without altering ordinary stderr

## Verification
- 20 focused sandbox tests pass
- TypeScript, ESLint, Prettier, and diff checks pass
- independent code review: approved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789181154&installation_model_id=19911&pr_number=364&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F364&signature=c4abfbd78f096fbaa32d229313fb3a4c75d1c8d971f453d03c3019e97a6db2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->