### PR TITLE
Allow five minutes for request bodies

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -452,7 +452,7 @@ function buildServer(app: App, deps: ServerOptions, allowUnsignedSourceAuth: boo
   const { fastify, routing } = buildFastify(wiring, server);
   const ready = Promise.resolve(fastify.ready());
   ready.catch((err: unknown) => console.error("[server] fastify initialization failed:", err));
-  server.requestTimeout = 30_000;
+  server.requestTimeout = 300_000;
   server.headersTimeout = 10_000;
   server.keepAliveTimeout = 5_000;
   server.maxConnections = 1024;

--- a/test/server-limits.test.ts
+++ b/test/server-limits.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+test("the Core server allows five minutes to receive a complete request", () => {
+  const built = buildApp(testConfig());
+  const server = createInsecureTestServer(built.app);
+  assert.equal(server.requestTimeout, 300_000);
+  assert.equal(server.headersTimeout, 10_000);
+  assert.equal(server.keepAliveTimeout, 5_000);
+  assert.equal(server.maxConnections, 1024);
+  server.close();
+});


### PR DESCRIPTION
## Summary

- extend the Core HTTP request-body deadline to five minutes
- lock the effective server limits with a regression test

## Testing

- `node --experimental-test-module-mocks --test test/server-limits.test.ts test/blob-endpoints.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789188588&installation_model_id=19911&pr_number=365&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F365&signature=601e2d5ce98f71b9cbdfe7d27e20a7008e2fb28d8007256dbbaed2396145ab33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->