### PR TITLE
[codex] Preserve canvas conversation across sign-in

### DIFF
--- a/plugins/web-ui/src/deep-link.ts
+++ b/plugins/web-ui/src/deep-link.ts
@@ -60,6 +60,10 @@ export function sessionLink(origin: string, base: string, sessionId: string): st
   return `${origin}${deepLinkPath(base, "chats", sessionId)}`;
 }
 
+export function authReturnPath(base: string, pathname: string, search: string, canvasSessionId: string | null): string {
+  return canvasSessionId ? deepLinkPath(base, "chats", canvasSessionId) : `${pathname}${search}`;
+}
+
 /** True for an unmodified left click — the case an in-app link should handle itself (SPA nav). Modified clicks (cmd/ctrl/shift/alt, middle-click) fall through to the browser so "open in new tab" works. */
 export function isPlainLeftClick(e: MouseEvent): boolean {
   return !(e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0);

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -33,12 +33,13 @@ import { markConnectorConnected } from "./chat";
 import { clearSkillsCache, resyncModelSelection, seedRuntimeConfig } from "./composer";
 import { ensureDeliveryStream, mainConversation, onExitCanvas } from "./conversations";
 import { clearAllDrafts, saveDraft, storedDraft } from "./drafts";
-import { deepLinkPath, isPlainLeftClick, parseDeepLink, UI_BASE } from "./deep-link";
+import { authReturnPath, deepLinkPath, isPlainLeftClick, parseDeepLink, UI_BASE } from "./deep-link";
 import {
   addBlankPane,
   canvasToast,
   drawCanvas,
   exitSplitIfActive,
+  focusedCanvasSessionId,
   loadPersistedSplit,
   mountRestoredCanvas,
   restoredCanvasNeedsSessionList,
@@ -279,7 +280,7 @@ function signInWithPortal(): void {
   } catch {
     void 0;
   }
-  const returnTo = `${location.pathname}${location.search}`;
+  const returnTo = authReturnPath(UI_BASE, location.pathname, location.search, focusedCanvasSessionId());
   location.href = `/auth/login?returnTo=${encodeURIComponent(returnTo)}`;
 }
 

--- a/plugins/web-ui/src/split-layout.ts
+++ b/plugins/web-ui/src/split-layout.ts
@@ -63,6 +63,30 @@ export function layoutNeedsSessionList(layout: unknown): boolean {
   });
 }
 
+export function serializedActiveSessionId(layout: unknown): string | null {
+  if (!layout || typeof layout !== "object") return null;
+  const o = layout as { activeGroup?: unknown; panels?: unknown; grid?: { root?: unknown } };
+  if (!o.panels || typeof o.panels !== "object") return null;
+  const panels = o.panels as Record<string, { params?: PaneSeedLike }>;
+  const stack: unknown[] = [o.grid?.root];
+  for (let budget = WALK_BUDGET; stack.length; budget--) {
+    if (budget <= 0) return null;
+    const node = stack.pop();
+    if (!node || typeof node !== "object") continue;
+    const n = node as { data?: unknown };
+    if (Array.isArray(n.data)) {
+      stack.push(...n.data);
+      continue;
+    }
+    if (!n.data || typeof n.data !== "object") continue;
+    const group = n.data as { id?: unknown; activeView?: unknown };
+    if (group.id !== o.activeGroup || typeof group.activeView !== "string") continue;
+    const sessionId = panels[group.activeView]?.params?.sessionId;
+    return typeof sessionId === "string" && sessionId ? sessionId : null;
+  }
+  return null;
+}
+
 interface PaneSeedLike {
   sessionId?: unknown;
   threadRef?: unknown;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -23,6 +23,7 @@ import {
   v1PaneSeeds,
   layoutNeedsSessionList,
   paneNeedsSessionList,
+  serializedActiveSessionId,
   type DropEdge,
   type PaneSeed,
   type SplitEdge,
@@ -359,6 +360,20 @@ function paneShowing(sessionId: string): IDockviewPanel | null {
 
 export function sessionInCanvas(sessionId: string): boolean {
   return splitState.active && paneShowing(sessionId) !== null;
+}
+
+export function focusedCanvasSessionId(): string | null {
+  if (!splitState.active) return null;
+  if (dockApi) {
+    const panel =
+      (splitState.focusedId ? dockApi.getPanel(splitState.focusedId) : null) ??
+      dockApi.activePanel ??
+      dockApi.panels[0];
+    if (panel) return panelParams(panel).sessionId ?? null;
+  }
+  if (pendingSeed?.kind === "v2") return serializedActiveSessionId(pendingSeed.layout);
+  if (pendingSeed?.kind === "v1") return pendingSeed.seeds.find((seed) => seed.sessionId)?.sessionId ?? null;
+  return lastLayout ? serializedActiveSessionId(lastLayout) : null;
 }
 
 export function splitInterceptsOpen(s: CoreSession): boolean {

--- a/plugins/web-ui/test/deep-link.test.ts
+++ b/plugins/web-ui/test/deep-link.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { deepLinkPath, parseDeepLink, sessionLink } from "../src/deep-link.ts";
+import { authReturnPath, deepLinkPath, parseDeepLink, sessionLink } from "../src/deep-link.ts";
 
 test("chats view with an active session is addressed by /?session=", () => {
   assert.equal(deepLinkPath("", "chats", "abc-123"), "/?session=abc-123");
@@ -93,4 +93,13 @@ test("only the first two path segments are addressed", () => {
 test("sessionLink builds an absolute link under the serving base", () => {
   assert.equal(sessionLink("https://portal.example", "/web-ui/", "s1"), "https://portal.example/web-ui/?session=s1");
   assert.equal(sessionLink("http://localhost:8096", "", "s1"), "http://localhost:8096/?session=s1");
+});
+
+test("auth return targets the focused canvas conversation", () => {
+  assert.equal(authReturnPath("", "/", "", "s1"), "/?session=s1");
+  assert.equal(authReturnPath("/web-ui", "/web-ui/", "", "s1"), "/web-ui/?session=s1");
+});
+
+test("auth return preserves the current page outside a conversation canvas", () => {
+  assert.equal(authReturnPath("", "/files", "?scope=personal%3Aalice", null), "/files?scope=personal%3Aalice");
 });

--- a/plugins/web-ui/test/split-layout.test.ts
+++ b/plugins/web-ui/test/split-layout.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { MAX_TILES, v1PaneSeeds } from "../src/split-layout.ts";
+import { MAX_TILES, serializedActiveSessionId, v1PaneSeeds } from "../src/split-layout.ts";
 
 const leaf = (sessionId: string | null = null, threadRef: string | null = null): object => ({
   kind: "leaf",
@@ -37,6 +37,27 @@ test("v1PaneSeeds normalizes non-string ids to null", () => {
     { sessionId: null, threadRef: null },
     { sessionId: "s2", threadRef: null },
   ]);
+});
+
+test("serializedActiveSessionId restores the active canvas tab before the dock mounts", () => {
+  const layout = {
+    activeGroup: "group-2",
+    panels: {
+      "panel-1": { params: { sessionId: "session-1" } },
+      "panel-2": { params: { sessionId: "session-2" } },
+    },
+    grid: {
+      root: {
+        data: [{ data: { id: "group-1", activeView: "panel-1" } }, { data: { id: "group-2", activeView: "panel-2" } }],
+      },
+    },
+  };
+  assert.equal(serializedActiveSessionId(layout), "session-2");
+});
+
+test("serializedActiveSessionId fails closed on incomplete persisted state", () => {
+  assert.equal(serializedActiveSessionId(null), null);
+  assert.equal(serializedActiveSessionId({ activeGroup: "missing", panels: {}, grid: {} }), null);
 });
 
 test("a conversation can be dropped onto a pane's tab strip to become a tab", () => {


### PR DESCRIPTION
## What changed

- return canvas users to the focused conversation after portal sign-in
- recover the active conversation from persisted canvas state when sign-in is required during boot
- preserve the existing current-page return behavior outside canvas mode

## Root cause

Canvas mode intentionally keeps the browser URL at `/`, while the timeout gate derived `returnTo` only from that URL. The portal correctly preserved the supplied target, but it was given the default route instead of the focused conversation.

Closes #344.

## Validation

- web UI tests: 503 passed
- focused portal auth and return-target tests: 37 passed
- web UI and portal typechecks
- affected-file lint, formatting, and `git diff --check`
- independent fresh-context review, including Dockview 7.0.4 serialized-layout verification

## QA limitation

The production-shaped dev instance could not start because this machine has no Slack pool configuration (`no poolN.env files in the pool store`). This is a navigation-only change with no rendered visual changes, so there is no screenshot delta; the focused browser-independent state and routing paths are covered by regression tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789194700&installation_model_id=19911&pr_number=366&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F366&signature=ed12fefd5fcb9d237621a52df65c348765794732862047cb4317c25a33462d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->