### PR TITLE
Add a GCP GKE Agent Sandbox runtime adapter

### DIFF
--- a/docs/gcp-runtime.md
+++ b/docs/gcp-runtime.md
@@ -22,6 +22,8 @@ Required runtime environment:
 
 The sandbox template owns isolation, persistence, limits, and egress policy. QM claims the template but cannot weaken it. Agent Pods should run non-root under gVisor, omit service-account tokens, drop all capabilities, use bounded resources, and accept ingress only from the sandbox router. The router should accept ingress only from QM core.
 
+The GKE workspace is created at `/home/agent/qm-workspace`. Managed Agent Sandbox mounts `/home/agent` as a writable volume root but can preserve an image-baked `/home/agent/workspace` directory as root-owned; using a runtime-created child keeps the agent non-root without an init container or ownership escalation.
+
 `GKE_SANDBOX_WARM_POOL` is not a claim selector in the managed `v1alpha1` API. Replace that legacy setting with `GKE_SANDBOX_TEMPLATE`; a separately managed warm pool can still reference the same template.
 
 The adapter intentionally does not create GKE, Cloud SQL, buckets, IAM, or Secret Manager resources. Those belong to the operator's versioned infrastructure repository. It also does not synchronize Secret Manager into Kubernetes Secret objects.

--- a/docs/gcp-runtime.md
+++ b/docs/gcp-runtime.md
@@ -1,0 +1,27 @@
+# GCP runtime adapter
+
+The GCP runtime uses two provider-native contracts:
+
+- `SANDBOX_BACKEND=gke` provisions `SandboxClaim` resources from a named GKE Agent Sandbox warm pool and routes the existing QM agent-daemon protocol through the upstream sandbox router.
+- `SNAPSHOT_STORE=gcs` and `TRANSFER_STORE=gcs` use Cloud Storage with Application Default Credentials and `GCS_BUCKET`.
+
+The control plane must run with Workload Identity and a namespace-scoped role that can create, get, list, watch, and delete `sandboxclaims.extensions.agents.x-k8s.io`. It does not need permission to create arbitrary Pods, Deployments, Secrets, Roles, or cluster-scoped resources.
+
+Required runtime environment:
+
+| Variable                 | Purpose                                       |
+| ------------------------ | --------------------------------------------- |
+| `SANDBOX_BACKEND=gke`    | Select GKE Agent Sandbox                      |
+| `GKE_SANDBOX_NAMESPACE`  | Namespace containing the warm pool and claims |
+| `GKE_SANDBOX_WARM_POOL`  | Existing `SandboxWarmPool` name               |
+| `GKE_SANDBOX_ROUTER_URL` | Internal sandbox-router URL                   |
+| `SNAPSHOT_STORE=gcs`     | Store file bytes in Cloud Storage             |
+| `TRANSFER_STORE=gcs`     | Store staged transfer blobs in Cloud Storage  |
+| `GCS_BUCKET`             | Dedicated runtime bucket                      |
+| `GCS_PREFIX`             | Optional deployment prefix                    |
+
+The sandbox template owns isolation, persistence, limits, and egress policy. QM claims the template but cannot weaken it. Agent Pods should run non-root under gVisor, omit service-account tokens, drop all capabilities, use bounded resources, and accept ingress only from the sandbox router. The router should accept ingress only from QM core.
+
+The adapter intentionally does not create GKE, Cloud SQL, buckets, IAM, or Secret Manager resources. Those belong to the operator's versioned infrastructure repository. It also does not synchronize Secret Manager into Kubernetes Secret objects.
+
+Set `DEPLOY_PROVIDER=disabled` for the GKE control plane. The GCP adapter covers QM agent computers and durable stores, not QM's separate hosted-app deployment feature. This makes hosted-app requests fail closed instead of falling through to a Docker daemon that does not exist in the cluster.

--- a/docs/gcp-runtime.md
+++ b/docs/gcp-runtime.md
@@ -12,7 +12,7 @@ Required runtime environment:
 | Variable                 | Purpose                                       |
 | ------------------------ | --------------------------------------------- |
 | `SANDBOX_BACKEND=gke`    | Select GKE Agent Sandbox                      |
-| `GKE_SANDBOX_NAMESPACE`  | Namespace containing the warm pool and claims |
+| `GKE_SANDBOX_NAMESPACE`  | Namespace containing the template and claims  |
 | `GKE_SANDBOX_TEMPLATE`   | Existing `SandboxTemplate` name               |
 | `GKE_SANDBOX_ROUTER_URL` | Internal sandbox-router URL                   |
 | `SNAPSHOT_STORE=gcs`     | Store file bytes in Cloud Storage             |
@@ -21,6 +21,8 @@ Required runtime environment:
 | `GCS_PREFIX`             | Optional deployment prefix                    |
 
 The sandbox template owns isolation, persistence, limits, and egress policy. QM claims the template but cannot weaken it. Agent Pods should run non-root under gVisor, omit service-account tokens, drop all capabilities, use bounded resources, and accept ingress only from the sandbox router. The router should accept ingress only from QM core.
+
+`GKE_SANDBOX_WARM_POOL` is not a claim selector in the managed `v1alpha1` API. Replace that legacy setting with `GKE_SANDBOX_TEMPLATE`; a separately managed warm pool can still reference the same template.
 
 The adapter intentionally does not create GKE, Cloud SQL, buckets, IAM, or Secret Manager resources. Those belong to the operator's versioned infrastructure repository. It also does not synchronize Secret Manager into Kubernetes Secret objects.
 

--- a/docs/gcp-runtime.md
+++ b/docs/gcp-runtime.md
@@ -9,16 +9,16 @@ The control plane must run with Workload Identity and a namespace-scoped role th
 
 Required runtime environment:
 
-| Variable                 | Purpose                                       |
-| ------------------------ | --------------------------------------------- |
-| `SANDBOX_BACKEND=gke`    | Select GKE Agent Sandbox                      |
-| `GKE_SANDBOX_NAMESPACE`  | Namespace containing the template and claims  |
-| `GKE_SANDBOX_TEMPLATE`   | Existing `SandboxTemplate` name               |
-| `GKE_SANDBOX_ROUTER_URL` | Internal sandbox-router URL                   |
-| `SNAPSHOT_STORE=gcs`     | Store file bytes in Cloud Storage             |
-| `TRANSFER_STORE=gcs`     | Store staged transfer blobs in Cloud Storage  |
-| `GCS_BUCKET`             | Dedicated runtime bucket                      |
-| `GCS_PREFIX`             | Optional deployment prefix                    |
+| Variable                 | Purpose                                      |
+| ------------------------ | -------------------------------------------- |
+| `SANDBOX_BACKEND=gke`    | Select GKE Agent Sandbox                     |
+| `GKE_SANDBOX_NAMESPACE`  | Namespace containing the template and claims |
+| `GKE_SANDBOX_TEMPLATE`   | Existing `SandboxTemplate` name              |
+| `GKE_SANDBOX_ROUTER_URL` | Internal sandbox-router URL                  |
+| `SNAPSHOT_STORE=gcs`     | Store file bytes in Cloud Storage            |
+| `TRANSFER_STORE=gcs`     | Store staged transfer blobs in Cloud Storage |
+| `GCS_BUCKET`             | Dedicated runtime bucket                     |
+| `GCS_PREFIX`             | Optional deployment prefix                   |
 
 The sandbox template owns isolation, persistence, limits, and egress policy. QM claims the template but cannot weaken it. Agent Pods should run non-root under gVisor, omit service-account tokens, drop all capabilities, use bounded resources, and accept ingress only from the sandbox router. The router should accept ingress only from QM core.
 

--- a/docs/gcp-runtime.md
+++ b/docs/gcp-runtime.md
@@ -2,7 +2,7 @@
 
 The GCP runtime uses two provider-native contracts:
 
-- `SANDBOX_BACKEND=gke` provisions `SandboxClaim` resources from a named GKE Agent Sandbox warm pool and routes the existing QM agent-daemon protocol through the upstream sandbox router.
+- `SANDBOX_BACKEND=gke` provisions `SandboxClaim` resources from a named GKE Agent Sandbox template and routes the existing QM agent-daemon protocol through the upstream sandbox router. GKE can satisfy matching claims from a separately managed warm pool.
 - `SNAPSHOT_STORE=gcs` and `TRANSFER_STORE=gcs` use Cloud Storage with Application Default Credentials and `GCS_BUCKET`.
 
 The control plane must run with Workload Identity and a namespace-scoped role that can create, get, list, watch, and delete `sandboxclaims.extensions.agents.x-k8s.io`. It does not need permission to create arbitrary Pods, Deployments, Secrets, Roles, or cluster-scoped resources.
@@ -13,7 +13,7 @@ Required runtime environment:
 | ------------------------ | --------------------------------------------- |
 | `SANDBOX_BACKEND=gke`    | Select GKE Agent Sandbox                      |
 | `GKE_SANDBOX_NAMESPACE`  | Namespace containing the warm pool and claims |
-| `GKE_SANDBOX_WARM_POOL`  | Existing `SandboxWarmPool` name               |
+| `GKE_SANDBOX_TEMPLATE`   | Existing `SandboxTemplate` name               |
 | `GKE_SANDBOX_ROUTER_URL` | Internal sandbox-router URL                   |
 | `SNAPSHOT_STORE=gcs`     | Store file bytes in Cloud Storage             |
 | `TRANSFER_STORE=gcs`     | Store staged transfer blobs in Cloud Storage  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@earendil-works/pi-ai": "0.82.0",
         "@earendil-works/pi-coding-agent": "https://github.com/yc-software/pi/releases/download/qm-pi-coding-agent-0.82.0-security.3/earendil-works-pi-coding-agent-0.82.0-qm-security.3.tgz",
         "@fly/sprites": "0.0.1",
+        "@google-cloud/storage": "^7.21.0",
+        "@kubernetes/client-node": "^1.4.0",
         "@openai/codex": "0.144.5",
         "@opencode-ai/plugin": "1.17.18",
         "@opencode-ai/sdk": "1.17.18",
@@ -60,7 +62,7 @@
     },
     "cli": {
       "name": "@yc-software/qm",
-      "version": "0.1.0",
+      "version": "0.1.6",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -768,87 +770,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
-      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
-        "diff": "8.0.4",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-ai": {
       "version": "0.82.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
@@ -950,16 +871,483 @@
         "@mariozechner/clipboard": "0.3.9"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
     },
-    "node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
-      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.0.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.82.0",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.82.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.0.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -967,6 +1355,1303 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1254,6 +2939,151 @@
         "node": ">=24.0.0"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
@@ -1356,183 +3186,72 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
-      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">= 10.16.0"
       },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
-        "@mariozechner/clipboard-darwin-universal": "0.3.9",
-        "@mariozechner/clipboard-darwin-x64": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
-      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
-      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
       }
     },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
-      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@kubernetes/client-node/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
-      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
-      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
-      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
-      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
-      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
-      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
-      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -1694,6 +3413,18 @@
         "@emnapi/core": "^2.0.0-alpha.3",
         "@emnapi/runtime": "^2.0.0-alpha.3"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@openai/codex": {
       "version": "0.144.5",
@@ -2958,12 +4689,6 @@
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@slack/bolt": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-4.7.3.tgz",
@@ -3203,6 +4928,15 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -3224,6 +4958,12 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -3281,6 +5021,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3313,6 +5059,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -3338,6 +5094,56 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -3366,6 +5172,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/tar-stream": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-3.1.4.tgz",
@@ -3375,6 +5190,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3609,6 +5430,18 @@
       "resolved": "cli",
       "link": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -3691,6 +5524,42 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -3783,6 +5652,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3944,6 +5814,7 @@
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3994,18 +5865,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/combined-stream": {
@@ -4192,15 +6051,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4213,6 +6063,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -4261,6 +6123,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -4525,6 +6396,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -4754,6 +6634,45 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastify": {
       "version": "5.10.0",
@@ -5080,18 +6999,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5140,23 +7047,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -5223,11 +7113,67 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gtoken/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -5268,15 +7214,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hono": {
       "version": "4.12.34",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
@@ -5286,17 +7223,30 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": ">=14"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -5364,6 +7314,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -5459,16 +7410,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5481,6 +7454,37 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "node_modules/json-bigint": {
@@ -5555,6 +7559,24 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -5800,18 +7822,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5846,6 +7856,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -5875,6 +7897,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -5884,15 +7907,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -6017,6 +8031,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -6268,6 +8291,19 @@
         "win32"
       ]
     },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6417,7 +8453,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -6517,6 +8552,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6524,22 +8574,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -6798,26 +8832,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -6870,6 +8884,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6948,6 +8972,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -6994,6 +9032,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7003,6 +9055,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
@@ -7277,11 +9335,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
     "node_modules/smol-toml": {
       "version": "1.7.1",
@@ -7294,6 +9356,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -7334,6 +9424,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
@@ -7343,6 +9457,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7358,6 +9481,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -7370,6 +9514,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
@@ -7380,6 +9538,94 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/teex": {
@@ -7467,6 +9713,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -7615,15 +9867,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -7648,6 +9891,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.1",
@@ -7688,6 +9937,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7742,6 +10007,21 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -7770,7 +10050,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@earendil-works/pi-ai": "0.82.0",
     "@earendil-works/pi-coding-agent": "https://github.com/yc-software/pi/releases/download/qm-pi-coding-agent-0.82.0-security.3/earendil-works-pi-coding-agent-0.82.0-qm-security.3.tgz",
     "@fly/sprites": "0.0.1",
+    "@google-cloud/storage": "^7.21.0",
+    "@kubernetes/client-node": "^1.4.0",
     "@openai/codex": "0.144.5",
     "@opencode-ai/plugin": "1.17.18",
     "@opencode-ai/sdk": "1.17.18",
@@ -90,6 +92,15 @@
     "fast-json-stringify": {
       "fast-uri": "4.1.2"
     },
+    "gaxios": {
+      "uuid": "11.1.1"
+    },
+    "gtoken": {
+      "uuid": "11.1.1"
+    },
+    "teeny-request": {
+      "uuid": "11.1.1"
+    },
     "protobufjs": "7.6.5"
   },
   "devDependencies": {
@@ -98,13 +109,13 @@
     "@types/node": "^24.0.0",
     "@types/pg": "^8.11.10",
     "@types/tar-stream": "^3.1.4",
+    "@yc-software/qm": "file:./cli",
     "eslint": "^10.4.1",
     "globals": "^17.6.0",
     "knip": "^6.26.0",
     "oxlint": "^1.74.0",
     "prettier": "3.9.1",
     "typescript": "^5.8.2",
-    "typescript-eslint": "^8.61.0",
-    "@yc-software/qm": "file:./cli"
+    "typescript-eslint": "^8.61.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -252,7 +252,7 @@ interface LocalSandboxEnv {
 
 interface GkeSandboxEnv {
   namespace: string;
-  warmPool: string;
+  sandboxTemplate: string;
   routerUrl: string;
   routerToken?: string;
   agentPort?: number;
@@ -263,7 +263,7 @@ interface GkeSandboxEnv {
 function gkeSandboxEnv(env: NodeJS.ProcessEnv): GkeSandboxEnv {
   return {
     namespace: env.GKE_SANDBOX_NAMESPACE ?? "qm-sandboxes",
-    warmPool: env.GKE_SANDBOX_WARM_POOL ?? "qm-sandbox-pool",
+    sandboxTemplate: env.GKE_SANDBOX_TEMPLATE ?? "qm-sandbox-template",
     routerUrl: env.GKE_SANDBOX_ROUTER_URL ?? "http://sandbox-router.agent-sandbox-system.svc.cluster.local:8080",
     ...(env.GKE_SANDBOX_ROUTER_TOKEN ? { routerToken: env.GKE_SANDBOX_ROUTER_TOKEN } : {}),
     ...(numEnvStrict("GKE_SANDBOX_AGENT_PORT", env.GKE_SANDBOX_AGENT_PORT) !== undefined

--- a/src/config.ts
+++ b/src/config.ts
@@ -635,6 +635,14 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     sandboxSecondaryBackend = secondary;
   }
   if (
+    (sandboxBackend === "gke" || sandboxSecondaryBackend === "gke") &&
+    env.GKE_SANDBOX_WARM_POOL?.trim()
+  ) {
+    throw new Error(
+      "GKE_SANDBOX_WARM_POOL is no longer supported — set GKE_SANDBOX_TEMPLATE to the SandboxTemplate referenced by the warm pool.",
+    );
+  }
+  if (
     env.NODE_ENV === "production" &&
     (sandboxBackend === "gke" || sandboxSecondaryBackend === "gke") &&
     !env.GKE_SANDBOX_ROUTER_TOKEN?.trim()

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,9 +31,9 @@ export interface Config {
   databaseUrl?: string;
   harness: "mock" | "pi" | "opencode" | "codex" | "claude";
   securityPosture: SecurityPosture;
-  sandboxBackend: "aws" | "local" | "sprites";
-  sandboxSecondaryBackend?: "aws" | "local" | "sprites";
-  deployProvider: "docker" | "aws";
+  sandboxBackend: "aws" | "gke" | "local" | "sprites";
+  sandboxSecondaryBackend?: "aws" | "gke" | "local" | "sprites";
+  deployProvider: "docker" | "aws" | "disabled";
   egressServiceHosts?: string[];
   brandingDefault?: { accent?: string; mark?: string; selfLabel?: string };
   modelId?: string;
@@ -96,11 +96,13 @@ export interface Config {
   pluginSkillDirs: string[];
   deploymentLayerDir?: string;
   layerEnv?: Readonly<Record<string, string | undefined>>;
-  snapshotStore: "local" | "s3";
-  transferStore: "local" | "s3";
+  snapshotStore: "gcs" | "local" | "s3";
+  transferStore: "gcs" | "local" | "s3";
   s3Bucket?: string;
   s3Region?: string;
   s3Prefix?: string;
+  gcsBucket?: string;
+  gcsPrefix?: string;
   deployIdleTtlMs?: number;
   deployGitDir: string;
   deployDialTimeoutMs: number;
@@ -142,6 +144,7 @@ export interface Config {
   awsSandbox: AwsSandboxEnv;
   localSandbox: LocalSandboxEnv;
   spritesSandbox: SpritesSandboxEnv;
+  gkeSandbox: GkeSandboxEnv;
   awsDeploy: AwsDeployEnv;
 }
 
@@ -245,6 +248,32 @@ interface LocalSandboxEnv {
   cpus?: number;
   memoryMb?: number;
   defaultTimeoutSec?: number;
+}
+
+interface GkeSandboxEnv {
+  namespace: string;
+  warmPool: string;
+  routerUrl: string;
+  routerToken?: string;
+  agentPort?: number;
+  defaultTimeoutSec?: number;
+  homeDir?: string;
+}
+
+function gkeSandboxEnv(env: NodeJS.ProcessEnv): GkeSandboxEnv {
+  return {
+    namespace: env.GKE_SANDBOX_NAMESPACE ?? "qm-sandboxes",
+    warmPool: env.GKE_SANDBOX_WARM_POOL ?? "qm-sandbox-pool",
+    routerUrl: env.GKE_SANDBOX_ROUTER_URL ?? "http://sandbox-router.agent-sandbox-system.svc.cluster.local:8080",
+    ...(env.GKE_SANDBOX_ROUTER_TOKEN ? { routerToken: env.GKE_SANDBOX_ROUTER_TOKEN } : {}),
+    ...(numEnvStrict("GKE_SANDBOX_AGENT_PORT", env.GKE_SANDBOX_AGENT_PORT) !== undefined
+      ? { agentPort: numEnvStrict("GKE_SANDBOX_AGENT_PORT", env.GKE_SANDBOX_AGENT_PORT) }
+      : {}),
+    ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
+      ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }
+      : {}),
+    ...(env.GKE_SANDBOX_HOME_DIR ? { homeDir: env.GKE_SANDBOX_HOME_DIR } : {}),
+  };
 }
 
 function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
@@ -476,8 +505,24 @@ function harnessEnvStrict(value: string | undefined): Config["harness"] {
 function sandboxBackendEnvStrict(value: string | undefined, name = "SANDBOX_BACKEND"): Config["sandboxBackend"] {
   if (value === undefined || value.trim() === "") return "local";
   const backend = value.trim();
-  if (backend === "aws" || backend === "local" || backend === "sprites") return backend;
-  throw new Error(`${name}=${JSON.stringify(value)} is not recognized — use aws, local, or sprites, or unset it.`);
+  if (backend === "aws" || backend === "gke" || backend === "local" || backend === "sprites") return backend;
+  throw new Error(`${name}=${JSON.stringify(value)} is not recognized — use aws, gke, local, or sprites, or unset it.`);
+}
+
+function deployProviderEnvStrict(value: string | undefined): Config["deployProvider"] {
+  if (value === undefined || value.trim() === "") return "docker";
+  const provider = value.trim();
+  if (provider === "aws" || provider === "docker" || provider === "disabled") return provider;
+  throw new Error(
+    `DEPLOY_PROVIDER=${JSON.stringify(value)} is not recognized — use aws, docker, or disabled, or unset it.`,
+  );
+}
+
+function objectStoreEnvStrict(value: string | undefined): Config["snapshotStore"] {
+  if (value === undefined || value.trim() === "") return "local";
+  const store = value.trim();
+  if (store === "s3" || store === "gcs" || store === "local") return store;
+  throw new Error(`object store ${JSON.stringify(value)} is not recognized — use s3, gcs, or local, or unset it.`);
 }
 
 function secretsBackendEnvStrict(value: string | undefined, prefix: string): Config["secretsBackend"] {
@@ -579,7 +624,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
   const dataDir = resolve(env.DATA_DIR ?? "./data");
   if (env.NODE_ENV === "production" && !env.SANDBOX_BACKEND?.trim()) {
-    throw new Error("SANDBOX_BACKEND must be set explicitly in production — use sprites, aws, or local.");
+    throw new Error("SANDBOX_BACKEND must be set explicitly in production — use sprites, aws, gke, or local.");
   }
   const sandboxBackend = sandboxBackendEnvStrict(env.SANDBOX_BACKEND);
   const secondaryRaw = env.SANDBOX_SECONDARY_BACKEND?.trim();
@@ -588,6 +633,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     const secondary = sandboxBackendEnvStrict(secondaryRaw, "SANDBOX_SECONDARY_BACKEND");
     if (secondary === sandboxBackend) throw new Error("SANDBOX_SECONDARY_BACKEND must differ from SANDBOX_BACKEND.");
     sandboxSecondaryBackend = secondary;
+  }
+  if (
+    env.NODE_ENV === "production" &&
+    (sandboxBackend === "gke" || sandboxSecondaryBackend === "gke") &&
+    !env.GKE_SANDBOX_ROUTER_TOKEN?.trim()
+  ) {
+    throw new Error("a GKE sandbox backend requires GKE_SANDBOX_ROUTER_TOKEN in production");
   }
   const securityScreenBackend = securityScreenBackendEnvStrict(env.SECURITY_SCREEN_BACKEND);
   const proxyProvider = env.SECURITY_SCREEN_PROXY_PROVIDER?.trim();
@@ -635,7 +687,10 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
   const publicApiUrl = env.PUBLIC_API_URL ?? env.AGENT_API_URL;
   const publicUrl = env.PUBLIC_WEB_URL ?? publicApiUrl;
-  const deployProvider: "aws" | "docker" = env.DEPLOY_PROVIDER === "aws" ? "aws" : "docker";
+  const deployProvider = deployProviderEnvStrict(env.DEPLOY_PROVIDER);
+  if ((env.SNAPSHOT_STORE === "gcs" || env.TRANSFER_STORE === "gcs") && !env.GCS_BUCKET?.trim()) {
+    throw new Error("SNAPSHOT_STORE=gcs or TRANSFER_STORE=gcs requires GCS_BUCKET");
+  }
   let runStore: "memory" | "postgres" = env.SESSION_STORE === "postgres" ? "postgres" : "memory";
   if (env.RUN_STORE === "memory" || env.RUN_STORE === "postgres") runStore = env.RUN_STORE;
   const providerBaseUrls = providerBaseUrlsFromEnv(env);
@@ -810,11 +865,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     ...(numEnvStrict("MEMORY_CAPTURE_MAX_TURNS", env.MEMORY_CAPTURE_MAX_TURNS) !== undefined
       ? { memoryCaptureMaxTurns: numEnvStrict("MEMORY_CAPTURE_MAX_TURNS", env.MEMORY_CAPTURE_MAX_TURNS) }
       : {}),
-    snapshotStore: env.SNAPSHOT_STORE === "s3" ? "s3" : "local",
-    transferStore: env.TRANSFER_STORE === "s3" ? "s3" : "local",
+    snapshotStore: objectStoreEnvStrict(env.SNAPSHOT_STORE),
+    transferStore: objectStoreEnvStrict(env.TRANSFER_STORE),
     ...(env.S3_BUCKET ? { s3Bucket: env.S3_BUCKET } : {}),
     ...(env.S3_REGION ? { s3Region: env.S3_REGION } : {}),
     ...(env.S3_PREFIX ? { s3Prefix: env.S3_PREFIX } : {}),
+    ...(env.GCS_BUCKET ? { gcsBucket: env.GCS_BUCKET } : {}),
+    ...(env.GCS_PREFIX ? { gcsPrefix: env.GCS_PREFIX } : {}),
     ...(numEnvStrict("DEPLOY_IDLE_TTL_MS", env.DEPLOY_IDLE_TTL_MS) !== undefined
       ? { deployIdleTtlMs: numEnvStrict("DEPLOY_IDLE_TTL_MS", env.DEPLOY_IDLE_TTL_MS) }
       : {}),
@@ -854,6 +911,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     awsSandbox: awsSandboxEnv(env),
     localSandbox: localSandboxEnv(env),
     spritesSandbox: spritesSandboxEnv(env),
+    gkeSandbox: gkeSandboxEnv(env),
     awsDeploy: awsDeployEnv(env),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -634,10 +634,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     if (secondary === sandboxBackend) throw new Error("SANDBOX_SECONDARY_BACKEND must differ from SANDBOX_BACKEND.");
     sandboxSecondaryBackend = secondary;
   }
-  if (
-    (sandboxBackend === "gke" || sandboxSecondaryBackend === "gke") &&
-    env.GKE_SANDBOX_WARM_POOL?.trim()
-  ) {
+  if ((sandboxBackend === "gke" || sandboxSecondaryBackend === "gke") && env.GKE_SANDBOX_WARM_POOL?.trim()) {
     throw new Error(
       "GKE_SANDBOX_WARM_POOL is no longer supported — set GKE_SANDBOX_TEMPLATE to the SandboxTemplate referenced by the warm pool.",
     );

--- a/src/deploy/disabled-deploy-provider.ts
+++ b/src/deploy/disabled-deploy-provider.ts
@@ -1,0 +1,16 @@
+import type { Deployment, DeploymentVersion } from "./deploy-store.ts";
+import type { DeployProvider } from "./deploy-provider.ts";
+
+const disabled = (): never => {
+  throw new Error("Hosted app deployments are disabled for this QM runtime");
+};
+
+export function createDisabledDeployProvider(): DeployProvider {
+  return {
+    profile: { managedScaleToZero: true },
+    async apply(_deployment: Deployment, _version: DeploymentVersion) {
+      return disabled();
+    },
+    async destroy(_deployment: Deployment): Promise<void> {},
+  };
+}

--- a/src/files/durable-byte-store.ts
+++ b/src/files/durable-byte-store.ts
@@ -4,6 +4,7 @@ import { once } from "node:events";
 import { Readable } from "node:stream";
 import { join } from "node:path";
 import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { Storage } from "@google-cloud/storage";
 import { swallowAs } from "../util/errors.ts";
 import { collectBytes, type ByteSource } from "../util/bytes.ts";
 import { bodyToReadable, isNoSuchKey, s3Client, type S3Send } from "../persistence/s3.ts";
@@ -127,6 +128,59 @@ export interface S3DurableByteOptions {
   region?: string;
   prefix?: string;
   _client?: S3Send;
+}
+
+interface GcsDurableFile {
+  save(data: Buffer, options?: { resumable?: boolean }): Promise<unknown>;
+  getMetadata(): Promise<Array<{ size?: string | number }>>;
+  createReadStream(): Readable;
+  delete(options?: { ignoreNotFound?: boolean }): Promise<unknown>;
+}
+
+interface GcsDurableBucket {
+  file(name: string): GcsDurableFile;
+}
+
+export interface GcsDurableByteOptions {
+  bucket: string;
+  prefix?: string;
+  _bucket?: GcsDurableBucket;
+}
+
+const isGcsNotFound = (error: unknown): boolean =>
+  (error as { code?: number | string } | undefined)?.code === 404 ||
+  (error as { code?: number | string } | undefined)?.code === "404";
+
+export function createGcsDurableByteStore(options: GcsDurableByteOptions): DurableByteStore {
+  const bucket = options._bucket ?? (new Storage().bucket(options.bucket) as unknown as GcsDurableBucket);
+  const prefix = options.prefix ?? "";
+
+  return {
+    async put(source, opts) {
+      const { data, sha256 } = await collect(source, opts?.maxBytes);
+      const blobKey = keyFor(sha256);
+      await bucket.file(prefix + blobKey).save(data, { resumable: false });
+      return { blobKey, sizeBytes: data.length, sha256 };
+    },
+
+    async open(blobKey) {
+      if (!BLOB_KEY.test(blobKey)) return null;
+      const file = bucket.file(prefix + blobKey);
+      let metadata: { size?: string | number };
+      try {
+        [metadata = {}] = await file.getMetadata();
+      } catch (error) {
+        if (isGcsNotFound(error)) return null;
+        throw error;
+      }
+      return { sizeBytes: Number(metadata.size ?? 0), stream: file.createReadStream() };
+    },
+
+    async delete(blobKey) {
+      if (!BLOB_KEY.test(blobKey)) return;
+      await bucket.file(prefix + blobKey).delete({ ignoreNotFound: true });
+    },
+  };
 }
 
 export function createS3DurableByteStore(options: S3DurableByteOptions): DurableByteStore {

--- a/src/persistence/blob-transfer.ts
+++ b/src/persistence/blob-transfer.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
 import { mkdir, readdir, rename, rm, stat } from "node:fs/promises";
 import { once } from "node:events";
-import { Readable } from "node:stream";
+import { Readable, type Writable } from "node:stream";
 import { join } from "node:path";
 import {
   AbortMultipartUploadCommand,
@@ -17,6 +17,7 @@ import {
   UploadPartCommand,
   type LifecycleRule,
 } from "@aws-sdk/client-s3";
+import { Storage } from "@google-cloud/storage";
 import { swallow, swallowAs } from "../util/errors.ts";
 import { asChunks, collectBytes, type ByteSource } from "../util/bytes.ts";
 import { bodyToReadable, isNoSuchKey, isNoSuchLifecycleConfiguration, s3Client, type S3Send } from "./s3.ts";
@@ -164,6 +165,114 @@ export interface S3BlobTransferOptions {
   region?: string;
   prefix?: string;
   _client?: S3Send;
+}
+
+interface GcsBlobFile {
+  createWriteStream(options?: { resumable?: boolean; metadata?: { metadata?: Record<string, string> } }): Writable;
+  createReadStream(): Readable;
+  getMetadata(): Promise<Array<{ size?: string | number; updated?: string; timeCreated?: string }>>;
+  delete(options?: { ignoreNotFound?: boolean }): Promise<unknown>;
+}
+
+interface GcsBlobBucket {
+  file(name: string): GcsBlobFile;
+  getFiles(options: { prefix: string }): Promise<Array<GcsBlobFile[]>>;
+}
+
+export interface GcsBlobTransferOptions {
+  bucket: string;
+  prefix?: string;
+  _bucket?: GcsBlobBucket;
+}
+
+const isGcsMissing = (error: unknown): boolean => {
+  const code = (error as { code?: number | string } | undefined)?.code;
+  return code === 404 || code === "404";
+};
+
+export function createGcsBlobTransferStore(options: GcsBlobTransferOptions): BlobTransferStore {
+  const bucket = options._bucket ?? (new Storage().bucket(options.bucket) as unknown as GcsBlobBucket);
+  const prefix = `${options.prefix ?? ""}transfer/`;
+
+  return {
+    async put(source, opts) {
+      const blobId = newBlobId();
+      const file = bucket.file(prefix + blobId);
+      const hash = createHash("sha256");
+      const output = file.createWriteStream({ resumable: true });
+      let rejectOutput: ((reason?: unknown) => void) | undefined;
+      const outputError = new Promise<never>((_resolve, reject) => {
+        rejectOutput = reject;
+      });
+      const onOutputError = (error: Error): void => rejectOutput?.(error);
+      output.once("error", onOutputError);
+      let sizeBytes = 0;
+      const chunks = asChunks(source)[Symbol.asyncIterator]();
+      try {
+        while (true) {
+          const next = await Promise.race([chunks.next(), outputError]);
+          if (next.done) break;
+          const chunk = next.value;
+          const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          sizeBytes += data.length;
+          if (opts?.maxBytes != null && sizeBytes > opts.maxBytes) throw new BlobTooLargeError();
+          hash.update(data);
+          if (!output.write(data)) await Promise.race([once(output, "drain"), outputError]);
+        }
+        await Promise.race([new Promise<void>((resolve) => output.end(resolve)), outputError]);
+      } catch (error) {
+        output.destroy();
+        await chunks.return?.().catch(swallowAs("blob-transfer: GCS source cleanup", undefined));
+        await file.delete({ ignoreNotFound: true }).catch(swallowAs("blob-transfer: GCS partial cleanup", undefined));
+        throw error;
+      } finally {
+        output.off("error", onOutputError);
+      }
+      const sha256 = hash.digest("hex");
+      if (opts?.expectedSha256 && opts.expectedSha256 !== sha256) {
+        await file.delete({ ignoreNotFound: true });
+        throw new BlobHashMismatchError();
+      }
+      return { blobId, sizeBytes, sha256 };
+    },
+
+    async open(blobId) {
+      if (!BLOB_ID.test(blobId)) return null;
+      const file = bucket.file(prefix + blobId);
+      let metadata: { size?: string | number };
+      try {
+        [metadata = {}] = await file.getMetadata();
+      } catch (error) {
+        if (isGcsMissing(error)) return null;
+        throw error;
+      }
+      return { sizeBytes: Number(metadata.size ?? 0), stream: file.createReadStream() };
+    },
+
+    async delete(blobId) {
+      if (!BLOB_ID.test(blobId)) return;
+      await bucket.file(prefix + blobId).delete({ ignoreNotFound: true });
+    },
+
+    async sweep(maxAgeMs) {
+      const cutoff = Date.now() - maxAgeMs;
+      const [files = []] = await bucket.getFiles({ prefix });
+      let removed = 0;
+      for (const file of files) {
+        try {
+          const [metadata = {}] = await file.getMetadata();
+          const timestamp = Date.parse(metadata.updated ?? metadata.timeCreated ?? "");
+          if (Number.isFinite(timestamp) && timestamp <= cutoff) {
+            await file.delete({ ignoreNotFound: true });
+            removed++;
+          }
+        } catch (error) {
+          if (!isGcsMissing(error)) swallow("blob-transfer: GCS sweep entry", error);
+        }
+      }
+      return removed;
+    },
+  };
 }
 
 export function createS3BlobTransferStore(options: S3BlobTransferOptions): BlobTransferStore {

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -1,0 +1,421 @@
+import { randomUUID } from "node:crypto";
+import { CustomObjectsApi, KubeConfig } from "@kubernetes/client-node";
+import type { WorkspaceLayer } from "../types.ts";
+import type { WorkspaceStore } from "../workspace/workspace-store.ts";
+import { ephemeralCredLinkPaths, ephemeralCredLinkScript } from "../credentials/resident-paths.ts";
+import { createKeyedQueue, sleep } from "../util/async.ts";
+import { shortHash } from "../util/crypto.ts";
+import { errMessage, swallowAs } from "../util/errors.ts";
+import { shq } from "../util/shell.ts";
+import { createExecBackup, createExecFileOps, posixJoin } from "./exec-file-ops.ts";
+import { killableScript, killScript } from "./exec-kill.ts";
+import { createExecProcessSessions, type ExecProcessIo } from "./exec-process-session.ts";
+import { materializeRoLayers } from "./ro-layers.ts";
+import { nonInteractiveShellPrefix } from "./sandbox-env.ts";
+import type {
+  AgentComputerProfile,
+  ExecOptions,
+  ExecResult,
+  ProvisionOptions,
+  Sandbox,
+  SandboxHandle,
+  TeardownOptions,
+} from "./sandbox.ts";
+
+const GROUP = "extensions.agents.x-k8s.io";
+const VERSION = "v1beta1";
+const PLURAL = "sandboxclaims";
+const RO_LAYERS_TAR = ".ro-layers.tar";
+const RO_LAYERS_MANIFEST = ".ro-layers.manifest";
+
+interface ClaimStatus {
+  sandbox?: { name?: string };
+  conditions?: Array<{ status?: string; type?: string; message?: string }>;
+}
+
+interface ClaimBody {
+  status?: ClaimStatus;
+}
+
+interface CustomObjectsClient {
+  createNamespacedCustomObject(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    body: unknown,
+  ): Promise<unknown>;
+  deleteNamespacedCustomObject(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<unknown>;
+  getNamespacedCustomObject(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<unknown>;
+}
+
+export interface GkeSandboxOptions {
+  namespace: string;
+  warmPool: string;
+  routerUrl: string;
+  routerToken?: string;
+  agentPort?: number;
+  defaultTimeoutSec?: number;
+  homeDir?: string;
+  claimTimeoutMs?: number;
+  daemonReadyTimeoutMs?: number;
+  extraTools?: string[];
+  client?: CustomObjectsClient;
+  fetchImpl?: typeof fetch;
+  onError?: (e: { category: string; code: string; message: string; scopeLabel?: string }) => void;
+}
+
+const bodyOf = <T>(value: unknown): T => ((value as { body?: unknown } | undefined)?.body ?? value) as T;
+
+const statusCodeOf = (error: unknown): number | undefined => {
+  const candidate = error as {
+    statusCode?: number;
+    response?: { statusCode?: number; status?: number };
+    body?: { code?: number };
+  };
+  return (
+    candidate?.statusCode ?? candidate?.response?.statusCode ?? candidate?.response?.status ?? candidate?.body?.code
+  );
+};
+
+const claimNameFor = (scope: string): string => {
+  const cleaned = scope
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 42)
+    .replace(/-+$/, "");
+  return `qm-${cleaned || "scope"}-${shortHash(scope)}`;
+};
+
+const claimStatus = (value: unknown): ClaimStatus => bodyOf<ClaimBody>(value).status ?? {};
+
+export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOptions): Sandbox {
+  const namespace = opts.namespace;
+  const agentPort = opts.agentPort ?? 8080;
+  const defaultTimeoutSec = opts.defaultTimeoutSec ?? 600;
+  const homeDir = opts.homeDir ?? "/home/agent";
+  const workspaceDir = `${homeDir}/workspace`;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const queue = createKeyedQueue<string>();
+  const claimBySandbox = new Map<string, string>();
+  const activeBySandbox = new Map<string, number>();
+  const api =
+    opts.client ??
+    (() => {
+      const config = new KubeConfig();
+      config.loadFromDefault();
+      return config.makeApiClient(CustomObjectsApi) as unknown as CustomObjectsClient;
+    })();
+
+  async function getClaim(name: string): Promise<unknown | null> {
+    try {
+      return await api.getNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, name);
+    } catch (error) {
+      if (statusCodeOf(error) === 404) return null;
+      throw error;
+    }
+  }
+
+  async function ensureClaim(scope: string): Promise<{ claim: string; sandbox: string; coldStart: boolean }> {
+    return queue(scope, async () => {
+      const claim = claimNameFor(scope);
+      let value = await getClaim(claim);
+      const coldStart = value === null;
+      if (value === null) {
+        value = await api.createNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, {
+          apiVersion: `${GROUP}/${VERSION}`,
+          kind: "SandboxClaim",
+          metadata: {
+            name: claim,
+            namespace,
+            labels: {
+              "app.kubernetes.io/managed-by": "qm",
+              "simplelend.io/scope-hash": shortHash(scope),
+            },
+          },
+          spec: {
+            warmPoolRef: { name: opts.warmPool },
+            additionalPodMetadata: {
+              labels: {
+                "sandbox.users.io/qm-claim": claim,
+              },
+            },
+          },
+        });
+      }
+
+      try {
+        const deadline = Date.now() + (opts.claimTimeoutMs ?? 180_000);
+        let last = claimStatus(value);
+        while (Date.now() < deadline) {
+          const sandbox = last.sandbox?.name;
+          if (sandbox) {
+            claimBySandbox.set(sandbox, claim);
+            await waitDaemon(sandbox);
+            activeBySandbox.set(sandbox, (activeBySandbox.get(sandbox) ?? 0) + 1);
+            return { claim, sandbox, coldStart };
+          }
+          await sleep(500);
+          const current = await getClaim(claim);
+          if (!current) throw new Error(`GKE sandbox claim ${claim} disappeared while provisioning`);
+          last = claimStatus(current);
+        }
+        const detail = last.conditions
+          ?.map((condition) => condition.message)
+          .filter(Boolean)
+          .join("; ");
+        throw new Error(`GKE sandbox claim ${claim} was not ready within the deadline${detail ? `: ${detail}` : ""}`);
+      } catch (error) {
+        for (const [sandbox, boundClaim] of claimBySandbox) {
+          if (boundClaim === claim) claimBySandbox.delete(sandbox);
+        }
+        if (coldStart) {
+          await api
+            .deleteNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, claim)
+            .catch(swallowAs("gke-sandbox: claim cleanup after provisioning failure", undefined));
+        }
+        throw error;
+      }
+    });
+  }
+
+  async function daemon(
+    sandbox: string,
+    path: string,
+    body?: unknown,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<{ status: number; text: string }> {
+    const res = await fetchImpl(`${opts.routerUrl.replace(/\/$/, "")}${path}`, {
+      method: body === undefined ? "GET" : "POST",
+      headers: {
+        "X-Sandbox-ID": sandbox,
+        "X-Sandbox-Namespace": namespace,
+        "X-Sandbox-Port": String(agentPort),
+        ...(opts.routerToken ? { authorization: `Bearer ${opts.routerToken}` } : {}),
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.any([AbortSignal.timeout(timeoutMs ?? 30_000), ...(signal ? [signal] : [])]),
+    });
+    return { status: res.status, text: await res.text() };
+  }
+
+  async function waitDaemon(sandbox: string): Promise<void> {
+    const deadline = Date.now() + (opts.daemonReadyTimeoutMs ?? 60_000);
+    let lastError = "";
+    while (Date.now() < deadline) {
+      try {
+        const response = await daemon(sandbox, "/health", undefined, 3000);
+        if (response.status === 200) return;
+        lastError = `http ${response.status}`;
+      } catch (error) {
+        lastError = errMessage(error);
+      }
+      await sleep(500);
+    }
+    throw new Error(`GKE sandbox ${sandbox} exec daemon never became reachable: ${lastError}`);
+  }
+
+  async function execRaw(
+    sandbox: string,
+    command: string,
+    timeoutSec: number,
+    signal?: AbortSignal,
+  ): Promise<ExecResult> {
+    const response = await daemon(sandbox, "/exec", { cmd: command, timeoutSec }, (timeoutSec + 15) * 1000, signal);
+    if (response.status !== 200) {
+      throw new Error(`GKE sandbox exec failed (${response.status}): ${response.text.slice(0, 300)}`);
+    }
+    const result = JSON.parse(response.text) as ExecResult;
+    return {
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      code: result.code,
+      timedOut: Boolean(result.timedOut),
+    };
+  }
+
+  async function writeAbsBytes(sandbox: string, path: string, data: Uint8Array): Promise<void> {
+    const response = await daemon(sandbox, "/write", { path, b64: Buffer.from(data).toString("base64") }, 120_000);
+    if (response.status !== 200) {
+      throw new Error(`GKE sandbox write ${path} failed (${response.status}): ${response.text.slice(0, 200)}`);
+    }
+  }
+
+  async function readAbsBytes(sandbox: string, path: string): Promise<Uint8Array | null> {
+    const response = await daemon(sandbox, "/read", { path }, 120_000);
+    if (response.status === 404) return null;
+    if (response.status !== 200) {
+      throw new Error(`GKE sandbox read ${path} failed (${response.status}): ${response.text.slice(0, 200)}`);
+    }
+    return Buffer.from((JSON.parse(response.text) as { b64: string }).b64, "base64");
+  }
+
+  const profile: AgentComputerProfile = {
+    backend: "gke-agent-sandbox",
+    writablePersistence: "resident_disk",
+    processSessions: true,
+    egressEnforcement: "ip_port",
+    spec: {
+      os: "Debian 12 under GKE Agent Sandbox with gVisor",
+      runtimes: ["Node 24", "Python 3"],
+      tools: ["git", "curl", "wget", "jq", "python3", "gh", ...(opts.extraTools ?? [])],
+      notInstalled: ["gcloud", "kubectl", "flyctl", "glab"],
+      homeDir,
+      workdir: workspaceDir,
+    },
+  };
+
+  const procIo: ExecProcessIo = {
+    async run(handle, command, execOpts): Promise<ExecResult> {
+      const timeoutSec = execOpts?.timeoutMs ? Math.ceil(execOpts.timeoutMs / 1000) : defaultTimeoutSec;
+      return execRaw(handle.id, command, timeoutSec);
+    },
+  };
+  const procSessions = createExecProcessSessions(procIo);
+  const execFileOps = createExecFileOps({
+    label: "gke",
+    exec: (id, script, timeout) => execRaw(id, script, timeout),
+    writeInline: (id, path, data) => writeAbsBytes(id, path, data),
+  });
+  const execBackup = createExecBackup({
+    label: "gke",
+    exec: (id, script, timeout) => execRaw(id, script, timeout),
+    readAbsBytes,
+    defaultHomeDir: homeDir,
+    ephemeralCredentialPrefixes: ephemeralCredLinkPaths().map(({ rel }) => rel),
+  });
+
+  const sandbox: Sandbox = {
+    profile,
+    startProcess: procSessions.startProcess,
+    readProcess: procSessions.readProcess,
+    writeStdin: procSessions.writeStdin,
+    signalProcess: procSessions.signalProcess,
+    listProcesses: procSessions.listProcesses,
+    ...execFileOps,
+
+    async provision(layers: WorkspaceLayer[], provisionOptions?: ProvisionOptions): Promise<SandboxHandle> {
+      const writable = layers.find((layer) => layer.mode === "rw") ?? layers[0];
+      const scope = provisionOptions?.scratch
+        ? `scratch:${provisionOptions.scratch.key}`
+        : (writable?.scopeId ?? "default");
+      const body = await ensureClaim(scope);
+      const env = provisionOptions?.env && Object.keys(provisionOptions.env).length ? provisionOptions.env : undefined;
+      const handle: SandboxHandle = {
+        id: body.sandbox,
+        rootDir: workspaceDir,
+        homeDir,
+        coldStart: body.coldStart,
+        backend: "gke",
+        scopeId: scope,
+        ...(provisionOptions?.scratch ? { scratch: true } : {}),
+        ...(env ? { env } : {}),
+      };
+
+      try {
+        const prep = await execRaw(
+          body.sandbox,
+          `mkdir -p ${shq(workspaceDir)} && ${ephemeralCredLinkScript(homeDir)}`,
+          30,
+        );
+        if (prep.code !== 0) throw new Error(`GKE sandbox provision prep failed: ${prep.stderr.slice(0, 200)}`);
+        await materializeRoLayers(
+          workspace,
+          layers,
+          handle,
+          {
+            readFile: (current, path) => sandbox.readFile(current, path),
+            writeFileBytes: (current, path, data) => sandbox.writeFileBytes(current, path, data),
+            exec: (script, timeout) => execRaw(body.sandbox, script, timeout),
+          },
+          { manifest: RO_LAYERS_MANIFEST, tar: RO_LAYERS_TAR, label: "gke" },
+        );
+        return handle;
+      } catch (error) {
+        await sandbox
+          .teardown(handle, { destroy: true })
+          .catch(swallowAs("gke-sandbox: teardown after failed provision", undefined));
+        throw error;
+      }
+    },
+
+    async run(handle, command, execOptions?: ExecOptions): Promise<ExecResult> {
+      const timeoutSec = execOptions?.timeoutMs ? Math.ceil(execOptions.timeoutMs / 1000) : defaultTimeoutSec;
+      const exports = Object.entries(handle.env ?? {})
+        .map(([name, value]) => `export ${name}=${shq(value)}`)
+        .join("; ");
+      const script = `${nonInteractiveShellPrefix()}${exports ? `${exports}; ` : ""}cd ${shq(handle.rootDir)} 2>/dev/null; ${command}`;
+      if (!execOptions?.signal) return execRaw(handle.id, script, timeoutSec);
+      const killUid = randomUUID();
+      const fireKill = () => {
+        execRaw(handle.id, killScript(killUid), 15).catch(swallowAs("gke-sandbox: kill in-flight exec", undefined));
+      };
+      if (execOptions.signal.aborted) fireKill();
+      execOptions.signal.addEventListener("abort", fireKill, { once: true });
+      try {
+        return await execRaw(handle.id, killableScript(script, killUid), timeoutSec, execOptions.signal);
+      } finally {
+        execOptions.signal.removeEventListener("abort", fireKill);
+      }
+    },
+
+    async writeFileBytes(handle, relPath, data): Promise<void> {
+      await writeAbsBytes(handle.id, posixJoin(handle.rootDir, relPath), data);
+    },
+    async writeFile(handle, relPath, data): Promise<void> {
+      await writeAbsBytes(handle.id, posixJoin(handle.rootDir, relPath), Buffer.from(data, "utf8"));
+    },
+    async readFileBytes(handle, relPath): Promise<Uint8Array | null> {
+      return readAbsBytes(handle.id, posixJoin(handle.rootDir, relPath));
+    },
+    async readFile(handle, relPath): Promise<string | null> {
+      const data = await readAbsBytes(handle.id, posixJoin(handle.rootDir, relPath));
+      return data === null ? null : Buffer.from(data).toString("utf8");
+    },
+    backupComputer: execBackup.backupComputer,
+
+    async teardown(handle, teardownOptions?: TeardownOptions): Promise<void> {
+      const remaining = (activeBySandbox.get(handle.id) ?? 1) - 1;
+      if (remaining > 0) {
+        activeBySandbox.set(handle.id, remaining);
+        return;
+      }
+      activeBySandbox.delete(handle.id);
+      if (!teardownOptions?.destroy) return;
+      const claim = claimBySandbox.get(handle.id);
+      if (!claim) return;
+      try {
+        await api.deleteNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, claim);
+      } catch (error) {
+        if (statusCodeOf(error) !== 404) {
+          opts.onError?.({
+            category: "sandbox_teardown",
+            code: "gke_claim_delete_failed",
+            message: errMessage(error),
+            ...(handle.scopeId ? { scopeLabel: handle.scopeId } : {}),
+          });
+          throw error;
+        }
+      } finally {
+        claimBySandbox.delete(handle.id);
+      }
+    },
+  };
+
+  return sandbox;
+}

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -29,7 +29,7 @@ const RO_LAYERS_TAR = ".ro-layers.tar";
 const RO_LAYERS_MANIFEST = ".ro-layers.manifest";
 
 interface ClaimStatus {
-  sandbox?: { name?: string };
+  sandbox?: { Name?: string; name?: string };
   conditions?: Array<{ status?: string; type?: string; message?: string }>;
 }
 
@@ -161,7 +161,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
         const deadline = Date.now() + (opts.claimTimeoutMs ?? 180_000);
         let last = claimStatus(value);
         while (Date.now() < deadline) {
-          const sandbox = last.sandbox?.name;
+          const sandbox = last.sandbox?.name ?? last.sandbox?.Name;
           if (sandbox) {
             claimBySandbox.set(sandbox, claim);
             await waitDaemon(sandbox);

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -23,7 +23,7 @@ import type {
 } from "./sandbox.ts";
 
 const GROUP = "extensions.agents.x-k8s.io";
-const VERSION = "v1beta1";
+const VERSION = "v1alpha1";
 const PLURAL = "sandboxclaims";
 const RO_LAYERS_TAR = ".ro-layers.tar";
 const RO_LAYERS_MANIFEST = ".ro-layers.manifest";

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import { CustomObjectsApi, KubeConfig } from "@kubernetes/client-node";
+import {
+  CustomObjectsApi,
+  KubeConfig,
+  type CustomObjectsApiCreateNamespacedCustomObjectRequest,
+  type CustomObjectsApiDeleteNamespacedCustomObjectRequest,
+  type CustomObjectsApiGetNamespacedCustomObjectRequest,
+} from "@kubernetes/client-node";
 import type { WorkspaceLayer } from "../types.ts";
 import type { WorkspaceStore } from "../workspace/workspace-store.ts";
 import { ephemeralCredLinkPaths, ephemeralCredLinkScript } from "../credentials/resident-paths.ts";
@@ -38,27 +44,9 @@ interface ClaimBody {
 }
 
 interface CustomObjectsClient {
-  createNamespacedCustomObject(
-    group: string,
-    version: string,
-    namespace: string,
-    plural: string,
-    body: unknown,
-  ): Promise<unknown>;
-  deleteNamespacedCustomObject(
-    group: string,
-    version: string,
-    namespace: string,
-    plural: string,
-    name: string,
-  ): Promise<unknown>;
-  getNamespacedCustomObject(
-    group: string,
-    version: string,
-    namespace: string,
-    plural: string,
-    name: string,
-  ): Promise<unknown>;
+  createNamespacedCustomObject(input: CustomObjectsApiCreateNamespacedCustomObjectRequest): Promise<unknown>;
+  deleteNamespacedCustomObject(input: CustomObjectsApiDeleteNamespacedCustomObjectRequest): Promise<unknown>;
+  getNamespacedCustomObject(input: CustomObjectsApiGetNamespacedCustomObjectRequest): Promise<unknown>;
 }
 
 export interface GkeSandboxOptions {
@@ -122,7 +110,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
 
   async function getClaim(name: string): Promise<unknown | null> {
     try {
-      return await api.getNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, name);
+      return await api.getNamespacedCustomObject({ group: GROUP, version: VERSION, namespace, plural: PLURAL, name });
     } catch (error) {
       if (statusCodeOf(error) === 404) return null;
       throw error;
@@ -135,22 +123,28 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
       let value = await getClaim(claim);
       const coldStart = value === null;
       if (value === null) {
-        value = await api.createNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, {
-          apiVersion: `${GROUP}/${VERSION}`,
-          kind: "SandboxClaim",
-          metadata: {
-            name: claim,
-            namespace,
-            labels: {
-              "app.kubernetes.io/managed-by": "qm",
-              "simplelend.io/scope-hash": shortHash(scope),
-            },
-          },
-          spec: {
-            warmPoolRef: { name: opts.warmPool },
-            additionalPodMetadata: {
+        value = await api.createNamespacedCustomObject({
+          group: GROUP,
+          version: VERSION,
+          namespace,
+          plural: PLURAL,
+          body: {
+            apiVersion: `${GROUP}/${VERSION}`,
+            kind: "SandboxClaim",
+            metadata: {
+              name: claim,
+              namespace,
               labels: {
-                "sandbox.users.io/qm-claim": claim,
+                "app.kubernetes.io/managed-by": "qm",
+                "simplelend.io/scope-hash": shortHash(scope),
+              },
+            },
+            spec: {
+              warmPoolRef: { name: opts.warmPool },
+              additionalPodMetadata: {
+                labels: {
+                  "sandbox.users.io/qm-claim": claim,
+                },
               },
             },
           },
@@ -184,7 +178,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
         }
         if (coldStart) {
           await api
-            .deleteNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, claim)
+            .deleteNamespacedCustomObject({ group: GROUP, version: VERSION, namespace, plural: PLURAL, name: claim })
             .catch(swallowAs("gke-sandbox: claim cleanup after provisioning failure", undefined));
         }
         throw error;
@@ -400,7 +394,13 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
       const claim = claimBySandbox.get(handle.id);
       if (!claim) return;
       try {
-        await api.deleteNamespacedCustomObject(GROUP, VERSION, namespace, PLURAL, claim);
+        await api.deleteNamespacedCustomObject({
+          group: GROUP,
+          version: VERSION,
+          namespace,
+          plural: PLURAL,
+          name: claim,
+        });
       } catch (error) {
         if (statusCodeOf(error) !== 404) {
           opts.onError?.({

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -51,7 +51,7 @@ interface CustomObjectsClient {
 
 export interface GkeSandboxOptions {
   namespace: string;
-  warmPool: string;
+  sandboxTemplate: string;
   routerUrl: string;
   routerToken?: string;
   agentPort?: number;
@@ -145,12 +145,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
               },
             },
             spec: {
-              warmPoolRef: { name: opts.warmPool },
-              additionalPodMetadata: {
-                labels: {
-                  "sandbox.users.io/qm-claim": claim,
-                },
-              },
+              sandboxTemplateRef: { name: opts.sandboxTemplate },
             },
           },
         });

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -100,7 +100,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
   const agentPort = opts.agentPort ?? 8080;
   const defaultTimeoutSec = opts.defaultTimeoutSec ?? 600;
   const homeDir = opts.homeDir ?? "/home/agent";
-  const workspaceDir = `${homeDir}/workspace`;
+  const workspaceDir = `${homeDir}/qm-workspace`;
   const fetchImpl = opts.fetchImpl ?? fetch;
   const queue = createKeyedQueue<string>();
   const claimBySandbox = new Map<string, string>();

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -69,12 +69,17 @@ const bodyOf = <T>(value: unknown): T => ((value as { body?: unknown } | undefin
 
 const statusCodeOf = (error: unknown): number | undefined => {
   const candidate = error as {
+    code?: number;
     statusCode?: number;
     response?: { statusCode?: number; status?: number };
     body?: { code?: number };
   };
   return (
-    candidate?.statusCode ?? candidate?.response?.statusCode ?? candidate?.response?.status ?? candidate?.body?.code
+    candidate?.code ??
+    candidate?.statusCode ??
+    candidate?.response?.statusCode ??
+    candidate?.response?.status ??
+    candidate?.body?.code
   );
 };
 

--- a/src/sandbox/gke-sandbox.ts
+++ b/src/sandbox/gke-sandbox.ts
@@ -136,7 +136,7 @@ export function createGkeSandbox(workspace: WorkspaceStore, opts: GkeSandboxOpti
               namespace,
               labels: {
                 "app.kubernetes.io/managed-by": "qm",
-                "simplelend.io/scope-hash": shortHash(scope),
+                "qm.dev/scope-hash": shortHash(scope),
               },
             },
             spec: {

--- a/src/sandbox/sandbox-routing.ts
+++ b/src/sandbox/sandbox-routing.ts
@@ -14,7 +14,7 @@ import {
   type TeardownOptions,
 } from "./sandbox.ts";
 
-export type SandboxBackendName = "sprites" | "aws" | "local";
+export type SandboxBackendName = "sprites" | "aws" | "gke" | "local";
 
 export interface SandboxRoute {
   backend: SandboxBackendName;

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -70,6 +70,7 @@ import { createPgBossCronQueue } from "./cron/job-queue.ts";
 import { createDeployStore, type Deployment } from "./deploy/deploy-store.ts";
 import { createDockerDeployProvider } from "./deploy/docker-deploy-provider.ts";
 import { createAwsDeployProvider, type StoredDeployBody } from "./deploy/aws-deploy-provider.ts";
+import { createDisabledDeployProvider } from "./deploy/disabled-deploy-provider.ts";
 import type { DeployProvider } from "./deploy/deploy-provider.ts";
 import { createDeployService } from "./deploy/deploy-service.ts";
 import {
@@ -87,11 +88,13 @@ import { createLocalWorkspaceStore, type WorkspaceStore } from "./workspace/work
 import { createMemoryService, type MemoryService } from "./memory/memory-service.ts";
 import { createPostgresMemoryService } from "./memory/postgres-memory-service.ts";
 import {
+  createGcsBlobTransferStore,
   createLocalBlobTransferStore,
   createS3BlobTransferStore,
   type BlobTransferStore,
 } from "./persistence/blob-transfer.ts";
 import {
+  createGcsDurableByteStore,
   createLocalDurableByteStore,
   createS3DurableByteStore,
   type DurableByteStore,
@@ -99,6 +102,7 @@ import {
 import { createMemoryFileArtifactStore, type FileArtifactStore } from "./files/file-artifact-store.ts";
 import { createPostgresFileArtifactStore } from "./files/postgres-file-artifact-store.ts";
 import { createAwsSandbox, type StoredMicrovm } from "./sandbox/aws-sandbox.ts";
+import { createGkeSandbox } from "./sandbox/gke-sandbox.ts";
 import { createLocalSandbox } from "./sandbox/local-sandbox.ts";
 import { createSpritesSandbox } from "./sandbox/sprites-sandbox.ts";
 import {
@@ -537,22 +541,40 @@ export function buildApp(
   const resolution = createResolutionService(config.orgId, configStore, acl);
 
   const workspace = createLocalWorkspaceStore(config.dataDir);
-  const blobTransfer: BlobTransferStore =
-    config.transferStore === "s3" && config.s3Bucket
-      ? createS3BlobTransferStore({
-          bucket: config.s3Bucket,
-          ...(config.s3Region ? { region: config.s3Region } : {}),
-          ...(config.s3Prefix ? { prefix: config.s3Prefix } : {}),
-        })
-      : createLocalBlobTransferStore(join(config.dataDir, "transfer"));
-  const fileBytes: DurableByteStore =
-    config.snapshotStore === "s3" && config.s3Bucket
-      ? createS3DurableByteStore({
-          bucket: config.s3Bucket,
-          ...(config.s3Region ? { region: config.s3Region } : {}),
-          ...(config.s3Prefix ? { prefix: config.s3Prefix } : {}),
-        })
-      : createLocalDurableByteStore(join(config.dataDir, "docstore"));
+  let blobTransfer: BlobTransferStore;
+  if (config.transferStore === "s3") {
+    if (!config.s3Bucket) throw new Error("TRANSFER_STORE=s3 requires S3_BUCKET");
+    blobTransfer = createS3BlobTransferStore({
+      bucket: config.s3Bucket,
+      ...(config.s3Region ? { region: config.s3Region } : {}),
+      ...(config.s3Prefix ? { prefix: config.s3Prefix } : {}),
+    });
+  } else if (config.transferStore === "gcs") {
+    if (!config.gcsBucket) throw new Error("TRANSFER_STORE=gcs requires GCS_BUCKET");
+    blobTransfer = createGcsBlobTransferStore({
+      bucket: config.gcsBucket,
+      ...(config.gcsPrefix ? { prefix: config.gcsPrefix } : {}),
+    });
+  } else {
+    blobTransfer = createLocalBlobTransferStore(join(config.dataDir, "transfer"));
+  }
+  let fileBytes: DurableByteStore;
+  if (config.snapshotStore === "s3") {
+    if (!config.s3Bucket) throw new Error("SNAPSHOT_STORE=s3 requires S3_BUCKET");
+    fileBytes = createS3DurableByteStore({
+      bucket: config.s3Bucket,
+      ...(config.s3Region ? { region: config.s3Region } : {}),
+      ...(config.s3Prefix ? { prefix: config.s3Prefix } : {}),
+    });
+  } else if (config.snapshotStore === "gcs") {
+    if (!config.gcsBucket) throw new Error("SNAPSHOT_STORE=gcs requires GCS_BUCKET");
+    fileBytes = createGcsDurableByteStore({
+      bucket: config.gcsBucket,
+      ...(config.gcsPrefix ? { prefix: config.gcsPrefix } : {}),
+    });
+  } else {
+    fileBytes = createLocalDurableByteStore(join(config.dataDir, "docstore"));
+  }
   const files: FileArtifactStore = config.databaseUrl
     ? createPostgresFileArtifactStore(config.databaseUrl, fileBytes)
     : createMemoryFileArtifactStore(fileBytes);
@@ -595,10 +617,17 @@ export function buildApp(
       onError: sandboxOnError,
     });
   };
+  const buildGke = (): Sandbox =>
+    createGkeSandbox(workspace, {
+      ...config.gkeSandbox,
+      extraTools: deploymentLayer.advertisedTools,
+      onError: sandboxOnError,
+    });
   const buildBackend: Record<Config["sandboxBackend"], () => Sandbox> = {
     local: buildLocal,
     sprites: buildSprites,
     aws: buildAws,
+    gke: buildGke,
   };
   const sandboxBackends: Partial<Record<SandboxBackendName, Sandbox>> = {
     [config.sandboxBackend]: buildBackend[config.sandboxBackend](),
@@ -814,33 +843,40 @@ export function buildApp(
     runStoreKind === "postgres"
       ? createPostgresRunActivityStore(requireDbUrl("RUN_STORE"))
       : createMemoryRunActivityStore();
+  let deployArchiveBytes: DurableByteStore | undefined;
+  if (config.snapshotStore === "s3" && config.s3Bucket) {
+    deployArchiveBytes = createS3DurableByteStore({
+      bucket: config.s3Bucket,
+      ...(config.s3Region ? { region: config.s3Region } : {}),
+      prefix: `${config.s3Prefix ?? ""}deploy-git/`,
+    });
+  } else if (config.snapshotStore === "gcs" && config.gcsBucket) {
+    deployArchiveBytes = createGcsDurableByteStore({
+      bucket: config.gcsBucket,
+      prefix: `${config.gcsPrefix ?? ""}deploy-git/`,
+    });
+  }
   const deployStore = createDeployStore({
     deployments: artifactMap<Deployment>("deployments"),
     git: {
       repoRoot: config.deployGitDir,
       archiveStore: artifactMap<DeployGitArchive>("deploy_git_repos"),
-      ...(config.snapshotStore === "s3" && config.s3Bucket
-        ? {
-            archiveBytes: createS3DurableByteStore({
-              bucket: config.s3Bucket,
-              ...(config.s3Region ? { region: config.s3Region } : {}),
-              prefix: `${config.s3Prefix ?? ""}deploy-git/`,
-            }),
-          }
-        : {}),
+      ...(deployArchiveBytes ? { archiveBytes: deployArchiveBytes } : {}),
     },
   });
-  const deployProvider: DeployProvider =
-    config.deployProvider === "aws"
-      ? createAwsDeployProvider({
-          ...config.awsDeploy,
-          ...(!config.awsDeploy.dataBucket && config.awsSandbox.s3Bucket
-            ? { dataBucket: config.awsSandbox.s3Bucket }
-            : {}),
-          advisoryLock,
-          store: artifactMap<StoredDeployBody>("aws_deploy_bodies"),
-        })
-      : createDockerDeployProvider();
+  let deployProvider: DeployProvider;
+  if (config.deployProvider === "aws") {
+    deployProvider = createAwsDeployProvider({
+      ...config.awsDeploy,
+      ...(!config.awsDeploy.dataBucket && config.awsSandbox.s3Bucket ? { dataBucket: config.awsSandbox.s3Bucket } : {}),
+      advisoryLock,
+      store: artifactMap<StoredDeployBody>("aws_deploy_bodies"),
+    });
+  } else if (config.deployProvider === "disabled") {
+    deployProvider = createDisabledDeployProvider();
+  } else {
+    deployProvider = createDockerDeployProvider();
+  }
   if (config.deployProvider === "aws" && !config.awsDeploy.dataBucket && !config.awsSandbox.s3Bucket) {
     console.warn(
       "[wiring] aws deploy: no data bucket resolved (AWS_DEPLOY_DATA_BUCKET unset, sandbox is not aws) — deployed apps have NO durable /data",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -43,6 +43,26 @@ test("store kinds default to memory and accept postgres", () => {
   );
 });
 
+test("GCS stores require a bucket and hosted app deployments can be disabled", () => {
+  assert.throws(() => loadConfig({ SNAPSHOT_STORE: "gcs" }), /requires GCS_BUCKET/);
+  assert.throws(() => loadConfig({ TRANSFER_STORE: "gcs" }), /requires GCS_BUCKET/);
+  assert.throws(() => loadConfig({ SNAPSHOT_STORE: "gcx" }), /object store "gcx" is not recognized/);
+  assert.throws(() => loadConfig({ TRANSFER_STORE: "GCS" }), /object store "GCS" is not recognized/);
+  const config = loadConfig({
+    SNAPSHOT_STORE: "gcs",
+    TRANSFER_STORE: "gcs",
+    GCS_BUCKET: "qm-runtime",
+    GCS_PREFIX: "prod/",
+    DEPLOY_PROVIDER: "disabled",
+  });
+  assert.equal(config.snapshotStore, "gcs");
+  assert.equal(config.transferStore, "gcs");
+  assert.equal(config.gcsBucket, "qm-runtime");
+  assert.equal(config.gcsPrefix, "prod/");
+  assert.equal(config.deployProvider, "disabled");
+  assert.throws(() => loadConfig({ DEPLOY_PROVIDER: "gcp" }), /DEPLOY_PROVIDER="gcp" is not recognized/);
+});
+
 test("production and unauthenticated-core escape hatch are parsed once", () => {
   assert.throws(() => loadConfig({ NODE_ENV: "production" }), /missing or insecure required core secrets/);
   assert.equal(loadConfig(productionEnv).production, true);
@@ -214,6 +234,21 @@ test("a set-but-unparseable env value refuses to boot instead of silently taking
 
 test("sandbox backend is parsed once before production backend guards", () => {
   assert.equal(loadConfig({ SANDBOX_BACKEND: " aws " }).sandboxBackend, "aws");
+  const gke = loadConfig({
+    SANDBOX_BACKEND: "gke",
+    GKE_SANDBOX_NAMESPACE: "sandboxes",
+    GKE_SANDBOX_WARM_POOL: "pool",
+    GKE_SANDBOX_ROUTER_URL: "http://router:8080",
+    GKE_SANDBOX_ROUTER_TOKEN: "router-token",
+  });
+  assert.equal(gke.sandboxBackend, "gke");
+  assert.deepEqual(gke.gkeSandbox, {
+    namespace: "sandboxes",
+    warmPool: "pool",
+    routerUrl: "http://router:8080",
+    routerToken: "router-token",
+  });
+  assert.throws(() => loadConfig({ ...productionEnv, SANDBOX_BACKEND: "gke" }), /requires GKE_SANDBOX_ROUTER_TOKEN/);
   assert.throws(
     () => loadConfig({ ...productionEnv, SANDBOX_BACKEND: "bogus" }),
     /SANDBOX_BACKEND="bogus" is not recognized/,
@@ -346,6 +381,18 @@ test("SANDBOX_BACKEND: unset defaults to local (dev only); the secondary must be
   assert.throws(
     () => loadConfig({ SANDBOX_BACKEND: "sprites", SANDBOX_SECONDARY_BACKEND: "sprites", SPRITES_TOKEN: "tok" }),
     /must differ/,
+  );
+});
+
+test("every production GKE backend requires router authentication", () => {
+  assert.throws(
+    () => loadConfig({ ...productionEnv, SANDBOX_SECONDARY_BACKEND: "gke" }),
+    /GKE sandbox backend requires GKE_SANDBOX_ROUTER_TOKEN/,
+  );
+  assert.equal(
+    loadConfig({ ...productionEnv, SANDBOX_SECONDARY_BACKEND: "gke", GKE_SANDBOX_ROUTER_TOKEN: "token" })
+      .sandboxSecondaryBackend,
+    "gke",
   );
 });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -250,6 +250,14 @@ test("sandbox backend is parsed once before production backend guards", () => {
   });
   assert.throws(() => loadConfig({ ...productionEnv, SANDBOX_BACKEND: "gke" }), /requires GKE_SANDBOX_ROUTER_TOKEN/);
   assert.throws(
+    () =>
+      loadConfig({
+        SANDBOX_BACKEND: "gke",
+        GKE_SANDBOX_WARM_POOL: "legacy-pool",
+      }),
+    /GKE_SANDBOX_WARM_POOL is no longer supported.*GKE_SANDBOX_TEMPLATE/,
+  );
+  assert.throws(
     () => loadConfig({ ...productionEnv, SANDBOX_BACKEND: "bogus" }),
     /SANDBOX_BACKEND="bogus" is not recognized/,
   );

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -237,14 +237,14 @@ test("sandbox backend is parsed once before production backend guards", () => {
   const gke = loadConfig({
     SANDBOX_BACKEND: "gke",
     GKE_SANDBOX_NAMESPACE: "sandboxes",
-    GKE_SANDBOX_WARM_POOL: "pool",
+    GKE_SANDBOX_TEMPLATE: "template",
     GKE_SANDBOX_ROUTER_URL: "http://router:8080",
     GKE_SANDBOX_ROUTER_TOKEN: "router-token",
   });
   assert.equal(gke.sandboxBackend, "gke");
   assert.deepEqual(gke.gkeSandbox, {
     namespace: "sandboxes",
-    warmPool: "pool",
+    sandboxTemplate: "template",
     routerUrl: "http://router:8080",
     routerToken: "router-token",
   });

--- a/test/disabled-deploy-provider.test.ts
+++ b/test/disabled-deploy-provider.test.ts
@@ -1,0 +1,22 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createDisabledDeployProvider } from "../src/deploy/disabled-deploy-provider.ts";
+import type { Deployment, DeploymentVersion } from "../src/deploy/deploy-store.ts";
+
+test("disabled deploy provider fails closed without requiring Docker", async () => {
+  const provider = createDisabledDeployProvider();
+  const version: DeploymentVersion = { version: 1, createdAt: 0, entrypoint: "node app.js", snapshotDir: "/tmp/app" };
+  const deployment: Deployment = {
+    id: "deployment-1",
+    ownerScopeId: "org:test",
+    createdBy: "tester",
+    currentVersion: 1,
+    status: "stopped",
+    endpoint: null,
+    versions: [version],
+  };
+
+  assert.equal(provider.profile.managedScaleToZero, true);
+  await assert.rejects(provider.apply(deployment, version), /Hosted app deployments are disabled/);
+  await assert.doesNotReject(provider.destroy(deployment));
+});

--- a/test/gcs-store.test.ts
+++ b/test/gcs-store.test.ts
@@ -69,11 +69,11 @@ class MemoryBucket {
 test("GCS durable byte store preserves content-addressed files", async () => {
   const bucket = new MemoryBucket();
   const store = createGcsDurableByteStore({ bucket: "test", _bucket: bucket as never });
-  const saved = await store.put(Buffer.from("simplelend"));
-  assert.equal(saved.sha256, createHash("sha256").update("simplelend").digest("hex"));
+  const saved = await store.put(Buffer.from("runtime-object"));
+  assert.equal(saved.sha256, createHash("sha256").update("runtime-object").digest("hex"));
   const opened = await store.open(saved.blobKey);
   assert.ok(opened);
-  assert.equal((await collectBlob(opened.stream)).toString(), "simplelend");
+  assert.equal((await collectBlob(opened.stream)).toString(), "runtime-object");
   await store.delete(saved.blobKey);
   assert.equal(await store.open(saved.blobKey), null);
 });

--- a/test/gcs-store.test.ts
+++ b/test/gcs-store.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { Readable, Writable } from "node:stream";
+import test from "node:test";
+import { createGcsDurableByteStore } from "../src/files/durable-byte-store.ts";
+import { collectBlob, createGcsBlobTransferStore } from "../src/persistence/blob-transfer.ts";
+
+class MemoryFile {
+  data?: Buffer;
+  updated = new Date().toISOString();
+
+  async save(data: Buffer): Promise<void> {
+    this.data = Buffer.from(data);
+    this.updated = new Date().toISOString();
+  }
+
+  createReadStream(): Readable {
+    return Readable.from(this.data ?? Buffer.alloc(0));
+  }
+
+  createWriteStream(): Writable {
+    const chunks: Buffer[] = [];
+    const save = (data: Buffer) => {
+      this.data = data;
+      this.updated = new Date().toISOString();
+    };
+    return new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+      final(callback) {
+        save(Buffer.concat(chunks));
+        callback();
+      },
+    });
+  }
+
+  async getMetadata(): Promise<Array<{ size: string; updated: string }>> {
+    if (!this.data) {
+      const error = new Error("missing") as Error & { code: number };
+      error.code = 404;
+      throw error;
+    }
+    return [{ size: String(this.data.length), updated: this.updated }];
+  }
+
+  async delete(): Promise<void> {
+    this.data = undefined;
+  }
+}
+
+class MemoryBucket {
+  files = new Map<string, MemoryFile>();
+
+  file(name: string): MemoryFile {
+    const current = this.files.get(name) ?? new MemoryFile();
+    this.files.set(name, current);
+    return current;
+  }
+
+  async getFiles({ prefix }: { prefix: string }): Promise<MemoryFile[][]> {
+    return [
+      [...this.files.entries()].filter(([name, file]) => name.startsWith(prefix) && file.data).map(([, file]) => file),
+    ];
+  }
+}
+
+test("GCS durable byte store preserves content-addressed files", async () => {
+  const bucket = new MemoryBucket();
+  const store = createGcsDurableByteStore({ bucket: "test", _bucket: bucket as never });
+  const saved = await store.put(Buffer.from("simplelend"));
+  assert.equal(saved.sha256, createHash("sha256").update("simplelend").digest("hex"));
+  const opened = await store.open(saved.blobKey);
+  assert.ok(opened);
+  assert.equal((await collectBlob(opened.stream)).toString(), "simplelend");
+  await store.delete(saved.blobKey);
+  assert.equal(await store.open(saved.blobKey), null);
+});
+
+test("GCS transfer store verifies hashes and leaves lifecycle policy to the operator", async () => {
+  const bucket = new MemoryBucket();
+  const store = createGcsBlobTransferStore({ bucket: "test", prefix: "qm/", _bucket: bucket as never });
+  const expectedSha256 = createHash("sha256").update("evidence").digest("hex");
+  const saved = await store.put(Buffer.from("evidence"), { expectedSha256 });
+  const opened = await store.open(saved.blobId);
+  assert.ok(opened);
+  assert.equal((await collectBlob(opened.stream)).toString(), "evidence");
+  assert.equal(store.ensureExpiry, undefined);
+  await store.delete(saved.blobId);
+  assert.equal(await store.open(saved.blobId), null);
+});
+
+test("GCS transfer store catches asynchronous upload errors and cleans up", async () => {
+  let deleted = false;
+  const failingFile = {
+    createWriteStream() {
+      const stream = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      });
+      setTimeout(() => stream.emit("error", new Error("upload failed")), 5);
+      return stream;
+    },
+    createReadStream: () => Readable.from([]),
+    getMetadata: async () => [{ size: "0" }],
+    delete: async () => {
+      deleted = true;
+    },
+  };
+  const store = createGcsBlobTransferStore({
+    bucket: "test",
+    _bucket: {
+      file: () => failingFile,
+      getFiles: async () => [[]],
+    },
+  });
+
+  async function* slowSource() {
+    yield Buffer.alloc(1024);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    yield Buffer.alloc(1024);
+  }
+
+  await assert.rejects(store.put(slowSource()), /upload failed/);
+  assert.equal(deleted, true);
+});

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createGkeSandbox } from "../src/sandbox/gke-sandbox.ts";
+import { createLocalWorkspaceStore } from "../src/workspace/workspace-store.ts";
+
+test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", async () => {
+  let created: Record<string, unknown> | undefined;
+  let deleted = "";
+  const requests: Array<{ path: string; headers: Headers; body: string }> = [];
+  const client = {
+    async createNamespacedCustomObject(
+      _group: string,
+      _version: string,
+      _namespace: string,
+      _plural: string,
+      body: unknown,
+    ) {
+      created = body as Record<string, unknown>;
+      return { body: { status: { sandbox: { name: "sandbox-abc" } } } };
+    },
+    async getNamespacedCustomObject() {
+      if (!created) {
+        const error = new Error("missing") as Error & { statusCode: number };
+        error.statusCode = 404;
+        throw error;
+      }
+      return { body: { status: { sandbox: { name: "sandbox-abc" } } } };
+    },
+    async deleteNamespacedCustomObject(
+      _group: string,
+      _version: string,
+      _namespace: string,
+      _plural: string,
+      name: string,
+    ) {
+      deleted = name;
+      return {};
+    },
+  };
+  const files = new Map<string, Buffer>();
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const headers = new Headers(init?.headers);
+    const body = String(init?.body ?? "");
+    requests.push({ path: url.pathname, headers, body });
+    if (url.pathname === "/health") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    if (url.pathname === "/exec") {
+      const command = (JSON.parse(body) as { cmd: string }).cmd;
+      return new Response(JSON.stringify({ stdout: command, stderr: "", code: 0, timedOut: false }), {
+        status: 200,
+      });
+    }
+    if (url.pathname === "/write") {
+      const payload = JSON.parse(body) as { path: string; b64: string };
+      files.set(payload.path, Buffer.from(payload.b64, "base64"));
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    if (url.pathname === "/read") {
+      const payload = JSON.parse(body) as { path: string };
+      const hit = files.get(payload.path);
+      return hit
+        ? new Response(JSON.stringify({ b64: hit.toString("base64") }), { status: 200 })
+        : new Response(JSON.stringify({ error: "missing" }), { status: 404 });
+    }
+    return new Response("missing", { status: 404 });
+  };
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-test-")));
+  const sandbox = createGkeSandbox(workspace, {
+    namespace: "qm-sandboxes",
+    warmPool: "qm-sandbox-pool",
+    routerUrl: "http://sandbox-router:8080",
+    routerToken: "router-test-token",
+    client,
+    fetchImpl,
+  });
+
+  const handle = await sandbox.provision([]);
+  assert.equal(handle.id, "sandbox-abc");
+  assert.equal(handle.rootDir, "/home/agent/workspace");
+  assert.equal(handle.backend, "gke");
+  assert.ok(created);
+  assert.equal((created.spec as { warmPoolRef: { name: string } }).warmPoolRef.name, "qm-sandbox-pool");
+
+  await sandbox.writeFile(handle, "evidence.txt", "ready");
+  assert.equal(await sandbox.readFile(handle, "evidence.txt"), "ready");
+  const result = await sandbox.run(handle, "printf ready");
+  assert.match(result.stdout, /printf ready/);
+  assert.ok(requests.every((request) => request.headers.get("x-sandbox-id") === "sandbox-abc"));
+  assert.ok(requests.every((request) => request.headers.get("x-sandbox-namespace") === "qm-sandboxes"));
+  assert.ok(requests.every((request) => request.headers.get("authorization") === "Bearer router-test-token"));
+
+  await sandbox.teardown(handle, { destroy: true });
+  assert.match(deleted, /^qm-default-/);
+});
+
+test("GKE sandbox deletes a newly-created claim when daemon readiness fails", async () => {
+  let created = false;
+  let deleted = "";
+  const client = {
+    async createNamespacedCustomObject() {
+      created = true;
+      return { body: { status: { sandbox: { name: "sandbox-broken" } } } };
+    },
+    async getNamespacedCustomObject() {
+      if (!created) {
+        const error = new Error("missing") as Error & { statusCode: number };
+        error.statusCode = 404;
+        throw error;
+      }
+      return { body: { status: { sandbox: { name: "sandbox-broken" } } } };
+    },
+    async deleteNamespacedCustomObject(
+      _group: string,
+      _version: string,
+      _namespace: string,
+      _plural: string,
+      name: string,
+    ) {
+      deleted = name;
+      return {};
+    },
+  };
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-failure-test-")));
+  const sandbox = createGkeSandbox(workspace, {
+    namespace: "qm-sandboxes",
+    warmPool: "qm-sandbox-pool",
+    routerUrl: "http://sandbox-router:8080",
+    routerToken: "router-test-token",
+    client,
+    fetchImpl: async () => new Response("not ready", { status: 503 }),
+    daemonReadyTimeoutMs: 10,
+  });
+
+  await assert.rejects(sandbox.provision([]), /never became reachable/);
+  assert.match(deleted, /^qm-default-/);
+});
+
+test("GKE sandbox deletes a newly-created claim that never binds", async () => {
+  let created = false;
+  let deleted = "";
+  const client = {
+    async createNamespacedCustomObject() {
+      created = true;
+      return { body: { status: {} } };
+    },
+    async getNamespacedCustomObject() {
+      if (!created) {
+        const error = new Error("missing") as Error & { statusCode: number };
+        error.statusCode = 404;
+        throw error;
+      }
+      return { body: { status: {} } };
+    },
+    async deleteNamespacedCustomObject(
+      _group: string,
+      _version: string,
+      _namespace: string,
+      _plural: string,
+      name: string,
+    ) {
+      deleted = name;
+      return {};
+    },
+  };
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-unbound-test-")));
+  const sandbox = createGkeSandbox(workspace, {
+    namespace: "qm-sandboxes",
+    warmPool: "qm-sandbox-pool",
+    routerUrl: "http://sandbox-router:8080",
+    routerToken: "router-test-token",
+    client,
+    fetchImpl: async () => new Response("unused", { status: 500 }),
+    claimTimeoutMs: 10,
+  });
+
+  await assert.rejects(sandbox.provision([]), /was not ready within the deadline/);
+  assert.match(deleted, /^qm-default-/);
+});

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -21,7 +21,7 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
     ) {
       createdVersion = version;
       created = body as Record<string, unknown>;
-      return { body: { status: { sandbox: { name: "sandbox-abc" } } } };
+      return { body: { status: { sandbox: { Name: "sandbox-abc" } } } };
     },
     async getNamespacedCustomObject() {
       if (!created) {
@@ -29,7 +29,7 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
         error.statusCode = 404;
         throw error;
       }
-      return { body: { status: { sandbox: { name: "sandbox-abc" } } } };
+      return { body: { status: { sandbox: { Name: "sandbox-abc" } } } };
     },
     async deleteNamespacedCustomObject(
       _group: string,

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -185,3 +185,45 @@ test("GKE sandbox deletes a newly-created claim that never binds", async () => {
   await assert.rejects(sandbox.provision([]), /was not ready within the deadline/);
   assert.match(deleted, /^qm-default-/);
 });
+
+test("GKE sandbox accepts an SDK 404 while deleting an already-removed claim", async () => {
+  let created = false;
+  const client = {
+    async createNamespacedCustomObject() {
+      created = true;
+      return { status: { sandbox: { name: "sandbox-removed" } } };
+    },
+    async getNamespacedCustomObject() {
+      if (!created) {
+        const error = new Error("missing") as Error & { code: number };
+        error.code = 404;
+        throw error;
+      }
+      return { status: { sandbox: { name: "sandbox-removed" } } };
+    },
+    async deleteNamespacedCustomObject() {
+      const error = new Error("already removed") as Error & { code: number };
+      error.code = 404;
+      throw error;
+    },
+  };
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-removed-test-")));
+  const sandbox = createGkeSandbox(workspace, {
+    namespace: "qm-sandboxes",
+    warmPool: "qm-sandbox-pool",
+    routerUrl: "http://sandbox-router:8080",
+    routerToken: "router-test-token",
+    client,
+    fetchImpl: async (input) => {
+      const path = new URL(String(input)).pathname;
+      if (path === "/health") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      if (path === "/exec") {
+        return new Response(JSON.stringify({ stdout: "", stderr: "", code: 0, timedOut: false }), { status: 200 });
+      }
+      return new Response("missing", { status: 404 });
+    },
+  });
+
+  const handle = await sandbox.provision([]);
+  await sandbox.teardown(handle, { destroy: true });
+});

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -76,7 +76,7 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
 
   const handle = await sandbox.provision([]);
   assert.equal(handle.id, "sandbox-abc");
-  assert.equal(handle.rootDir, "/home/agent/workspace");
+  assert.equal(handle.rootDir, "/home/agent/qm-workspace");
   assert.equal(handle.backend, "gke");
   assert.ok(created);
   assert.deepEqual(createRequest, {

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -78,6 +78,11 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
   assert.equal(handle.id, "sandbox-abc");
   assert.equal(handle.rootDir, "/home/agent/qm-workspace");
   assert.equal(handle.backend, "gke");
+  const provisionCommand = requests
+    .filter((request) => request.path === "/exec")
+    .map((request) => (JSON.parse(request.body) as { cmd: string }).cmd)
+    .find((command) => command.includes("mkdir -p"));
+  assert.match(provisionCommand ?? "", /mkdir -p '\/home\/agent\/qm-workspace'/);
   assert.ok(created);
   assert.deepEqual(createRequest, {
     group: "extensions.agents.x-k8s.io",

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -3,42 +3,37 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import type {
+  CustomObjectsApiCreateNamespacedCustomObjectRequest,
+  CustomObjectsApiDeleteNamespacedCustomObjectRequest,
+  CustomObjectsApiGetNamespacedCustomObjectRequest,
+} from "@kubernetes/client-node";
 import { createGkeSandbox } from "../src/sandbox/gke-sandbox.ts";
 import { createLocalWorkspaceStore } from "../src/workspace/workspace-store.ts";
 
 test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", async () => {
   let created: Record<string, unknown> | undefined;
-  let createdVersion = "";
-  let deleted = "";
+  let createRequest: CustomObjectsApiCreateNamespacedCustomObjectRequest | undefined;
+  let getRequest: CustomObjectsApiGetNamespacedCustomObjectRequest | undefined;
+  let deleteRequest: CustomObjectsApiDeleteNamespacedCustomObjectRequest | undefined;
   const requests: Array<{ path: string; headers: Headers; body: string }> = [];
   const client = {
-    async createNamespacedCustomObject(
-      _group: string,
-      version: string,
-      _namespace: string,
-      _plural: string,
-      body: unknown,
-    ) {
-      createdVersion = version;
-      created = body as Record<string, unknown>;
-      return { body: { status: { sandbox: { Name: "sandbox-abc" } } } };
+    async createNamespacedCustomObject(input: CustomObjectsApiCreateNamespacedCustomObjectRequest) {
+      createRequest = input;
+      created = input.body as Record<string, unknown>;
+      return { status: { sandbox: { Name: "sandbox-abc" } } };
     },
-    async getNamespacedCustomObject() {
+    async getNamespacedCustomObject(input: CustomObjectsApiGetNamespacedCustomObjectRequest) {
+      getRequest = input;
       if (!created) {
         const error = new Error("missing") as Error & { statusCode: number };
         error.statusCode = 404;
         throw error;
       }
-      return { body: { status: { sandbox: { Name: "sandbox-abc" } } } };
+      return { status: { sandbox: { Name: "sandbox-abc" } } };
     },
-    async deleteNamespacedCustomObject(
-      _group: string,
-      _version: string,
-      _namespace: string,
-      _plural: string,
-      name: string,
-    ) {
-      deleted = name;
+    async deleteNamespacedCustomObject(input: CustomObjectsApiDeleteNamespacedCustomObjectRequest) {
+      deleteRequest = input;
       return {};
     },
   };
@@ -84,7 +79,20 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
   assert.equal(handle.rootDir, "/home/agent/workspace");
   assert.equal(handle.backend, "gke");
   assert.ok(created);
-  assert.equal(createdVersion, "v1alpha1");
+  assert.deepEqual(createRequest, {
+    group: "extensions.agents.x-k8s.io",
+    version: "v1alpha1",
+    namespace: "qm-sandboxes",
+    plural: "sandboxclaims",
+    body: created,
+  });
+  assert.deepEqual(getRequest, {
+    group: "extensions.agents.x-k8s.io",
+    version: "v1alpha1",
+    namespace: "qm-sandboxes",
+    plural: "sandboxclaims",
+    name: (created.metadata as { name: string }).name,
+  });
   assert.equal(created.apiVersion, "extensions.agents.x-k8s.io/v1alpha1");
   assert.equal((created.spec as { warmPoolRef: { name: string } }).warmPoolRef.name, "qm-sandbox-pool");
 
@@ -97,7 +105,13 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
   assert.ok(requests.every((request) => request.headers.get("authorization") === "Bearer router-test-token"));
 
   await sandbox.teardown(handle, { destroy: true });
-  assert.match(deleted, /^qm-default-/);
+  assert.deepEqual(deleteRequest, {
+    group: "extensions.agents.x-k8s.io",
+    version: "v1alpha1",
+    namespace: "qm-sandboxes",
+    plural: "sandboxclaims",
+    name: (created.metadata as { name: string }).name,
+  });
 });
 
 test("GKE sandbox deletes a newly-created claim when daemon readiness fails", async () => {
@@ -116,14 +130,8 @@ test("GKE sandbox deletes a newly-created claim when daemon readiness fails", as
       }
       return { body: { status: { sandbox: { name: "sandbox-broken" } } } };
     },
-    async deleteNamespacedCustomObject(
-      _group: string,
-      _version: string,
-      _namespace: string,
-      _plural: string,
-      name: string,
-    ) {
-      deleted = name;
+    async deleteNamespacedCustomObject(input: { name: string }) {
+      deleted = input.name;
       return {};
     },
   };
@@ -158,14 +166,8 @@ test("GKE sandbox deletes a newly-created claim that never binds", async () => {
       }
       return { body: { status: {} } };
     },
-    async deleteNamespacedCustomObject(
-      _group: string,
-      _version: string,
-      _namespace: string,
-      _plural: string,
-      name: string,
-    ) {
-      deleted = name;
+    async deleteNamespacedCustomObject(input: { name: string }) {
+      deleted = input.name;
       return {};
     },
   };

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -8,16 +8,18 @@ import { createLocalWorkspaceStore } from "../src/workspace/workspace-store.ts";
 
 test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", async () => {
   let created: Record<string, unknown> | undefined;
+  let createdVersion = "";
   let deleted = "";
   const requests: Array<{ path: string; headers: Headers; body: string }> = [];
   const client = {
     async createNamespacedCustomObject(
       _group: string,
-      _version: string,
+      version: string,
       _namespace: string,
       _plural: string,
       body: unknown,
     ) {
+      createdVersion = version;
       created = body as Record<string, unknown>;
       return { body: { status: { sandbox: { name: "sandbox-abc" } } } };
     },
@@ -82,6 +84,8 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
   assert.equal(handle.rootDir, "/home/agent/workspace");
   assert.equal(handle.backend, "gke");
   assert.ok(created);
+  assert.equal(createdVersion, "v1alpha1");
+  assert.equal(created.apiVersion, "extensions.agents.x-k8s.io/v1alpha1");
   assert.equal((created.spec as { warmPoolRef: { name: string } }).warmPoolRef.name, "qm-sandbox-pool");
 
   await sandbox.writeFile(handle, "evidence.txt", "ready");

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -26,8 +26,8 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
     async getNamespacedCustomObject(input: CustomObjectsApiGetNamespacedCustomObjectRequest) {
       getRequest = input;
       if (!created) {
-        const error = new Error("missing") as Error & { statusCode: number };
-        error.statusCode = 404;
+        const error = new Error("missing") as Error & { code: number };
+        error.code = 404;
         throw error;
       }
       return { status: { sandbox: { Name: "sandbox-abc" } } };

--- a/test/gke-sandbox.test.ts
+++ b/test/gke-sandbox.test.ts
@@ -67,7 +67,7 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-test-")));
   const sandbox = createGkeSandbox(workspace, {
     namespace: "qm-sandboxes",
-    warmPool: "qm-sandbox-pool",
+    sandboxTemplate: "qm-sandbox-template",
     routerUrl: "http://sandbox-router:8080",
     routerToken: "router-test-token",
     client,
@@ -94,7 +94,7 @@ test("GKE sandbox claims a scope, routes daemon calls, and destroys the claim", 
     name: (created.metadata as { name: string }).name,
   });
   assert.equal(created.apiVersion, "extensions.agents.x-k8s.io/v1alpha1");
-  assert.equal((created.spec as { warmPoolRef: { name: string } }).warmPoolRef.name, "qm-sandbox-pool");
+  assert.deepEqual(created.spec, { sandboxTemplateRef: { name: "qm-sandbox-template" } });
 
   await sandbox.writeFile(handle, "evidence.txt", "ready");
   assert.equal(await sandbox.readFile(handle, "evidence.txt"), "ready");
@@ -138,7 +138,7 @@ test("GKE sandbox deletes a newly-created claim when daemon readiness fails", as
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-failure-test-")));
   const sandbox = createGkeSandbox(workspace, {
     namespace: "qm-sandboxes",
-    warmPool: "qm-sandbox-pool",
+    sandboxTemplate: "qm-sandbox-template",
     routerUrl: "http://sandbox-router:8080",
     routerToken: "router-test-token",
     client,
@@ -174,7 +174,7 @@ test("GKE sandbox deletes a newly-created claim that never binds", async () => {
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-unbound-test-")));
   const sandbox = createGkeSandbox(workspace, {
     namespace: "qm-sandboxes",
-    warmPool: "qm-sandbox-pool",
+    sandboxTemplate: "qm-sandbox-template",
     routerUrl: "http://sandbox-router:8080",
     routerToken: "router-test-token",
     client,
@@ -210,7 +210,7 @@ test("GKE sandbox accepts an SDK 404 while deleting an already-removed claim", a
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "qm-gke-removed-test-")));
   const sandbox = createGkeSandbox(workspace, {
     namespace: "qm-sandboxes",
-    warmPool: "qm-sandbox-pool",
+    sandboxTemplate: "qm-sandbox-template",
     routerUrl: "http://sandbox-router:8080",
     routerToken: "router-test-token",
     client,


### PR DESCRIPTION
## Summary

Add a provider-native GCP runtime path for QM:

- provision isolated agent computers through GKE Agent Sandbox SandboxClaim resources
- route the existing agent-daemon protocol through the in-cluster sandbox router
- store durable file bytes and transfer blobs in Cloud Storage
- allow hosted-app deployment to fail closed when no deploy provider is configured
- document the Workload Identity, namespace RBAC, runtime variables, and operator-owned infrastructure boundary

The adapter does not create GKE, Cloud SQL, buckets, IAM, or Secret Manager resources.

## Verification

- 37 focused config/GKE/GCS/disabled-provider tests passed
- TypeScript typecheck passed
- ESLint passed on the changed TypeScript files
- diff check passed
- independent review of the GKE control path passed

## Live validation

The adapter has been exercised against a GKE Agent Sandbox warm pool. The final compatibility fix uses the request-object API required by @kubernetes/client-node 1.4 for custom resource create/get/delete calls.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201951&installation_model_id=19911&pr_number=367&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F367&signature=c10881c0f0a9751be2491696d8ce6d1e9b96e9b7eff2a5021bc6f32ff4a54732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->