### PR TITLE
Force HTTP transport for compatible Codex providers

### DIFF
--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -612,6 +612,20 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
       environments: [],
       config: {
         web_search: "disabled",
+        ...(opts.env?.OPENAI_BASE_URL
+          ? {
+              model_provider: "openai_compatible",
+              model_providers: {
+                openai_compatible: {
+                  name: "OpenAI compatible",
+                  base_url: opts.env.OPENAI_BASE_URL,
+                  env_key: "OPENAI_API_KEY",
+                  wire_api: "responses",
+                  supports_websockets: false,
+                },
+              },
+            }
+          : {}),
         ...(codexReasoningEffort(turn.thinkingLevel)
           ? { model_reasoning_effort: codexReasoningEffort(turn.thinkingLevel) }
           : {}),

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -58,6 +58,12 @@ rl.on("line", (line) => {
     if (msg.params.sandbox !== "read-only" || msg.params.approvalPolicy !== "never" || !Array.isArray(msg.params.dynamicTools) ||
         !Array.isArray(msg.params.environments) || msg.params.environments.length !== 0 ||
         msg.params.config?.features?.shell_tool !== false || msg.params.config?.features?.unified_exec !== false ||
+        (process.env.OPENAI_BASE_URL &&
+          (msg.params.config?.model_provider !== "openai_compatible" ||
+           msg.params.config?.model_providers?.openai_compatible?.base_url !== process.env.OPENAI_BASE_URL ||
+           msg.params.config?.model_providers?.openai_compatible?.env_key !== "OPENAI_API_KEY" ||
+           msg.params.config?.model_providers?.openai_compatible?.wire_api !== "responses" ||
+           msg.params.config?.model_providers?.openai_compatible?.supports_websockets !== false)) ||
         process.env.CORE_SIGNING_SECRET || process.env.DATABASE_URL || process.env.HOME !== msg.params.cwd ||
         !process.env.CODEX_HOME?.startsWith(msg.params.cwd)) {
       return send({ id: msg.id, error: { code: -1, message: "unsafe or missing adapter settings" } });
@@ -176,7 +182,11 @@ test("Codex forwards external-content screening into its native tool bridge", ()
 test("Codex harness drives app-server JSON-RPC with a read-only jail", async (t) => {
   const dir = mkdtempSync(join(tmpdir(), "qm-codex-test-"));
   const tasks = createMemoryTaskStore();
-  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: process.env, tasks });
+  const harness = createCodexHarness({
+    binaryPath: fakeCodexBinary(dir),
+    env: { ...process.env, OPENAI_BASE_URL: "https://proxy.example.com/v1" },
+    tasks,
+  });
   t.after(async () => {
     await harness.turns.close?.();
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- configure Codex app-server with a custom provider when `OPENAI_BASE_URL` is set
- force the compatible provider onto the Responses HTTP transport
- preserve the built-in provider when no custom base URL is configured

## Verification

- `node --experimental-test-module-mocks --test test/codex-harness.test.ts`
- `npx prettier --check src/harness/codex-harness.ts test/codex-harness.test.ts`
- `npx eslint src/harness/codex-harness.ts test/codex-harness.test.ts`
- `npm run typecheck`
- real Codex app-server probe confirmed `POST /v1/responses` without a WebSocket upgrade

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789202403&installation_model_id=19911&pr_number=368&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F368&signature=926f1b2aba71326cf32004e6853355086ca32e1c9d39665c8463625ba21a6c7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->