### PR TITLE
Give agents live web search on the Claude and Codex harnesses

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,8 +129,9 @@ these, not through them.
   how a compromised agent process can use it.
 - **Security screening is incomplete and heuristic.** Auto screens supported,
   provenance-labelled external text and supported tool results. Command and
-  background-process output, opaque or multimodal results, raw webhook payloads, and
-  replay remediation across a shadow-to-enforcement cutover are not all covered.
+  background-process output, opaque or multimodal results, raw webhook payloads,
+  provider-executed web-search results, and replay remediation across a
+  shadow-to-enforcement cutover are not all covered.
   Classifier approval is not authorization and cannot guarantee prompt-injection
   resistance.
 - **Audience-floor filtering has known gaps.** Model-context entries do not yet carry

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,6 +136,7 @@ export interface Config {
   reachDeniedNotifyChannel?: string;
   scratchExecEnabled: boolean;
   reachExecEnabled: boolean;
+  webSearchEnabled: boolean;
   sharedOwnerAuthIsolation: boolean;
   surfaceDebugFooter: boolean;
   eagerProvisionEnabled: boolean;
@@ -847,6 +848,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
       numEnvStrict("INSIGHTS_INTERVAL_MS", env.INSIGHTS_INTERVAL_MS) ?? CONFIG_DEFAULTS.insightsIntervalMs,
     ...(env.REACH_DENIED_NOTIFY_CHANNEL ? { reachDeniedNotifyChannel: env.REACH_DENIED_NOTIFY_CHANNEL.trim() } : {}),
     scratchExecEnabled: boolEnvStrict("EXECUTE_SCRATCH", env.EXECUTE_SCRATCH) ?? false,
+    webSearchEnabled: boolEnvStrict("WEB_SEARCH", env.WEB_SEARCH) ?? true,
     reachExecEnabled: boolEnvStrict("REACH_EXEC", env.REACH_EXEC) ?? false,
     sharedOwnerAuthIsolation: boolEnvStrict("SHARED_OWNER_AUTH_ISOLATION", env.SHARED_OWNER_AUTH_ISOLATION) ?? false,
     surfaceDebugFooter: boolEnvStrict("SURFACE_DEBUG_FOOTER", env.SURFACE_DEBUG_FOOTER) ?? false,

--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -58,6 +58,7 @@ export interface ClaudeHarnessOptions {
   backgroundJobTtlMaxMs?: number;
   signals?: RunSignalStore;
   tasks?: TaskStore;
+  webSearch?: boolean;
 }
 
 export function claudeHarnessConfigOptions(config: Config): ClaudeHarnessOptions {
@@ -70,6 +71,7 @@ export function claudeHarnessConfigOptions(config: Config): ClaudeHarnessOptions
     env: config.claudeProcessEnv,
     ...coreToolOptions(config),
     turnWallClockMs: config.turnWallClockMs,
+    webSearch: config.webSearchEnabled,
   };
 }
 
@@ -337,15 +339,20 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
       .filter((definition) => CHILD_TOOL_NAMES.has(definition.name))
       .map((definition) => `mcp__qm__${definition.name}`);
     const allowSubagents = !turn.readOnly;
+    const webTools =
+      toolsEnabled && opts.webSearch !== false && !turn.readOnly && !turn.toolApprovalGate ? ["WebSearch"] : [];
+    const baseTools = [...webTools, ...(allowSubagents ? ["Agent"] : [])];
+    const allowedTools = [...baseTools, ...bridgedNames];
+    const childTools = [...webTools, ...childToolNames];
     const childPolicy = `${turn.systemPrompt}\n\nComplete only the delegated task. Do not contact people, schedule work, change standing configuration, or suppress the parent reply.`;
     const childAgents = {
       research: {
         description: "Research a bounded question and report evidence.",
         prompt: childPolicy,
-        tools: childToolNames,
+        tools: childTools,
       },
-      code: { description: "Implement or inspect a bounded code task.", prompt: childPolicy, tools: childToolNames },
-      consult: { description: "Provide an independent expert analysis.", prompt: childPolicy, tools: childToolNames },
+      code: { description: "Implement or inspect a bounded code task.", prompt: childPolicy, tools: childTools },
+      consult: { description: "Provide an independent expert analysis.", prompt: childPolicy, tools: childTools },
     };
     const queue = new MessageQueue();
     let terminateProvider = () => {
@@ -430,12 +437,12 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
         abortController: controller,
         cwd: jail,
         env: claudeChildEnv(opts.env ?? {}, jail),
-        tools: allowSubagents ? ["Agent"] : [],
+        tools: baseTools,
         skills: [],
         settingSources: [],
         strictMcpConfig: true,
         mcpServers: { qm: server },
-        allowedTools: [...(allowSubagents ? ["Agent"] : []), ...bridgedNames],
+        allowedTools,
         ...(allowSubagents ? { agents: childAgents } : {}),
         ...(allowSubagents
           ? {
@@ -522,8 +529,8 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
     const recordedRequest = {
       system: turn.systemPrompt,
       prompt: text,
-      tools: allowSubagents ? ["Agent"] : [],
-      allowedTools: [...(allowSubagents ? ["Agent"] : []), ...bridgedNames],
+      tools: baseTools,
+      allowedTools,
       childAgents: allowSubagents ? childAgents : {},
       permissionMode: "bypassPermissions",
       cwd: "[ephemeral control jail]",

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -36,6 +36,7 @@ export interface CodexHarnessOptions {
   appServerStartTimeoutMs?: number;
   signals?: RunSignalStore;
   tasks?: TaskStore;
+  webSearch?: boolean;
 }
 
 export function codexHarnessConfigOptions(config: Config): CodexHarnessOptions {
@@ -48,6 +49,7 @@ export function codexHarnessConfigOptions(config: Config): CodexHarnessOptions {
     env: config.codexProcessEnv,
     ...coreToolOptions(config),
     turnWallClockMs: config.turnWallClockMs,
+    webSearch: config.webSearchEnabled,
   };
 }
 
@@ -611,7 +613,8 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
       experimentalRawEvents: true,
       environments: [],
       config: {
-        web_search: "disabled",
+        web_search:
+          toolsEnabled && opts.webSearch !== false && !turn.readOnly && !turn.toolApprovalGate ? "live" : "disabled",
         ...(codexReasoningEffort(turn.thinkingLevel)
           ? { model_reasoning_effort: codexReasoningEffort(turn.thinkingLevel) }
           : {}),

--- a/test/claude-harness-turn.test.ts
+++ b/test/claude-harness-turn.test.ts
@@ -9,10 +9,18 @@ type FakeSdkMessage = Record<string, unknown>;
 type Script = (prompts: AsyncIterable<{ message: { content: unknown } }>) => AsyncGenerator<FakeSdkMessage>;
 
 let currentScript: Script = async function* () {};
+let lastQueryOptions: Record<string, unknown> = {};
 
 mock.module("@anthropic-ai/claude-agent-sdk", {
   namedExports: {
-    query: ({ prompt }: { prompt: AsyncIterable<{ message: { content: unknown } }> }) => {
+    query: ({
+      prompt,
+      options,
+    }: {
+      prompt: AsyncIterable<{ message: { content: unknown } }>;
+      options: Record<string, unknown>;
+    }) => {
+      lastQueryOptions = options;
       const generator = currentScript(prompt);
       return {
         async initializationResult() {
@@ -300,4 +308,61 @@ test("the claude harness offers compaction and detection so a utility role canno
     recordModelCall: () => {},
   });
   assert.equal(verdict.respond, true);
+});
+
+test("web search reaches the agent and its subagents, and is withheld under approval gating", async () => {
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    yield resultMessage("ok");
+  };
+  const harness = createClaudeHarness({});
+  const open = harnessTurn({ readOnly: false });
+  await harness.turns.runTurn(open.turn);
+  assert.deepEqual(lastQueryOptions.tools, ["WebSearch", "Agent"]);
+  assert.ok((lastQueryOptions.allowedTools as string[]).includes("WebSearch"));
+  const agents = lastQueryOptions.agents as Record<string, { tools: string[] }>;
+  assert.ok(agents.research!.tools.includes("WebSearch"));
+  assert.ok(agents.code!.tools.includes("WebSearch"));
+
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    yield resultMessage("ok");
+  };
+  const gated = harnessTurn({ readOnly: false, toolApprovalGate: () => true });
+  await harness.turns.runTurn(gated.turn);
+  assert.deepEqual(lastQueryOptions.tools, ["Agent"]);
+  assert.ok(!(lastQueryOptions.allowedTools as string[]).includes("WebSearch"));
+  const gatedAgents = lastQueryOptions.agents as Record<string, { tools: string[] }>;
+  assert.ok(!gatedAgents.research!.tools.includes("WebSearch"));
+
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    yield resultMessage("ok");
+  };
+  const readOnly = harnessTurn();
+  await harness.turns.runTurn(readOnly.turn);
+  assert.deepEqual(lastQueryOptions.tools, []);
+});
+
+test("the web-search switch and the toolless oneshot path both keep the turn webless", async () => {
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    yield resultMessage("ok");
+  };
+  const disabled = createClaudeHarness({ webSearch: false });
+  const open = harnessTurn({ readOnly: false });
+  await disabled.turns.runTurn(open.turn);
+  assert.deepEqual(lastQueryOptions.tools, ["Agent"]);
+
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    yield resultMessage("a compact summary");
+  };
+  const harness = createClaudeHarness({});
+  await harness.models.compactHistory!({
+    session: { id: "session-1" } as HarnessTurnInput["session"],
+    history: [],
+    recordModelCall: () => {},
+  });
+  assert.deepEqual(lastQueryOptions.tools, []);
 });

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -42,8 +42,8 @@ test("Codex replay keeps paired tool ids within the provider's 64-character limi
   assert.equal(codexReplayCallId("short-id"), "short-id");
 });
 
-function fakeCodexBinary(dir: string): string {
-  const path = join(dir, "fake-codex");
+function fakeCodexBinary(dir: string, expectedWebSearch = "live"): string {
+  const path = join(dir, `fake-codex-${expectedWebSearch}`);
   writeFileSync(
     path,
     `#!/usr/bin/env node
@@ -58,6 +58,7 @@ rl.on("line", (line) => {
     if (msg.params.sandbox !== "read-only" || msg.params.approvalPolicy !== "never" || !Array.isArray(msg.params.dynamicTools) ||
         !Array.isArray(msg.params.environments) || msg.params.environments.length !== 0 ||
         msg.params.config?.features?.shell_tool !== false || msg.params.config?.features?.unified_exec !== false ||
+        msg.params.config?.web_search !== ${JSON.stringify(expectedWebSearch)} ||
         process.env.CORE_SIGNING_SECRET || process.env.DATABASE_URL || process.env.HOME !== msg.params.cwd ||
         !process.env.CODEX_HOME?.startsWith(msg.params.cwd)) {
       return send({ id: msg.id, error: { code: -1, message: "unsafe or missing adapter settings" } });
@@ -214,6 +215,94 @@ test("Codex harness drives app-server JSON-RPC with a read-only jail", async (t)
     (await tasks.list()).map(({ title, status }) => ({ title, status })),
     [{ title: "return ALPHA", status: "completed" }],
   );
+});
+
+test("Codex withholds live web search when tool approvals gate the turn", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-test-"));
+  const tasks = createMemoryTaskStore();
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir, "disabled"), env: process.env, tasks });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const entries: SessionEntry[] = [];
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  const session = { id: "session-approvals" } as Session;
+  const result = await harness.turns.runTurn({
+    session,
+    input: "hi",
+    systemPrompt: "be concise",
+    history: [],
+    tools: {} as HarnessTurnInput["tools"],
+    scopeLabel: scope,
+    orgScopeId: scope,
+    toolApprovalGate: () => true,
+    emit: async (entry) => {
+      const saved = { ...entry, sessionId: session.id, seq: entries.length + 1, createdAt: Date.now() } as SessionEntry;
+      entries.push(saved);
+      return saved;
+    },
+    recordModelCall: () => {},
+  });
+  assert.equal(result.reply, "hello");
+
+  const readOnlyEntries: SessionEntry[] = [];
+  const readOnlyResult = await harness.turns.runTurn({
+    session: { id: "session-readonly" } as Session,
+    input: "hi",
+    systemPrompt: "be concise",
+    history: [],
+    tools: {} as HarnessTurnInput["tools"],
+    scopeLabel: scope,
+    orgScopeId: scope,
+    readOnly: true,
+    emit: async (entry) => {
+      const saved = {
+        ...entry,
+        sessionId: "session-readonly",
+        seq: readOnlyEntries.length + 1,
+        createdAt: Date.now(),
+      } as SessionEntry;
+      readOnlyEntries.push(saved);
+      return saved;
+    },
+    recordModelCall: () => {},
+  });
+  assert.equal(readOnlyResult.reply, "hello");
+});
+
+test("Codex keeps web search off when the deployment disables it", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-test-"));
+  const tasks = createMemoryTaskStore();
+  const harness = createCodexHarness({
+    binaryPath: fakeCodexBinary(dir, "disabled"),
+    env: process.env,
+    tasks,
+    webSearch: false,
+  });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const entries: SessionEntry[] = [];
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  const session = { id: "session-switch" } as Session;
+  const result = await harness.turns.runTurn({
+    session,
+    input: "hi",
+    systemPrompt: "be concise",
+    history: [],
+    tools: {} as HarnessTurnInput["tools"],
+    scopeLabel: scope,
+    orgScopeId: scope,
+    emit: async (entry) => {
+      const saved = { ...entry, sessionId: session.id, seq: entries.length + 1, createdAt: Date.now() } as SessionEntry;
+      entries.push(saved);
+      return saved;
+    },
+    recordModelCall: () => {},
+  });
+  assert.equal(result.reply, "hello");
 });
 
 test("Codex task titles stay concise when the provider includes the parent request", () => {
@@ -669,7 +758,7 @@ test(
       experimentalRawEvents: true,
       environments: [],
       config: {
-        web_search: "disabled",
+        web_search: "live",
         features: {
           shell_tool: false,
           unified_exec: false,


### PR DESCRIPTION
## Problem

Both the Claude and the Codex harness run the model with every native web capability disabled, and qm's bridged tool surface has no web tool either. An agent asked to research something on the public web has no path to it. The failure is worst with subagents: a parent fans research out to child agents, each child inspects its toolset, finds nothing web-shaped, and reports that web access is unavailable — so the parent degrades to guessing or gives up.

## Change

- **Claude harness** — offer the `WebSearch` tool to the main agent and to the `research` / `code` / `consult` child agents.
- **Codex harness** — start threads with `web_search: "live"` instead of `"disabled"` (valid config variants of the pinned app-server: `disabled | cached | indexed | live`; the existing contract test against the real binary now exercises `live`).
- **`WEB_SEARCH=false`** (new env knob, default on) turns it off deployment-wide — for API gateways without the server-side search tool, or regions where provider search is unavailable.

## Transport, verified against the real binaries

Codex live search executes provider-side. The Claude CLI implements `WebSearch` as a client tool that issues one follow-up `/v1/messages` call to the configured model API base carrying Anthropic's server-side `web_search` tool (up to 8 searches per invocation). So the only host-originated traffic is to the API base the host already reaches on every model call; arbitrary hosts are never contacted from the core host, and the sandbox isolation model is unchanged. The follow-up call is billed like a model call: it lands in `total_cost_usd`, but not in the per-call token rows, which only see streamed messages.

## What stays closed

- **Read-only turns** — the locked-down shape that also drops `execute` and surface tools stays webless.
- **Turns under strict tool approvals** (`turn.toolApprovalGate` set) — native tools cannot pause for human approval, and search queries composed by a possibly-injected agent are an exfiltration channel that posture exists to close.
- **Tool-less oneshot calls** (titles, summaries, classification) — `single()` passes `toolsEnabled=false` and stays webless.

## Known limitations (documented in SECURITY.md)

- Search results reach the model inside provider tool-result blocks and bypass Auto-posture external-content screening.
- Searches appear in the harness tape but not as `tool_call`/`tool_result` session entries.
- The per-scope egress policy does not constrain provider-side search domains; both providers accept domain allow/deny lists on the tool, so wiring the resolved policy through is a natural follow-up.
- **pi harness** and **opencode harness** stay webless: pi needs server-side tool support in its agent library, and opencode's `websearch` calls an external search provider that needs its own credential.

## Tests

- `test/claude-harness-turn.test.ts` — `WebSearch` present in `tools` / `allowedTools` / each child agent's tools on a normal turn; absent on approval-gated turns, read-only turns, with `webSearch: false`, and on the toolless `compactHistory` path.
- `test/codex-harness.test.ts` — the fake app-server rejects a `thread/start` whose `web_search` differs from the expected mode; full-turn tests enforce `"live"`, and gated / read-only / switched-off turns are exercised against a binary expecting `"disabled"`.
- The real-app-server contract test sends `web_search: "live"` and passes against the installed Codex binary.

https://claude.ai/code/session_01S9xLAKdwE3dzs3SkEKNnev

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215834&installation_model_id=19911&pr_number=371&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F371&signature=e9a2e8a8e7ad99ba650e48650d8bfbec468d33308ad32f87cf08e074dd7e854b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->