### PR TITLE
Forward portal identity for OAuth self-connect

### DIFF
--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -650,8 +650,19 @@ async function handleSelfConnect(res: ServerResponse, o: { provider: string; ses
     `/v1/connectors/oauth/${encodeURIComponent(o.provider)}/start?${qs.toString()}`,
     CORE_SIGNING_SECRET,
   );
+  const headers = {
+    ...signedHeaders(CORE_SIGNING_SECRET, "GET", path),
+    ...(PORTAL_IDENTITY_SECRET
+      ? {
+          [PORTAL_IDENTITY_HEADER]: mintPortalIdentity(
+            { p: o.session.sub, exp: Date.now() + 60_000 },
+            PORTAL_IDENTITY_SECRET,
+          ),
+        }
+      : {}),
+  };
   try {
-    const r = await fetch(`${CORE}${path}`, { headers: signedHeaders(CORE_SIGNING_SECRET, "GET", path) });
+    const r = await fetch(`${CORE}${path}`, { headers });
     const data = (await r.json().catch(() => ({}))) as { authorizeUrl?: string; message?: string };
     if (data.authorizeUrl) {
       res.writeHead(302, { location: data.authorizeUrl, "cache-control": "no-store" });

--- a/plugins/portal/test/router.test.ts
+++ b/plugins/portal/test/router.test.ts
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
+import { verifyPortalIdentity } from "../../chassis/src/portal-identity.ts";
 
 let whoamiProbes = 0;
 let lastConsentClicker: string | null = null;
+let lastSelfConnectIdentity: string | null = null;
 let lastImpersonateIdentity: string | null = null;
 let agentApiRequests = 0;
 const VALID_AGENT_CAPABILITY = "valid.agent.capability";
@@ -37,6 +39,10 @@ const upstream = createServer((req: IncomingMessage, res) => {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ url: req.url, headers: req.headers, body: Buffer.concat(chunks).toString("utf8") }));
     });
+  }
+  if (typeof req.url === "string" && req.url.startsWith("/v1/connectors/oauth/google/start")) {
+    lastSelfConnectIdentity =
+      typeof req.headers["x-portal-identity"] === "string" ? req.headers["x-portal-identity"] : null;
   }
   if (typeof req.url === "string" && req.url.startsWith("/v1/connectors/oauth/consent/redeem/")) {
     lastConsentClicker = (req.headers["x-consent-clicker"] as string | undefined) ?? null;
@@ -78,6 +84,7 @@ const PUBLIC = "http://portal.test";
 process.env.PORTAL_PUBLIC_URL = PUBLIC;
 process.env.PORTAL_SESSION_SECRET = "router-test-portal-secret";
 process.env.CORE_SIGNING_SECRET = "router-test-core-secret";
+process.env.PORTAL_IDENTITY_SECRET = "router-test-identity-secret";
 process.env.WEB_UI_UPSTREAM = upstreamUrl;
 process.env.ADMIN_UPSTREAM = upstreamUrl;
 process.env.CORE_API_URL = upstreamUrl;
@@ -260,6 +267,10 @@ test("new human path /connect/:provider/self-connect: session-gated; with sessio
     r.status,
     200,
     "reaches core (the mock returns no authorizeUrl, so the portal renders a page rather than 404ing)",
+  );
+  assert.equal(
+    verifyPortalIdentity(lastSelfConnectIdentity ?? "", "router-test-identity-secret", Date.now())?.p,
+    "eve@acme",
   );
 });
 


### PR DESCRIPTION
## Summary

- forward a signed portal identity when a signed-in user starts an OAuth self-connect flow
- keep the OAuth principal bound to the verified portal session
- add regression coverage that verifies the forwarded identity token and its principal

## Problem

The self-connect route called the user-scoped OAuth start endpoint with source authentication but without the signed portal identity. Production cores that require signed portal identities rejected the request before the OAuth flow could begin.

## Verification

- portal plugin tests: 105 passed
- portal plugin typecheck
- independent fresh-context security review: no blocking findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789216206&installation_model_id=19911&pr_number=372&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F372&signature=65a6b6c8c3d32c5552d756df7776d2e870ed6357ccd1bfc57e1ee3746699214b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->