### PR TITLE
Exclude deployment-layer credential paths from local-sandbox home backups

### DIFF
--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -14,7 +14,7 @@ import { materializeRoLayers } from "./ro-layers.ts";
 import { createExecBackup, createExecFileOps, posixJoin } from "./exec-file-ops.ts";
 import { spawnDockerExec, type DockerExec } from "./docker-exec.ts";
 import { ephemeralCredLinkScript } from "../credentials/resident-paths.ts";
-import { ephemeralCredLinkPaths } from "../credentials/resident-paths.ts";
+import { ephemeralCredLinkPaths, type CredentialPathSpec } from "../credentials/resident-paths.ts";
 import { shortHash } from "../util/crypto.ts";
 import { killableScript, killScript } from "./exec-kill.ts";
 import type {
@@ -46,6 +46,7 @@ export interface LocalSandboxOptions {
   defaultTimeoutSec?: number;
   homeDir?: string;
   repoRoot?: string;
+  credentialPaths?: CredentialPathSpec[];
   dockerExec?: DockerExec;
   fetchImpl?: typeof fetch;
   onError?: (e: { category: string; code: string; message: string; scopeLabel?: string }) => void;
@@ -352,7 +353,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     exec: (id, script, t) => execRaw(id, script, t),
     readAbsBytes,
     defaultHomeDir: homeDir,
-    ephemeralCredentialPrefixes: ephemeralCredLinkPaths().map(({ rel }) => rel),
+    ephemeralCredentialPrefixes: ephemeralCredLinkPaths(opts.credentialPaths ?? []).map(({ rel }) => rel),
   });
 
   const sandbox: Sandbox = {

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -570,6 +570,7 @@ export function buildApp(
   const buildLocal = (): Sandbox =>
     createLocalSandbox(workspace, {
       ...config.localSandbox,
+      credentialPaths: deploymentLayer.credentialPaths,
       onError: sandboxOnError,
     });
   const buildSprites = (): Sandbox =>

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -118,6 +118,21 @@ test("cold provision creates volume + container, run() execs over the daemon, by
   assert.equal(await sb.readFileBytes(h, "bin/missing.dat"), null);
 });
 
+test("layer credential paths stay out of default home backups", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake, { credentialPaths: [{ path: ".config/example", kind: "directory" }] });
+  const h = await sb.provision(rw(scopeId("personal", "U9")));
+  const seeded = await sb.run(
+    h,
+    'mkdir -p "$HOME/.config/example" && printf secret > "$HOME/.config/example/token" && printf keep > "$HOME/backup-note.txt"',
+  );
+  assert.equal(seeded.code, 0);
+  const entries = await sb.backupComputer!(h, { include: ["home"] });
+  const paths = entries.map((entry) => entry.path);
+  assert.ok(paths.includes("backup-note.txt"));
+  assert.ok(!paths.some((path) => path.startsWith(".config/example")));
+});
+
 test("teardown parks the container and the next provision restarts it warm", async () => {
   const fake = installFakeDocker(daemonPort);
   const sb = makeSandbox(fake);


### PR DESCRIPTION
## Problem

The sprites and aws sandbox builders receive the deployment layer's `credentialPaths` and fold them into the default backup exclusion, but the local builder never got them. A layer-declared credential file — an API token a connector stores under `~/.config/<service>/` — therefore rides along in every default home backup on `SANDBOX_BACKEND=local`, contradicting the agent-facing promise that logins are never written into workspace backups.

## Change

Pass `credentialPaths` from the deployment layer through `buildLocal` into the local sandbox's `ephemeralCredentialPrefixes`, mirroring the sprites and aws builders.

Deliberately narrow:

- Only the **default** backup exclusion changes. Callers that pass their own include/exclude — resident-auth capture for app deploys — keep their explicit behavior.
- The boot-time cred-link script is left **without** the extra paths: on the local backend the scoped home is a durable volume with no capture/restore flow, so linking layer credentials into `/tmp/agent-creds` would silently drop them on every container recreation.
- `extraTools` remains absent on local because the local profile renders no installed-CLI advertisement surface.

## Tests

`test/local-sandbox.test.ts` — new test provisions a box with a layer credential path, seeds a credential file plus a normal home file through the real exec daemon, and asserts the default home backup contains the normal file and nothing under the credential path.

https://claude.ai/code/session_01S9xLAKdwE3dzs3SkEKNnev

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789216611&installation_model_id=19911&pr_number=373&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F373&signature=9dd310eb6dbd64c0b959334fbb1f5898bafe1f06fcd6dad3754f6e3983222e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->