### PR TITLE
[codex] Prevent concurrent memory rewrites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "opencode-ai": "1.17.18",
         "pg": "^8.13.1",
         "pg-boss": "^12.26.1",
+        "proper-lockfile": "^4.1.2",
         "tar-stream": "^3.2.0",
         "typebox": "^1.1.38",
         "zod": "4.4.3"
@@ -43,6 +44,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@types/node": "^24.0.0",
         "@types/pg": "^8.11.10",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/tar-stream": "^3.1.4",
         "@yc-software/qm": "file:./cli",
         "eslint": "^10.4.1",
@@ -3323,6 +3325,16 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "opencode-ai": "1.17.18",
     "pg": "^8.13.1",
     "pg-boss": "^12.26.1",
+    "proper-lockfile": "^4.1.2",
     "tar-stream": "^3.2.0",
     "typebox": "^1.1.38",
     "zod": "4.4.3"
@@ -97,6 +98,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "@types/node": "^24.0.0",
     "@types/pg": "^8.11.10",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/tar-stream": "^3.1.4",
     "eslint": "^10.4.1",
     "globals": "^17.6.0",

--- a/src/memory/memory-service.ts
+++ b/src/memory/memory-service.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { type ScopeId, parseScopeId, scopeId as makeScopeId } from "../types.ts";
 import type { WorkspaceStore } from "../workspace/workspace-store.ts";
+import { createKeyedQueue } from "../util/async.ts";
 import { RECALL_MAX_CHARS, bullets, capTail, dateStr, isBullet, normalize } from "./notebook.ts";
 
 export const MEMORY_FILE = "memory/MEMORY.md";
@@ -105,17 +106,30 @@ export function normalizeReplace(content: string): string {
 }
 
 export function createMemoryService(workspace: WorkspaceStore): MemoryService {
+  const perScope = createKeyedQueue<ScopeId>();
   return {
     async recall(scopeId) {
       return recallBody((await workspace.read(scopeId, MEMORY_FILE)) ?? "");
     },
 
     async capture(scopeId, facts, at, author) {
-      const existing = (await workspace.read(scopeId, MEMORY_FILE)) ?? "";
-      const { body, added } = foldCapture(existing, facts, at, author?.startsWith("cc:") === true);
-      if (!added) return 0;
-      await workspace.write(scopeId, MEMORY_FILE, `${body}\n`);
-      return added;
+      return perScope(scopeId, async () => {
+        let added = 0;
+        if (workspace.update) {
+          await workspace.update(scopeId, MEMORY_FILE, (current) => {
+            const folded = foldCapture(current ?? "", facts, at, author?.startsWith("cc:") === true);
+            added = folded.added;
+            return folded.added ? `${folded.body}\n` : current;
+          });
+          return added;
+        }
+        const existing = (await workspace.read(scopeId, MEMORY_FILE)) ?? "";
+        const { body, added: fallbackAdded } = foldCapture(existing, facts, at, author?.startsWith("cc:") === true);
+        added = fallbackAdded;
+        if (!added) return 0;
+        await workspace.write(scopeId, MEMORY_FILE, `${body}\n`);
+        return added;
+      });
     },
 
     async query(scopeId, q, limit = 20) {
@@ -127,12 +141,18 @@ export function createMemoryService(workspace: WorkspaceStore): MemoryService {
     },
 
     async replace(scopeId, content) {
-      const next = normalizeReplace(content);
-      if (!next) {
-        await workspace.remove(scopeId, MEMORY_FILE);
-        return;
-      }
-      await workspace.write(scopeId, MEMORY_FILE, next);
+      await perScope(scopeId, async () => {
+        const next = normalizeReplace(content);
+        if (workspace.update) {
+          await workspace.update(scopeId, MEMORY_FILE, () => next || null);
+          return;
+        }
+        if (!next) {
+          await workspace.remove(scopeId, MEMORY_FILE);
+          return;
+        }
+        await workspace.write(scopeId, MEMORY_FILE, next);
+      });
     },
 
     async readHead(scopeId) {
@@ -141,12 +161,23 @@ export function createMemoryService(workspace: WorkspaceStore): MemoryService {
     },
 
     async replaceIfRevision(scopeId, content, revision) {
-      const current = (await workspace.read(scopeId, MEMORY_FILE)) ?? "";
-      if (revisionToken(current) !== revision) return false;
-      const next = normalizeReplace(content);
-      if (!next) await workspace.remove(scopeId, MEMORY_FILE);
-      else await workspace.write(scopeId, MEMORY_FILE, next);
-      return true;
+      return perScope(scopeId, async () => {
+        let replaced = false;
+        if (workspace.update) {
+          await workspace.update(scopeId, MEMORY_FILE, (current) => {
+            if (revisionToken(current ?? "") !== revision) return current;
+            replaced = true;
+            return normalizeReplace(content) || null;
+          });
+          return replaced;
+        }
+        const current = (await workspace.read(scopeId, MEMORY_FILE)) ?? "";
+        if (revisionToken(current) !== revision) return false;
+        const next = normalizeReplace(content);
+        if (!next) await workspace.remove(scopeId, MEMORY_FILE);
+        else await workspace.write(scopeId, MEMORY_FILE, next);
+        return true;
+      });
     },
   };
 }

--- a/src/memory/strategies/consolidation.ts
+++ b/src/memory/strategies/consolidation.ts
@@ -133,7 +133,8 @@ export function createConsolidator(deps: {
   const degraded = new Set<ScopeId>();
   async function maintain(scopeId: ScopeId): Promise<void> {
     if (degraded.has(scopeId) || !deps.harness.oneShot) return;
-    const body = await deps.memory.read(scopeId);
+    const head = await deps.memory.readHead?.(scopeId);
+    const body = head?.content ?? (await deps.memory.read(scopeId));
     const bullets = body.split("\n").filter(isBullet);
     if (!bullets.length) return;
 
@@ -146,6 +147,10 @@ export function createConsolidator(deps: {
     }
     const at = now();
     const next = applyConsolidationActions(body, parseConsolidationActions(out ?? ""), at);
+    if (head && deps.memory.replaceIfRevision) {
+      await deps.memory.replaceIfRevision(scopeId, next, head.revision, "system");
+      return;
+    }
     await deps.memory.replace(scopeId, next, "system");
 
     const after = await deps.memory.read(scopeId);

--- a/src/memory/strategies/scratch-promote.ts
+++ b/src/memory/strategies/scratch-promote.ts
@@ -72,21 +72,33 @@ export interface ScratchPromoteDeps {
 export function createScratchPromote(deps: ScratchPromoteDeps): { strategy: MemoryStrategy; memory: MemoryService } {
   const base = deps.memory;
   const workspace = deps.workspace;
+  const perScope = createKeyedQueue<ScopeId>();
+
+  async function updateNotebook(scopeId: ScopeId, update: (body: string) => string): Promise<string> {
+    if (!base.readHead || !base.replaceIfRevision) {
+      const next = update(await base.read(scopeId));
+      await base.replace(scopeId, next);
+      return next;
+    }
+    for (;;) {
+      const head = await base.readHead(scopeId);
+      const next = update(head.content);
+      if (await base.replaceIfRevision(scopeId, next, head.revision)) return next;
+    }
+  }
 
   async function bumpMarker(scopeId: ScopeId, by: number): Promise<number> {
-    const body = await base.read(scopeId);
-    const m = body.match(MARKER_RE);
-    const count = (m ? Number(m[1]) : 0) + by;
-    const marker = `<!-- captures-since-promote: ${count} -->`;
-    const next = m ? body.replace(MARKER_RE, marker) : `${body.trim() || "# Memory"}\n\n${marker}`;
-    await base.replace(scopeId, next);
-    return count;
+    const next = await updateNotebook(scopeId, (body) => {
+      const m = body.match(MARKER_RE);
+      const count = (m ? Number(m[1]) : 0) + by;
+      const marker = `<!-- captures-since-promote: ${count} -->`;
+      return m ? body.replace(MARKER_RE, marker) : `${body.trim() || "# Memory"}\n\n${marker}`;
+    });
+    return Number(next.match(MARKER_RE)?.[1] ?? 0);
   }
 
   async function resetMarker(scopeId: ScopeId): Promise<void> {
-    const body = await base.read(scopeId);
-    if (MARKER_RE.test(body))
-      await base.replace(scopeId, body.replace(MARKER_RE, "<!-- captures-since-promote: 0 -->"));
+    await updateNotebook(scopeId, (body) => body.replace(MARKER_RE, "<!-- captures-since-promote: 0 -->"));
   }
 
   async function readLogWindow(
@@ -114,31 +126,43 @@ export function createScratchPromote(deps: ScratchPromoteDeps): { strategy: Memo
     },
 
     async capture(scopeId, facts, at) {
-      const clean = facts.map((f) => f.replace(/\s+/g, " ").trim()).filter(Boolean);
-      if (!clean.length) return 0;
-      const path = logPath(at);
-      const existing = (await workspace.read(scopeId, path)) ?? "";
-      const seen = new Set(bullets(existing).map(normalize));
-      const date = dateStr(at);
-      const added: string[] = [];
-      for (const f of clean) {
-        const key = normalize(f);
-        if (!key || seen.has(key)) continue;
-        seen.add(key);
-        added.push(`- (${date}) ${f}`);
-      }
-      if (!added.length) return 0;
-      const body = existing.trim()
-        ? `${existing.replace(/\s+$/, "")}\n${added.join("\n")}`
-        : `# Scratch log ${date}\n\n${added.join("\n")}`;
-      await workspace.write(scopeId, path, `${body}\n`);
-
-      const count = await bumpMarker(scopeId, added.length);
-      if (deps.consolidateAfter > 0 && count >= deps.consolidateAfter) {
-        await resetMarker(scopeId);
-        await strategy.maintain!(scopeId).catch(() => {});
-      }
-      return added.length;
+      const result = await perScope(scopeId, async () => {
+        const clean = facts.map((f) => f.replace(/\s+/g, " ").trim()).filter(Boolean);
+        if (!clean.length) return { added: 0, promote: false };
+        const path = logPath(at);
+        const existing = (await workspace.read(scopeId, path)) ?? "";
+        const seen = new Set(bullets(existing).map(normalize));
+        const date = dateStr(at);
+        const added: string[] = [];
+        for (const f of clean) {
+          const key = normalize(f);
+          if (!key || seen.has(key)) continue;
+          seen.add(key);
+          added.push(`- (${date}) ${f}`);
+        }
+        if (!added.length) return { added: 0, promote: false };
+        if (workspace.update) {
+          let committed: string[] = [];
+          await workspace.update(scopeId, path, (current) => {
+            const latest = current ?? "";
+            const currentSeen = new Set(bullets(latest).map(normalize));
+            committed = added.filter((line) => !currentSeen.has(normalize(line)));
+            if (!committed.length) return current;
+            return `${latest.replace(/\s+$/, "")}${latest.trim() ? "\n" : ""}${committed.join("\n")}\n`;
+          });
+          added.splice(0, added.length, ...committed);
+          if (!added.length) return { added: 0, promote: false };
+        } else {
+          const body = existing.trim() ? `${existing.replace(/\s+$/, "")}\n${added.join("\n")}` : `${added.join("\n")}`;
+          await workspace.write(scopeId, path, `${body}\n`);
+        }
+        const count = await bumpMarker(scopeId, added.length);
+        const promote = deps.consolidateAfter > 0 && count >= deps.consolidateAfter;
+        if (promote) await resetMarker(scopeId);
+        return { added: added.length, promote };
+      });
+      if (result.promote) await strategy.maintain!(scopeId).catch(() => {});
+      return result.added;
     },
 
     async query(scopeId, q, limit = 20) {
@@ -156,19 +180,15 @@ export function createScratchPromote(deps: ScratchPromoteDeps): { strategy: Memo
     },
   };
 
-  const perScope = createKeyedQueue<ScopeId>();
-
   async function flushBurst(burst: Burst): Promise<void> {
     const autonomous = isAutonomousBurst(burst);
     const facts = await extractFacts(deps.harness, burst.turns, { autonomous });
     if (!facts.length) return;
     const at = Date.now();
-    await perScope(burst.scopeId, () => memory.capture(burst.scopeId, facts, at));
+    await memory.capture(burst.scopeId, facts, at);
     const ccTarget = autonomous ? null : ccTargetFor(burst.conversationScopeId, burst.actorId);
     if (!ccTarget) return;
-    await perScope(ccTarget, () =>
-      ccCaptureToPersonal(memory, burst.conversationScopeId, burst.actorId, facts, at, burst.conversationLabel),
-    );
+    await ccCaptureToPersonal(memory, burst.conversationScopeId, burst.actorId, facts, at, burst.conversationLabel);
   }
 
   const strategy: MemoryStrategy = {
@@ -181,9 +201,10 @@ export function createScratchPromote(deps: ScratchPromoteDeps): { strategy: Memo
 
     async maintain(scopeId) {
       const now = Date.now();
+      const head = await base.readHead?.(scopeId);
       const window = await readLogWindow(scopeId, now, LOG_RETENTION_DAYS);
       if (window.length && deps.harness.oneShot) {
-        const longTerm = stripMarker(await base.read(scopeId));
+        const longTerm = stripMarker(head?.content ?? (await base.read(scopeId)));
         const scratch = window.map(({ date, body }) => `## ${date}\n${body}`).join("\n\n");
         const out = (
           (await deps.harness.oneShot(
@@ -191,7 +212,10 @@ export function createScratchPromote(deps: ScratchPromoteDeps): { strategy: Memo
             `Current notebook:\n${longTerm || "(empty)"}\n\nScratch log:\n${scratch}`,
           )) ?? ""
         ).trim();
-        if (out && !/^none$/i.test(out)) await base.replace(scopeId, out);
+        if (out && !/^none$/i.test(out)) {
+          if (head && base.replaceIfRevision) await base.replaceIfRevision(scopeId, out, head.revision);
+          else await base.replace(scopeId, out);
+        }
       }
       const cutoff = dateStr(now - LOG_RETENTION_DAYS * 86_400_000);
       for (const abs of await workspace.list(scopeId)) {

--- a/src/workspace/workspace-store.ts
+++ b/src/workspace/workspace-store.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile, readdir, rm } from "node:fs/promises";
 import { join, resolve, relative, isAbsolute, dirname } from "node:path";
+import { lock } from "proper-lockfile";
 import type { ScopeId } from "../types.ts";
 import { scopeStorageKey } from "../util/scope-storage-key.ts";
 
@@ -9,6 +10,11 @@ export interface WorkspaceStore {
   read(scopeId: ScopeId, relPath: string): Promise<string | null>;
   readBytes(scopeId: ScopeId, relPath: string): Promise<Uint8Array | null>;
   write(scopeId: ScopeId, relPath: string, data: string | Uint8Array): Promise<void>;
+  update?(
+    scopeId: ScopeId,
+    relPath: string,
+    derive: (current: string | null) => string | Uint8Array | null,
+  ): Promise<void>;
   remove(scopeId: ScopeId, relPath: string): Promise<void>;
   list(scopeId: ScopeId): Promise<string[]>;
 }
@@ -20,6 +26,24 @@ function safeJoin(baseDir: string, relPath: string): string {
     throw new Error(`path escapes workspace: ${relPath}`);
   }
   return target;
+}
+
+async function updateFile(path: string, derive: (current: string | null) => string | Uint8Array | null) {
+  await mkdir(dirname(path), { recursive: true });
+  const release = await lock(path, { realpath: false, retries: { retries: 100, minTimeout: 10, maxTimeout: 100 } });
+  try {
+    let current: string | null;
+    try {
+      current = await readFile(path, "utf8");
+    } catch {
+      current = null;
+    }
+    const next = derive(current);
+    if (next === null) await rm(path, { force: true });
+    else await writeFile(path, next);
+  } finally {
+    await release();
+  }
 }
 
 export function createLocalWorkspaceStore(rootDir: string): WorkspaceStore {
@@ -54,6 +78,9 @@ export function createLocalWorkspaceStore(rootDir: string): WorkspaceStore {
       const path = safeJoin(scopeDir(scopeId), relPath);
       await mkdir(dirname(path), { recursive: true });
       await writeFile(path, data);
+    },
+    async update(scopeId, relPath, derive) {
+      await updateFile(safeJoin(scopeDir(scopeId), relPath), derive);
     },
     async remove(scopeId, relPath) {
       await rm(safeJoin(scopeDir(scopeId), relPath), { force: true });

--- a/test/memory-strategy-consolidation.test.ts
+++ b/test/memory-strategy-consolidation.test.ts
@@ -35,6 +35,12 @@ function oneShotHarness(reply: string, calls?: Array<{ system: string; prompt: s
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
 test("parseConsolidationActions: UPDATE/DELETE/ADD in, NONE/prose/malformed out", () => {
   assert.deepEqual(
     parseConsolidationActions(
@@ -153,6 +159,59 @@ test("a one-shot failure leaves the notebook untouched — consolidation is best
   };
   await createConsolidator({ harness, memory })!.maintain(SCOPE);
   assert.equal(await workspace.read(SCOPE, MEMORY_FILE), before);
+});
+
+test("a capture during consolidation survives the stale model result", async () => {
+  const { memory } = freshMemory();
+  await memory.capture(SCOPE, ["original"], AT);
+  const entered = deferred<void>();
+  const release = deferred<string>();
+  const consolidator = createConsolidator({
+    memory,
+    harness: {
+      async oneShot() {
+        entered.resolve();
+        return release.promise;
+      },
+    },
+    now: () => AT,
+  })!;
+  const maintaining = consolidator.maintain(SCOPE);
+  await entered.promise;
+  await memory.capture(SCOPE, ["concurrent capture"], AT);
+  release.resolve("NONE");
+  await maintaining;
+  assert.match(await memory.read(SCOPE), /concurrent capture/);
+  assert.doesNotMatch(await memory.read(SCOPE), /consolidated:/);
+});
+
+test("a revision conflict skips consolidation without degrading the scope", async () => {
+  const body = "# Memory\n\n- a fact\n";
+  let calls = 0;
+  const logs: string[] = [];
+  const memory: MemoryService = {
+    recall: () => Promise.resolve(body),
+    capture: () => Promise.resolve(0),
+    query: () => Promise.resolve([]),
+    read: () => Promise.resolve(body),
+    replace: () => Promise.resolve(),
+    readHead: () => Promise.resolve({ content: body, revision: "1" }),
+    replaceIfRevision: () => Promise.resolve(false),
+  };
+  const consolidator = createConsolidator({
+    memory,
+    harness: {
+      oneShot: async () => {
+        calls++;
+        return "NONE";
+      },
+    },
+    log: (line) => logs.push(line),
+  })!;
+  await consolidator.maintain(SCOPE);
+  await consolidator.maintain(SCOPE);
+  assert.equal(calls, 2);
+  assert.deepEqual(logs, []);
 });
 
 test("degrades to capture-only when the store can't round-trip a rewrite: logs once, stops trying, never crashes", async () => {

--- a/test/memory-strategy-scratch-promote.test.ts
+++ b/test/memory-strategy-scratch-promote.test.ts
@@ -17,6 +17,12 @@ function harnessOf(oneShot?: HarnessModelUtilities["oneShot"]): HarnessModelUtil
   return oneShot ? { oneShot } : {};
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
 function fresh(opts: { oneShot?: HarnessModelUtilities["oneShot"]; consolidateAfter?: number } = {}) {
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "msp-")));
   const base = createMemoryService(workspace);
@@ -101,6 +107,26 @@ test("maintain promotes: one-shot judges the window, rewrites MEMORY.md, leaves 
   assert.equal(await workspace.read(SCOPE, logPath(TODAY)), logBefore, "log untouched");
 });
 
+test("an edit during promotion survives the stale model result", async () => {
+  const entered = deferred<void>();
+  const release = deferred<string>();
+  const { strategy, memory } = fresh({
+    oneShot: async () => {
+      entered.resolve();
+      return release.promise;
+    },
+  });
+  await memory.replace(SCOPE, "# Memory\n\n- original");
+  await memory.capture(SCOPE, ["recent"], TODAY);
+  const maintaining = withNow(TODAY, () => strategy.maintain!(SCOPE));
+  await entered.promise;
+  await memory.replace(SCOPE, "# Memory\n\n- original\n- concurrent edit");
+  release.resolve("# Memory\n\n- stale promotion");
+  await maintaining;
+  assert.match(await memory.read(SCOPE), /concurrent edit/);
+  assert.doesNotMatch(await memory.read(SCOPE), /stale promotion/);
+});
+
 test("maintain is a no-op rewrite when the judge says NONE, and prunes logs past retention", async () => {
   const { workspace, strategy, memory } = fresh({ oneShot: () => Promise.resolve("NONE") });
   await memory.replace(SCOPE, "# Memory\n\n- keep me");
@@ -144,6 +170,36 @@ test("after-N marker trigger: the Nth capture fires promotion and resets the dur
     /captures-since-promote: [1-9]/,
     "counter reset",
   );
+});
+
+test("concurrent captures preserve every scratch fact and marker increment", async () => {
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "msp-")));
+  const base = createMemoryService(workspace);
+  const first = createScratchPromote({ harness: {}, memory: base, workspace, consolidateAfter: 0 }).memory;
+  const second = createScratchPromote({ harness: {}, memory: base, workspace, consolidateAfter: 0 }).memory;
+  await Promise.all([
+    first.capture(SCOPE, ["first concurrent fact"], TODAY),
+    second.capture(SCOPE, ["second concurrent fact"], TODAY),
+  ]);
+  const log = (await workspace.read(SCOPE, logPath(TODAY))) ?? "";
+  assert.match(log, /first concurrent fact/);
+  assert.match(log, /second concurrent fact/);
+  assert.match(await first.read(SCOPE), /captures-since-promote: 2/);
+});
+
+test("concurrent equivalent captures dedupe the scratch fact and marker increment", async () => {
+  const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "msp-")));
+  const base = createMemoryService(workspace);
+  const first = createScratchPromote({ harness: {}, memory: base, workspace, consolidateAfter: 0 }).memory;
+  const second = createScratchPromote({ harness: {}, memory: base, workspace, consolidateAfter: 0 }).memory;
+  const results = await Promise.all([
+    first.capture(SCOPE, ["same concurrent fact"], TODAY),
+    second.capture(SCOPE, ["SAME concurrent fact"], TODAY),
+  ]);
+  const log = (await workspace.read(SCOPE, logPath(TODAY))) ?? "";
+  assert.equal((log.match(/concurrent fact/gi) ?? []).length, 1);
+  assert.deepEqual(results.sort(), [0, 1]);
+  assert.match(await first.read(SCOPE), /captures-since-promote: 1/);
 });
 
 test("onTurnEnd extracts facts and captures them into today's log", async () => {


### PR DESCRIPTION
## Summary

- guard consolidation and scratch promotion with notebook revision compare-and-swap
- make file-backed notebook and scratch-log updates atomic across processes
- retry marker mutations without losing concurrent increments or duplicate-capture semantics
- keep revision conflicts retryable instead of falsely degrading consolidation

## Root cause

Model-driven maintenance computed replacements from stale notebook snapshots and then wrote them unconditionally. The scratch promotion counter and scratch log used separate read-modify-write operations, while the existing keyed queues only serialized work inside one process.

The shared local workspace store now exposes an atomic update primitive backed by `proper-lockfile`. Both file-backed memory mutations and scratch-log deduplication flow through it; Postgres continues to use its transactional advisory-lock compare-and-swap.

## Validation

- 40 affected memory strategy and caller tests
- adversarial tests for concurrent consolidation capture, promotion edits, cross-instance distinct and equivalent scratch captures, marker increments, and false degradation
- `npm run typecheck`
- ESLint on affected files
- oxlint on affected files
- independent fresh-context concurrency review

Fixes #339

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789234220&installation_model_id=19911&pr_number=378&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F378&signature=9949e644f28ab3f28c9a2616ad183d8afd3de5c1d3b8b053eed331f91a433497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->