### PR TITLE
Give each local byte-store write a unique temp path

### DIFF
--- a/src/files/durable-byte-store.ts
+++ b/src/files/durable-byte-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
 import { mkdir, rename, rm, stat } from "node:fs/promises";
 import { once } from "node:events";
@@ -84,7 +85,7 @@ export function createLocalDurableByteStore(dir: string): DurableByteStore {
       } catch (error) {
         void error;
       }
-      const partPath = join(base, `${sha256}.${process.pid}.part`);
+      const partPath = join(base, `${sha256}.${randomUUID()}.part`);
       const out = createWriteStream(partPath);
       try {
         if (!out.write(data)) await once(out, "drain");
@@ -95,7 +96,12 @@ export function createLocalDurableByteStore(dir: string): DurableByteStore {
         await rm(partPath, { force: true }).catch(swallowAs("files: partial-file cleanup", undefined));
         throw err;
       }
-      await rename(partPath, finalPath);
+      try {
+        await rename(partPath, finalPath);
+      } catch (err) {
+        await rm(partPath, { force: true }).catch(swallowAs("files: partial-file cleanup", undefined));
+        throw err;
+      }
       return { blobKey, sizeBytes: data.length, sha256 };
     },
 

--- a/test/file-artifact-store.test.ts
+++ b/test/file-artifact-store.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -71,6 +71,21 @@ test("DurableByteStore (local-fs) round-trips binary intact across a fresh store
     assert.deepEqual(back, PNG);
     const again = await w.put(PNG);
     assert.equal(again.blobKey, blobKey);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("DurableByteStore (local-fs) accepts concurrent identical writes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "docstore-"));
+  try {
+    const bytes = createLocalDurableByteStore(dir);
+    const big = Buffer.concat([PNG, Buffer.alloc(4 * 1024 * 1024, 7)]);
+    const results = await Promise.all(Array.from({ length: 8 }, () => bytes.put(big)));
+    for (const r of results) assert.equal(r.blobKey, results[0]!.blobKey);
+    assert.deepEqual(await drain(bytes as never, results[0]!.blobKey), big);
+    const leftovers = (await readdir(join(dir, "files"))).filter((name) => name.endsWith(".part"));
+    assert.deepEqual(leftovers, [], "no orphaned partial files survive the race");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
In the local durable byte store, two concurrent writes of identical bytes shared the same <sha256>.<pid>.part temporary path: both passed the initial existence check, the first rename won, and the second failed with ENOENT. Each write now uses a random per-write temp path; identical content still converges on the same content-addressed final path via atomic rename, so  tidti l l d ll d dth tilfil i l d h th fil concurrent identical uploads all succeed, and the partial file is cleaned up when the rename fails. A repo-wide check confirmed this was the only affected temp-path site — the blob-transfer path already mints a unique id per put. Includes a deterministic concurrency regression test that fails on the unfixed code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237813&installation_model_id=19911&pr_number=383&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F383&signature=b73861f1e99293de318a2d176575091db84a1c01d58e971cda5473bacf0287fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->