### PR TITLE
web-ui: stop showing zero-second work folds

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1775,9 +1775,20 @@ export function createChatSurface(
   }
 
   function workSeconds(work: WorkBlock): number {
-    if (work.startedAt == null) return 0;
-    const end = work.finishedAt ?? Date.now();
-    return Math.max(0, Math.round((end - work.startedAt) / 1000));
+    const times = work.activity.map((a) => a.createdAt).filter((t) => typeof t === "number" && t > 0);
+    const start = work.startedAt ?? (times.length ? Math.min(...times) : null);
+    if (start == null) return 0;
+    const live = work.status === "thinking" || work.status === "working";
+    let end = work.finishedAt;
+    if (end == null) {
+      if (live) end = Date.now();
+      else end = times.length ? Math.max(...times, start) : start;
+    }
+    return Math.max(0, Math.round((end - start) / 1000));
+  }
+
+  function workedLabel(prefix: string, secs: number): string {
+    return secs > 0 ? `${prefix} for ${secs}s` : prefix;
   }
 
   function usedToolsSuffix(work: WorkBlock): string {
@@ -1789,7 +1800,7 @@ export function createChatSurface(
     if (work.stale && (work.status === "thinking" || work.status === "working")) return "Interrupted — resuming…";
     if (work.status === "thinking") return "Thinking";
     const secs = workSeconds(work);
-    return work.status === "working" ? `Working for ${secs}s` : `Worked for ${secs}s`;
+    return work.status === "working" ? `Working for ${secs}s` : workedLabel("Worked", secs);
   }
 
   function workBlock(work: WorkBlock, isStreaming: boolean): TemplateResult {
@@ -1827,7 +1838,11 @@ export function createChatSurface(
     };
     for (const it of timeline) {
       const demoted = it.kind === "text" && (it.activity.payload as { demoted?: boolean } | null)?.demoted === true;
-      if (it.kind === "text" && !demoted) {
+      // Closing self-logs after a successful surface post are bookkeeping, not
+      // another piece of visible work. Keeping them in the transcript is useful
+      // for audit/replay, but rendering them creates an empty "Worked" fold.
+      if (demoted) continue;
+      if (it.kind === "text") {
         flushSeg();
         const text = ((it.activity.payload as { text?: string } | null)?.text ?? "").trim();
         if (text) parts.push(html`<div class="work-said">${markdown(text)}</div>`);
@@ -1836,14 +1851,15 @@ export function createChatSurface(
       }
     }
     flushSeg();
-    return html`<div class="work work-${work.status}">${parts}</div>`;
+    return parts.length ? html`<div class="work work-${work.status}">${parts}</div>` : html``;
   }
 
   function segmentSummaryLabel(items: TimelineItem[], work: WorkBlock): string {
     const tools = items.filter((it) => it.kind === "tool").length;
     if (tools > 0) return `${tools} tool call${tools === 1 ? "" : "s"}`;
     const secs = workSeconds(work);
-    return work.status === "failed" ? `Failed after ${secs}s` : `Worked for ${secs}s`;
+    if (work.status === "failed") return secs > 0 ? `Failed after ${secs}s` : "Failed";
+    return workedLabel("Worked", secs);
   }
 
   function approvalSummaryView(a: PendingApproval, expanded = false): TemplateResult {

--- a/plugins/web-ui/test/work-fold-source.test.ts
+++ b/plugins/web-ui/test/work-fold-source.test.ts
@@ -6,7 +6,7 @@ const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 
 test("finished turns render mid-turn text OUTSIDE the collapsed fold, at its place in the timeline", () => {
-  assert.match(chat, /if \(it\.kind === "text" && !demoted\) \{\s*\n\s*flushSeg\(\);/);
+  assert.match(chat, /if \(demoted\) continue;\s*\n\s*if \(it\.kind === "text"\) \{\s*\n\s*flushSeg\(\);/);
   assert.match(chat, /class="work-said"/);
   assert.match(chat, /<details class="work-fold"/);
 });
@@ -21,11 +21,12 @@ test("promoted speech keeps full reply styling", () => {
   assert.match(css, /\.work-said \{[\s\S]{0,200}?color: var\(--foreground\);/);
 });
 
-test("a demoted post-delivery self-log stays folded as narration — never promoted to speech", () => {
+test("a demoted post-delivery self-log remains auditable but is omitted from the UI", () => {
   const bridge = readFileSync(new URL("../src/core-bridge.ts", import.meta.url), "utf8");
   assert.match(bridge, /payload: \{ text, demoted: true \}/);
   assert.match(chat, /demoted === true/);
-  assert.match(chat, /it\.kind === "text" && !demoted/);
+  assert.match(chat, /if \(demoted\) continue;/);
+  assert.match(chat, /return parts\.length \? .* : html``;/);
 });
 
 test("the fold chevron rotates when a work-fold is open", () => {


### PR DESCRIPTION
Collapsed work folds could render 'Worked for 0s' or 'Failed after 0s': the duration label only appears for tool-less segments, which span a single transcript entry, so the computed span was always zero — and demoted bookkeeping entries produced entirely empty 'Worked' folds. Work duration now falls back to the span of activity timestamps when start/finish markers are missing, labels drop the 'for Ns' suffix when no measurable time elapsed, and a fold with nothing visible to show is not rendered at all.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237818&installation_model_id=19911&pr_number=384&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F384&signature=9405f68081d31938855f30f863ebe6c40baaac0b81c43ca06af51a2e30d86113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->