### PR TITLE
Only restart a reattached background job on a confirmed missing process

### DIFF
--- a/src/connectors/background-exec-broker.ts
+++ b/src/connectors/background-exec-broker.ts
@@ -1,7 +1,7 @@
 import type { ProcessSandbox, ProcessState, SandboxHandle } from "../sandbox/sandbox.ts";
 import type { ProcessRegistry, ProcessStatus } from "../processes/process-registry.ts";
 import { awaitProcessExit } from "../sandbox/await-process-exit.ts";
-import { pollProcess } from "../sandbox/process-poll.ts";
+import { pollProcess, processIsGone } from "../sandbox/process-poll.ts";
 import { redactCommand } from "../sandbox/exec-process-session.ts";
 import { CONFIG_DEFAULTS } from "../config.ts";
 
@@ -108,7 +108,8 @@ export function createBackgroundBroker(deps: BackgroundExecBrokerDeps): Backgrou
             await deps.registry.markStatus(existingProcessId, "exited");
             processId = null;
           }
-        } catch {
+        } catch (error) {
+          if (!processIsGone(error)) throw error;
           await deps.registry.delete(existingProcessId);
           processId = null;
         }

--- a/test/background-exec-broker.test.ts
+++ b/test/background-exec-broker.test.ts
@@ -20,6 +20,7 @@ function fakeSandbox(opts?: { seedOutput?: string }) {
   const starts: Array<{ command: string; opts?: StartProcessOptions }> = [];
   const signals: Array<{ id: string; signal: string }> = [];
   const writes: Array<{ id: string; data: string }> = [];
+  const readErrors = new Map<string, unknown>();
   let n = 0;
 
   const sandbox: ProcessSandbox = {
@@ -53,6 +54,11 @@ function fakeSandbox(opts?: { seedOutput?: string }) {
       return { processId };
     },
     async readProcess(_h, id, opts) {
+      if (readErrors.has(id)) {
+        const error = readErrors.get(id);
+        readErrors.delete(id);
+        throw error;
+      }
       if (missing.has(id)) throw new Error(`no such process session: ${id}`);
       const p = procs.get(id);
       if (!p) throw new Error(`no such process session: ${id}`);
@@ -104,6 +110,7 @@ function fakeSandbox(opts?: { seedOutput?: string }) {
       }
     },
     vanish: (id: string) => missing.add(id),
+    failNextRead: (id: string, error: unknown) => readErrors.set(id, error),
   };
 }
 
@@ -364,6 +371,17 @@ test("liveness probe: a row whose backend process is gone is deleted and a fresh
   const rows = (await registry.listByScope(SCOPE)).filter((r) => r.kind === "background");
   assert.equal(rows.length, 1);
   assert.equal(rows[0]!.processId, second.processId);
+});
+
+test("liveness probe: a transient backend error preserves the running process and registry row", async () => {
+  const { broker, registry, starts, failNextRead } = build();
+  const first = await broker.start(handle, "long-build");
+  const error = new Error("backend unavailable");
+  failNextRead(first.processId, error);
+
+  await assert.rejects(broker.start(handle, "long-build"), error);
+  assert.equal(starts.length, 1);
+  assert.equal((await registry.get(first.processId))?.status, "running");
 });
 
 test("TTL clamp: a requested lifetime above the max is clamped (mirrors PR C's ceiling clamp)", async () => {


### PR DESCRIPTION
The reattach probe in the background exec broker treated any readProcess failure as proof the process was gone: it deleted the durable registry row and launched the command again. A transient backend error could therefore leave the original process running unrecorded, start a duplicate, and lose the record of the first. Route the decision through the shared processIsGone predicate: only a definitive no-such-process error drops the row and relaunches; any other failure keeps the row intact and surfaces to the caller. A regression test pins a transient backend error preserving both the process and its row. Fixes #285.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237822&installation_model_id=19911&pr_number=385&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F385&signature=8f006475316521ef110cb63fe2b3b9a802e1f9504fef87d4aef7f82876cb900a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->