### PR TITLE
Reject a run attempt whose lease was lost before completion

### DIFF
--- a/src/runs/worker.ts
+++ b/src/runs/worker.ts
@@ -68,7 +68,9 @@ export async function processRun(deps: ProcessDeps, run: Run, opts?: { backgroun
       ...(queueMs !== undefined ? { queueMs } : {}),
     });
     stopBeat();
-    await deps.runs.complete(run.id, token, result);
+    if (!(await deps.runs.complete(run.id, token, result))) {
+      throw new Error(`run ${run.id} lost its lease before completion`);
+    }
     return result;
   } catch (err) {
     stopBeat();

--- a/test/process-run.test.ts
+++ b/test/process-run.test.ts
@@ -85,6 +85,31 @@ test("processRun threads runId + background into the turn and completes the run 
   assert.equal(seen[1]?.background, true, "the worker-loop flag reaches the orchestrator");
 });
 
+test("processRun rejects when a reaped attempt finishes after a retry claims the run", async () => {
+  const { runs } = createMemoryRunStore();
+  let finish = (_: TurnResult) => {};
+  const turnResult = new Promise<TurnResult>((resolve) => {
+    finish = resolve;
+  });
+  const orchestrator = fakeOrchestrator(() => turnResult);
+
+  await runs.enqueue({ sessionId: "s1", request: turn });
+  const first = await runs.claim("w1", -1);
+  const pending = processRun({ runs, orchestrator, leaseTtlMs: 5_000 }, first!);
+
+  assert.deepEqual(await runs.reapExpired(), { requeued: 1, parked: 0 });
+  const second = await runs.claim("w2", 5_000);
+  assert.equal(second?.attempts, 2);
+
+  finish({ status: "ok", reply: "stale" });
+  await assert.rejects(pending, /lost.*lease/i);
+
+  const current = await runs.get(first!.id);
+  assert.equal(current?.status, "running");
+  assert.equal(current?.leaseToken, second?.leaseToken);
+  assert.equal(current?.result, null);
+});
+
 test("processRun upgrades legacy queued provenance before orchestration", async () => {
   const { runs } = createMemoryRunStore();
   const legacy = { ...turn, origin: undefined, liveActor: true, triggerTs: "1" } as unknown as OrchestratorInput;


### PR DESCRIPTION
If an attempt's lease expired and the run was reclaimed by a newer attempt, the finishing stale attempt called the lease-fenced complete(), ignored its false result, and returned an ok reply anyway — reporting success for a run still executing under the new attempt. processRun now rejects when complete() returns false. The subsequent lease-fenced fail() with the stale token is a no-op, so the live attempt's claim, status, and result are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237825&installation_model_id=19911&pr_number=386&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F386&signature=e4b451a47672a0c69d4d9d2d9dda5fcce2fb8965bdc59e8a02527c3f079b9149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->