### PR TITLE
Record a consent-withheld cron delivery as refused and tell the owner

### DIFF
--- a/src/triggers/run-trigger.ts
+++ b/src/triggers/run-trigger.ts
@@ -12,7 +12,7 @@ import type { IdentityService } from "../identity/identity-service.ts";
 import type { DeliveryStore } from "../delivery/delivery-store.ts";
 import type { IdempotencyStore } from "../idempotency/idempotency-store.ts";
 import { turnModelOptions } from "../core/turn-options.ts";
-import { reachEnqueue } from "../reach/reach.ts";
+import { principalDestination, reachEnqueue } from "../reach/reach.ts";
 import { consentRequiredRecipient, recipientConsentSatisfied } from "./trigger-store.ts";
 import { isVisible, type VisibilityDirectory } from "../directory/visibility.ts";
 import { samePerson } from "../directory/person.ts";
@@ -188,15 +188,27 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
   let note: string | undefined;
   let reply: string | undefined;
   let sessionId: string | undefined;
+  const ownerSkipNotice = async () => {
+    await deps.deliveries.enqueue({
+      destination: principalDestination(spec.owner, spec.owner),
+      text: `Scheduled delivery skipped: ${consentNote}`,
+      idempotencyKey: `${spec.fireKey}:err`,
+      provenance: deliveryProvenance(spec, threadRef),
+      ...(spec.shadow ? { shadow: true } : {}),
+    });
+  };
   const ran = await deps.idempotency.once(spec.fireKey, async () => {
     if (spec.message !== undefined) {
       status = "ok";
       if (!spec.destination) return;
       if (!consented) {
+        status = "refused";
         note = consentNote;
+        await ownerSkipNotice();
         return;
       }
       if (!deliverable) {
+        status = "refused";
         note = notVisibleNote;
         return;
       }
@@ -248,10 +260,13 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
       if (!spec.destination) return;
       if (liveDelivery) return;
       if (!consented) {
+        status = "refused";
         note = consentNote;
+        await ownerSkipNotice();
         return;
       }
       if (!deliverable) {
+        status = "refused";
         note = notVisibleNote;
         return;
       }

--- a/test/cron-scheduler.test.ts
+++ b/test/cron-scheduler.test.ts
@@ -291,7 +291,13 @@ test("a recurring teammate-DM cron without current recipient consent is withheld
     },
   });
   await scheduler.runNow(cron.id);
-  assert.equal((await deliveries.pending("principal")).length, 0);
+  const pending = await deliveries.pending("principal");
+  assert.equal(pending.length, 1);
+  assert.equal(pending[0]?.destination.target, "U1");
+  assert.match(pending[0]?.text ?? "", /consent.*skipped/i);
+  const stored = await crons.get(cron.id);
+  assert.equal(stored?.fireLog?.[0]?.status, "refused");
+  assert.match(stored?.fireLog?.[0]?.note ?? "", /consent/);
 });
 
 test("a teammate-DM cron created in a channel delivers its real output (§10 parity gate)", async () => {

--- a/test/trigger-consent.test.ts
+++ b/test/trigger-consent.test.ts
@@ -113,7 +113,8 @@ describe("runTrigger: recipient-consent gate", () => {
       recipientConsent: { recipientId: "U-alice", status: "pending" },
     });
     assert.equal(
-      (await deps.deliveries.pending("principal")).length,
+      (await deps.deliveries.pending("principal")).filter((delivery) => delivery.destination.target === "U-alice")
+        .length,
       0,
       "nothing reaches a recipient who hasn't accepted",
     );
@@ -145,7 +146,11 @@ describe("runTrigger: recipient-consent gate", () => {
       destination: toAlice,
       recipientConsentRequired: true,
     });
-    assert.equal((await deps.deliveries.pending("principal")).length, 0);
+    assert.equal(
+      (await deps.deliveries.pending("principal")).filter((delivery) => delivery.destination.target === "U-alice")
+        .length,
+      0,
+    );
   });
 
   it("accepted consent for a prior recipient does not authorize a retargeted standing DM", async () => {
@@ -160,7 +165,26 @@ describe("runTrigger: recipient-consent gate", () => {
       recipientConsent: { recipientId: "U-alice", status: "accepted" },
       recipientConsentRequired: true,
     });
-    assert.equal((await deps.deliveries.pending("principal")).length, 0);
+    assert.equal(
+      (await deps.deliveries.pending("principal")).filter((delivery) => delivery.destination.target === "U-bob").length,
+      0,
+    );
+  });
+
+  it("an unrelated turn refusal sends no consent notice (nothing was withheld for consent)", async () => {
+    const deps = triggerDeps(async () => ({ status: "refused", reason: "runtime not approved" }));
+    const out = await runTrigger(deps, {
+      owner: "U-carol",
+      ownerScopeId: scopeId("personal", "U-carol"),
+      input: "compose",
+      fireKey: "c-unrelated",
+      surface: "cron",
+      destination: toAlice,
+      recipientConsentRequired: true,
+    });
+    assert.equal(out.status, "refused");
+    assert.doesNotMatch(out.note ?? "", /consent/);
+    assert.equal((await deps.deliveries.pending("principal")).length, 0, "no misleading skip notice to anyone");
   });
 
   it("withholds a verbatim relay too (a declined recipient gets nothing)", async () => {
@@ -177,7 +201,11 @@ describe("runTrigger: recipient-consent gate", () => {
       destination: toAlice,
       recipientConsent: { recipientId: "U-alice", status: "declined" },
     });
-    assert.equal((await deps.deliveries.pending("principal")).length, 0);
+    assert.equal(
+      (await deps.deliveries.pending("principal")).filter((delivery) => delivery.destination.target === "U-alice")
+        .length,
+      0,
+    );
     assert.match(out.note ?? "", /turned this delivery off/);
   });
 });

--- a/test/visibility.test.ts
+++ b/test/visibility.test.ts
@@ -123,6 +123,7 @@ describe("runTrigger: fire-time visibility gate", () => {
     assert.equal(out.authzFailed, false, "not disabled — staleness must not kill a cron");
     assert.equal((await deps.deliveries.pending("slack")).length, 0, "no post to a channel the owner can't see");
     assert.match(out.note ?? "", /no longer visible/);
+    assert.equal(out.status, "refused", "a withheld delivery is not recorded as a success");
   });
 
   it("skips the run entirely (§10 leg a) when the actor lost the HOME scope — the exfil shape", async () => {


### PR DESCRIPTION
A cron whose principal destination is someone other than its owner requires the recipient's consent, but a fire skipped for missing consent was logged as {status: "ok"} with only a note, and the owner-notification path was gated off — the owner never learned the reminder didn't go out, and the fire log was indistinguishable from a delivered one. Both consent-skip paths (verbatim relay and task output) now record status "refused" with the explanatory note, and the owner gets a "Scheduled delivery skipped" notice. Tests cover the declined and awaiting-consent cases and that fire history distinguishes withheld from delivered.

**Deployment notes**

Behavior flip (a fix): consent-skipped and not-visible cron fires now record status 'refused'
instead of 'ok' — dashboards/queries keying on fire status will see new values for events
previously logged as ok.
New unsolicited owner DM on consent-skip: cron owners in upstream orgs start receiving skip
notices with no opt-in; idempotent via fire key so no double-send on replay.
No schema change; reuses existing fire-log fields.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237828&installation_model_id=19911&pr_number=387&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F387&signature=e8d086b1dc488538a5c5a2f51f46e2077f6a34c633f75b436dc89e7edd902a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->