### PR TITLE
web-ui: only offer session-drop targets that will really happen

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6630,6 +6630,11 @@ h3.ambient-field-label {
   color: var(--foreground);
 }
 
+.split-canvas.session-dragging .dv-tabs-and-actions-container {
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--primary) 55%, var(--border));
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+}
+
 .zone-top {
   left: 25%;
   right: 25%;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -152,6 +152,7 @@ function buildDock(): DockviewApi {
       guarded.add(group);
       group.model.onWillDrop(holdTileCap);
     }
+    if (sessionDrag) refreshSessionDrag();
     persistSoon();
   });
   api.onDidActivePanelChange((e) => {
@@ -513,14 +514,23 @@ function drawToast(): void {
 export function beginSessionDrag(s: CoreSession): void {
   if (!s.id) return;
   sessionDrag = { sessionId: s.id, threadRef: s.threadRef };
-  if (splitState.active) syncAllZones();
+  if (splitState.active) refreshSessionDrag();
   else showSingleDropOverlay();
+}
+
+function refreshSessionDrag(): void {
+  const drag = sessionDrag;
+  if (!drag) return;
+  const addsTab = !paneShowing(drag.sessionId) && (dockApi?.panels.length ?? 0) < MAX_PANES;
+  canvasHost?.classList.toggle("session-dragging", addsTab);
+  syncAllZones();
 }
 
 export function endSessionDrag(): void {
   if (!sessionDrag) return;
   sessionDrag = null;
   hideSingleDropOverlay();
+  canvasHost?.classList.remove("session-dragging");
   if (splitState.active) syncAllZones();
 }
 
@@ -548,12 +558,31 @@ function zoneTpl(edge: DropEdge, label: string, onDrop: () => void): TemplateRes
   </div>`;
 }
 
-function zonesTpl(act: (edge: DropEdge) => () => void): TemplateResult {
+function splitZonesTpl(act: (edge: DropEdge) => () => void): TemplateResult {
   return html`
-    ${zoneTpl("center", "Open here", act("center"))} ${zoneTpl("left", "Split left", act("left"))}
-    ${zoneTpl("right", "Split right", act("right"))} ${zoneTpl("top", "Split up", act("top"))}
-    ${zoneTpl("bottom", "Split down", act("bottom"))}
+    ${zoneTpl("left", "Split left", act("left"))} ${zoneTpl("right", "Split right", act("right"))}
+    ${zoneTpl("top", "Split up", act("top"))} ${zoneTpl("bottom", "Split down", act("bottom"))}
   `;
+}
+
+function zonesTpl(act: (edge: DropEdge) => () => void): TemplateResult {
+  return html`${zoneTpl("center", "Open here", act("center"))} ${splitZonesTpl(act)}`;
+}
+
+function paneZonesTpl(paneId: string): TemplateResult | typeof nothing {
+  const drag = sessionDrag;
+  if (!drag || !dockApi) return nothing;
+  const act = paneZoneAct(paneId);
+  const showing = paneShowing(drag.sessionId);
+  if (showing)
+    return showing.id === paneId
+      ? zoneTpl("center", "Show here", () => {
+          endSessionDrag();
+          focusPane(paneId);
+        })
+      : nothing;
+  const canSplit = dockApi.panels.length < MAX_PANES && dockApi.groups.length < MAX_TILES;
+  return html`${zoneTpl("center", "Open here", act("center"))} ${canSplit ? splitZonesTpl(act) : nothing}`;
 }
 
 function paneZoneAct(paneId: string): (edge: DropEdge) => () => void {
@@ -595,9 +624,12 @@ function showSingleDropOverlay(): void {
     }
     activateCanvas(current, { sessionId: drag.sessionId, threadRef: drag.threadRef }, edge);
   };
+  const drag = sessionDrag;
+  const splittable =
+    Boolean(drag) && mainConversation().state.sessionId !== drag?.sessionId && currentChatParams() !== null;
   singleOverlay = document.createElement("div");
   singleOverlay.className = "split-zones split-zones-single";
-  render(zonesTpl(act), singleOverlay);
+  render(splittable ? zonesTpl(act) : zoneTpl("center", "Open here", act("center")), singleOverlay);
   appState.mainEl.appendChild(singleOverlay);
 }
 
@@ -768,7 +800,7 @@ class PaneContent implements IContentRenderer {
   }
 
   syncZones(): void {
-    render(sessionDrag ? zonesTpl(paneZoneAct(this.panelId)) : nothing, this.zonesEl);
+    render(sessionDrag ? paneZonesTpl(this.panelId) : nothing, this.zonesEl);
   }
 
   dispose(): void {

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -96,8 +96,8 @@ test("a strip drop lands where a dragged pane header would, not merely at the en
 
 test("the pane body no longer offers a tab zone", () => {
   assert.doesNotMatch(layout, /"tab"/, "DropEdge must drop the zone that no longer exists");
-  const zones = fn(split, "zonesTpl");
-  assert.doesNotMatch(zones, /tab/i);
+  const zones = fn(split, "zonesTpl") + fn(split, "splitZonesTpl");
+  assert.doesNotMatch(zones, /"tab"/);
   assert.match(zones, /zoneTpl\("center", "Open here"/);
   for (const edge of ["left", "right", "top", "bottom"]) assert.match(zones, new RegExp(`zoneTpl\\("${edge}"`));
   assert.doesNotMatch(css, /\.zone-tab \{/);

--- a/plugins/web-ui/test/split-drop-legitimacy.test.ts
+++ b/plugins/web-ui/test/split-drop-legitimacy.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
+
+test("a pane only offers the drops that will really happen", () => {
+  const zones = split.match(/^function paneZonesTpl\([\s\S]*?\n\}/m)?.[0] ?? "";
+  assert.ok(zones, "paneZonesTpl not found");
+  assert.match(zones, /paneShowing\(drag\.sessionId\)/, "a session already on the canvas gets no split/tab targets");
+  assert.match(
+    zones,
+    /"Show here", \(\) => \{\n\s*endSessionDrag\(\);\n\s*focusPane\(paneId\);/,
+    "its own pane offers a target that really focuses it",
+  );
+  assert.match(zones, /groups\.length < MAX_TILES/, "split targets vanish at the tile cap");
+  assert.match(zones, /panels\.length < MAX_PANES/, "split targets also vanish at the pane ceiling");
+  assert.match(split, /render\(sessionDrag \? paneZonesTpl\(this\.panelId\) : nothing, this\.zonesEl\);/);
+});
+
+test("the tab strips light up as targets from the moment the drag starts", () => {
+  const refresh = split.match(/^function refreshSessionDrag\([\s\S]*?\n\}/m)?.[0] ?? "";
+  assert.ok(refresh, "refreshSessionDrag not found");
+  assert.match(
+    refresh,
+    /!paneShowing\(drag\.sessionId\) && \(dockApi\?\.panels\.length \?\? 0\) < MAX_PANES/,
+    "but only when a strip drop would really add a tab",
+  );
+  assert.match(refresh, /classList\.toggle\("session-dragging", addsTab\)/);
+  assert.match(split, /classList\.remove\("session-dragging"\)/);
+  assert.match(css, /\.split-canvas\.session-dragging \.dv-tabs-and-actions-container \{/);
+});
+
+test("targets and highlights stay honest when the layout changes mid-drag", () => {
+  assert.match(
+    split,
+    /if \(sessionDrag\) refreshSessionDrag\(\);\n\s*persistSoon\(\);/,
+    "a layout change during a drag recomputes the drop targets and strip highlight",
+  );
+});
+
+test("the single-view overlay hides splits the drop cannot honor", () => {
+  const single = split.match(/^function showSingleDropOverlay\([\s\S]*?\n\}/m)?.[0] ?? "";
+  assert.ok(single, "showSingleDropOverlay not found");
+  assert.match(
+    single,
+    /currentChatParams\(\) !== null/,
+    "a dirty unsaved chat cannot seed a pane, so no split targets",
+  );
+  assert.match(single, /state\.sessionId !== drag\?\.sessionId/, "dropping the chat onto itself cannot split");
+  assert.match(single, /splittable \? zonesTpl\(act\) : zoneTpl\("center", "Open here", act\("center"\)\)/);
+});

--- a/plugins/web-ui/test/split-layout.test.ts
+++ b/plugins/web-ui/test/split-layout.test.ts
@@ -43,6 +43,10 @@ test("a conversation can be dropped onto a pane's tab strip to become a tab", ()
   const splitTs = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
   assert.match(splitTs, /e\.target === "tab" \|\| e\.target === "header_space"/, "no strip drop target");
   assert.match(splitTs, /api\.onDidDrop\(\(e\) => \{[\s\S]*?tabIntoPane\(/, "the strip drop must join the pane");
-  const edges = [...splitTs.matchAll(/zoneTpl\("([a-z]+)"/g)].map((m) => m[1]);
-  assert.deepEqual(edges, ["center", "left", "right", "top", "bottom"], "the body zones must not restate the strip");
+  const edges = new Set([...splitTs.matchAll(/zoneTpl\("([a-z]+)"/g)].map((m) => m[1]));
+  assert.deepEqual(
+    edges,
+    new Set(["center", "left", "right", "top", "bottom"]),
+    "the body zones must not restate the strip",
+  );
 });


### PR DESCRIPTION
Dragging a session onto the multiview canvas rendered all five drop zones (open-here plus four splits) unconditionally, with legitimacy decided only inside the drop handlers after the drop. So the UI advertised actions that wouldn't happen: at the pane cap a "Split" drop silently became a tab, and dragging a session already on the canvas showed full zones but any drop just focused its existing pane. The overlay now computes which targets are legitimate before rendering and only offers those, so what the user sees is what the drop will do. Tests cover the cap, the already-open session, and single-view cases.

**Deployment notes**

Builds on the multiview pane work in #1885 (e06ba40af) — land that first or together
Web-ui drag/drop UI logic only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237832&installation_model_id=19911&pr_number=388&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F388&signature=255307e27382f83752dda99ea9a7cf5b6fc53bd872c7b581cb28061fe9f1e106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->