### PR TITLE
memory: coerce miscalled remember calls into facts

### DIFF
--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -121,6 +121,44 @@ function capText(t: string): string {
   return t.length > MAX_TOOL_RESULT_CHARS ? `${t.slice(0, MAX_TOOL_RESULT_CHARS)}…[truncated]` : t;
 }
 
+function contentFactLines(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^[-*]\s+/, "")
+        .trim(),
+    )
+    .filter(Boolean);
+}
+
+function passedRememberFields(params: { facts?: unknown; content?: unknown; query?: unknown }): string {
+  const fields = ["facts", "content", "query"].filter((field) => params[field as keyof typeof params] !== undefined);
+  return fields.length ? fields.join(", ") : "none";
+}
+
+function rememberFacts(params: { facts?: unknown; content?: unknown; query?: unknown }): {
+  facts: string[];
+  coercedFrom?: "facts" | "content" | "query";
+} {
+  if (typeof params.facts === "string") {
+    const fact = params.facts.trim();
+    if (fact) return { facts: [fact], coercedFrom: "facts" };
+  }
+  const facts = Array.isArray(params.facts) ? params.facts.map((fact) => String(fact).trim()).filter(Boolean) : [];
+  if (facts.length) return { facts };
+  if (typeof params.content === "string") {
+    const contentFacts = contentFactLines(params.content);
+    if (contentFacts.length) return { facts: contentFacts, coercedFrom: "content" };
+  }
+  if (typeof params.query === "string") {
+    const fact = params.query.trim();
+    if (fact) return { facts: [fact], coercedFrom: "query" };
+  }
+  return { facts: [] };
+}
+
 function fmtStatus(s: { state: "running" } | { state: "exited"; code: number }): string {
   return s.state === "exited" ? `exited ${s.code}` : "running";
 }
@@ -892,7 +930,7 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
         ...(params.query !== undefined ? { query: params.query } : {}),
         ...(params.limit !== undefined ? { limit: params.limit } : {}),
         ...(params.facts !== undefined ? { facts: params.facts } : {}),
-        ...(params.content !== undefined ? { chars: params.content.length } : {}),
+        ...(typeof params.content === "string" ? { chars: params.content.length } : {}),
       });
       const unavailable = () =>
         recordResult(
@@ -937,19 +975,24 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
           );
         }
         case "remember": {
-          const facts = (params.facts ?? []).map((f) => f.trim()).filter(Boolean);
+          const resolved = rememberFacts(params);
+          const { facts } = resolved;
           if (!facts.length)
             return recordResult(
               callId,
               { tool: "memory", action, error: "facts required" },
-              text("[error] memory remember requires `facts` (a non-empty list)."),
+              text(
+                `[error] memory remember requires \`facts\` (a non-empty list). Received: ${passedRememberFields(
+                  params,
+                )} (use facts instead).`,
+              ),
               true,
             );
           const added = await tc.memoryRemember(facts);
           if (added === null) return unavailable();
           return recordResult(
             callId,
-            { tool: "memory", action, added },
+            { tool: "memory", action, added, ...(resolved.coercedFrom ? { coercedFrom: resolved.coercedFrom } : {}) },
             text(
               added
                 ? `Remembered ${added} fact${added === 1 ? "" : "s"}.`

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -1104,6 +1104,134 @@ test("tool entries carry the call id + faithful model-facing result (WAL replay 
   assert.match(result("call-exec").result, /\[exit 0\]/);
 });
 
+test("memory remember accepts facts as a single string and records coercion", async () => {
+  const emitted: Emitted[] = [];
+  const remembered: string[][] = [];
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      async memoryRemember(facts) {
+        remembered.push(facts);
+        return facts.length;
+      },
+    },
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+  };
+  const memory = createPiTools(ref).find((tool) => tool.name === "memory");
+
+  await call(memory, { action: "remember", facts: "Owns billing." });
+
+  assert.deepEqual(remembered, [["Owns billing."]]);
+  const result = emitted.find((e) => e.type === "tool_result" && e.payload.tool === "memory")!.payload;
+  assert.equal(result.coercedFrom, "facts");
+  assert.equal(result.added, 1);
+});
+
+test("memory remember falls back to content lines with bullets", async () => {
+  const emitted: Emitted[] = [];
+  const remembered: string[][] = [];
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      async memoryRemember(facts) {
+        remembered.push(facts);
+        return facts.length;
+      },
+    },
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+  };
+  const memory = createPiTools(ref).find((tool) => tool.name === "memory");
+
+  await call(memory, { action: "remember", facts: [], content: "\n- Owns billing.\n- Likes short updates.\n\n" });
+
+  assert.deepEqual(remembered, [["Owns billing.", "Likes short updates."]]);
+  const result = emitted.find((e) => e.type === "tool_result" && e.payload.tool === "memory")!.payload;
+  assert.equal(result.coercedFrom, "content");
+  assert.equal(result.added, 2);
+});
+
+test("memory remember falls back to query when facts and content are empty", async () => {
+  const emitted: Emitted[] = [];
+  const remembered: string[][] = [];
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      async memoryRemember(facts) {
+        remembered.push(facts);
+        return facts.length;
+      },
+    },
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+  };
+  const memory = createPiTools(ref).find((tool) => tool.name === "memory");
+
+  await call(memory, { action: "remember", facts: [], content: "  ", query: "Prefers email summaries." });
+
+  assert.deepEqual(remembered, [["Prefers email summaries."]]);
+  const result = emitted.find((e) => e.type === "tool_result" && e.payload.tool === "memory")!.payload;
+  assert.equal(result.coercedFrom, "query");
+  assert.equal(result.added, 1);
+});
+
+test("memory remember keeps normal facts arrays unchanged", async () => {
+  const emitted: Emitted[] = [];
+  const remembered: string[][] = [];
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      async memoryRemember(facts) {
+        remembered.push(facts);
+        return facts.length;
+      },
+    },
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+  };
+  const memory = createPiTools(ref).find((tool) => tool.name === "memory");
+
+  await call(memory, { action: "remember", facts: ["Owns billing.", "Likes short updates."] });
+
+  assert.deepEqual(remembered, [["Owns billing.", "Likes short updates."]]);
+  const result = emitted.find((e) => e.type === "tool_result" && e.payload.tool === "memory")!.payload;
+  assert.equal(result.coercedFrom, undefined);
+  assert.equal(result.added, 2);
+});
+
+test("memory remember all-empty error names the supplied fields", async () => {
+  const emitted: Emitted[] = [];
+  const ref: ToolContextRef = {
+    current: fakeToolContext(),
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+  };
+  const memory = createPiTools(ref).find((tool) => tool.name === "memory");
+
+  const ret = (await call(memory, { action: "remember", facts: [], content: "", query: "" })) as {
+    content: Array<{ text: string }>;
+  };
+
+  assert.equal(
+    ret.content[0]!.text,
+    "[error] memory remember requires `facts` (a non-empty list). Received: facts, content, query (use facts instead).",
+  );
+  const result = emitted.find((e) => e.type === "tool_result" && e.payload.tool === "memory")!.payload;
+  assert.equal(result.isError, true);
+  assert.equal(result.error, "facts required");
+});
+
 test("not-found read and denied command record isError + the faithful error text", async () => {
   const emitted: Emitted[] = [];
   const denyTC: ToolContext = {


### PR DESCRIPTION
Agents routinely call the memory tool with action 'remember' but without a usable facts array — putting the fact text in content, in query, or passing a bare string — and every such call errored, wasting the turn and silently losing the memory the agent meant to save; in practice this was the single largest cluster of agent tool errors. The common miscalls are now coerced into a fact list in priority order: a bare-string facts becomes one fact, content is split on newlines with leading bullets stripped, and query becomes one fact. Only when all three are empty does the call still error, and the message now names what was passed. The tool result records when coercion happened so the miscall rate stays visible rather than masked, and well-formed calls are entirely unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237855&installation_model_id=19911&pr_number=394&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F394&signature=eadf992b4726cdb0a0410c2f4c6bf189d96bd7e3f2c5a434af520e6660072251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->