### PR TITLE
web-ui: session top bar with project crumb, status pill, and quick tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,14 @@ Two habits that keep task-focused changes from scarring the rest of the repo:
   Slack Mac app, and don't ask permission first — do it on your own; don't wait to be
   asked. Skip it for trivial refactors, docs, config, or pure-logic changes already
   covered by tests.
-- **Screenshot every front-end change in the PR.** Anything an operator or user sees
-  rendered — admin/web/portal UI, Slack surfaces, emails — ships with a screenshot of the
-  after state (before/after when it's a change to something that already existed) in the PR
-  description, so a reviewer sees the result without booting it. Can't reach the surface
-  live? Render it against realistic data and say so.
+- **Demo every front-end change in the PR.** Anything an operator or user sees
+  rendered — admin/web/portal UI, Slack surfaces, emails — ships with a way for a
+  reviewer to see the result without booting it. Prefer a link to a live demo app
+  (e.g. the built UI served against a small mock API, published internally) so the
+  reviewer can click around the real thing; note in the PR what's mocked. Fall back
+  to screenshots only when a live demo isn't practical (e.g. Slack surfaces, emails),
+  and then show the after state (before/after for changes to something that existed),
+  rendered against realistic data.
 
 ## Private forks
 

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -17,7 +17,6 @@ import {
   FileText,
   Files,
   GitFork,
-  Hash,
   Maximize2,
   Paperclip,
   Pencil,
@@ -27,7 +26,6 @@ import {
   Rocket,
   ScrollText,
   Terminal,
-  Users,
   Wrench,
   type IconNode,
 } from "lucide";
@@ -52,7 +50,6 @@ import {
   makeOpenerStreamFn,
   makeRunResumeStreamFn,
   runApprovalTurn,
-  sharedContextLabel,
   TAIL_TURNS,
   type ApprovalDecision,
   type AssistantWork,
@@ -84,7 +81,9 @@ import {
   harnessSupportsFastMode,
 } from "./model-options";
 import { browserRenderableImage, formatBytes, icon, relTime } from "./ui";
-import { adminSessionLogUrl, appState, can, renderSidebarTop, syncUrlFromState } from "./shell";
+import { adminSessionLogUrl, appState, can, renderSidebarTop, switchView, syncUrlFromState } from "./shell";
+import { contextsState, scopeTitle } from "./contexts";
+import { openProjectPage, scopeCronCount, sessionTopbarTpl, setScopedSession } from "./session-scope";
 import {
   addPendingSession,
   dropPendingSession,
@@ -1024,7 +1023,7 @@ export function createChatSurface(
                 </div>`
               : nothing
           }
-          ${contextBanner()}
+          ${glanceTier ? nothing : sessionTopbar(agent)}
           ${
             glanceTier
               ? paneGlance(agent, messages, glanceTier)
@@ -1086,16 +1085,40 @@ export function createChatSurface(
     return null;
   }
 
-  function contextBanner(): TemplateResult | typeof nothing {
-    const label = sharedContextLabel(chatState.scopeId, chatState.contextName);
-    if (!label) return nothing;
-    const glyph = chatState.scopeId?.startsWith("group:") ? Users : Hash;
-    return html`<div
-      class="context-banner"
-      title="This chat runs in the ${label} context — the agent works with that context's files and memory, separate from your personal context."
-    >
-      ${icon(glyph, 13)}<span><strong>${label}</strong> context</span>
-    </div>`;
+  function pillState(needsYou: boolean, working: boolean): "needs-you" | "working" | null {
+    if (needsYou) return "needs-you";
+    return working ? "working" : null;
+  }
+
+  function sessionTopbar(agent: Agent): TemplateResult {
+    const scope = chatState.scopeId;
+    const session = sessionsState.list.find((s) =>
+      chatState.sessionId
+        ? s.id === chatState.sessionId
+        : Boolean(chatState.threadRef) && s.threadRef === chatState.threadRef,
+    );
+    const title = session?.title?.trim() || "New chat";
+    const crumb = scope && !scope.startsWith("personal:") ? scopeTitle(scope, chatState.contextName) : null;
+    const needsYou = activePendingApprovals().length > 0;
+    const working = !needsYou && (agent.state.isStreaming || chatState.resolvingApprovals.size > 0);
+    return sessionTopbarTpl({
+      crumb,
+      title,
+      onCrumb: crumb && scope ? () => openProjectPage(scope) : null,
+      pill: pillState(needsYou, working),
+      cronCount: scope ? scopeCronCount(scope, () => drawActiveChat()) : null,
+      onTool: (tool) => {
+        setScopedSession({
+          scopeId: scope ?? "",
+          sessionId: chatState.sessionId,
+          threadRef: chatState.threadRef,
+          title,
+          crumb,
+        });
+        if (scope && tool !== "memory") contextsState.selected = scope;
+        switchView(tool);
+      },
+    });
   }
 
   function chatHeader(title: string | TemplateResult, detail: string, readOnly: boolean): TemplateResult {

--- a/plugins/web-ui/src/crons.ts
+++ b/plugins/web-ui/src/crons.ts
@@ -4,7 +4,8 @@ import { api } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
 import { icon } from "./ui";
 import { listBackLink, listPageTpl } from "./list-page";
-import { ensureContexts, scopeChip } from "./contexts";
+import { contextsState, ensureContexts, scopeChip } from "./contexts";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 import { appState } from "./shell";
 import { mainConversation } from "./conversations";
 import { deepLinkPath, isPlainLeftClick, UI_BASE } from "./deep-link";
@@ -185,6 +186,11 @@ function cronStatusText(c: CronView): string {
 
 export async function renderCronsPage(): Promise<void> {
   if (appState.currentView !== "crons") return;
+  if (scopedSession.active) cronsScope = scopedSession.active.scopeId;
+  else if (contextsState.selected) {
+    cronsScope = contextsState.selected;
+    contextsState.selected = null;
+  }
   await ensureContexts();
   drawCronsPage();
   const loaded = await refreshCrons({ showLoading: cronList.length === 0 && visibleCronList.length === 0 });
@@ -252,14 +258,19 @@ function drawCronsPage(): void {
   if (cronsNotice) empty = cronsNotice;
   else if (cronsLoading && cronList.length === 0 && visibleCronList.length === 0) empty = "Loading crons…";
   else if (cronsScope) empty = "No crons in this context.";
+  const scoped = Boolean(scopedSession.active);
+  cronsPageHost.classList.toggle("scoped-view", scoped);
   render(
-    listPageTpl({
+    html`${scopedViewTopbar("crons", drawCronsPage)}
+    ${listPageTpl({
       title: "Crons",
       scope: cronsScope,
-      onScope: (s) => {
-        cronsScope = s;
-        drawCronsPage();
-      },
+      onScope: scoped
+        ? undefined
+        : (s) => {
+            cronsScope = s;
+            drawCronsPage();
+          },
       onRefresh: () => {
         cronRuns.clear();
         void renderCronsPage();
@@ -275,7 +286,7 @@ function drawCronsPage(): void {
       },
       rows,
       empty,
-    }),
+    })}`,
     cronsPageHost,
   );
 }

--- a/plugins/web-ui/src/files.ts
+++ b/plugins/web-ui/src/files.ts
@@ -6,6 +6,7 @@ import { browserRenderableImage, fieldSelect, formatBytes, icon, relTime } from 
 import { contextsState, ensureContexts, personalScopeId, scopeChip, scopeFilterControl } from "./contexts";
 import { appState } from "./shell";
 import { fileListNeedsAllPages } from "./file-list";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 
 interface FileItem {
   id: string;
@@ -93,20 +94,27 @@ function drawFiles(loading = false): void {
   else if (filesUploading) dropLabel = "Uploading…";
   const status = filesNotice || (loading && !fileRows.length ? "Loading files…" : "");
   const uploadTarget = filesScope ?? personalScopeId();
+  const scoped = Boolean(scopedSession.active);
+  filesHost.classList.toggle("scoped-view", scoped);
   render(
     html`
+      ${scopedViewTopbar("files", drawFiles)}
       <div class="list-page-head">
         <div>
           <h1 class="pane-title">Files</h1>
           <div class="pane-subtitle">Files created, uploaded, or shared with you</div>
         </div>
         <div class="list-page-actions">
-          ${scopeFilterControl(filesScope, (s) => {
-            filesScope = s;
-            fileRows = [];
-            filesNextCursor = null;
-            void loadFiles(appState.viewRenderSeq);
-          })}<button class="btn primary" type="button" ?disabled=${filesUploading} @click=${pickFiles}>
+          ${
+            scoped
+              ? nothing
+              : scopeFilterControl(filesScope, (s) => {
+                  filesScope = s;
+                  fileRows = [];
+                  filesNextCursor = null;
+                  void loadFiles(appState.viewRenderSeq);
+                })
+          }<button class="btn primary" type="button" ?disabled=${filesUploading} @click=${pickFiles}>
             ${icon(Upload, 15)}<span>Upload</span>
           </button>
         </div>
@@ -386,7 +394,14 @@ async function loadFiles(seq: number): Promise<void> {
 
 export async function renderFiles(): Promise<void> {
   if (appState.currentView !== "files") return;
-  if (contextsState.selected) {
+  if (scopedSession.active) {
+    if (filesScope !== scopedSession.active.scopeId) {
+      filesScope = scopedSession.active.scopeId;
+      fileRows = [];
+      filesNextCursor = null;
+    }
+    contextsState.selected = null;
+  } else if (contextsState.selected) {
     filesScope = contextsState.selected;
     fileRows = [];
     filesNextCursor = null;

--- a/plugins/web-ui/src/memory.ts
+++ b/plugins/web-ui/src/memory.ts
@@ -4,6 +4,7 @@ import { api, ApiError } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
 import { icon } from "./ui";
 import { appState, replacePanePreservingFocus } from "./shell";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 
 interface RevisionRow {
   revision: string;
@@ -64,9 +65,10 @@ function drawMemory(loading = false): void {
     (fact) => !search || fact.text.toLowerCase().includes(search.toLowerCase()),
   );
   const host = document.createElement("div");
-  host.className = "pane";
+  host.className = scopedSession.active ? "pane scoped-view" : "pane";
   render(
     html`
+      ${scopedViewTopbar("memory", () => drawMemory())}
       <div class="pane-head">
         <div>
           <h1 class="pane-title">Memory</h1>

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -1,0 +1,165 @@
+import { html, nothing, type TemplateResult } from "lit";
+import { Brain, Clock3, Files } from "lucide";
+import { api } from "./core-bridge";
+import { icon } from "./ui";
+
+/** A session's context carried into the crons/files/memory views so the whole
+ * view stays scoped to that project and keeps the session top bar. */
+export interface ScopedSessionInfo {
+  scopeId: string;
+  sessionId: string | null;
+  threadRef: string | null;
+  title: string;
+  crumb: string | null;
+}
+
+export const scopedSession: { active: ScopedSessionInfo | null } = { active: null };
+
+export function setScopedSession(info: ScopedSessionInfo | null): void {
+  scopedSession.active = info;
+}
+
+interface CronLite {
+  id: string;
+  ownerScopeId: string;
+  enabled: boolean;
+  archived?: boolean;
+}
+
+const cronCountCache = new Map<string, { count: number; at: number }>();
+const cronCountInFlight = new Set<string>();
+
+/** Cached count of enabled crons owned by a scope; kicks off a refresh and
+ * calls onReady when a fresh count lands. */
+export function scopeCronCount(scope: string, onReady: () => void): number | null {
+  const hit = cronCountCache.get(scope);
+  if (hit && Date.now() - hit.at < 60_000) return hit.count;
+  if (!cronCountInFlight.has(scope)) {
+    cronCountInFlight.add(scope);
+    void api<{ crons?: CronLite[]; visible?: CronLite[] }>("/api/crons")
+      .then((r) => {
+        const seen = new Set<string>();
+        let count = 0;
+        for (const c of [...(r.crons ?? []), ...(r.visible ?? [])]) {
+          if (seen.has(c.id)) continue;
+          seen.add(c.id);
+          if (c.ownerScopeId === scope && c.enabled && !c.archived) count++;
+        }
+        cronCountCache.set(scope, { count, at: Date.now() });
+      })
+      .catch(() => cronCountCache.set(scope, { count: hit?.count ?? 0, at: Date.now() }))
+      .finally(() => {
+        cronCountInFlight.delete(scope);
+        onReady();
+      });
+  }
+  return hit?.count ?? null;
+}
+
+export type SessionTool = "crons" | "files" | "memory";
+
+export interface SessionTopbarOpts {
+  crumb: string | null;
+  title: string;
+  pill?: "working" | "needs-you" | null;
+  activeTool?: SessionTool | null;
+  cronCount?: number | null;
+  onTitle?: (() => void) | null;
+  onCrumb?: (() => void) | null;
+  onTool: (tool: SessionTool) => void;
+}
+
+export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
+  const crumbTpl = ((): TemplateResult | typeof nothing => {
+    if (!o.crumb) return nothing;
+    if (!o.onCrumb) return html`<span class="session-crumb">${o.crumb}</span><span class="session-crumb-sep">/</span>`;
+    return html`<button
+        class="session-crumb as-link"
+        type="button"
+        title="Open the ${o.crumb} project"
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          o.onCrumb!();
+        }}
+      >
+        ${o.crumb}</button
+      ><span class="session-crumb-sep">/</span>`;
+  })();
+  const heading = html`
+    ${crumbTpl}
+    <span class="session-title">${o.title}</span>
+    ${
+      o.pill
+        ? html`<span class="session-pill ${o.pill === "needs-you" ? "needs-you" : "working"}"
+            ><span class="pill-dot"></span>${o.pill === "needs-you" ? "needs you" : "working"}</span
+          >`
+        : nothing
+    }
+  `;
+  const headingTitle = o.crumb
+    ? `This chat runs in the ${o.crumb} context — the agent works with that context's files and memory, separate from your personal context.`
+    : o.title;
+  const tool = (t: SessionTool, glyph: Parameters<typeof icon>[0], label: string, hint: string) => html`
+    <button
+      class="session-tool ${o.activeTool === t ? "active" : ""}"
+      type="button"
+      title=${hint}
+      @click=${() => o.onTool(t)}
+    >
+      ${icon(glyph, 15)}<span>${label}</span>
+    </button>
+  `;
+  const cronLabel = o.cronCount ? `${o.cronCount} ${o.cronCount === 1 ? "cron" : "crons"}` : "Crons";
+  return html`
+    <header class="chat-topbar session-topbar">
+      ${
+        o.onTitle
+          ? html`<button class="session-heading as-link" type="button" title="Back to this chat" @click=${o.onTitle}>
+              ${heading}
+            </button>`
+          : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
+      }
+      <div class="topbar-actions session-tools">
+        ${tool("crons", Clock3, cronLabel, "Crons in this context")}
+        ${tool("files", Files, "Files", "Files in this context")} ${tool("memory", Brain, "Memory", "Memory")}
+      </div>
+    </header>
+  `;
+}
+
+export function openProjectPage(scopeId: string): void {
+  setScopedSession(null);
+  void import("./contexts").then(({ openProjectDetail }) => openProjectDetail(scopeId));
+}
+
+/** Top bar for the scoped crons/files/memory views: same bar, title links back
+ * to the session, tools swap views while keeping the scope. */
+export function scopedViewTopbar(current: SessionTool, redraw: () => void): TemplateResult | typeof nothing {
+  const active = scopedSession.active;
+  if (!active) return nothing;
+  return sessionTopbarTpl({
+    crumb: active.crumb,
+    title: active.title,
+    onCrumb: active.crumb ? () => openProjectPage(active.scopeId) : null,
+    activeTool: current,
+    cronCount: scopeCronCount(active.scopeId, redraw),
+    onTitle: () => {
+      setScopedSession(null);
+      void Promise.all([import("./shell"), import("./sessions")]).then(
+        ([{ appState, renderSidebarTop }, { sessionsState, openSession }]) => {
+          const s = sessionsState.list.find(
+            (row) => (active.sessionId && row.id === active.sessionId) || row.threadRef === active.threadRef,
+          );
+          if (!s) return;
+          appState.currentView = "chats";
+          renderSidebarTop();
+          void openSession(s);
+        },
+      );
+    },
+    onTool: (t) => {
+      if (t === current) return;
+      void import("./shell").then(({ switchView }) => switchView(t));
+    },
+  });
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1049,6 +1049,134 @@ a.chat-row-open {
   align-items: center;
   gap: 4px;
 }
+.session-topbar {
+  gap: 12px;
+}
+.session-heading {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.25;
+}
+.session-crumb {
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 3 auto;
+}
+.session-crumb-sep {
+  color: color-mix(in srgb, var(--muted-foreground) 65%, transparent);
+  flex: none;
+}
+.session-title {
+  font-weight: 650;
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-pill {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 550;
+}
+.session-pill .pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.session-pill.working {
+  color: color-mix(in srgb, #3b82f6 85%, var(--foreground));
+  background: color-mix(in srgb, #3b82f6 12%, transparent);
+}
+.session-pill.needs-you {
+  color: color-mix(in srgb, #d97706 85%, var(--foreground));
+  background: color-mix(in srgb, #f59e0b 14%, transparent);
+}
+.session-tools {
+  gap: 2px;
+  flex: none;
+}
+.session-tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  font-weight: 550;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.session-tool:hover {
+  background: color-mix(in srgb, var(--secondary) 70%, transparent);
+  color: var(--foreground);
+}
+.session-tool.active {
+  background: color-mix(in srgb, var(--secondary) 85%, transparent);
+  color: var(--foreground);
+}
+.session-heading.as-link {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.session-heading.as-link:hover .session-title {
+  text-decoration: underline;
+}
+.pane .session-topbar {
+  margin: -28px -28px 12px;
+  position: sticky;
+  top: -28px;
+  z-index: 5;
+}
+.scoped-view .pane-title {
+  font-size: 14px;
+  font-weight: 550;
+  color: var(--muted-foreground);
+}
+.scoped-view .pane-subtitle {
+  display: none;
+}
+.scoped-view .list-page-head,
+.scoped-view .pane-head {
+  margin-bottom: 8px;
+}
+.session-crumb.as-link {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 3 auto;
+}
+.session-crumb.as-link:hover {
+  color: var(--foreground);
+  text-decoration: underline;
+}
 .icon-btn {
   width: 34px;
   height: 34px;
@@ -4138,6 +4266,13 @@ a.chat-row-open {
   .chat-topbar {
     height: calc(54px + var(--surface-safe-top));
     padding: var(--surface-safe-top) max(10px, env(safe-area-inset-right)) 0 max(10px, env(safe-area-inset-left));
+  }
+  .session-tool span {
+    display: none;
+  }
+  .session-crumb,
+  .session-crumb-sep {
+    display: none;
   }
   .message-stack {
     gap: 6px;

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -58,6 +58,7 @@ import {
 } from "./sessions";
 import { openCronById, renderCronsPage, resetActiveCron, routeCronsHistory } from "./crons";
 import { renderFiles } from "./files";
+import { setScopedSession } from "./session-scope";
 import { clearConnectorNotice, noteConnectorResult, renderConnectors, resetKeychainState } from "./connectors";
 import { renderDeploys } from "./deploys";
 import { renderMemory, resetMemoryState } from "./memory";
@@ -564,6 +565,7 @@ function onNavClick(e: Event): void {
   if (!isView(view)) return;
   if (e instanceof MouseEvent && !isPlainLeftClick(e)) return;
   e.preventDefault();
+  setScopedSession(null);
   switchView(view);
   closeSidebarOnNarrowView();
 }


### PR DESCRIPTION
Live chat sessions get a top bar: a muted project crumb before the session title (personal chats show just the title), a status pill ("working" while the agent streams, "needs you" when an approval is pending), and quick tools for crons, files, and memory. Clicking a tool opens that view scoped to the session's project — only that project's items show, the scope filter is locked, and the same top bar persists across the view with the title linking back to the chat. The crons button carries a live count of enabled crons in the session's scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237860&installation_model_id=19911&pr_number=395&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F395&signature=f33a1f00cd5a0e0aeb9914c76097a182f47148eeb09fc600f814757d5556c13f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->