### PR TITLE
Let the guidance tool read and set a channel's ambient-replies mode

### DIFF
--- a/src/core/orchestrator/surface-tools.ts
+++ b/src/core/orchestrator/surface-tools.ts
@@ -417,9 +417,14 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
       if (conversation.kind === "dm" || !conversation.channelRef)
         return { ok: false, message: "standing orders are per-channel — there isn't one for a DM." };
       const p = await deps.channelPolicy.get(conversation.channelRef);
-      return { ok: true, orders: p?.orders ?? "", ...(p?.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}) };
+      return {
+        ok: true,
+        orders: p?.orders ?? "",
+        ...(p?.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}),
+        ...(p?.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
+      };
     },
-    setStandingOrder: async (orders: string, bots?: Record<string, BotPolicy>) => {
+    setStandingOrder: async (orders: string, bots?: Record<string, BotPolicy>, ambientEnabled?: boolean | null) => {
       if (!deps.channelPolicy) return { ok: false, message: "standing orders aren't available on this turn" };
       if (conversation.kind === "dm" || !conversation.channelRef)
         return { ok: false, message: "standing orders are per-channel — you can only set one from inside a channel." };
@@ -433,6 +438,7 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
         setBy: actor.id,
         bots: parsedBots,
         sessionId: session.id,
+        ambientEnabled,
       });
       deps.auditLog.record({
         at: Date.now(),
@@ -441,7 +447,12 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
         resource: conversation.channelRef,
         scopeLabel: scopeId,
       });
-      return { ok: true, orders, ...(p.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}) };
+      return {
+        ok: true,
+        orders,
+        ...(p.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}),
+        ...(p.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
+      };
     },
     staySilent: async (reason: string) => {
       spine.staySilentReason = reason;

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -1742,6 +1742,12 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
       action: Type.Union([Type.Literal("read"), Type.Literal("write")]),
       scope: Type.Optional(Type.Union([Type.Literal("channel"), Type.Literal("conversation")])),
       content: Type.Optional(Type.String()),
+      ambientEnabled: Type.Optional(
+        Type.Union([Type.Boolean(), Type.Null()], {
+          description:
+            "Channel scope only. true judges every message for an unprompted reply, false responds only when addressed, and null uses the platform default.",
+        }),
+      ),
       bots: Type.Optional(
         Type.Record(
           Type.String(),
@@ -1796,22 +1802,37 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
           const note = convoExists
             ? "\n\n(conversation-scope guidance also exists — read with scope=conversation)"
             : "";
-          const body = (channel!.orders.trim() ? channel!.orders : "[no channel guidance set]") + ledger + note;
+          let ambientState = "default";
+          if (channel!.ambientEnabled !== undefined) ambientState = channel!.ambientEnabled ? "on" : "off";
+          const ambient = `\n\nAmbient replies: ${ambientState}`;
+          const body =
+            (channel!.orders.trim() ? channel!.orders : "[no channel guidance set]") + ambient + ledger + note;
           return recordResult(callId, { tool: "guidance", scope, ok: true }, text(body));
         }
-        if (typeof params.content !== "string" && params.bots === undefined) {
+        if (typeof params.content !== "string" && params.bots === undefined && params.ambientEnabled === undefined) {
           return recordResult(
             callId,
-            { tool: "guidance", scope, error: "content or bots required" },
-            text("[error] guidance write needs `content` (the full new channel guidance) and/or `bots`."),
+            { tool: "guidance", scope, error: "content, bots, or ambientEnabled required" },
+            text(
+              "[error] guidance write needs `content` (the full new channel guidance), `bots`, and/or `ambientEnabled`.",
+            ),
             true,
           );
         }
         const orders = typeof params.content === "string" ? params.content : channel!.orders;
-        const r = await tc.setStandingOrder(orders, params.bots);
+        const r = await tc.setStandingOrder(orders, params.bots, params.ambientEnabled);
         if (!r.ok)
           return recordResult(callId, { tool: "guidance", scope, ok: false }, text(`[error] ${r.message}`), true);
         return recordResult(callId, { tool: "guidance", scope, ok: true }, text("[channel guidance updated]"));
+      }
+
+      if (params.ambientEnabled !== undefined) {
+        return recordResult(
+          callId,
+          { tool: "guidance", scope, error: "ambientEnabled is channel scope only" },
+          text("[error] `ambientEnabled` applies only to channel scope."),
+          true,
+        );
       }
 
       if (params.action === "read") {

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -305,7 +305,8 @@ interface SurfaceFileResult {
 }
 
 type SurfaceStandingOrderResult =
-  { ok: true; orders: string; bots?: Record<string, BotPolicy> } | { ok: false; message: string };
+  | { ok: true; orders: string; bots?: Record<string, BotPolicy>; ambientEnabled?: boolean }
+  | { ok: false; message: string };
 
 export interface SurfaceToolDeps {
   post(text: string, opts?: SurfacePostOpts, files?: readonly string[]): Promise<SurfacePostResult>;
@@ -319,7 +320,11 @@ export interface SurfaceToolDeps {
   readMembers(): Promise<SurfaceMembersResult>;
   readFile(ref: string): Promise<SurfaceFileResult>;
   getStandingOrder(): Promise<SurfaceStandingOrderResult>;
-  setStandingOrder(orders: string, bots?: Record<string, BotPolicy>): Promise<SurfaceStandingOrderResult>;
+  setStandingOrder(
+    orders: string,
+    bots?: Record<string, BotPolicy>,
+    ambientEnabled?: boolean | null,
+  ): Promise<SurfaceStandingOrderResult>;
   staySilent(reason: string): Promise<{ ok: true; message: string }>;
 }
 
@@ -943,7 +948,8 @@ export function createToolContext(deps: ToolContextDeps): ToolContext {
     readMembers: () => surfaceOp((s) => s.readMembers()),
     readFile: (ref) => surfaceOp((s) => s.readFile(ref)),
     getStandingOrder: () => surfaceOp((s) => s.getStandingOrder()),
-    setStandingOrder: (orders, bots) => surfaceOp((s) => s.setStandingOrder(orders, bots)),
+    setStandingOrder: (orders, bots, ambientEnabled) =>
+      surfaceOp((s) => s.setStandingOrder(orders, bots, ambientEnabled)),
     staySilent: (reason) =>
       deps.surface
         ? deps.surface.staySilent(reason)

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -1574,7 +1574,7 @@ test("guidance conversation scope reads the effective SOUL; write requires conte
 });
 
 test("guidance defaults to channel scope when a channel is available, and rewrites the channel order", async () => {
-  assert.match(textOut(await call(tool("guidance"), { action: "read" })), /no channel guidance set/);
+  assert.match(textOut(await call(tool("guidance"), { action: "read" })), /Ambient replies: default/);
   assert.match(
     textOut(await call(tool("guidance"), { action: "write", content: "reply piratey to tweets" })),
     /channel guidance updated/,
@@ -1585,7 +1585,44 @@ test("guidance defaults to channel scope when a channel is available, and rewrit
   );
   assert.match(
     textOut(await call(tool("guidance"), { action: "write" })),
-    /\[error\].*needs `content`.*and\/or `bots`/,
+    /\[error\].*needs `content`.*`bots`.*and\/or `ambientEnabled`/,
+  );
+});
+
+test("guidance reads and writes channel ambient replies without changing omitted state", async () => {
+  let ambientEnabled: boolean | undefined;
+  const tc: ToolContext = {
+    ...fakeToolContext(),
+    async getStandingOrder() {
+      return { ok: true, orders: "keep watch", ...(ambientEnabled === undefined ? {} : { ambientEnabled }) };
+    },
+    async setStandingOrder(orders, _bots, nextAmbientEnabled) {
+      if (nextAmbientEnabled !== undefined) ambientEnabled = nextAmbientEnabled ?? undefined;
+      return { ok: true, orders, ...(ambientEnabled === undefined ? {} : { ambientEnabled }) };
+    },
+  };
+
+  assert.match(textOut(await call(tool("guidance", tc), { action: "write", ambientEnabled: true })), /updated/);
+  assert.match(textOut(await call(tool("guidance", tc), { action: "read" })), /Ambient replies: on/);
+  await call(tool("guidance", tc), { action: "write", content: "keep watching" });
+  assert.match(textOut(await call(tool("guidance", tc), { action: "read" })), /Ambient replies: on/);
+  await call(tool("guidance", tc), { action: "write", ambientEnabled: false });
+  assert.match(textOut(await call(tool("guidance", tc), { action: "read" })), /Ambient replies: off/);
+  await call(tool("guidance", tc), { action: "write", ambientEnabled: null });
+  assert.match(textOut(await call(tool("guidance", tc), { action: "read" })), /Ambient replies: default/);
+});
+
+test("guidance rejects ambient replies at conversation scope", async () => {
+  assert.match(
+    textOut(
+      await call(tool("guidance"), {
+        action: "write",
+        scope: "conversation",
+        content: "Be terse.",
+        ambientEnabled: true,
+      }),
+    ),
+    /\[error\].*applies only to channel scope/,
   );
 });
 

--- a/test/surface-post-files.test.ts
+++ b/test/surface-post-files.test.ts
@@ -7,6 +7,7 @@ import { createMemoryFileArtifactStore } from "../src/files/file-artifact-store.
 import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts";
 import { scopeId } from "../src/types.ts";
 import type { Sandbox, SandboxHandle } from "../src/sandbox/sandbox.ts";
+import { createMemoryChannelPolicyStore } from "../src/surface-cache/channel-policy-store.ts";
 
 function fakeSandbox(files: Record<string, Uint8Array>, outboxListing: string[]): Sandbox {
   return {
@@ -100,6 +101,38 @@ test("surface post rejects traversal before provisioning or staging any attachme
   const r = await tools!.post("hello", undefined, ["report.pdf", "../.ssh/id_ed25519"]);
   assert.equal(r.ok, false);
   assert.deepEqual(calls, { provision: 0, read: 0, put: 0, grant: 0 });
+});
+
+test("surface standing orders preserve and reset the stored ambient reply policy", async () => {
+  const channelPolicy = createMemoryChannelPolicyStore();
+  const tools = createSurfaceToolDeps({
+    deps: { deliveries: {}, channelPolicy, auditLog: { record() {} } },
+    input: { surfaceTools: true },
+    actor: { id: "U1" },
+    conversation: { kind: "channel", channelRef: "C1" },
+    session: { id: "S1" },
+    scopeId: "channel:C1",
+    defaultDestination: {},
+    strictReadOnly: false,
+    blobTransfer: {},
+    fileRegistration: {},
+    provision: async () => handle,
+    postProvenance() {
+      return {};
+    },
+    spine: { surfaceOutboundCount: 0, crossConversationPosts: 0 },
+  } as unknown as SurfaceToolsContext)!;
+
+  await tools.setStandingOrder("watch", undefined, true);
+  assert.equal((await channelPolicy.get("C1"))?.ambientEnabled, true);
+  const enabledOrder = await tools.getStandingOrder();
+  assert.equal(enabledOrder.ok && enabledOrder.ambientEnabled, true);
+  await tools.setStandingOrder("keep watching");
+  assert.equal((await channelPolicy.get("C1"))?.ambientEnabled, true);
+  await tools.setStandingOrder("keep watching", undefined, null);
+  assert.equal((await channelPolicy.get("C1"))?.ambientEnabled, undefined);
+  const defaultOrder = await tools.getStandingOrder();
+  assert.equal(defaultOrder.ok && defaultOrder.ambientEnabled, undefined);
 });
 
 test("collectNamedOutbound: a missing/empty path is reported (so post can fail the WHOLE call)", async () => {


### PR DESCRIPTION
The per-channel ambient-replies toggle could only be changed from the UI — the agent's guidance tool couldn't see or manage it, leaving a parity gap between what a person can configure and what they can ask the agent to configure. The guidance tool now reports the current ambient mode when reading channel guidance and accepts an ambientEnabled parameter on writes: true judges every message for an unprompted reply, false responds only when addressed, and null resets to the platform default. Ambient-only writes work, omitted values stay unchanged, and conversation scope rejects the channel-only setting.

**Deployment notes**

Behavior flip: ambient channel reply handling moves under guidance control (tool schema/prompt
changes in surface-tools/pi-tools/primitives) — agents may reply differently in ambient channels
with no opt-in; no persisted or config changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237866&installation_model_id=19911&pr_number=397&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F397&signature=679335f67d943ff9f914ac6ab0fe1556ba6fe4a1c9cb9c4c4e6e496f60364c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->