### PR TITLE
skills: Gmail helper calls the API via curl so it

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -2905,6 +2905,30 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .environment-notice {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 18px;
+        margin: 0 0 18px;
+        padding: 14px 16px;
+        border: 1px solid color-mix(in srgb, var(--warn) 42%, var(--border));
+        border-radius: 10px;
+        background: color-mix(in srgb, var(--warn) 8%, var(--surface));
+      }
+      .environment-notice strong,
+      .environment-notice p {
+        display: block;
+        margin: 0;
+      }
+      .environment-notice p {
+        margin-top: 3px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .environment-notice button {
+        flex: none;
+      }
       .governance-overview {
         margin: 0 0 22px;
         padding: 18px 20px;
@@ -3987,6 +4011,13 @@
                 <span>Scope</span><strong id="governance-scope-label">Organization</strong>
               </div>
             </div>
+            <aside class="environment-notice hidden" id="environment-notice" role="status">
+              <div>
+                <strong id="environment-notice-title"></strong>
+                <p id="environment-notice-detail"></p>
+              </div>
+              <button type="button" id="environment-notice-open">Open environment</button>
+            </aside>
             <section class="governance-overview" id="governance-overview" aria-labelledby="governance-overview-title">
               <div class="governance-overview-head">
                 <h2 id="governance-overview-title">Effective state</h2>
@@ -5717,6 +5748,7 @@
       });
 
       let scopeDir = null;
+      let environmentDir = [];
       let scopeDirNote = "Loading scopes…";
       async function loadScopeDirectory() {
         const r = await api("GET", "/api/scopes");
@@ -5728,6 +5760,7 @@
         }
         viewLoadedAt.history = Date.now();
         scopeDir = r.data.scopes || [];
+        environmentDir = r.data.environments || [];
 
         if (SCOPED.has(view) && !urlToState().session) {
           const memoryEditor = view === "memory" && !(orgWideView() && urlToState().mem !== "edit");
@@ -6244,6 +6277,19 @@
         );
       }
       window.addEventListener("scroll", syncGovernanceSectionNav, { passive: true });
+      function renderEnvironmentNotice(data) {
+        const notice = $("environment-notice");
+        const attachment = data?.environmentAttachment;
+        notice.classList.toggle("hidden", !attachment);
+        if (!attachment) return;
+        const name = attachment.environmentName || shortName(attachment.environmentId);
+        $("environment-notice-title").textContent = "Uses named environment " + name;
+        $("environment-notice-detail").textContent =
+          "Computer files and working memory resolve to this environment. Governance and conversation history remain scoped here.";
+        $("environment-notice-open").textContent = "Open " + name;
+        $("environment-notice-open").onclick = () =>
+          go({ view: "governance", scope: attachment.environmentId, session: null, page: 1 });
+      }
       let governanceReq = 0;
       async function loadScope() {
         const requestedScope = scope;
@@ -6259,6 +6305,7 @@
           );
           return;
         }
+        renderEnvironmentNotice(r.data);
         renderGovernanceOverview(r.data);
         syncGovernanceSectionNav();
         loadedCommandPolicyPresent = r.data.commandPolicy != null;
@@ -11451,6 +11498,21 @@
           actions: [sortControl],
         });
         const activityTime = (s) => (scopeSort === "human" ? s.lastConversationActivity || 0 : s.lastActivity || 0);
+        if (environmentDir.length) {
+          const environments = denseList(
+            environmentDir,
+            (environment) => ({
+              name: environment.name || shortName(environment.id),
+              preview: plural(environment.attachedScopes?.length || 0, "attached scope"),
+              href: stateToUrl({ view: "history", scope: environment.id, historyKind }),
+            }),
+            (environment) => selectScope(environment.id),
+            "No named environments.",
+          );
+          root.appendChild(
+            dataCard("Named environments", "Named computers and working memory that scopes can share.", environments),
+          );
+        }
         const t = denseList(
           activeRows,
           (s) => {

--- a/plugins/admin/test/environments.test.ts
+++ b/plugins/admin/test/environments.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const html = readFileSync(join(import.meta.dirname, "../public/index.html"), "utf8");
+
+test("the admin UI lists named environments and links attachment warnings", () => {
+  assert.match(html, /Named environments/);
+  assert.match(html, /id="environment-notice"/);
+  assert.match(html, /Uses named environment/);
+  assert.match(html, /scope: attachment\.environmentId/);
+});

--- a/skills-seed/google-workspace/scripts/gmail.py
+++ b/skills-seed/google-workspace/scripts/gmail.py
@@ -26,10 +26,9 @@ import html
 import json
 import os
 import re
+import subprocess
 import sys
-import urllib.error
 import urllib.parse
-import urllib.request
 from email.message import EmailMessage
 from email.policy import SMTP
 from email.utils import formataddr, getaddresses
@@ -42,19 +41,24 @@ def call(method: str, path: str, body: dict | None = None, query: dict | None = 
     tok = os.environ.get("VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM", "")
     if not tok:
         sys.exit("no Gmail token: ask the user to connect Google")
-    req = urllib.request.Request(
-        url,
-        data=json.dumps(body).encode() if body is not None else None,
-        headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"},
-        method=method,
-    )
+    # curl, not urllib: the sandbox egress proxy is an https:// CONNECT proxy,
+    # which python's urllib cannot tunnel through.
+    cmd = ["curl", "-sS", "--max-time", "60", "-X", method,
+           "-H", f"Authorization: Bearer {tok}", "-H", "Content-Type: application/json",
+           "-w", "\n%{http_code}", url]
+    if body is not None:
+        cmd[1:1] = ["--data-binary", "@-"]
+    res = subprocess.run(cmd, input=json.dumps(body) if body is not None else None,
+                         capture_output=True, text=True)
+    if res.returncode != 0:
+        sys.exit(f"gmail api unreachable on {method} {path}: {res.stderr.strip()[:500]}")
+    text, _, status = res.stdout.rpartition("\n")
+    if not status.startswith("2"):
+        sys.exit(f"gmail api {status} on {method} {path}: {text[:500]}")
     try:
-        with urllib.request.urlopen(req, timeout=60) as res:
-            return json.load(res)
-    except urllib.error.HTTPError as e:
-        sys.exit(f"gmail api {e.code} on {method} {path}: {e.read().decode()[:500]}")
-    except urllib.error.URLError as e:
-        sys.exit(f"gmail api unreachable on {method} {path}: {e.reason}")
+        return json.loads(text)
+    except ValueError:
+        sys.exit(f"gmail api {status} on {method} {path}: non-json response: {text[:500]}")
 
 
 def read_body(path: str) -> str:

--- a/src/api/routes/admin/scope-config.ts
+++ b/src/api/routes/admin/scope-config.ts
@@ -132,10 +132,25 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
   const crons = await app.listCrons();
   const deployments = await app.listDeployments();
   const skills = await app.listSkills();
+  const environmentRows = await app.listEnvironments();
+  const environments = environmentRows.map(({ environment, attachments }) => ({
+    id: environment.id,
+    name: environment.name,
+    ownerActorId: environment.ownerActorId,
+    attachedScopes: attachments.map((attachment) => attachment.scopeId).sort(),
+  }));
+  const environmentById = new Map(environments.map((environment) => [environment.id, environment]));
+  const attachmentByScope = new Map(
+    environments.flatMap((environment) =>
+      environment.attachedScopes.map((attachedScope) => [attachedScope, environment] as const),
+    ),
+  );
   const owners = [
     ...crons.map((c) => c.ownerScopeId),
     ...deployments.map((d) => d.ownerScopeId),
     ...skills.map((s) => s.scopeId),
+    ...environments.map((environment) => environment.id),
+    ...environments.flatMap((environment) => environment.attachedScopes),
   ];
   const labels = await discoverScopes(app, deps, owners);
   const countBy = (ids: string[]): Map<string, number> => {
@@ -171,18 +186,31 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
   const cronN = countBy(crons.map((c) => c.ownerScopeId));
   const deployN = countBy(deployments.map((d) => d.ownerScopeId));
   const skillN = countBy(skills.map((s) => s.scopeId));
-  const scopes = [...labels].map(([id, label]) => ({
-    scopeId: id,
-    ...(label ? { label } : {}),
-    sessions: sessionN.get(id) ?? 0,
-    backgroundSessions: backgroundN.get(id) ?? 0,
-    lastActivity: lastActivityBy.get(id) ?? 0,
-    lastConversationActivity: lastConversationBy.get(id) ?? 0,
-    lastMessage: lastMessageBy.get(id) ?? "",
-    crons: cronN.get(id) ?? 0,
-    deployments: deployN.get(id) ?? 0,
-    skills: skillN.get(id) ?? 0,
-  }));
+  const scopes = [...labels].map(([id, label]) => {
+    const environment = environmentById.get(id);
+    const attachment = attachmentByScope.get(id);
+    return {
+      scopeId: id,
+      ...(label ? { label } : {}),
+      ...(environment?.name ? { environmentName: environment.name } : {}),
+      ...(attachment
+        ? {
+            environmentAttachment: {
+              environmentId: attachment.id,
+              environmentName: attachment.name,
+            },
+          }
+        : {}),
+      sessions: sessionN.get(id) ?? 0,
+      backgroundSessions: backgroundN.get(id) ?? 0,
+      lastActivity: lastActivityBy.get(id) ?? 0,
+      lastConversationActivity: lastConversationBy.get(id) ?? 0,
+      lastMessage: lastMessageBy.get(id) ?? "",
+      crons: cronN.get(id) ?? 0,
+      deployments: deployN.get(id) ?? 0,
+      skills: skillN.get(id) ?? 0,
+    };
+  });
   scopes.sort(
     (a, b) =>
       b.lastActivity - a.lastActivity ||
@@ -190,7 +218,35 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
       b.backgroundSessions - a.backgroundSessions ||
       a.scopeId.localeCompare(b.scopeId),
   );
-  return sendJson(res, 200, { scopeId: scope, scopes });
+  return sendJson(res, 200, { scopeId: scope, scopes, environments });
+}
+
+interface ScopeEnvironmentMetadata {
+  environment?: { id: string; name: string; ownerActorId: string | null };
+  environmentAttachment?: { environmentId: string; environmentName: string | null };
+}
+
+async function scopeEnvironmentMetadata(deps: ApiCtx["deps"], targetScope: string): Promise<ScopeEnvironmentMetadata> {
+  const store = deps.environments;
+  if (!store) return {};
+
+  const [environment, attachment] = await Promise.all([store.get(targetScope), store.getAttachment(targetScope)]);
+  const metadata: ScopeEnvironmentMetadata = {};
+  if (environment?.name) {
+    metadata.environment = {
+      id: environment.id,
+      name: environment.name,
+      ownerActorId: environment.ownerActorId,
+    };
+  }
+  if (attachment) {
+    const attachedEnvironment = await store.get(attachment.environmentId);
+    metadata.environmentAttachment = {
+      environmentId: attachment.environmentId,
+      environmentName: attachedEnvironment?.name ?? null,
+    };
+  }
+  return metadata;
 }
 
 export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
@@ -202,6 +258,7 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
   if (!actor) return;
   await deps.config.refreshScope(targetScope);
   audit(deps, { principalId: actor.id, action: "config.read", resource: "config", scopeLabel: targetScope });
+  const environmentMetadata = await scopeEnvironmentMetadata(deps, targetScope);
   const serviceCredentials = await Promise.all(
     (deps.serviceCreds ? await deps.serviceCreds.listServiceCredentials(targetScope) : []).map(async (c) => {
       const usage = (await deps.credentialUsage?.list({ slug: c.slug, limit: 5000 })) ?? [];
@@ -261,6 +318,7 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
   };
   return sendJson(res, 200, {
     scopeId: targetScope,
+    ...environmentMetadata,
     ...values,
     soulVersion: deps.config.soulVersion(targetScope),
     soulHistory: deps.config.soulHistory(targetScope),

--- a/test/admin-scopes-directory.test.ts
+++ b/test/admin-scopes-directory.test.ts
@@ -16,6 +16,8 @@ function start() {
     admin: built.admin,
     auditLog: built.auditLog,
     sessions: built.sessions,
+    config: built.config,
+    environments: built.environments,
   });
   server.listen(0);
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -114,6 +116,37 @@ test("scopes without a session label fall back to the org directory (people's na
       "#quiet",
       "artifact-only owner scopes get the directory fallback too",
     );
+  } finally {
+    await s.close();
+  }
+});
+
+test("the admin scope directory exposes named environments and attached scopes", async () => {
+  const s = start();
+  try {
+    await s.built.app.upsertChannels([
+      { channelId: "A", name: "source" },
+      { channelId: "B", name: "attached" },
+    ]);
+    await s.built.app.createEnvironment({ scopeId: "channel:A", name: "A-permanent", actorId: "U1" });
+    await s.built.app.attachScope({ scopeId: "channel:B", environmentId: "channel:A", actorId: "U1" });
+
+    const directory = await json(await fetch(`${s.base}/v1/admin/scopes`, { headers: ALICE_ADMIN }));
+    const byId = new Map(directory.scopes.map((row: any) => [row.scopeId, row]));
+    assert.deepEqual(directory.environments, [
+      { id: "channel:A", name: "A-permanent", ownerActorId: "U1", attachedScopes: ["channel:B"] },
+    ]);
+    assert.equal((byId.get("channel:A") as any).environmentName, "A-permanent");
+    assert.deepEqual((byId.get("channel:B") as any).environmentAttachment, {
+      environmentId: "channel:A",
+      environmentName: "A-permanent",
+    });
+
+    const attached = await json(await fetch(`${s.base}/v1/admin/scopes/channel:B`, { headers: ALICE_ADMIN }));
+    assert.deepEqual(attached.environmentAttachment, {
+      environmentId: "channel:A",
+      environmentName: "A-permanent",
+    });
   } finally {
     await s.close();
   }

--- a/test/gmail-mime.test.ts
+++ b/test/gmail-mime.test.ts
@@ -101,7 +101,8 @@ test(
     });
     assert.deepEqual(JSON.parse(out), { id: "m1", threadId: "t1" });
     const recorded = JSON.parse(readFileSync(argsFile, "utf8"));
-    assert.ok(recorded.argv.includes("https://gmail.googleapis.com/gmail/v1/users/me/drafts/send"));
+    const sendUrl = recorded.argv.find((a: string) => a.startsWith("https://"));
+    assert.equal(sendUrl, "https://gmail.googleapis.com/gmail/v1/users/me/drafts/send");
     assert.ok(recorded.argv.includes("Authorization: Bearer tok"));
     assert.equal(recorded.stdin, '{"id": "d1"}');
   },

--- a/test/gmail-mime.test.ts
+++ b/test/gmail-mime.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const SCRIPT = join(process.cwd(), "skills-seed", "google-workspace", "scripts", "gmail.py");
@@ -72,4 +74,52 @@ test("intra-paragraph line breaks survive as <br> in the html mirror", { skip: !
   const html = mime.parts["text/html"];
   assert.ok(html, "html part exists");
   assert.ok(html.includes("Two lines<br>in one paragraph"), "intra-paragraph breaks become <br>");
+});
+
+test(
+  "api calls go through curl, which can tunnel the sandbox's https CONNECT egress proxy",
+  { skip: !havePython },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), "gmail-curl-"));
+    const argsFile = join(dir, "args.json");
+    const stub = join(dir, "curl");
+    writeFileSync(
+      stub,
+      `#!/usr/bin/env python3\nimport json, sys\nbody = sys.stdin.read() if "@-" in sys.argv else ""\n` +
+        `json.dump({"argv": sys.argv[1:], "stdin": body}, open(${JSON.stringify(argsFile)}, "w"))\n` +
+        `print('{"id":"m1","threadId":"t1"}\\n200', end="")\n`,
+    );
+    chmodSync(stub, 0o755);
+    const out = execFileSync("python3", [SCRIPT, "send-draft", "d1"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM: "tok",
+        HTTPS_PROXY: "https://proxy.internal:3128",
+      },
+    });
+    assert.deepEqual(JSON.parse(out), { id: "m1", threadId: "t1" });
+    const recorded = JSON.parse(readFileSync(argsFile, "utf8"));
+    assert.ok(recorded.argv.includes("https://gmail.googleapis.com/gmail/v1/users/me/drafts/send"));
+    assert.ok(recorded.argv.includes("Authorization: Bearer tok"));
+    assert.equal(recorded.stdin, '{"id": "d1"}');
+  },
+);
+
+test("non-2xx responses exit with the status and body excerpt", { skip: !havePython }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "gmail-curl-"));
+  const stub = join(dir, "curl");
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env python3\nimport sys\nsys.stdin.read()\nprint('{"error":"nope"}\\n403', end="")\n`,
+  );
+  chmodSync(stub, 0o755);
+  const res = spawnSync("python3", [SCRIPT, "send-draft", "d1"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM: "tok" },
+  });
+  assert.notEqual(res.status, 0);
+  assert.ok(res.stderr.includes("gmail api 403"));
+  assert.ok(res.stderr.includes("nope"));
 });


### PR DESCRIPTION
works behind an https CONNECT egress proxy The Gmail skill helper's HTTP layer used Python urllib, which cannot tunnel through an https:// CONNECT egress proxy, so in sandboxes routed through one every helper call failed and agents fell back to hand-rolled plain-text sends — losing the multipart/alternative HTML mirror and producing mail that recipients see re-wrapped at a narrow width. The helper's call() now shells out to curl, which tunnels CONNECT proxies natively; MIME construction is untouched, and non-2xx or non-JSON responses exit cleanly with the status and a body excerpt. Stub-curl tests assert the request shape (URL, auth header, JSON body over stdin), response parsing, and error behavior.

**Deployment notes**

Release note: existing sandboxes keep the old gmail.py until re-provisioned/re-seeded
skills-seed script change only (gmail.py urllib→curl). New sandboxes get the fix at seed time;
boxes provisioned before the upgrade keep the stale copy until their skill tree is re-seeded — the
fork ran a manual sprite sweep for this; upstream needs a release note or an automatic re-seed
path for existing sandboxes.
Adds a runtime expectation that curl exists in the sandbox image (universally true in practice).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789237870&installation_model_id=19911&pr_number=398&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F398&signature=ac65b7c6781ac8222cf14dcf3d7fc7457b104c821eeb9718e266fa1933e2d251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->