### PR TITLE
policy: treat heredoc bodies fed to non-interpreter commands as data

### DIFF
--- a/src/policy/command-policy.ts
+++ b/src/policy/command-policy.ts
@@ -87,7 +87,24 @@ function scannableCommandAtDepth(command: string, depth: number): string {
 function stripWrittenHeredocs(command: string): string {
   return command.replace(
     /^([^\n]*)<<-?\s*(["']?)([A-Za-z_]\w*)\2([^\n]*)\n([\s\S]*?)^\s*\3\s*$/gm,
-    (full, pre, _q, _delim, post) => (/[>]/.test(pre + post) && !heredocRunsShell(pre + post) ? "" : full),
+    (full, pre, quote, _delim, post, body) => {
+      if (heredocRunsInterpreter(pre + post)) return full;
+      // The heredoc body is data (written to a file or fed to a non-interpreter
+      // command like cat/gh/jq), not something the shell executes. Keep only
+      // command substitutions, which DO execute when the delimiter is unquoted.
+      if (quote) return "";
+      const subs = (body as string).match(/\$\([^)]*\)|`[^`]*`/g);
+      return subs ? subs.join(" ") : "";
+    },
+  );
+}
+
+function heredocRunsInterpreter(commandLine: string): boolean {
+  if (heredocRunsShell(commandLine)) return true;
+  // SQL clients and script interpreters execute their stdin, so a heredoc fed
+  // to them must stay visible to the rules (e.g. destructive SQL via psql).
+  return /(?:^|[|;&]\s*)(?:\S*\/)?(?:psql|mysql|mariadb|sqlite3?|sqlcmd|python\d?(?:\.\d+)?|node|perl|ruby)\b/.test(
+    commandLine,
   );
 }
 

--- a/test/command-policy.test.ts
+++ b/test/command-policy.test.ts
@@ -446,3 +446,27 @@ test("parseCommandPolicy rejects regexes with catastrophic repetition", () => {
     assert.ok("error" in parsed, pattern);
   }
 });
+test("a heredoc fed to a non-interpreter command (cat, gh) is data, not gated", () => {
+  const policy = defaultOrgPolicy();
+  const prBody = [
+    `gh pr create --title x --body "$(cat <<'EOF'`,
+    "Extract SQL payloads safely; previously DROP TABLE users in payloads broke parsing.",
+    "EOF",
+    ')"',
+  ].join("\n");
+  assert.equal(evaluateCommand(prBody, policy).decision, "allow");
+  const piped = ["cat <<'EOF' | gh pr create --body-file -", "fixes DROP TABLE handling", "EOF"].join("\n");
+  assert.equal(evaluateCommand(piped, policy).decision, "allow");
+});
+
+test("a heredoc fed to a SQL client or interpreter stays gated", () => {
+  const policy = defaultOrgPolicy();
+  const sql = ["psql mydb <<EOF", "drop table users;", "EOF"].join("\n");
+  assert.equal(evaluateCommand(sql, policy).decision, "require_approval");
+});
+
+test("an unquoted heredoc's command substitutions still execute and stay gated", () => {
+  const policy = defaultOrgPolicy();
+  const sneaky = ["cat <<EOF | gh pr create --body-file -", "hello $(rm -rf /tmp/x)", "EOF"].join("\n");
+  assert.equal(evaluateCommand(sneaky, policy).decision, "require_approval");
+});


### PR DESCRIPTION
The command screener only stripped heredoc bodies when the line had a redirect, so a heredoc piped to cat, gh, or jq — for example a PR body that merely mentions destructive SQL — tripped the destructive-SQL approval gate as a false positive. Heredoc bodies are now stripped from the scannable text unless the consumer actually executes its stdin: shells, SQL clients (psql, mysql, sqlite, …), and script interpreters (python, node, perl, ruby) keep their heredocs fully visible to the q , ), p p (py , ,p, y) p y rules. Command substitutions inside unquoted heredocs are also kept, since those do execute even when the body is data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789239226&installation_model_id=19911&pr_number=405&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F405&signature=3d21b3a9d36d648f8676db51b7952c33decdfdf35ab6f7d3d35a9b08ad3fe680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->