### PR TITLE
web-ui: close a session's open panes when it is archived

### DIFF
--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -80,6 +80,7 @@ import {
   beginSessionDrag,
   endSessionDrag,
   notifySessionsChanged,
+  closeSessionSurfaces,
   sessionInCanvas,
   splitInterceptsOpen,
   splitState,
@@ -1068,6 +1069,7 @@ async function commitRename(s: CoreSession): Promise<void> {
 
 function setArchived(s: CoreSession, archived: boolean): void {
   sessionsState.openMenuId = null;
+  if (archived && s.id) closeSessionSurfaces(s.id);
   void persistSessionPatch(s.id, { archived });
 }
 

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -361,6 +361,23 @@ export function sessionInCanvas(sessionId: string): boolean {
   return splitState.active && paneShowing(sessionId) !== null;
 }
 
+/** Close any pane (and, outside the canvas, the main view) showing this session. */
+export function closeSessionSurfaces(sessionId: string): boolean {
+  if (!sessionId) return false;
+  if (splitState.active && dockApi) {
+    const showing = dockApi.panels.filter((p) => panelParams(p).sessionId === sessionId);
+    if (showing.length) {
+      closePanels(showing);
+      return true;
+    }
+    return false;
+  }
+  const conv = mainConversation();
+  if (conv.state.sessionId !== sessionId) return false;
+  conv.newChat();
+  return true;
+}
+
 export function splitInterceptsOpen(s: CoreSession): boolean {
   if (!splitState.active || appState.currentView !== "chats" || !s.id) return false;
   const target = splitState.focusedId ?? dockApi?.panels[0]?.id ?? "";

--- a/plugins/web-ui/test/archive-closes-pane.test.ts
+++ b/plugins/web-ui/test/archive-closes-pane.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (f: string): string => readFileSync(new URL(`../src/${f}`, import.meta.url), "utf8");
+const split = read("split.ts");
+const sessions = read("sessions.ts");
+
+const fn = (src: string, name: string): string => {
+  const body = src.match(new RegExp(`^(?:export )?(?:async )?function ${name}\\([\\s\\S]*?\\n\\}`, "m"))?.[0] ?? "";
+  assert.ok(body, `${name} not found`);
+  return body;
+};
+
+test("archiving a session closes any surface still showing it", () => {
+  const close = fn(split, "closeSessionSurfaces");
+  assert.match(close, /dockApi\.panels\.filter\(\(p\) => panelParams\(p\)\.sessionId === sessionId\)/);
+  assert.match(close, /closePanels\(showing\)/, "open panes must be removed, and reconciled by closePanels");
+  assert.match(close, /conv\.state\.sessionId !== sessionId\) return false;/, "leave other conversations alone");
+  assert.match(close, /conv\.newChat\(\);/, "outside the canvas the main view drops the archived session");
+
+  const archived = fn(sessions, "setArchived");
+  assert.match(archived, /if \(archived && s\.id\) closeSessionSurfaces\(s\.id\);/);
+  assert.ok(
+    archived.indexOf("closeSessionSurfaces") < archived.indexOf("persistSessionPatch"),
+    "close the surface before the patch round-trip so the UI reacts immediately",
+  );
+  assert.doesNotMatch(archived, /!archived.*closeSessionSurfaces/s, "unarchiving must not close anything");
+});


### PR DESCRIPTION
Archiving a session left any pane or tab still displaying it on screen, showing a conversation the user just put away. A new closeSessionSurfaces(sessionId) removes every split-canvas pane and tab whose params point at the archived session and runs the normal post-close reconcile (last pane maximizes or the canvas exits); outside the canvas, if the main conversation is on that session it resets to a new chat. Other sessions' surfaces are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789239277&installation_model_id=19911&pr_number=406&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F406&signature=8085bd0688a7c449039f84d7808594e9c24061a5df978bfcd543ef29e21d8581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->