### PR TITLE
logs: never pass a raw error object to console.*

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,14 @@ export default tseslint.config(
             "Read configuration through loadConfig() (src/config.ts) and pass it down — process.env is parsed exactly once at the boundary.",
         },
         {
+          // Never dump a raw error object to the console: an error can carry HTTP
+          // response bodies, connection strings, or credential material. Wrap it in
+          // errMessage(...) (src/util/errors.ts) so only the message is logged.
+          selector: "CallExpression[callee.object.name='console'] > Identifier.arguments[name=/^(e|err|error)$/]",
+          message:
+            "Pass errMessage(e), not the raw error object, to console.* — raw errors can leak response bodies or secrets into logs.",
+        },
+        {
           selector: "VariableDeclarator[init.name='process'] ObjectPattern Property[key.name='env']",
           message:
             "Read configuration through loadConfig() (src/config.ts) and pass it down — process.env is parsed exactly once at the boundary.",
@@ -81,6 +89,21 @@ export default tseslint.config(
                 "Read configuration through loadConfig() (src/config.ts) and pass it down — process.env is parsed exactly once at the boundary.",
             },
           ],
+        },
+      ],
+    },
+  },
+  {
+    // Same raw-error rule for plugin server code and the src files the env-boundary
+    // block above deliberately skips (local scripts/ and test/ CLIs keep full stacks).
+    files: ["plugins/**/*.ts", "src/config.ts", "src/index.ts", "src/runs/worker-main.ts", "src/egress-authz-main.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "CallExpression[callee.object.name='console'] > Identifier.arguments[name=/^(e|err|error)$/]",
+          message:
+            "Pass errMessage(e), not the raw error object, to console.* — raw errors can leak response bodies or secrets into logs.",
         },
       ],
     },

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -2905,6 +2905,30 @@
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .environment-notice {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 18px;
+        margin: 0 0 18px;
+        padding: 14px 16px;
+        border: 1px solid color-mix(in srgb, var(--warn) 42%, var(--border));
+        border-radius: 10px;
+        background: color-mix(in srgb, var(--warn) 8%, var(--surface));
+      }
+      .environment-notice strong,
+      .environment-notice p {
+        display: block;
+        margin: 0;
+      }
+      .environment-notice p {
+        margin-top: 3px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .environment-notice button {
+        flex: none;
+      }
       .governance-overview {
         margin: 0 0 22px;
         padding: 18px 20px;
@@ -3987,6 +4011,13 @@
                 <span>Scope</span><strong id="governance-scope-label">Organization</strong>
               </div>
             </div>
+            <aside class="environment-notice hidden" id="environment-notice" role="status">
+              <div>
+                <strong id="environment-notice-title"></strong>
+                <p id="environment-notice-detail"></p>
+              </div>
+              <button type="button" id="environment-notice-open">Open environment</button>
+            </aside>
             <section class="governance-overview" id="governance-overview" aria-labelledby="governance-overview-title">
               <div class="governance-overview-head">
                 <h2 id="governance-overview-title">Effective state</h2>
@@ -5717,6 +5748,7 @@
       });
 
       let scopeDir = null;
+      let environmentDir = [];
       let scopeDirNote = "Loading scopes…";
       async function loadScopeDirectory() {
         const r = await api("GET", "/api/scopes");
@@ -5728,6 +5760,7 @@
         }
         viewLoadedAt.history = Date.now();
         scopeDir = r.data.scopes || [];
+        environmentDir = r.data.environments || [];
 
         if (SCOPED.has(view) && !urlToState().session) {
           const memoryEditor = view === "memory" && !(orgWideView() && urlToState().mem !== "edit");
@@ -6244,6 +6277,19 @@
         );
       }
       window.addEventListener("scroll", syncGovernanceSectionNav, { passive: true });
+      function renderEnvironmentNotice(data) {
+        const notice = $("environment-notice");
+        const attachment = data?.environmentAttachment;
+        notice.classList.toggle("hidden", !attachment);
+        if (!attachment) return;
+        const name = attachment.environmentName || shortName(attachment.environmentId);
+        $("environment-notice-title").textContent = "Uses named environment " + name;
+        $("environment-notice-detail").textContent =
+          "Computer files and working memory resolve to this environment. Governance and conversation history remain scoped here.";
+        $("environment-notice-open").textContent = "Open " + name;
+        $("environment-notice-open").onclick = () =>
+          go({ view: "governance", scope: attachment.environmentId, session: null, page: 1 });
+      }
       let governanceReq = 0;
       async function loadScope() {
         const requestedScope = scope;
@@ -6259,6 +6305,7 @@
           );
           return;
         }
+        renderEnvironmentNotice(r.data);
         renderGovernanceOverview(r.data);
         syncGovernanceSectionNav();
         loadedCommandPolicyPresent = r.data.commandPolicy != null;
@@ -11451,6 +11498,21 @@
           actions: [sortControl],
         });
         const activityTime = (s) => (scopeSort === "human" ? s.lastConversationActivity || 0 : s.lastActivity || 0);
+        if (environmentDir.length) {
+          const environments = denseList(
+            environmentDir,
+            (environment) => ({
+              name: environment.name || shortName(environment.id),
+              preview: plural(environment.attachedScopes?.length || 0, "attached scope"),
+              href: stateToUrl({ view: "history", scope: environment.id, historyKind }),
+            }),
+            (environment) => selectScope(environment.id),
+            "No named environments.",
+          );
+          root.appendChild(
+            dataCard("Named environments", "Named computers and working memory that scopes can share.", environments),
+          );
+        }
         const t = denseList(
           activeRows,
           (s) => {

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -141,7 +141,7 @@ async function forward(
     res.writeHead(r.status, { "content-type": "application/json" });
     pipeBody(res, r.body);
   } catch (err) {
-    console.error("[admin] core request failed:", err);
+    console.error("[admin] core request failed:", String(err));
     json(res, 502, { error: "core_unreachable", message: "core unavailable" });
   }
 }
@@ -176,7 +176,7 @@ async function forwardDownload(res: ServerResponse, principal: string, corePath:
     res.writeHead(r.status, headers);
     pipeBody(res, r.body);
   } catch (err) {
-    console.error("[admin] core download failed:", err);
+    console.error("[admin] core download failed:", String(err));
     json(res, 502, { error: "core_unreachable", message: "core unavailable" });
   }
 }
@@ -236,7 +236,7 @@ async function uploadFileFromRequest(
     });
     return forward(req, res, principal, "POST", corePath, body);
   } catch (err) {
-    console.error("[admin] upload failed:", err);
+    console.error("[admin] upload failed:", String(err));
     return json(res, 502, { error: "core_unreachable", message: "core unavailable" });
   }
 }
@@ -301,7 +301,7 @@ const server = createServer((req, res) => {
   void portalTokenStore
     .run(token, () => handle(req, res))
     .catch((err: unknown) => {
-      console.error("[admin] unhandled request error:", err);
+      console.error("[admin] unhandled request error:", String(err));
       json(res, 500, { error: "internal_error", message: "internal server error" });
     });
 });
@@ -402,7 +402,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
         res.writeHead(r.status, { "content-type": "application/json" });
         res.end(text);
       } catch (err) {
-        console.error("[admin] core request failed:", err);
+        console.error("[admin] core request failed:", String(err));
         json(res, 502, { error: "core_unreachable", message: "core unavailable" });
       }
       return;

--- a/plugins/admin/test/environments.test.ts
+++ b/plugins/admin/test/environments.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const html = readFileSync(join(import.meta.dirname, "../public/index.html"), "utf8");
+
+test("the admin UI lists named environments and links attachment warnings", () => {
+  assert.match(html, /Named environments/);
+  assert.match(html, /id="environment-notice"/);
+  assert.match(html, /Uses named environment/);
+  assert.match(html, /scope: attachment\.environmentId/);
+});

--- a/plugins/auth/src/index.ts
+++ b/plugins/auth/src/index.ts
@@ -32,7 +32,7 @@ export async function startServer(): Promise<void> {
   });
   const server = createServer((req, res) => {
     void handle(req, res).catch((err: unknown) => {
-      console.error(`[auth] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, err);
+      console.error(`[auth] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, String(err));
       if (!res.headersSent) json(res, 500, { error: "internal_error" });
       else res.end();
     });

--- a/plugins/auth/src/index.ts
+++ b/plugins/auth/src/index.ts
@@ -32,7 +32,7 @@ export async function startServer(): Promise<void> {
   });
   const server = createServer((req, res) => {
     void handle(req, res).catch((err: unknown) => {
-      console.error(`[auth] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, String(err));
+      console.error("[auth] 500 %s %s: %s", req.method ?? "?", (req.url ?? "?").split("?")[0], String(err));
       if (!res.headersSent) json(res, 500, { error: "internal_error" });
       else res.end();
     });

--- a/plugins/chassis/src/branding.ts
+++ b/plugins/chassis/src/branding.ts
@@ -29,7 +29,7 @@ export function createBrandingCache(fetchBranding: () => Promise<OrgBranding>): 
         warmed = true;
         nextAt = Date.now() + REFRESH_MS;
       } catch (err) {
-        if (process.env.BRANDING_DEBUG) console.error("[branding] fetch failed:", err);
+        if (process.env.BRANDING_DEBUG) console.error("[branding] fetch failed:", String(err));
         nextAt = Date.now() + RETRY_MS;
       } finally {
         inflight = null;

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -812,7 +812,7 @@ function renewSessionCookie(req: IncomingMessage, res: ServerResponse): void {
 
 const server = createServer((req, res) => {
   void handle(req, res).catch((err: unknown) => {
-    console.error(`[portal] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, err);
+    console.error(`[portal] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, String(err));
     if (!res.headersSent) json(res, 500, { error: "internal_error" });
     else res.end();
   });

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -812,7 +812,7 @@ function renewSessionCookie(req: IncomingMessage, res: ServerResponse): void {
 
 const server = createServer((req, res) => {
   void handle(req, res).catch((err: unknown) => {
-    console.error(`[portal] 500 ${req.method ?? "?"} ${(req.url ?? "?").split("?")[0]}:`, String(err));
+    console.error("[portal] 500 %s %s: %s", req.method ?? "?", (req.url ?? "?").split("?")[0], String(err));
     if (!res.headersSent) json(res, 500, { error: "internal_error" });
     else res.end();
   });

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1918,7 +1918,7 @@ export const handler = async (req: IncomingMessage, res: ServerResponse) => {
 
 const server = createServer((req, res) => {
   void handler(req, res).catch((err: unknown) => {
-    console.error(`[web-ui] 502 ${req.method ?? "?"} ${req.url ?? "?"}:`, err);
+    console.error(`[web-ui] 502 ${req.method ?? "?"} ${req.url ?? "?"}:`, String(err));
     if (!res.headersSent) json(res, 502, { error: "bad_gateway", message: "upstream error" });
     else res.end();
   });
@@ -1942,7 +1942,7 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
       });
     })
     .catch((err: unknown) => {
-      console.error("[web-ui] failed to start:", err);
+      console.error("[web-ui] failed to start:", String(err));
       process.exit(1);
     });
 }

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1918,7 +1918,7 @@ export const handler = async (req: IncomingMessage, res: ServerResponse) => {
 
 const server = createServer((req, res) => {
   void handler(req, res).catch((err: unknown) => {
-    console.error(`[web-ui] 502 ${req.method ?? "?"} ${req.url ?? "?"}:`, String(err));
+    console.error("[web-ui] 502 %s %s: %s", req.method ?? "?", req.url ?? "?", String(err));
     if (!res.headersSent) json(res, 502, { error: "bad_gateway", message: "upstream error" });
     else res.end();
   });

--- a/src/admin/postgres-audit-log.ts
+++ b/src/admin/postgres-audit-log.ts
@@ -1,6 +1,7 @@
 import { createPgPool } from "../persistence/pg-pool.ts";
 import type { ScopeId } from "../types.ts";
 import type { AuditEvent, AuditLog } from "../audit/audit-log.ts";
+import { errMessage } from "../util/errors.ts";
 
 function rowToEvent(r: Record<string, unknown>): AuditEvent {
   return {
@@ -61,7 +62,7 @@ export function createPostgresAuditLog(connectionString: string): AuditLog {
         e.detail ?? null,
       ])
         .then(() => undefined)
-        .catch((err) => console.error("[audit] failed to persist event to durable store:", err));
+        .catch((err) => console.error("[audit] failed to persist event to durable store:", errMessage(err)));
       pendingWrites.add(write);
       void write.finally(() => pendingWrites.delete(write));
     },

--- a/src/admin/postgres-metrics-sink.ts
+++ b/src/admin/postgres-metrics-sink.ts
@@ -1,5 +1,6 @@
 import { createPostgresEventSink, type EventColumn } from "./scoped-event-sink.ts";
 import type { MetricsSink, TurnMetricSample } from "./metrics-sink.ts";
+import { errMessage } from "../util/errors.ts";
 
 const COLUMNS: readonly EventColumn<keyof TurnMetricSample & string>[] = [
   ["ts", "ts", "BIGINT", "number", true],
@@ -76,7 +77,7 @@ export function createPostgresMetricsSink(connectionString: string): MetricsSink
       params.push(runId);
       await sink
         .q(`UPDATE turn_metrics SET ${sets.join(", ")} WHERE run_id = $${params.length}`, params)
-        .catch((err) => console.error("[metrics] failed to patch turn metric:", err));
+        .catch((err) => console.error("[metrics] failed to patch turn metric:", errMessage(err)));
     },
     list: (opts = {}) => sink.list(opts),
   };

--- a/src/admin/scoped-event-sink.ts
+++ b/src/admin/scoped-event-sink.ts
@@ -1,5 +1,6 @@
 import type { ScopeId } from "../types.ts";
 import { createPgPool, type PgPool } from "../persistence/pg-pool.ts";
+import { errMessage } from "../util/errors.ts";
 
 export interface ScopedEvent {
   scopeLabel: ScopeId;
@@ -162,7 +163,7 @@ export function createPostgresEventSink<E>(cfg: PostgresEventSinkConfig<E>): Pos
       const s = input as Record<string, unknown>;
       const values = cfg.columns.map(([, js]) => (js === "ts" ? Date.now() : (s[js] ?? null)));
       const write = q(insertSql, values)
-        .catch((err) => console.error(cfg.persistErrorMessage, err))
+        .catch((err) => console.error(cfg.persistErrorMessage, errMessage(err)))
         .finally(() => pendingWrites.delete(write));
       pendingWrites.add(write);
     },

--- a/src/api/routes/admin/scope-config.ts
+++ b/src/api/routes/admin/scope-config.ts
@@ -132,10 +132,25 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
   const crons = await app.listCrons();
   const deployments = await app.listDeployments();
   const skills = await app.listSkills();
+  const environmentRows = await app.listEnvironments();
+  const environments = environmentRows.map(({ environment, attachments }) => ({
+    id: environment.id,
+    name: environment.name,
+    ownerActorId: environment.ownerActorId,
+    attachedScopes: attachments.map((attachment) => attachment.scopeId).sort(),
+  }));
+  const environmentById = new Map(environments.map((environment) => [environment.id, environment]));
+  const attachmentByScope = new Map(
+    environments.flatMap((environment) =>
+      environment.attachedScopes.map((attachedScope) => [attachedScope, environment] as const),
+    ),
+  );
   const owners = [
     ...crons.map((c) => c.ownerScopeId),
     ...deployments.map((d) => d.ownerScopeId),
     ...skills.map((s) => s.scopeId),
+    ...environments.map((environment) => environment.id),
+    ...environments.flatMap((environment) => environment.attachedScopes),
   ];
   const labels = await discoverScopes(app, deps, owners);
   const countBy = (ids: string[]): Map<string, number> => {
@@ -171,18 +186,31 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
   const cronN = countBy(crons.map((c) => c.ownerScopeId));
   const deployN = countBy(deployments.map((d) => d.ownerScopeId));
   const skillN = countBy(skills.map((s) => s.scopeId));
-  const scopes = [...labels].map(([id, label]) => ({
-    scopeId: id,
-    ...(label ? { label } : {}),
-    sessions: sessionN.get(id) ?? 0,
-    backgroundSessions: backgroundN.get(id) ?? 0,
-    lastActivity: lastActivityBy.get(id) ?? 0,
-    lastConversationActivity: lastConversationBy.get(id) ?? 0,
-    lastMessage: lastMessageBy.get(id) ?? "",
-    crons: cronN.get(id) ?? 0,
-    deployments: deployN.get(id) ?? 0,
-    skills: skillN.get(id) ?? 0,
-  }));
+  const scopes = [...labels].map(([id, label]) => {
+    const environment = environmentById.get(id);
+    const attachment = attachmentByScope.get(id);
+    return {
+      scopeId: id,
+      ...(label ? { label } : {}),
+      ...(environment?.name ? { environmentName: environment.name } : {}),
+      ...(attachment
+        ? {
+            environmentAttachment: {
+              environmentId: attachment.id,
+              environmentName: attachment.name,
+            },
+          }
+        : {}),
+      sessions: sessionN.get(id) ?? 0,
+      backgroundSessions: backgroundN.get(id) ?? 0,
+      lastActivity: lastActivityBy.get(id) ?? 0,
+      lastConversationActivity: lastConversationBy.get(id) ?? 0,
+      lastMessage: lastMessageBy.get(id) ?? "",
+      crons: cronN.get(id) ?? 0,
+      deployments: deployN.get(id) ?? 0,
+      skills: skillN.get(id) ?? 0,
+    };
+  });
   scopes.sort(
     (a, b) =>
       b.lastActivity - a.lastActivity ||
@@ -190,7 +218,35 @@ export async function listAdminScopes(ctx: ApiCtx): Promise<void> {
       b.backgroundSessions - a.backgroundSessions ||
       a.scopeId.localeCompare(b.scopeId),
   );
-  return sendJson(res, 200, { scopeId: scope, scopes });
+  return sendJson(res, 200, { scopeId: scope, scopes, environments });
+}
+
+interface ScopeEnvironmentMetadata {
+  environment?: { id: string; name: string; ownerActorId: string | null };
+  environmentAttachment?: { environmentId: string; environmentName: string | null };
+}
+
+async function scopeEnvironmentMetadata(deps: ApiCtx["deps"], targetScope: string): Promise<ScopeEnvironmentMetadata> {
+  const store = deps.environments;
+  if (!store) return {};
+
+  const [environment, attachment] = await Promise.all([store.get(targetScope), store.getAttachment(targetScope)]);
+  const metadata: ScopeEnvironmentMetadata = {};
+  if (environment?.name) {
+    metadata.environment = {
+      id: environment.id,
+      name: environment.name,
+      ownerActorId: environment.ownerActorId,
+    };
+  }
+  if (attachment) {
+    const attachedEnvironment = await store.get(attachment.environmentId);
+    metadata.environmentAttachment = {
+      environmentId: attachment.environmentId,
+      environmentName: attachedEnvironment?.name ?? null,
+    };
+  }
+  return metadata;
 }
 
 export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
@@ -202,6 +258,7 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
   if (!actor) return;
   await deps.config.refreshScope(targetScope);
   audit(deps, { principalId: actor.id, action: "config.read", resource: "config", scopeLabel: targetScope });
+  const environmentMetadata = await scopeEnvironmentMetadata(deps, targetScope);
   const serviceCredentials = await Promise.all(
     (deps.serviceCreds ? await deps.serviceCreds.listServiceCredentials(targetScope) : []).map(async (c) => {
       const usage = (await deps.credentialUsage?.list({ slug: c.slug, limit: 5000 })) ?? [];
@@ -261,6 +318,7 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
   };
   return sendJson(res, 200, {
     scopeId: targetScope,
+    ...environmentMetadata,
     ...values,
     soulVersion: deps.config.soulVersion(targetScope),
     soulHistory: deps.config.soulHistory(targetScope),

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -299,7 +299,7 @@ function respondError(req: IncomingMessage, res: ServerResponse, err: unknown): 
     else res.destroy();
     return;
   }
-  console.error(`[server] 500 ${req.method ?? "?"} ${req.url ?? "?"}:`, err);
+  console.error(`[server] 500 ${req.method ?? "?"} ${req.url ?? "?"}:`, errMessage(err));
   if (!res.headersSent) sendJson(res, 500, { error: "internal_error", message: "internal server error" });
   else res.destroy();
 }
@@ -368,7 +368,7 @@ function buildFastify(wiring: Wiring, server: Server): { fastify: FastifyInstanc
   fastify.decorateRequest("gate", undefined);
 
   fastify.setErrorHandler((err, request, reply) => {
-    console.error(`[server] 500 ${request.raw.method ?? "?"} ${request.raw.url ?? "?"}:`, err);
+    console.error(`[server] 500 ${request.raw.method ?? "?"} ${request.raw.url ?? "?"}:`, errMessage(err));
     return reply.code(500).send({ error: "internal_error", message: "internal server error" });
   });
 
@@ -451,7 +451,7 @@ function buildServer(app: App, deps: ServerOptions, allowUnsignedSourceAuth: boo
   });
   const { fastify, routing } = buildFastify(wiring, server);
   const ready = Promise.resolve(fastify.ready());
-  ready.catch((err: unknown) => console.error("[server] fastify initialization failed:", err));
+  ready.catch((err: unknown) => console.error("[server] fastify initialization failed:", errMessage(err)));
   server.requestTimeout = 30_000;
   server.headersTimeout = 10_000;
   server.keepAliveTimeout = 5_000;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -299,7 +299,7 @@ function respondError(req: IncomingMessage, res: ServerResponse, err: unknown): 
     else res.destroy();
     return;
   }
-  console.error(`[server] 500 ${req.method ?? "?"} ${req.url ?? "?"}:`, errMessage(err));
+  console.error("[server] 500 %s %s: %s", req.method ?? "?", req.url ?? "?", errMessage(err));
   if (!res.headersSent) sendJson(res, 500, { error: "internal_error", message: "internal server error" });
   else res.destroy();
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -511,7 +511,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         try {
           await deps.sessions.recordLlmRequest(screenSession.id, { ...rec, scopeLabel: scopeId });
         } catch (err) {
-          console.error("[orchestrator] failed to persist security screen request snapshot:", err);
+          console.error("[orchestrator] failed to persist security screen request snapshot:", errMessage(err));
         }
       };
       let screenedOverheard: OverheardEntryPayload[] = [];
@@ -2282,7 +2282,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               try {
                 await deps.sessions.recordLlmRequest(session.id, { ...rec, scopeLabel: scopeId });
               } catch (err) {
-                console.error("[orchestrator] failed to persist LLM request snapshot:", err);
+                console.error("[orchestrator] failed to persist LLM request snapshot:", errMessage(err));
               }
             },
           });

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -188,12 +188,12 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
     const t = nowArg ?? now();
     await leaderLease.hold(TICK_LEASE_KEY, async () => {
       await fireDue(t);
-      await deps.sweepAsks?.(t).catch((e: unknown) => console.error("[scheduler] ask sweep failed:", e));
+      await deps.sweepAsks?.(t).catch((e: unknown) => console.error("[scheduler] ask sweep failed:", errMessage(e)));
     });
   };
 
   const sweeper = createSweeper(
-    () => tick().catch((e: unknown) => console.error("[scheduler] tick failed:", e)),
+    () => tick().catch((e: unknown) => console.error("[scheduler] tick failed:", errMessage(e))),
     1000,
     { label: "scheduler" },
   );
@@ -227,7 +227,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
         return;
       }
     } catch (e) {
-      console.error("[scheduler] fire failed:", e);
+      console.error("[scheduler] fire failed:", errMessage(e));
       await deps.crons.unclaimSlot(job.cronId, slot, t, cron.lastFiredAt);
       return;
     }
@@ -242,9 +242,9 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
         if (slot !== undefined) await deps.jobQueue!.enqueueFire({ cronId: cron.id, scheduledAt: slot });
       }
     } catch (e) {
-      console.error("[scheduler] tick failed:", e);
+      console.error("[scheduler] tick failed:", errMessage(e));
     }
-    await deps.sweepAsks?.(now()).catch((e: unknown) => console.error("[scheduler] ask sweep failed:", e));
+    await deps.sweepAsks?.(now()).catch((e: unknown) => console.error("[scheduler] ask sweep failed:", errMessage(e)));
   }
 
   const leaseGuard = createSweeper(

--- a/src/delivery/run-result-delivery.ts
+++ b/src/delivery/run-result-delivery.ts
@@ -4,6 +4,7 @@ import type { DeliveryStore } from "./delivery-store.ts";
 import type { Task, TaskStore } from "../tasks/task-store.ts";
 import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../../plugins/chassis/src/security-quarantine.ts";
 import { resolveTurnOrigin } from "../core/turn-origin.ts";
+import { errMessage } from "../util/errors.ts";
 
 export interface RunResultDelivery {
   destination: Destination;
@@ -56,6 +57,8 @@ export function wireRunResultDeliveries(runs: RunStore, deliveries: DeliveryStor
       const delivery = runResultDelivery(run, taskList);
       if (!delivery) return;
       await deliveries.enqueue(delivery);
-    })().catch((err) => console.error(`[delivery] failed to enqueue recovery delivery for run ${run.id}:`, err));
+    })().catch((err) =>
+      console.error(`[delivery] failed to enqueue recovery delivery for run ${run.id}:`, errMessage(err)),
+    );
   });
 }

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -76,6 +76,7 @@ import { ELIDED_IMAGE_TEXT, planTapeSeed } from "./tape-fold.ts";
 import { compactTranscript, deterministicCompactSummary, estimateHistoryTokens } from "./context-compaction.ts";
 import { countTokens } from "../util/tokens.ts";
 import { parseSecurityScreenVerdict, SECURITY_SCREEN_SYSTEM_PROMPT } from "../security/security-posture.ts";
+import { errMessage } from "../util/errors.ts";
 
 export interface PiHarnessOptions {
   modelId?: string | ((scope?: ScopeId) => string | undefined);
@@ -1271,7 +1272,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
     try {
       reconstructed = reconstructMessagesFromHistory(history);
     } catch (err) {
-      console.error("[pi-harness] history reconstruction failed; will fall back:", err);
+      console.error("[pi-harness] history reconstruction failed; will fall back:", errMessage(err));
       reconstructed = null;
     }
     let foldSeed: PiReplayMessage[] | null = null;
@@ -1290,7 +1291,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           );
         }
       } catch (err) {
-        console.error(`${tag} fold threw:`, err);
+        console.error(`${tag} fold threw:`, errMessage(err));
       }
     }
     const seedSource = foldSeed ?? reconstructed;
@@ -1337,7 +1338,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
       try {
         seedRawMessagesIntoSession(session, seedSource!);
       } catch (err) {
-        console.error("[pi-harness] failed to seed reconstructed history (continuing without it):", err);
+        console.error("[pi-harness] failed to seed reconstructed history (continuing without it):", errMessage(err));
       }
     } else if (seedPlan === "priorTurns") {
       try {
@@ -1356,7 +1357,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           }
         }
       } catch (err) {
-        console.error("[pi-harness] failed to seed prior turns (continuing without them):", err);
+        console.error("[pi-harness] failed to seed prior turns (continuing without them):", errMessage(err));
       }
     }
 

--- a/src/idempotency/idempotency-store.ts
+++ b/src/idempotency/idempotency-store.ts
@@ -1,4 +1,5 @@
 import type { DurableMap } from "../persistence/durable-map.ts";
+import { errMessage } from "../util/errors.ts";
 
 export interface IdempotencyRecord {
   key: string;
@@ -41,7 +42,7 @@ export function createIdempotencyStore(
         if (r.at < cutoff) await backing.delete(r.key);
       }
     })().catch((e: unknown) => {
-      console.error("[idempotency] retention prune failed:", e);
+      console.error("[idempotency] retention prune failed:", errMessage(e));
     });
   }
 

--- a/src/monitors/monitor-poller.ts
+++ b/src/monitors/monitor-poller.ts
@@ -264,13 +264,13 @@ export function createMonitorPoller(deps: MonitorPollerDeps): MonitorPoller {
           if (await poll(sandbox, handle, m, t)) fires++;
         } catch (e) {
           await deps.monitors.recordError(m.id, errMessage(e));
-          console.error(`[monitor] poll failed for ${m.id}:`, e);
+          console.error(`[monitor] poll failed for ${m.id}:`, errMessage(e));
         }
       }
     } finally {
       for (const handle of handles.values()) {
         await sandbox.teardown(handle, { keepWarm: true }).catch((e: unknown) => {
-          console.error("[monitor] teardown failed:", e);
+          console.error("[monitor] teardown failed:", errMessage(e));
         });
       }
     }
@@ -282,7 +282,7 @@ export function createMonitorPoller(deps: MonitorPollerDeps): MonitorPoller {
   };
 
   const sweeper = createSweeper(
-    () => tick().catch((e: unknown) => console.error("[monitor] tick failed:", e)),
+    () => tick().catch((e: unknown) => console.error("[monitor] tick failed:", errMessage(e))),
     10_000,
     { label: "monitor" },
   );

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -1,5 +1,6 @@
 import type { Pool, PoolClient } from "pg";
 import { swallowAs } from "../util/errors.ts";
+import { errMessage } from "../util/errors.ts";
 
 export type { Pool, PoolClient };
 
@@ -63,7 +64,7 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
       poolP = (async () => {
         const pg = (await import("pg")).default;
         const p = new pg.Pool({ connectionString });
-        p.on("error", (err) => console.error("[pg] idle client error:", err));
+        p.on("error", (err) => console.error("[pg] idle client error:", errMessage(err)));
         try {
           await applyDdl(p, schema);
         } catch (e) {

--- a/src/processes/process-reaper.ts
+++ b/src/processes/process-reaper.ts
@@ -4,6 +4,7 @@ import { createNoopLeaderLease, type LeaderLease } from "../persistence/leader-l
 import { awaitProcessExit } from "../sandbox/await-process-exit.ts";
 import { processIsGone } from "../sandbox/process-poll.ts";
 import type { ProcessSandbox } from "../sandbox/sandbox.ts";
+import { errMessage } from "../util/errors.ts";
 
 const PROCESS_REAPER_LEASE_KEY = "processes:reaper";
 
@@ -66,7 +67,9 @@ export function createProcessReaper(registry: ProcessRegistry, opts: ProcessReap
       if (!flipped) continue;
       reaped++;
       if (opts.onReaped)
-        await opts.onReaped(rec).catch((err) => console.error("[process-reaper] onReaped hook failed:", err));
+        await opts
+          .onReaped(rec)
+          .catch((err) => console.error("[process-reaper] onReaped hook failed:", errMessage(err)));
     }
     return { reaped };
   }

--- a/src/ratelimit/postgres-budget.ts
+++ b/src/ratelimit/postgres-budget.ts
@@ -1,6 +1,7 @@
 import { createPgPool } from "../persistence/pg-pool.ts";
 import type { BudgetTracker } from "./budget.ts";
 import { DEFAULT_BUDGET_WINDOW_MS } from "./budget.ts";
+import { errMessage } from "../util/errors.ts";
 
 export function createPostgresBudgetTracker(
   connectionString: string,
@@ -45,7 +46,7 @@ export function createPostgresBudgetTracker(
           );
         }
       } catch (err) {
-        console.error("[budget] failed to persist spend:", err);
+        console.error("[budget] failed to persist spend:", errMessage(err));
       }
     },
   };

--- a/src/resolution/config-store.ts
+++ b/src/resolution/config-store.ts
@@ -19,6 +19,7 @@ import {
   type PublicConnectorClient,
   type DecryptedConnectorClient,
 } from "../connectors/connector-client-store.ts";
+import { errMessage } from "../util/errors.ts";
 
 export interface PersistedSoul {
   scopeId: ScopeId;
@@ -267,7 +268,8 @@ export function createMemoryConfigStore(
   const browseModelStore = opts.browseModels ?? createMemoryMap<PersistedBrowseModel>();
   const turnWallClockStore = opts.turnWallClocks ?? createMemoryMap<PersistedTurnWallClock>();
   const deploymentIdentity = opts.deploymentIdentity ?? createMemoryMap<PersistedDeploymentIdentity>();
-  const persistWarn = (what: string) => (e: unknown) => console.error(`[config] failed to persist ${what}:`, e);
+  const persistWarn = (what: string) => (e: unknown) =>
+    console.error(`[config] failed to persist ${what}:`, errMessage(e));
   const writeQueue = createKeyedQueue();
   const pendingWrites = new Map<string, Promise<void>>();
   const persist = (key: string, what: string, op: () => Promise<unknown>): void => {
@@ -285,7 +287,7 @@ export function createMemoryConfigStore(
       try {
         listener(id);
       } catch (e) {
-        console.error("[config] runtime-selection listener failed:", e);
+        console.error("[config] runtime-selection listener failed:", errMessage(e));
       }
     }
   };

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -512,13 +512,13 @@ export function buildApp(
       }
     };
     skillsReady = Promise.all([
-      installCatalogs().catch((e) => console.error("[seed] failed to install seed skills:", e)),
-      deploymentLayerReady.catch((e) => console.error("[seed] deployment layer not ready:", e)),
+      installCatalogs().catch((e) => console.error("[seed] failed to install seed skills:", errMessage(e))),
+      deploymentLayerReady.catch((e) => console.error("[seed] deployment layer not ready:", errMessage(e))),
     ]).then(() => undefined);
   } else {
     skillsReady = deploymentLayerReady.then(
       () => undefined,
-      (e) => console.error("[seed] deployment layer not ready:", e),
+      (e) => console.error("[seed] deployment layer not ready:", errMessage(e)),
     );
   }
   const rateLimitOpts = { maxPerWindow: config.rateLimitPerWindow, windowMs: config.rateLimitWindowMs };

--- a/test/admin-scopes-directory.test.ts
+++ b/test/admin-scopes-directory.test.ts
@@ -16,6 +16,8 @@ function start() {
     admin: built.admin,
     auditLog: built.auditLog,
     sessions: built.sessions,
+    config: built.config,
+    environments: built.environments,
   });
   server.listen(0);
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -114,6 +116,37 @@ test("scopes without a session label fall back to the org directory (people's na
       "#quiet",
       "artifact-only owner scopes get the directory fallback too",
     );
+  } finally {
+    await s.close();
+  }
+});
+
+test("the admin scope directory exposes named environments and attached scopes", async () => {
+  const s = start();
+  try {
+    await s.built.app.upsertChannels([
+      { channelId: "A", name: "source" },
+      { channelId: "B", name: "attached" },
+    ]);
+    await s.built.app.createEnvironment({ scopeId: "channel:A", name: "A-permanent", actorId: "U1" });
+    await s.built.app.attachScope({ scopeId: "channel:B", environmentId: "channel:A", actorId: "U1" });
+
+    const directory = await json(await fetch(`${s.base}/v1/admin/scopes`, { headers: ALICE_ADMIN }));
+    const byId = new Map(directory.scopes.map((row: any) => [row.scopeId, row]));
+    assert.deepEqual(directory.environments, [
+      { id: "channel:A", name: "A-permanent", ownerActorId: "U1", attachedScopes: ["channel:B"] },
+    ]);
+    assert.equal((byId.get("channel:A") as any).environmentName, "A-permanent");
+    assert.deepEqual((byId.get("channel:B") as any).environmentAttachment, {
+      environmentId: "channel:A",
+      environmentName: "A-permanent",
+    });
+
+    const attached = await json(await fetch(`${s.base}/v1/admin/scopes/channel:B`, { headers: ALICE_ADMIN }));
+    assert.deepEqual(attached.environmentAttachment, {
+      environmentId: "channel:A",
+      environmentName: "A-permanent",
+    });
   } finally {
     await s.close();
   }


### PR DESCRIPTION
An error object can carry HTTP response bodies, connection strings, or credential material in its properties — in a codebase that handles decrypted credentials, dumping it wholesale into logs is a leak vector. Wrap every raw error passed to console.* in errMessage(...) across src/ (String(e) in plugins that cannot import core utilities) and enforce the pattern with a no-restricted-syntax lint rule so new call sites cannot regress. Local scripts and test CLI crash handlers keep full stacks for debugging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789239390&installation_model_id=19911&pr_number=408&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F408&signature=c9e2e2a00e9dbecb2474f06019764ed988077c08cce8ef2eb443b48d03c39347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->