### PR TITLE
ci: reject GitHub noreply addresses in Co-Authored-By trailers

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -122,6 +122,31 @@ jobs:
             *) echo "cli/package.json version must be semver, got $head_version" >&2; exit 1 ;;
           esac
 
+  coauthor-trailers:
+    name: Co-author trailers
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Reject GitHub noreply addresses in Co-Authored-By trailers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          offenders=$(git log --format=%H --regexp-ignore-case \
+            --grep='^co-authored-by:.*@users\.noreply\.github\.com' "$base..$HEAD_SHA")
+          [ -n "$offenders" ] || exit 0
+          echo "$offenders" | xargs git show -s --format='%h %s' >&2
+          echo "Co-Authored-By trailers must not use @users.noreply.github.com addresses:" >&2
+          echo "GitHub credits them to whichever account owns that username, which may be a stranger." >&2
+          echo "Use the contributor's real email, or drop the trailer." >&2
+          exit 1
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -138,13 +138,19 @@ jobs:
         run: |
           set -euo pipefail
           base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
-          offenders=$(git log --format=%H --regexp-ignore-case \
-            --grep='^co-authored-by:.*@users\.noreply\.github\.com' "$base..$HEAD_SHA")
+          offenders=""
+          for sha in $(git rev-list "$base..$HEAD_SHA"); do
+            if git log -1 --format='%(trailers:key=Co-authored-by,valueonly)' "$sha" \
+              | grep -qi '@users\.noreply\.github\.com'; then
+              offenders="$offenders $sha"
+            fi
+          done
           [ -n "$offenders" ] || exit 0
           echo "$offenders" | xargs git show -s --format='%h %s' >&2
           echo "Co-Authored-By trailers must not use @users.noreply.github.com addresses:" >&2
           echo "GitHub credits them to whichever account owns that username, which may be a stranger." >&2
-          echo "Use the contributor's real email, or drop the trailer." >&2
+          echo "This repo bans all such addresses, including your own privacy address;" >&2
+          echo "use the contributor's real email, or drop the trailer." >&2
           exit 1
 
   lint:


### PR DESCRIPTION
## What

Adds a pull-request CI check that fails when any commit in the PR carries a `Co-Authored-By` trailer with an `@users.noreply.github.com` email address. The check parses each commit's trailer block (`%(trailers:key=Co-authored-by)`), so quoting such an address in a commit body does not trip it.

## Why

GitHub resolves a `users.noreply.github.com` address to whichever GitHub account owns that username. #360 landed with `Co-Authored-By: QM <qm@users.noreply.github.com>` (commit ee5ed9e), which credited the unrelated github.com/qm account as a contributor to this repository. Agents writing commit messages can invent such addresses, so the guard blocks them before merge.

## Scope decisions

- **All `@users.noreply.github.com` addresses are banned, including a contributor's own `id+login` privacy address.** An invented address is indistinguishable from a real one at CI time, and this repo's convention is real emails or vendor noreply addresses (e.g. `noreply@anthropic.com`, `noreply@sprites.dev`). The failure message says so.
- **Known gap:** trailers GitHub itself appends at squash-merge time are composed after CI runs and are not scanned. Those come from real commit author identities, not invented ones, so the incident class this guards against is covered.
- "Co-author trailers" must be added to the branch's required status checks to actually gate merges (repo admin step, done alongside this PR).

Verified against history: the check flags ee5ed9e (and #360's squash commit, which inherited the trailer) and nothing else in the recent 20 commits on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
