### PR TITLE
web-ui: give the session top bar its own grid row

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -978,8 +978,13 @@ a.chat-row-open {
   min-height: 0;
   min-width: 0;
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   position: relative;
+}
+/* Glance tiers render no top bar: two children (glance, dock), two rows. */
+[data-density="card"] .custom-chat-shell,
+[data-density="strip"] .custom-chat-shell {
+  grid-template-rows: minmax(0, 1fr) auto;
 }
 .drop-overlay {
   position: absolute;


### PR DESCRIPTION
The session top bar added a third child to .custom-chat-shell, but the grid kept two rows (minmax(0,1fr) auto): the auto row swallowed the height, the header's row collapsed to 0px, and the message scroller painted over the bar — overlapping ghost text and unclickable header buttons. Rows are now auto minmax(0,1fr) auto, with the card/strip glance tiers (which render no top bar) keeping the old two-row template.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789244888&installation_model_id=19911&pr_number=433&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F433&signature=c2bfcf56939ff1dde7bbfec67f82168e24d3feafe567b16f3144c6ff0ed6ad4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->