### PR TITLE
web-ui: render post(files) attachments in web sessions

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1397,7 +1397,13 @@ export function createChatSurface(
         );
       }
     }
-    if (parts.length === 0 && message.stopReason !== "error" && message.stopReason !== "aborted" && !hasWork)
+    if (
+      parts.length === 0 &&
+      message.stopReason !== "error" &&
+      message.stopReason !== "aborted" &&
+      !hasWork &&
+      !(message as AssistantWork).deliveredFiles?.length
+    )
       parts.push(typingRow());
     return parts;
   }

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -1143,8 +1143,9 @@ interface HistoryUserMessage {
 }
 
 function postCallText(payload: unknown): string | null {
-  const p = (payload ?? {}) as { action?: unknown; text?: unknown };
-  if (p.action !== "post" || typeof p.text !== "string" || !p.text.trim()) return null;
+  const p = (payload ?? {}) as { action?: unknown; text?: unknown; files?: unknown };
+  if (p.action !== "post" || typeof p.text !== "string") return null;
+  if (!p.text.trim() && !(Array.isArray(p.files) && p.files.length)) return null;
   return p.text;
 }
 
@@ -1180,6 +1181,14 @@ export function entriesToMessages(entries: SessionEntry[], model: Model<Api>): A
       return;
     }
     deliveryFiles.push(...files);
+  };
+  const appendPostFiles = (resultPayload: unknown): void => {
+    const files = (
+      resultPayload as {
+        files?: Array<{ name?: string; mimetype?: string; sizeBytes?: number; artifactId?: string }>;
+      } | null
+    )?.files;
+    deliveryFiles.push(...deliveredFilesFromAttachments(files));
   };
   const flushWork = (text: string, at?: number, closed = false): void => {
     if (!text && !pending.length && !deliveryFiles.length) return;
@@ -1242,7 +1251,7 @@ export function entriesToMessages(entries: SessionEntry[], model: Model<Api>): A
       };
       if (e.type === "tool_call") {
         const postText = postCallText(e.payload);
-        if (postText && typeof payload?.callId === "string") {
+        if (postText !== null && typeof payload?.callId === "string") {
           heldPosts.set(payload.callId, { text: postText, activity });
           continue;
         }
@@ -1251,6 +1260,7 @@ export function entriesToMessages(entries: SessionEntry[], model: Model<Api>): A
         const held = heldPosts.get(payload.callId)!;
         heldPosts.delete(payload.callId);
         if (postResultOk(e.payload)) {
+          appendPostFiles(e.payload);
           flushWork(held.text, e.createdAt);
           posted = true;
         } else {

--- a/plugins/web-ui/test/history.test.ts
+++ b/plugins/web-ui/test/history.test.ts
@@ -1125,3 +1125,89 @@ test("a turn resumed past a hidden note renders as one block with the real reply
     "the work block is not split at the hidden note",
   );
 });
+
+test("a file-only post (empty text) still renders its delivered files", () => {
+  const entries: SessionEntry[] = [
+    { type: "user", payload: { text: "just send the file" }, createdAt: 100, seq: 0 },
+    {
+      type: "tool_call",
+      payload: { tool: "web", action: "post", text: "", files: ["out/report.pdf"], callId: "c2" },
+      createdAt: 110,
+      seq: 1,
+      parentSeq: 0,
+    },
+    {
+      type: "tool_result",
+      payload: {
+        tool: "web",
+        action: "post",
+        ok: true,
+        callId: "c2",
+        isError: false,
+        result: "[sent]",
+        files: [{ name: "report.pdf", mimetype: "application/pdf", sizeBytes: 512, artifactId: "art-7" }],
+      },
+      createdAt: 120,
+      seq: 2,
+      parentSeq: 1,
+    },
+  ];
+  const msgs = entriesToMessages(entries, MODEL);
+  const reply = msgs[1] as AssistantWork & { content: Array<{ text?: string }> };
+  assert.equal(reply.role, "assistant");
+  assert.equal(reply.content[0]?.text, "");
+  assert.deepEqual(
+    reply.deliveredFiles?.map((f) => ({ name: f.name, artifactId: f.artifactId })),
+    [{ name: "report.pdf", artifactId: "art-7" }],
+    "the file-only post's attachment still surfaces on the message",
+  );
+});
+
+test("a surface post's sent files render as delivered files on the reply bubble", () => {
+  const entries: SessionEntry[] = [
+    { type: "user", payload: { text: "send the drafts" }, createdAt: 100, seq: 0 },
+    {
+      type: "tool_call",
+      payload: {
+        tool: "web",
+        action: "post",
+        text: "Here they are — profiles A/B/C.",
+        files: ["qm-brand/profile_A.png", "qm-brand/profile_B.png"],
+        callId: "c1",
+      },
+      createdAt: 110,
+      seq: 1,
+      parentSeq: 0,
+    },
+    {
+      type: "tool_result",
+      payload: {
+        tool: "web",
+        action: "post",
+        ok: true,
+        callId: "c1",
+        isError: false,
+        result: "[sent]",
+        files: [
+          { name: "profile_A.png", mimetype: "image/png", sizeBytes: 28720, artifactId: "art-1" },
+          { name: "profile_B.png", mimetype: "image/png", sizeBytes: 21922, artifactId: "art-2" },
+        ],
+      },
+      createdAt: 120,
+      seq: 2,
+      parentSeq: 1,
+    },
+  ];
+  const msgs = entriesToMessages(entries, MODEL);
+  const reply = msgs[1] as AssistantWork & { content: Array<{ text?: string }> };
+  assert.equal(reply.role, "assistant");
+  assert.equal(reply.content[0]?.text, "Here they are — profiles A/B/C.");
+  assert.deepEqual(
+    reply.deliveredFiles?.map((f) => ({ name: f.name, artifactId: f.artifactId })),
+    [
+      { name: "profile_A.png", artifactId: "art-1" },
+      { name: "profile_B.png", artifactId: "art-2" },
+    ],
+    "the attachments the post actually sent are surfaced on the message",
+  );
+});

--- a/src/core/orchestrator/surface-tools.ts
+++ b/src/core/orchestrator/surface-tools.ts
@@ -21,6 +21,7 @@ import { hasParentPathSegment, type SandboxHandle } from "../../sandbox/sandbox.
 import type {
   SurfaceToolDeps,
   SurfacePostResult,
+  PostedFileMeta,
   SurfaceReactInput,
   SurfaceEditInput,
   SurfaceDeleteInput,
@@ -62,6 +63,15 @@ export interface SurfaceToolsContext {
   provision: () => Promise<SandboxHandle>;
   postProvenance: (deliveryKey: string) => DeliveryProvenance;
   spine: SpineState;
+}
+
+function postedFileMetas(attachments: readonly OutgoingAttachment[]): PostedFileMeta[] {
+  return attachments.map((a) => ({
+    name: a.name,
+    mimetype: a.mimetype,
+    sizeBytes: a.sizeBytes,
+    ...(a.artifactId ? { artifactId: a.artifactId } : {}),
+  }));
 }
 
 export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps | undefined {
@@ -217,7 +227,8 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
         ...(taskList?.length ? { taskList: taskList.map(({ id, title, status }) => ({ id, title, status })) } : {}),
         ...(footer ? { debugFooter: footer } : {}),
       };
-      return enqueue(projectedDestination, postText, f.attachments);
+      const sent = await enqueue(projectedDestination, postText, f.attachments);
+      return sent.ok && f.attachments?.length ? { ...sent, attachments: postedFileMetas(f.attachments) } : sent;
     },
     reach: async (postText, target, files) => {
       if (spine.crossConversationPosts >= 5) return { ok: false, message: "outbound limit reached for this turn" };
@@ -233,8 +244,9 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
       const sending = postText.trim().length > 0 || (f.attachments?.length ?? 0) > 0;
       const d = await resolveDestination(target, { mayOpenGroup: sending });
       if (!d.ok) return { ok: false, message: d.message };
-      const r = await enqueue(d.destination, postText, f.attachments);
-      if (!r.ok) return r;
+      const r0 = await enqueue(d.destination, postText, f.attachments);
+      if (!r0.ok) return r0;
+      const r = f.attachments?.length ? { ...r0, attachments: postedFileMetas(f.attachments) } : r0;
       spine.crossConversationPosts += 1;
       let label = `a group DM (${target.participants?.length ?? 0} people)`;
       if (target.channel !== undefined) label = `#${target.channel.replace(/^#/, "")}`;

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -2137,7 +2137,13 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
           const r = await tc.post(params.text, opts, params.files);
           return recordResult(
             callId,
-            { tool: surfaceName, action: "post", ok: r.ok, ...(r.deliveryId ? { deliveryId: r.deliveryId } : {}) },
+            {
+              tool: surfaceName,
+              action: "post",
+              ok: r.ok,
+              ...(r.deliveryId ? { deliveryId: r.deliveryId } : {}),
+              ...(r.ok && r.attachments?.length ? { files: r.attachments } : {}),
+            },
             text(r.ok ? "[sent]" : `[not sent] ${r.message ?? "delivery failed"}`),
             !r.ok,
           );
@@ -2174,7 +2180,13 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
           const r = await tc.reach(params.text, target, params.files);
           return recordResult(
             callId,
-            { tool: surfaceName, action: "reach", ok: r.ok, ...(r.deliveryId ? { deliveryId: r.deliveryId } : {}) },
+            {
+              tool: surfaceName,
+              action: "reach",
+              ok: r.ok,
+              ...(r.deliveryId ? { deliveryId: r.deliveryId } : {}),
+              ...(r.ok && r.attachments?.length ? { files: r.attachments } : {}),
+            },
             text(
               r.ok
                 ? `[sent to ${r.matched ?? "the named destination"}]`

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -259,11 +259,19 @@ export interface SurfaceDeleteInput {
   participants?: readonly string[];
 }
 
+export interface PostedFileMeta {
+  name: string;
+  mimetype: string;
+  sizeBytes: number;
+  artifactId?: string;
+}
+
 export interface SurfacePostResult {
   ok: boolean;
   deliveryId?: string;
   message?: string;
   matched?: string;
+  attachments?: PostedFileMeta[];
 }
 
 interface SurfaceReadResult {

--- a/test/surface-post-files.test.ts
+++ b/test/surface-post-files.test.ts
@@ -179,3 +179,47 @@ test("collectOutbound: harvests every outbox file (the turn-result rail for a no
   const r = await collectOutbound(sandbox, handle, transfer);
   assert.deepEqual(r.attachments.map((a) => a.name).sort(), ["cover.png", "leftover.txt"]);
 });
+
+test("surface post returns the sent attachments' metadata (so surfaces can render them)", async () => {
+  const enqueued: unknown[] = [];
+  const tools = createSurfaceToolDeps({
+    deps: {
+      deliveries: {
+        async enqueue(input: unknown) {
+          enqueued.push(input);
+          return { id: "d1" };
+        },
+      },
+      sandbox: fakeSandbox({ "qm-brand/cover.png": bytes("PNGDATA") }, []),
+    },
+    input: { surfaceTools: true },
+    actor: { id: "U1" },
+    conversation: { kind: "group" },
+    session: { id: "S1" },
+    scopeId: scopeId("personal", "U1"),
+    defaultDestination: { type: "web", target: "web:thread" },
+    strictReadOnly: false,
+    provision: async () => handle,
+    blobTransfer: createMemoryBlobTransferStore(),
+    fileRegistration: {
+      store: createMemoryFileArtifactStore(createMemoryDurableByteStore()),
+      ownerScopeId: scopeId("personal", "U1"),
+      createdBy: "U1",
+      seed: "run-post",
+    },
+    postProvenance() {
+      return {};
+    },
+    spine: { surfaceOutboundCount: 0, crossConversationPosts: 0 },
+  } as unknown as SurfaceToolsContext)!;
+  const r = await tools.post("Here they are", undefined, ["qm-brand/cover.png"]);
+  assert.equal(r.ok, true);
+  assert.equal(enqueued.length, 1, "the delivery was enqueued");
+  assert.equal(r.attachments?.length, 1, "the post result names what it sent");
+  const a = r.attachments![0]!;
+  assert.equal(a.name, "cover.png");
+  assert.equal(a.mimetype, "image/png");
+  assert.ok(a.sizeBytes > 0);
+  assert.ok(a.artifactId, "artifact id present so the web surface can serve the bytes");
+  assert.ok(!("blobId" in a), "internal blob handle is not leaked to surfaces");
+});


### PR DESCRIPTION
A surface post with files staged the blobs and enqueued the delivery correctly, but the web delivery pump only nudges the client and acks the delivery — the attachments were discarded and session history never carried them, so the post text rendered while the files silently vanished even though the tool reported them sent. The post/reach result now carries the sent attachments' metadata (name, mimetype, sizeBytes, artifactId — never the internal blob id), the tool_result entry persists it as files, and the web renderer surfaces those as delivered files on the reply bubble, with images inline via the existing artifact content route. File-only posts (empty text) render correctly and no longer leave a typing placeholder; the native Slack delivery path is untouched.

**Deployment notes**

tool_result session entries now persist a files array (name/mimetype/sizeBytes/artifactId, never
blobId). Additive persisted-format change: old code replaying/rendering these entries ignores the
extra field; new code reading old entries sees no files and renders as before.
Blue-green: an old web-ui instance won't render deliveredFiles written by the new instance during
overlap — cosmetic only.