### PR TITLE
web-ui: reserve room for both sidebar hover actions

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -487,7 +487,7 @@ a.chat-row-open {
   box-sizing: border-box;
   text-align: left;
 
-  padding: 5px 34px 5px 11px;
+  padding: 5px 62px 5px 11px;
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -4252,7 +4252,7 @@ a.chat-row-open {
     min-height: 44px;
   }
   .session {
-    padding-right: 48px;
+    padding-right: 92px;
   }
   .session-menu {
     right: 0;


### PR DESCRIPTION
so the archive icon doesn't overlap long titles Long ellipsized session titles in the sidebar ran underneath the hover archive quick-action. The row's right padding (34px desktop, 48px touch) was sized for a single 26px menu button, but the absolutely-positioned hover menu now holds two buttons, so the title's ellipsis point sat under the archive icon. Reserving 62px on desktop and 92px on touch layouts makes titles end just short of the first button. CSS-only, two lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789244919&installation_model_id=19911&pr_number=439&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F439&signature=df81330605f6f7371aa59d900d586a58969fcec504e14e296820d0da18bd5125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->