### PR TITLE
web-ui: center the conversation loading spinner in the pane

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2735,6 +2735,7 @@ a.chat-row-open {
 }
 .chat-loading {
   flex: 1;
+  grid-row: 1 / -1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/plugins/web-ui/test/loading-pane-centered.test.ts
+++ b/plugins/web-ui/test/loading-pane-centered.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+
+test("the loading pane renders chat-loading as the shell's only child", () => {
+  const fn = chat.match(/function mountLoadingPane\(\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
+  assert.match(fn, /custom-chat-shell/);
+  assert.match(fn, /chat-loading/);
+});
+
+test("chat-loading spans every shell grid row so the spinner centers vertically", () => {
+  const shell = css.match(/\.custom-chat-shell \{[^}]*\}/)?.[0] ?? "";
+  assert.match(shell, /display: grid;/, "the shell is a grid, so a lone child needs an explicit row span");
+  const block = css.match(/\.chat-loading \{[^}]*\}/)?.[0] ?? "";
+  assert.match(block, /grid-row: 1 \/ -1;/, "without spanning all rows the spinner hugs the top auto row");
+  assert.match(block, /align-items: center;/);
+  assert.match(block, /justify-content: center;/);
+});


### PR DESCRIPTION
mountLoadingPane renders .chat-loading as the sole child of .custom-chat-shell, a grid with rows auto/1fr/auto — the spinner sat in the top auto row (flex:1 is inert inside a grid) and hugged the top of the window. Spanning it across every row with grid-row: 1 / -1 lets its own flex centering put the spinner in the middle of the pane. Includes a test pinning the rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245110&installation_model_id=19911&pr_number=444&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F444&signature=e81f9137a124a0284b6fada80e76c187848b1fcf92b935fcb780a9be8b6a9c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->