### PR TITLE
web-ui: sessions header shares the list's scrollbar gutter

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -295,6 +295,10 @@ a.chat-row-open {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  /* Match the list's reserved scrollbar gutter so the Web-only toggle shares a
+     right edge with the session rows below. */
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
 }
 .web-only-toggle {
   display: inline-flex;
@@ -345,6 +349,7 @@ a.chat-row-open {
 .sidebar .list {
   flex: 1;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   display: flex;
   flex-direction: column;
   gap: 1px;


### PR DESCRIPTION
The sessions header renders outside the scrolling session list, so when the list's scrollbar appears it shrinks only the rows — leaving the header's Web-only toggle overhanging the row edge by the scrollbar width. Reserving a stable scrollbar gutter (scrollbar-gutter: stable) on both the list and the header gives them one shared right edge whether or not a scrollbar is visible. CSS-only, five lines; the no-scrollbar case is unchanged.