### PR TITLE
web-ui: sessions header shares the list's scrollbar gutter

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -295,6 +295,10 @@ a.chat-row-open {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  /* Match the list's reserved scrollbar gutter so the Web-only toggle shares a
+     right edge with the session rows below. */
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
 }
 .web-only-toggle {
   display: inline-flex;
@@ -345,6 +349,7 @@ a.chat-row-open {
 .sidebar .list {
   flex: 1;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   display: flex;
   flex-direction: column;
   gap: 1px;


### PR DESCRIPTION
The sessions header renders outside the scrolling session list, so when the list's scrollbar appears it shrinks only the rows — leaving the header's Web-only toggle overhanging the row edge by the scrollbar width. Reserving a stable scrollbar gutter (scrollbar-gutter: stable) on both the list and the header gives them one shared right edge whether or not a scrollbar is visible. CSS-only, five lines; the no-scrollbar case is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245189&installation_model_id=19911&pr_number=447&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F447&signature=d7851eddd164bd801b43f09328cd5578b42b6bd666a8f195f7a395e2566fa7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->