### PR TITLE
web-ui: remove the admin session-log link from chat surfaces

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -81,7 +81,7 @@ import {
   harnessSupportsFastMode,
 } from "./model-options";
 import { browserRenderableImage, formatBytes, icon, relTime } from "./ui";
-import { adminSessionLogUrl, appState, can, renderSidebarTop, switchView, syncUrlFromState } from "./shell";
+import { appState, renderSidebarTop, switchView, syncUrlFromState } from "./shell";
 import { contextsState, scopeTitle } from "./contexts";
 import { openProjectPage, scopeCronCount, sessionTopbarTpl, setScopedSession } from "./session-scope";
 import {
@@ -1129,18 +1129,6 @@ export function createChatSurface(
           <div class="chat-subtitle">${readOnly ? "Read-only" : detail}</div>
         </div>
         <div class="topbar-actions">
-          ${
-            chatState.sessionId && can("admin")
-              ? html`<a
-                  class="icon-btn subtle"
-                  title="View session log (admin)"
-                  href=${adminSessionLogUrl(chatState.sessionId, chatState.scopeId ?? `org:${appState.me?.org ?? ""}`)}
-                  target="_blank"
-                  rel="noreferrer"
-                  >${icon(ScrollText, 17)}</a
-                >`
-              : nothing
-          }
           <button
             class="icon-btn subtle"
             title="Refresh conversations"

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -11,7 +11,6 @@ import {
   ChevronDown,
   FileText,
   Paperclip,
-  ScrollText,
   SlidersHorizontal,
   Square,
   X,
@@ -46,7 +45,7 @@ import {
 import { modelSupportsFastMode, setFastModeModelIds } from "./pi-models";
 import type { ComposerSurface, ConvCtx } from "./conv-types";
 import { bumpSessionActivity, dropPendingSession, renderList } from "./sessions";
-import { adminSessionLogUrl, appState, can } from "./shell";
+import { appState } from "./shell";
 import { base64ToText, bytesToBase64, insertIntoDraft, pasteChipLabel } from "./paste-text";
 import { clearDraft, newChatDraftKey, saveDraft } from "./drafts";
 
@@ -447,18 +446,6 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
         }
         <div class="composer-toolbar">
           <div class="composer-left">
-            ${
-              !ctx.pane && ctx.chat.state.sessionId && can("admin")
-                ? html`<a
-                    class="icon-btn"
-                    title="View session log (admin)"
-                    href=${adminSessionLogUrl(ctx.chat.state.sessionId, ctx.chat.state.scopeId ?? `org:${appState.me?.org ?? ""}`)}
-                    target="_blank"
-                    rel="noreferrer"
-                    >${icon(ScrollText, 18)}</a
-                  >`
-                : nothing
-            }
             <input
               class="file-input"
               type="file"

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -84,11 +84,6 @@ export const ADMIN_BASE = (() => {
 })();
 export const ADMIN_HOME_URL = `${ADMIN_BASE}/`;
 
-export function adminSessionLogUrl(sessionId: string, scopeId: string): string {
-  const q = new URLSearchParams({ view: "history", scope: scopeId, session: sessionId });
-  return `${ADMIN_BASE}/?${q.toString()}`;
-}
-
 export function syncUrlFromState(): void {
   const chatState = mainConversation().state;
   const sessionId = splitState.active ? null : (chatState.sessionId ?? chatState.rememberedSessionId);


### PR DESCRIPTION
The chat header and composer toolbar showed a per-session 'View session log (admin)' icon to admin users, duplicating navigation the admin panel already provides and cluttering the conversation UI for everyone with the admin capability. Remove the icon from both surfaces and delete the now-unused adminSessionLogUrl helper. Admins reach session logs through the admin panel as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245454&installation_model_id=19911&pr_number=449&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F449&signature=d79f474fac388c974389d7e7c6d856bf4060cd0aa19a313579c0a8aca185fdfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->