### PR TITLE
Autoloadpersontopersonskillgrantsintotheturn'sskilllist

### DIFF
--- a/src/acl/acl-store.ts
+++ b/src/acl/acl-store.ts
@@ -66,6 +66,13 @@ export interface AclStore {
     orgScopeId: ScopeId,
     entitled: ScopeEntitlement,
   ): Promise<Grant[]>;
+  sharedOfKindForAudience(
+    kind: Exclude<ResourceKind, "file">,
+    audience: readonly Principal[],
+    sessionScopeId: ScopeId,
+    orgScopeId: ScopeId,
+    entitled: ScopeEntitlement,
+  ): Promise<Grant[]>;
   list(): Promise<readonly Grant[]>;
 }
 
@@ -200,6 +207,19 @@ export function createAclStore(
           g.ref.startsWith(prefix) &&
           g.ownerScopeId === orgScopeId &&
           audience.every((p) => entitled(p, g.granteeScopeId, sessionScopeId, orgScopeId)),
+      );
+    },
+    async sharedOfKindForAudience(kind, audience, sessionScopeId, orgScopeId, entitled) {
+      if (audience.length === 0) return [];
+      const prefix = refPrefix(kind);
+      const reaches = (p: Principal, g: Grant) =>
+        entitled(p, g.granteeScopeId, sessionScopeId, orgScopeId) ||
+        entitled(p, g.ownerScopeId, sessionScopeId, orgScopeId);
+      return (await persist.all()).filter(
+        (g) =>
+          g.ref.startsWith(prefix) &&
+          audience.some((p) => entitled(p, g.granteeScopeId, sessionScopeId, orgScopeId)) &&
+          audience.every((p) => reaches(p, g)),
       );
     },
     list: () => persist.all(),

--- a/src/api/app-skills.ts
+++ b/src/api/app-skills.ts
@@ -10,6 +10,9 @@ import { persistedSkillRecordPaths, SKILL_MATERIALIZATION_LOCK } from "../skills
 import { triggerBlocksSharedSkill } from "./artifact-share.ts";
 
 import type { App, AppDeps } from "./app-types.ts";
+import { parseRef } from "../acl/resource-ref.ts";
+import { principalEntitledToScope } from "../resolution/context-filter.ts";
+import type { Principal } from "../types.ts";
 import type { AppHelpers } from "./app-helpers.ts";
 
 function requireRegistry(deps: AppDeps): { packs: SkillPackStore; fetcher: SkillPackFetcher } {
@@ -234,7 +237,20 @@ export function createSkillMethods(
       const shared = member.filter((sid): sid is ScopeId => sid !== null);
       const teams = (actor.teamIds ?? []).map((t) => scopeId("team", t));
       const ordered = [...new Set([scopeId("personal", principalId), ...shared, ...teams, scopeId("org", orgIdOf())])];
-      return deps.skills.visibleFor(ordered);
+      const entitled = (p: Principal, label: ScopeId, sess: ScopeId, org: ScopeId) =>
+        principalEntitledToScope(p, label, sess, org) || accessibleScopes.has(label);
+      const granted = (
+        await deps.acl
+          .sharedOfKindForAudience(
+            "skill",
+            [actor],
+            scopeId("personal", principalId),
+            scopeId("org", orgIdOf()),
+            entitled,
+          )
+          .catch(() => [])
+      ).map((g) => ({ id: parseRef(g.ref).id, ownerScopeId: g.ownerScopeId }));
+      return deps.skills.visibleFor(ordered, granted);
     },
     canManageSkill(skill, principalId) {
       return canManageSkill(skill, principalId);

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -127,7 +127,7 @@ import { sleep } from "../util/async.ts";
 import { hashId } from "../util/crypto.ts";
 import { randomUUID } from "node:crypto";
 import { LRUCache } from "lru-cache";
-import type { SkillResolution } from "../skills/skill-store.ts";
+import type { SkillResolution, GrantedSkillRef } from "../skills/skill-store.ts";
 import type { Orchestrator, OrchestratorDeps, OrchestratorInput } from "./orchestrator/types.ts";
 import { resolveModel } from "../model/pi-models.ts";
 import {
@@ -762,6 +762,17 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           ? { ...(useMemory && memoryPolicy.capture !== "off" ? { write: memoryScopeId } : {}), read: recallScopes }
           : undefined;
       const skillScopes = visibleSkillScopes(resolution, scopeId);
+      const grantedSkills: GrantedSkillRef[] = (
+        await deps.acl
+          .sharedOfKindForAudience(
+            "skill",
+            conversation.audience,
+            scopeId,
+            resolution.orgScopeId,
+            principalEntitledToScope,
+          )
+          .catch(swallowAs("orchestrator: skill grants for audience", []))
+      ).map((g) => ({ id: parseRef(g.ref).id, ownerScopeId: g.ownerScopeId }));
       const recalledSections: string[] = [];
       let recallMs = 0;
       for (const recallScope of recallScopes) {
@@ -835,7 +846,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           )
         : [];
       const visibleSkillsForTurn = async (): Promise<SkillResolution[]> =>
-        filterConnectorSkills((await deps.skills?.visibleFor(skillScopes)) ?? [], configuredProviders);
+        filterConnectorSkills((await deps.skills?.visibleFor(skillScopes, grantedSkills)) ?? [], configuredProviders);
       const visibleSkills = await visibleSkillsForTurn();
       const transferId = turnFileId(input.runId, input.attempt);
       const turnSessionDir = `${TURN_FILES_DIR}/${hashId([conversation.threadRef], 24)}`;
@@ -1273,7 +1284,6 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         cutoverModeOf,
         visibleSkills,
         visibleSkillsForTurn,
-        skillScopes,
         skillMaterializer,
         residentAuthConnectors,
         emitGapWork,

--- a/src/core/orchestrator/sandboxes.ts
+++ b/src/core/orchestrator/sandboxes.ts
@@ -48,7 +48,6 @@ export interface TurnSandboxContext {
   cutoverModeOf: (service: string) => DeviceFlowCutoverMode;
   visibleSkills: SkillResolution[];
   visibleSkillsForTurn: () => Promise<SkillResolution[]>;
-  skillScopes: ScopeId[];
   skillMaterializer: ReturnType<typeof createSkillMaterializer>;
   residentAuthConnectors: () => ResidentAuthConnector[];
   emitGapWork: (phase: GapPhase, start: number, end: number) => void;
@@ -80,7 +79,6 @@ export function createTurnSandboxes(ctx: TurnSandboxContext) {
     cutoverModeOf,
     visibleSkills,
     visibleSkillsForTurn,
-    skillScopes,
     skillMaterializer,
     residentAuthConnectors,
     emitGapWork,
@@ -330,7 +328,7 @@ export function createTurnSandboxes(ctx: TurnSandboxContext) {
     try {
       const handle = await provision();
       await skillMaterializer.materializeTree(deps.sandbox, handle, r, [], async () => {
-        const latest = (await deps.skills!.visibleFor(skillScopes)).find(
+        const latest = (await visibleSkillsForTurn()).find(
           (candidate) => candidate.skill && safeSkillDirName(candidate.skill.manifest.name) === skillDir,
         );
         if (!latest) return null;

--- a/src/skills/skill-store.ts
+++ b/src/skills/skill-store.ts
@@ -62,6 +62,11 @@ export interface Skill {
   pack?: { packId: string; commit: string; upstreamName: string };
 }
 
+export interface GrantedSkillRef {
+  id: string;
+  ownerScopeId: ScopeId;
+}
+
 export interface SkillResolution {
   skill: Skill | null;
   shadowed: Skill[];
@@ -85,7 +90,7 @@ export interface SkillStore {
   delete(id: string): Promise<void>;
   recordUse(id: string, at?: number): Promise<void>;
   resolve(name: string, orderedScopes: ScopeId[]): Promise<SkillResolution>;
-  visibleFor(orderedScopes: ScopeId[]): Promise<SkillResolution[]>;
+  visibleFor(orderedScopes: ScopeId[], granted?: readonly GrantedSkillRef[]): Promise<SkillResolution[]>;
   promote(id: string, targetScopeId: ScopeId): Promise<Skill>;
   move(id: string, toScopeId: ScopeId): Promise<Skill>;
 }
@@ -222,7 +227,7 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
       return resolveFromIndex(publishedByScopeAndName(await skills.all()), name, orderedScopes);
     },
 
-    async visibleFor(orderedScopes) {
+    async visibleFor(orderedScopes, granted) {
       const all = await skills.all();
       const index = publishedByScopeAndName(all);
       const inScope = new Set(orderedScopes);
@@ -233,9 +238,29 @@ export function createSkillStore(opts: SkillStoreOptions = {}): SkillStore {
             .map((s) => s.manifest.name),
         ),
       ];
-      return names
+      const visible = names
         .map((n) => resolveFromIndex(index, n, orderedScopes))
         .filter((r): r is SkillResolution & { skill: Skill } => r.skill !== null);
+      if (granted?.length) {
+        const byName = new Map(visible.map((r) => [r.skill.manifest.name, r]));
+        const seen = new Set<string>();
+        for (const ref of granted) {
+          if (seen.has(ref.id)) continue;
+          seen.add(ref.id);
+          const s = await skills.get(ref.id);
+          if (!s || s.status !== "published" || s.scopeId !== ref.ownerScopeId || !isSafeSkillName(s.manifest.name))
+            continue;
+          const existing = byName.get(s.manifest.name);
+          if (existing) {
+            if (existing.skill.id !== s.id && !existing.shadowed.some((x) => x.id === s.id)) existing.shadowed.push(s);
+            continue;
+          }
+          const r = { skill: s, shadowed: [] as Skill[] };
+          byName.set(s.manifest.name, r);
+          visible.push(r);
+        }
+      }
+      return visible;
     },
 
     async promote(id, targetScopeId) {

--- a/test/skill-grant-autoload.test.ts
+++ b/test/skill-grant-autoload.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createAclStore } from "../src/acl/acl-store.ts";
+import { encodeRef, skillRef, parseRef } from "../src/acl/resource-ref.ts";
+import { principalEntitledToScope } from "../src/resolution/context-filter.ts";
+import { createSkillStore, type SkillManifest, type SkillStore } from "../src/skills/skill-store.ts";
+import { scopeId, type Principal, type ScopeId } from "../src/types.ts";
+
+const ORG = scopeId("org", "default-org");
+const JOSH = scopeId("personal", "josh");
+const ERIC = scopeId("personal", "eric");
+const P = (id: string, teamIds: string[] = []): Principal => ({ id, type: "internal", teamIds });
+
+const manifest = (name: string): SkillManifest => ({
+  name,
+  description: "d",
+  requiredCapabilities: [],
+  body: `# ${name}`,
+});
+
+async function publishedSkill(store: SkillStore, scope: ScopeId, name: string) {
+  const s = await store.create({ scopeId: scope, manifest: manifest(name), createdBy: "josh" });
+  await store.review(s.id, "reviewer", []);
+  return store.publish(s.id);
+}
+
+test("person-to-person skill grant reaches the grantee's audience", async () => {
+  const acl = createAclStore();
+  await acl.grant({
+    ownerScopeId: JOSH,
+    ref: encodeRef(skillRef("s1")),
+    granteeScopeId: ERIC,
+    permission: "read",
+    grantedBy: "josh",
+  });
+
+  const inEricsDm = await acl.sharedOfKindForAudience("skill", [P("eric")], ERIC, ORG, principalEntitledToScope);
+  assert.deepEqual(
+    inEricsDm.map((g) => parseRef(g.ref).id),
+    ["s1"],
+  );
+
+  const together = await acl.sharedOfKindForAudience(
+    "skill",
+    [P("eric"), P("josh")],
+    scopeId("channel", "C"),
+    ORG,
+    principalEntitledToScope,
+  );
+  assert.equal(together.length, 1);
+
+  const mixed = await acl.sharedOfKindForAudience(
+    "skill",
+    [P("eric"), P("mallory")],
+    scopeId("channel", "C"),
+    ORG,
+    principalEntitledToScope,
+  );
+  assert.deepEqual(mixed, []);
+
+  const other = await acl.sharedOfKindForAudience(
+    "skill",
+    [P("alice")],
+    scopeId("personal", "alice"),
+    ORG,
+    principalEntitledToScope,
+  );
+  assert.deepEqual(other, []);
+});
+
+test("visibleFor includes granted skills, shadowed by scope-owned skills of the same name", async () => {
+  const store = createSkillStore({ signingSecret: "grant-test" });
+  const granted = await publishedSkill(store, JOSH, "quickbooks");
+  const own = await publishedSkill(store, ERIC, "quickbooks");
+  const unique = await publishedSkill(store, JOSH, "reconcile");
+
+  const before = await store.visibleFor([ERIC, ORG]);
+  assert.deepEqual(
+    before.map((r) => r.skill!.id),
+    [own.id],
+  );
+
+  const ref = (s: { id: string; scopeId: ReturnType<typeof scopeId> }) => ({ id: s.id, ownerScopeId: s.scopeId });
+
+  const withGrant = await store.visibleFor([ERIC, ORG], [ref(unique)]);
+  assert.deepEqual(new Set(withGrant.map((r) => r.skill!.id)), new Set([own.id, unique.id]));
+
+  const collided = await store.visibleFor([ERIC, ORG], [ref(granted), ref(unique)]);
+  const quickbooks = collided.filter((r) => r.skill!.manifest.name === "quickbooks");
+  assert.equal(quickbooks.length, 1);
+  assert.equal(quickbooks[0]!.skill!.id, own.id);
+  assert.deepEqual(
+    quickbooks[0]!.shadowed.map((s) => s.id),
+    [granted.id],
+  );
+
+  const draft = await store.create({ scopeId: JOSH, manifest: manifest("draft-skill"), createdBy: "josh" });
+  const ignored = await store.visibleFor([ERIC, ORG], [ref(draft), { id: "no-such-id", ownerScopeId: JOSH }]);
+  assert.deepEqual(
+    ignored.map((r) => r.skill!.id),
+    [own.id],
+  );
+});
+
+test("a grant redundant with scope visibility does not self-shadow", async () => {
+  const store = createSkillStore({ signingSecret: "self-shadow-test" });
+  const own = await publishedSkill(store, ERIC, "quickbooks");
+
+  const rows = await store.visibleFor([ERIC, ORG], [{ id: own.id, ownerScopeId: ERIC }]);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.skill!.id, own.id);
+  assert.deepEqual(rows[0]!.shadowed, []);
+});
+
+test("a grant whose claimed owner scope does not match the skill's home is ignored", async () => {
+  const store = createSkillStore({ signingSecret: "forge-test" });
+  const victim = await publishedSkill(store, JOSH, "victim-skill");
+
+  const forged = await store.visibleFor([ERIC, ORG], [{ id: victim.id, ownerScopeId: ERIC }]);
+  assert.deepEqual(forged, []);
+
+  const legit = await store.visibleFor([ERIC, ORG], [{ id: victim.id, ownerScopeId: JOSH }]);
+  assert.deepEqual(
+    legit.map((r) => r.skill!.id),
+    [victim.id],
+  );
+});


### PR DESCRIPTION
Auto-load person-to-person skill grants into the turn's skill list Sharing a skill to another user records an ACL grant, but the per-turn skill list was built only from visibleSkillScopes (own scope, shared-room layers, org) and never consulted grants — so the grantee's agent never saw the shared skill in its prompt index and it never materialized on disk. Deployments, files, and shared credentials all read grants on the turn path; skills were the odd one out. The ACL store gains sharedOfKindForAudience, and the orchestrator folds skill grants reaching the conversation's audience into the turn's skill list and sandbox materialization. A test covers a user-to-user share appearing in the grantee's next turn.

**Deployment notes**

Release note: pre-existing skill grants activate on upgrade; orgs that shared skills before (no-
op then) will see them start loading
Behavior flip on existing data: skill-share ACL grants that were previously inert (written but never
read on prompt assembly) become live on upgrade — any grants already sitting in upstream orgs'
acl_grants tables suddenly inject skills into grantees' prompts/sandboxes with no action taken at
upgrade time.
Security posture is considered in the diff (P0 fix validates grant owner scope against the skill's
home scope before dereferencing, blocking forged grants), which matters precisely because old
rows become live.
API change is additive: /v1/skills now folds in grants; no schema change (new
AclStore.sharedOfKindForAudience reads existing rows).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245505&installation_model_id=19911&pr_number=450&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F450&signature=e3a25c14e3d9d3bb1baf11dc64f1203296e6797cd4bc58d888b933845d6fa9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->