### PR TITLE
web-ui: remember the multi-view layout server-side per user

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -916,6 +916,24 @@ const routeRequest = async (req: IncomingMessage, res: ServerResponse) => {
       return relay(res, r);
     }
 
+    if (method === "GET" && path === "/api/ui-state") {
+      const key = url.searchParams.get("key") ?? "";
+      const qs = new URLSearchParams({ principalId: user, key });
+      const r = await coreFetch("GET", `/v1/ui-state?${qs.toString()}`);
+      return relay(res, r);
+    }
+
+    if (method === "PUT" && path === "/api/ui-state") {
+      let body: Record<string, unknown>;
+      try {
+        body = JSON.parse((await readBody(req)) || "{}") as Record<string, unknown>;
+      } catch {
+        return json(res, 400, { error: "bad_request" });
+      }
+      const r = await coreFetch("PUT", "/v1/ui-state", JSON.stringify({ ...body, principalId: user }));
+      return relay(res, r);
+    }
+
     if (method === "GET" && path === "/api/runtime-config") {
       const scopeId = url.searchParams.get("scopeId") || `personal:${user}`;
       const qs = new URLSearchParams({ principalId: user, scopeId });

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -449,6 +449,19 @@ export function reportSigninRequired(detail: SigninRequired): void {
   onSigninRequired?.(detail);
 }
 
+export interface UiStateRecord {
+  value: unknown;
+  updatedAt: number;
+}
+
+export function fetchUiState(key: string): Promise<UiStateRecord> {
+  return api<UiStateRecord>(`/api/ui-state?key=${encodeURIComponent(key)}`);
+}
+
+export function putUiState(key: string, value: unknown, updatedAt: number, init?: RequestInit): Promise<unknown> {
+  return api("/api/ui-state", { method: "PUT", body: JSON.stringify({ key, value, updatedAt }), ...init });
+}
+
 export async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(withBase(path), { headers: { "content-type": "application/json" }, ...init });
   const text = await r.text();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -36,6 +36,7 @@ import { clearAllDrafts, saveDraft, storedDraft } from "./drafts";
 import { deepLinkPath, isPlainLeftClick, parseDeepLink, UI_BASE } from "./deep-link";
 import {
   addBlankPane,
+  adoptRemoteSplit,
   canvasToast,
   drawCanvas,
   exitSplitIfActive,
@@ -838,6 +839,7 @@ export async function boot(): Promise<void> {
   ensureDeliveryStream();
   warmDeferredChunks();
   loadPersistedSplit();
+  await adoptRemoteSplit();
 
   const params = new URLSearchParams(location.search);
   const {

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -55,6 +55,7 @@ import {
 } from "./sessions";
 import { conversationBackground, type RowIndicators } from "./session-list";
 import type { CoreSession } from "./core-bridge";
+import { fetchUiState, putUiState } from "./core-bridge";
 
 export const splitState = {
   active: false,
@@ -62,6 +63,7 @@ export const splitState = {
 };
 
 const STORE_KEY = "web-ui:split-canvas:v1";
+const REMOTE_STATE_KEY = "split-canvas";
 
 interface PaneParams {
   sessionId?: string;
@@ -85,6 +87,9 @@ let toastMsg = "";
 let toastTimer: number | null = null;
 let headerSignature = "";
 let persistTimer: number | null = null;
+let remoteTimer: number | null = null;
+let remotePayload: { updatedAt: number } | null = null;
+let persistedUpdatedAt = 0;
 
 function uid(): string {
   return crypto.randomUUID().slice(0, 8);
@@ -93,11 +98,41 @@ function uid(): string {
 function persist(): void {
   try {
     if (dockApi) lastLayout = dockApi.toJSON();
-    localStorage.setItem(STORE_KEY, JSON.stringify({ v: 2, active: splitState.active, layout: lastLayout }));
+    persistedUpdatedAt = Date.now();
+    const payload = { v: 2, active: splitState.active, layout: lastLayout, updatedAt: persistedUpdatedAt };
+    localStorage.setItem(STORE_KEY, JSON.stringify(payload));
+    pushRemoteSoon(payload);
   } catch {
     void 0;
   }
 }
+
+function pushRemoteSoon(payload: { updatedAt: number }): void {
+  remotePayload = payload;
+  if (remoteTimer !== null) window.clearTimeout(remoteTimer);
+  remoteTimer = window.setTimeout(() => {
+    remoteTimer = null;
+    const p = remotePayload;
+    remotePayload = null;
+    if (p) void putUiState(REMOTE_STATE_KEY, p, p.updatedAt).catch(() => void 0);
+  }, 400);
+}
+
+function flushRemoteNow(): void {
+  if (remoteTimer !== null) {
+    window.clearTimeout(remoteTimer);
+    remoteTimer = null;
+  }
+  const p = remotePayload;
+  if (!p) return;
+  remotePayload = null;
+  void putUiState(REMOTE_STATE_KEY, p, p.updatedAt, { keepalive: true }).catch(() => void 0);
+}
+
+window.addEventListener("pagehide", flushRemoteNow);
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden") flushRemoteNow();
+});
 
 function persistSoon(): void {
   if (persistTimer !== null) window.clearTimeout(persistTimer);
@@ -304,16 +339,13 @@ export function exitSplitIfActive(): void {
   renderSidebarTop();
 }
 
-export function loadPersistedSplit(): void {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(localStorage.getItem(STORE_KEY) ?? "null");
-  } catch {
-    return;
-  }
+function adoptPersisted(raw: unknown): void {
   if (!raw || typeof raw !== "object") return;
-  const o = raw as { v?: unknown; active?: unknown; layout?: unknown };
+  const o = raw as { v?: unknown; active?: unknown; layout?: unknown; updatedAt?: unknown };
   if (o.v === 2) {
+    if (typeof o.updatedAt === "number") persistedUpdatedAt = o.updatedAt;
+    pendingSeed = null;
+    splitState.active = false;
     if (o.active !== true || !o.layout || typeof o.layout !== "object") return;
     const panels = (o.layout as { panels?: object }).panels;
     const n = panels && typeof panels === "object" ? Object.keys(panels).length : 0;
@@ -326,6 +358,38 @@ export function loadPersistedSplit(): void {
   if (!seeds) return;
   pendingSeed = { kind: "v1", seeds };
   splitState.active = true;
+}
+
+export function loadPersistedSplit(): void {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(localStorage.getItem(STORE_KEY) ?? "null");
+  } catch {
+    return;
+  }
+  adoptPersisted(raw);
+}
+
+export async function adoptRemoteSplit(timeoutMs = 2000): Promise<void> {
+  let rec: Awaited<ReturnType<typeof fetchUiState>>;
+  try {
+    rec = await Promise.race([
+      fetchUiState(REMOTE_STATE_KEY),
+      new Promise<never>((_, reject) => window.setTimeout(reject, timeoutMs)),
+    ]);
+  } catch {
+    return;
+  }
+  if (!rec || typeof rec !== "object") return;
+  const at = typeof rec.updatedAt === "number" ? rec.updatedAt : 0;
+  if (!rec.value || typeof rec.value !== "object" || at <= persistedUpdatedAt) return;
+  adoptPersisted(rec.value);
+  persistedUpdatedAt = at;
+  try {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ ...rec.value, updatedAt: at }));
+  } catch {
+    void 0;
+  }
 }
 
 export function restoredCanvasNeedsSessionList(): boolean {

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -170,3 +170,13 @@ test("a pane gives the conversation the same height chain the full-screen .main 
   assert.match(pane, /height: 100%;/, "…of definite height");
   assert.match(pane, /overflow: hidden;/, "…that clips instead of growing the pane");
 });
+
+test("adopting a remote layout normalizes the mirrored timestamp to the server record", () => {
+  const adopt = fn(split, "adoptRemoteSplit");
+  assert.match(adopt, /persistedUpdatedAt = at;/, "the in-memory watermark takes the server record's time");
+  assert.match(
+    adopt,
+    /JSON\.stringify\(\{ \.\.\.rec\.value, updatedAt: at \}\)/,
+    "the local mirror must carry the server-clamped timestamp, not the value's inner claim",
+  );
+});

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -45,6 +45,7 @@ import type { DeploymentLayerStore } from "../deployment/deployment-layer-store.
 import type { AmbientJudgmentStore } from "../surface-cache/ambient-judgment-store.ts";
 import type { AckEmojiPickStore } from "../surface-cache/ack-emoji-pick-store.ts";
 import type { ChannelPolicyStore } from "../surface-cache/channel-policy-store.ts";
+import type { UiStateStore } from "../surfaces/ui-state.ts";
 import type { RateLimiter } from "../ratelimit/rate-limiter.ts";
 import type { AdvisoryLock } from "../persistence/advisory-lock.ts";
 import type { SlackInstallationStore, SlackSocketAppIdReader } from "../surfaces/slack-installation.ts";
@@ -109,6 +110,7 @@ export interface ServerDeps {
   ambientJudgments?: AmbientJudgmentStore;
   ackEmojiPicks?: AckEmojiPickStore;
   channelPolicy?: ChannelPolicyStore;
+  uiState?: UiStateStore;
   environments?: EnvironmentStore;
   deploymentLayer?: DeploymentLayerStore;
   brokeredServices?: () => readonly string[];

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -20,6 +20,13 @@ import { renderAgentApis } from "../agent-api-catalog.ts";
 import { mintCapabilityToken, CAPABILITY_TTL_MS } from "../../auth/capability-token.ts";
 import { contentTypeWithUtf8Charset, pipeToResponse, sendJson } from "../http.ts";
 import { audit, isObj, orgScope } from "./shared.ts";
+import {
+  UI_STATE_KEY_PATTERN,
+  UI_STATE_MAX_BYTES,
+  UI_STATE_MAX_FUTURE_SKEW_MS,
+  storeUiState,
+  uiStateId,
+} from "../../surfaces/ui-state.ts";
 import { type ApiCtx, type Route } from "./route.ts";
 import {
   ARTIFACT_TYPES,
@@ -476,6 +483,34 @@ async function listScopeResources(ctx: ApiCtx): Promise<void> {
     skills: out.skills,
     manageable: out.manageable,
   });
+}
+
+async function getUiState(ctx: ApiCtx): Promise<void> {
+  const { res, deps, url } = ctx;
+  const principalId = url.searchParams.get("principalId");
+  const key = url.searchParams.get("key") ?? "";
+  if (!principalId || !UI_STATE_KEY_PATTERN.test(key))
+    return sendJson(res, 400, { error: "bad_request", message: "principalId and a valid key required" });
+  if (!deps.uiState) return sendJson(res, 404, { error: "not_found" });
+  const rec = await deps.uiState.get(uiStateId(principalId, key));
+  return sendJson(res, 200, rec ?? { value: null, updatedAt: 0 });
+}
+
+async function putUiState(ctx: ApiCtx): Promise<void> {
+  const { res, deps, body } = ctx;
+  const b = body as { principalId?: unknown; key?: unknown; value?: unknown; updatedAt?: unknown };
+  const principalId = typeof b.principalId === "string" ? b.principalId : "";
+  const key = typeof b.key === "string" ? b.key : "";
+  if (!principalId || !UI_STATE_KEY_PATTERN.test(key))
+    return sendJson(res, 400, { error: "bad_request", message: "principalId and a valid key required" });
+  if (b.value === undefined) return sendJson(res, 400, { error: "bad_request", message: "value required" });
+  if (Buffer.byteLength(JSON.stringify(b.value)) > UI_STATE_MAX_BYTES)
+    return sendJson(res, 413, { error: "payload_too_large", message: "ui state too large" });
+  if (!deps.uiState) return sendJson(res, 404, { error: "not_found" });
+  const claimed = typeof b.updatedAt === "number" && Number.isFinite(b.updatedAt) ? b.updatedAt : Date.now();
+  const updatedAt = Math.min(claimed, Date.now() + UI_STATE_MAX_FUTURE_SKEW_MS);
+  const result = await storeUiState(deps.uiState, uiStateId(principalId, key), { value: b.value, updatedAt });
+  return sendJson(res, 200, result);
 }
 
 async function getSelfMemory(ctx: ApiCtx): Promise<void> {
@@ -1342,6 +1377,8 @@ export const surfaceRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "POST", path: "/v1/conversations/:id/fork", auth: "either", handle: forkAgentConversation },
   { method: "GET", path: "/v1/contexts", auth: "source", handle: listContexts },
   { method: "GET", path: "/v1/scope-resources", auth: "source", handle: listScopeResources },
+  { method: "GET", path: "/v1/ui-state", auth: "source", handle: getUiState },
+  { method: "PUT", path: "/v1/ui-state", auth: "source", handle: putUiState },
   { method: "GET", path: "/v1/memory", auth: "source", handle: getSelfMemory },
   { method: "PUT", path: "/v1/memory", auth: "source", handle: putSelfMemory },
   { method: "GET", path: "/v1/memory/history", auth: "either", handle: getSelfMemoryHistory },

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ const server = createServer(built.app, {
   ...(built.ambientJudgments ? { ambientJudgments: built.ambientJudgments } : {}),
   ...(built.ackEmojiPicks ? { ackEmojiPicks: built.ackEmojiPicks } : {}),
   channelPolicy: built.channelPolicy,
+  uiState: built.uiState,
   environments: built.environments,
   sandboxMigration: built.sandboxMigration,
 });

--- a/src/surfaces/ui-state.ts
+++ b/src/surfaces/ui-state.ts
@@ -1,0 +1,42 @@
+import type { DurableMap } from "../persistence/durable-map.ts";
+
+export interface PersistedUiState {
+  value: unknown;
+  updatedAt: number;
+}
+
+export type UiStateStore = DurableMap<PersistedUiState>;
+
+export const UI_STATE_KEY_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+export const UI_STATE_MAX_BYTES = 65536;
+export const UI_STATE_MAX_FUTURE_SKEW_MS = 300_000;
+
+export function uiStateId(principalId: string, key: string): string {
+  return `${principalId}#${key}`;
+}
+
+export async function storeUiState(
+  store: UiStateStore,
+  id: string,
+  next: PersistedUiState,
+): Promise<{ ok: boolean; updatedAt: number }> {
+  if (!store.update || !store.insertIfAbsent) {
+    const existing = await store.get(id);
+    if (existing && existing.updatedAt > next.updatedAt) return { ok: false, updatedAt: existing.updatedAt };
+    await store.put(id, next);
+    return { ok: true, updatedAt: next.updatedAt };
+  }
+  for (;;) {
+    let refusedAt = 0;
+    const updated = await store.update(id, (existing) => {
+      if (existing.updatedAt > next.updatedAt) {
+        refusedAt = existing.updatedAt;
+        return existing;
+      }
+      return next;
+    });
+    if (refusedAt) return { ok: false, updatedAt: refusedAt };
+    if (updated) return { ok: true, updatedAt: next.updatedAt };
+    if (await store.insertIfAbsent(id, next)) return { ok: true, updatedAt: next.updatedAt };
+  }
+}

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -32,6 +32,7 @@ import { createSkillBundleStore, type SkillBundle, type SkillBundleStore } from 
 import { createGitFetcher, resolvePackAuth, type SkillPackFetcher } from "./skills/pack-fetcher.ts";
 import { installSeedSkills } from "./skills/seed.ts";
 import { createMemoryMap, createPostgresMapFactory, type DurableMap } from "./persistence/durable-map.ts";
+import type { PersistedUiState, UiStateStore } from "./surfaces/ui-state.ts";
 import { createPostgresLeaderLease, createNoopLeaderLease, type LeaderLease } from "./persistence/leader-lease.ts";
 import {
   createMemoryAdvisoryLock,
@@ -362,6 +363,7 @@ export interface BuiltApp {
   ambientJudgments?: AmbientJudgmentStore;
   ackEmojiPicks?: AckEmojiPickStore;
   channelPolicy: ChannelPolicyStore;
+  uiState: UiStateStore;
   skillSyncEngine: SkillSyncEngine;
   slackCore: SlackCoreClient;
 }
@@ -1484,6 +1486,7 @@ export function buildApp(
     ...(ambientJudgments ? { ambientJudgments } : {}),
     ...(ackEmojiPicks ? { ackEmojiPicks } : {}),
     channelPolicy,
+    uiState: artifactMap<PersistedUiState>("web_ui_state"),
     skillSyncEngine,
     slackCore,
   };

--- a/test/ui-state-http.test.ts
+++ b/test/ui-state-http.test.ts
@@ -1,0 +1,130 @@
+import "./support/auto-fake-sprites.ts";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+function start() {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "ui-state-http-")) }));
+  const server = createInsecureTestServer(built.app, {
+    admin: built.admin,
+    auditLog: built.auditLog,
+    uiState: built.uiState,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  return { base, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+const json = async (r: Response): Promise<any> => r.json();
+
+test("ui-state stores and returns a per-user record, isolated by principal", async () => {
+  const s = start();
+  try {
+    const empty = await json(await fetch(`${s.base}/v1/ui-state?principalId=U1&key=split-canvas`));
+    assert.equal(empty.value, null, "nothing stored yet");
+    assert.equal(empty.updatedAt, 0);
+
+    const layout = { v: 2, active: true, layout: { grid: {} }, updatedAt: 1111 };
+    const put = await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U1", key: "split-canvas", value: layout, updatedAt: 1111 }),
+    });
+    assert.equal(put.status, 200);
+
+    const got = await json(await fetch(`${s.base}/v1/ui-state?principalId=U1&key=split-canvas`));
+    assert.deepEqual(got.value, layout, "the stored layout round-trips");
+    assert.equal(got.updatedAt, 1111);
+
+    const other = await json(await fetch(`${s.base}/v1/ui-state?principalId=U2&key=split-canvas`));
+    assert.equal(other.value, null, "another user's state is separate");
+
+    const stale = await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U1", key: "split-canvas", value: { old: true }, updatedAt: 42 }),
+    });
+    assert.equal((await json(stale)).ok, false, "a stale write is refused");
+    const kept = await json(await fetch(`${s.base}/v1/ui-state?principalId=U1&key=split-canvas`));
+    assert.deepEqual(kept.value, layout, "the newer record survives a stale overwrite attempt");
+  } finally {
+    await s.close();
+  }
+});
+
+test("ui-state rejects bad keys and oversized values", async () => {
+  const s = start();
+  try {
+    const badKey = await fetch(`${s.base}/v1/ui-state?principalId=U1&key=No%20Good!`);
+    assert.equal(badKey.status, 400);
+
+    const noValue = await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U1", key: "split-canvas" }),
+    });
+    assert.equal(noValue.status, 400);
+
+    const huge = await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U1", key: "split-canvas", value: "x".repeat(140000) }),
+    });
+    assert.equal(huge.status, 413);
+  } finally {
+    await s.close();
+  }
+});
+
+test("ui-state measures the cap in bytes, races atomically, and clamps future clocks", async () => {
+  const s = start();
+  try {
+    const emoji = await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U3", key: "split-canvas", value: "\u{1F991}".repeat(20000) }),
+    });
+    assert.equal(emoji.status, 413, "a value under the UTF-16 length cap but over the byte cap is refused");
+
+    const race = (updatedAt: number, tag: string) =>
+      fetch(`${s.base}/v1/ui-state`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ principalId: "U3", key: "race", value: { tag }, updatedAt }),
+      });
+    for (let i = 0; i < 20; i++) {
+      const base = (i + 1) * 10;
+      await Promise.all([race(base + 2, "newer"), race(base + 1, "older")]);
+      const got = await json(await fetch(`${s.base}/v1/ui-state?principalId=U3&key=race`));
+      assert.deepEqual(got.value, { tag: "newer" }, "concurrent writes settle on the newest record");
+      assert.equal(got.updatedAt, base + 2);
+    }
+
+    const farFuture = Date.now() + 365 * 24 * 3600 * 1000;
+    await fetch(`${s.base}/v1/ui-state`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ principalId: "U3", key: "skewed", value: { v: 1 }, updatedAt: farFuture }),
+    });
+    const skewed = await json(await fetch(`${s.base}/v1/ui-state?principalId=U3&key=skewed`));
+    assert.ok(skewed.updatedAt < Date.now() + 600000, "a far-future client clock is clamped near server time");
+
+    const catchUp = await json(
+      await fetch(`${s.base}/v1/ui-state`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ principalId: "U3", key: "skewed", value: { v: 2 }, updatedAt: skewed.updatedAt + 1 }),
+      }),
+    );
+    assert.equal(catchUp.ok, true, "other devices are not locked out for the skew duration");
+  } finally {
+    await s.close();
+  }
+});


### PR DESCRIPTION
The multi-view (split canvas) arrangement was persisted only in localStorage, so it survived relaunching the same browser but came up empty on a new device, new profile, or cleared storage — nothing tied the layout to the user. Core gains a small per-user ui-state record (GET/PUT /v1/ui-state, backed by a durable map with a Postgres table and an in-memory fallback, 128 KB value cap); the web-ui server proxies it with the authenticated user's principal stamped in. The frontend keeps writing localStorage, pushes to the server debounced, and at boot adopts whichever of the local or server copy is newer — last write wins across devices.

**Deployment notes**

New DurableMap web_ui_state via the existing artifactMap pattern — table created idempotently
at boot, no migration step.
New GET/PUT /v1/ui-state (auth: source). Blue-green: during overlap an old instance 404s the
route; the client treats missing server state as absent and keeps localStorage, so degradation is
graceful.
Stale-write guard, 64KB byte cap, and +5min clock-skew clamp are server-side only; no config or
secret needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245583&installation_model_id=19911&pr_number=452&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F452&signature=94238addcc6c5fa4a66b305cb86f5b24c91684b9a32185d77eae461a03e147d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->