### PR TITLE
web-ui: sidebar session clicks load the chat from any view

### DIFF
--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -30,7 +30,7 @@ import {
 import { UI_BASE } from "./deep-link";
 import { errMessage } from "../../chassis/src/errors";
 import { actionSnippet, closeFormMenus, fieldSelect, formatBytes, icon, initials, relTime, toggleFormMenu } from "./ui";
-import { appState, renderSidebarTop, replacePanePreservingFocus, switchView, syncUrlFromState } from "./shell";
+import { appState, replacePanePreservingFocus, switchView, syncUrlFromState } from "./shell";
 import { mainConversation } from "./conversations";
 import { groupDmTitle, openSession, refreshSessions, sessionsState, slackLogo, surfaceOf } from "./sessions";
 import { activityOf } from "./session-list";
@@ -1235,7 +1235,5 @@ function startChatIn(c: CoreContext): void {
 }
 
 async function openFromContext(s: CoreSession): Promise<void> {
-  appState.currentView = "chats";
-  renderSidebarTop();
   await openSession(s);
 }

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -72,7 +72,7 @@ import {
 } from "./contexts";
 import { groupDmLabel, groupDmText } from "./group-dm-label";
 import { transcriptModel } from "./model-options";
-import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty } from "./shell";
+import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, syncUrlFromState } from "./shell";
 import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
@@ -81,6 +81,7 @@ import {
   endSessionDrag,
   notifySessionsChanged,
   closeSessionSurfaces,
+  drawCanvas,
   sessionInCanvas,
   splitInterceptsOpen,
   splitState,
@@ -1181,6 +1182,14 @@ export async function refreshSessions(
 }
 
 export async function openSession(s: CoreSession, entriesPrefetch?: Promise<TranscriptPage | null>): Promise<void> {
+  if (appState.currentView !== "chats") {
+    appState.currentView = "chats";
+    appState.viewRenderSeq++;
+    renderSidebarTop();
+    renderList();
+    if (splitState.active) drawCanvas();
+    syncUrlFromState(s.id || null);
+  }
   if (splitInterceptsOpen(s)) return;
   closeSidebarOnNarrowView();
   if (projectName(s.scopeId) && sessionsState.collapsedProjectScopes.delete(s.scopeId)) renderList();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -544,23 +544,21 @@ export function renderSidebarTop(): void {
           `,
         )}
       </nav>
-      ${
-        html`
-              <div class="section-label recents-label">
-                <span>Sessions</span>
-                <button
-                  class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
-                  type="button"
-                  role="switch"
-                  aria-checked=${sessionsState.webOnly ? "true" : "false"}
-                  title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
-                  @click=${toggleWebOnly}
-                >
-                  <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
-                </button>
-              </div>
-            `
-      }
+      ${html`
+        <div class="section-label recents-label">
+          <span>Sessions</span>
+          <button
+            class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
+            type="button"
+            role="switch"
+            aria-checked=${sessionsState.webOnly ? "true" : "false"}
+            title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
+            @click=${toggleWebOnly}
+          >
+            <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
+          </button>
+        </div>
+      `}
     `,
     appState.topEl,
   );

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -90,9 +90,11 @@ export function adminSessionLogUrl(sessionId: string, scopeId: string): string {
   return `${ADMIN_BASE}/?${q.toString()}`;
 }
 
-export function syncUrlFromState(): void {
+export function syncUrlFromState(sessionOverride?: string | null): void {
   const chatState = mainConversation().state;
-  const sessionId = splitState.active ? null : (chatState.sessionId ?? chatState.rememberedSessionId);
+  const fromState =
+    sessionOverride !== undefined ? sessionOverride : (chatState.sessionId ?? chatState.rememberedSessionId);
+  const sessionId = splitState.active ? null : fromState;
   const next = deepLinkPath(UI_BASE, appState.currentView, sessionId, contextsState.selected);
   if (`${location.pathname}${location.search}` !== next) history.replaceState(null, "", next);
 }

--- a/plugins/web-ui/test/open-session-view-switch.test.ts
+++ b/plugins/web-ui/test/open-session-view-switch.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sessions = readFileSync(new URL("../src/sessions.ts", import.meta.url), "utf8");
+const contexts = readFileSync(new URL("../src/contexts.ts", import.meta.url), "utf8");
+
+const openSessionBody = sessions.match(/export async function openSession\([^]*?\n\}/)?.[0] ?? "";
+
+test("openSession returns to the chats view before mounting (sidebar sessions are visible on every view)", () => {
+  const guard = openSessionBody.match(/if \(appState\.currentView !== "chats"\) \{[^]*?\n {2}\}/)?.[0] ?? "";
+  assert.ok(guard, "openSession must switch back to the chats view when invoked from another view");
+  assert.match(guard, /appState\.currentView = "chats"/);
+  assert.match(guard, /appState\.viewRenderSeq\+\+/, "must invalidate pending renders of the previous view");
+  assert.match(guard, /renderSidebarTop\(\)/);
+  assert.match(guard, /if \(splitState\.active\) drawCanvas\(\)/, "split canvas must be redrawn on return to chats");
+  assert.match(
+    guard,
+    /syncUrlFromState\(s\.id \|\| null\)/,
+    "URL must leave the old view — with the target session, not a stale remembered one — even when the split intercept returns early",
+  );
+  assert.ok(
+    openSessionBody.indexOf(guard) < openSessionBody.indexOf("splitInterceptsOpen"),
+    "view switch must happen before the split intercept so canvas opens intercept correctly",
+  );
+});
+
+test("openFromContext delegates the view switch to openSession", () => {
+  const body = contexts.match(/async function openFromContext\([^]*?\n\}/)?.[0] ?? "";
+  assert.ok(body, "openFromContext exists");
+  assert.match(body, /await openSession\(s\)/);
+  assert.doesNotMatch(body, /appState\.currentView = "chats"/);
+});


### PR DESCRIPTION
With the sidebar Sessions list visible on every view, clicking a session while on Projects (or Files, Crons, etc.) left a blank main pane: the conversation mounted but the chat renderer no-ops when the chats view isn't active, and the URL stayed on the old view. openSession now switches back to the chats view before mounting — redrawing the split canvas when it is active — syncs the URL to the target session rather than a stale remembered one, and the previous per-caller workaround i d is removed.

Stacked on #453 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789246044&installation_model_id=19911&pr_number=459&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F459&signature=c4463a69323bb85577fc2de3e64b81a69ea88c9758f16db61029480025665627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->