### PR TITLE
cron: make no-op PATCHes idempotent

### DIFF
--- a/src/api/control-service.ts
+++ b/src/api/control-service.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import type { Cron, CronFireLogEntry, CronSchedule, Destination, Principal } from "../types.ts";
 import type { CreateCronInput, CronPatch } from "../cron/cron-store.ts";
 import type { CapabilityClaims } from "../auth/capability-token.ts";
@@ -85,6 +86,9 @@ export interface CronRunsResult {
   total: number;
 }
 
+export const CRON_PATCH_NOTHING_TO_CHANGE =
+  "nothing to change — pass title, task, schedule, enabled, archived, unfurlLinks, runAs, or unattendedGrants";
+
 export type ControlOk<T> = { ok: true } & T;
 export type ControlErr<C extends string> = { ok: false; code: C; message: string };
 
@@ -155,6 +159,26 @@ function scopeIsMembershipControlled(scope: string, cap: { scopeId: string; priv
   return cap.privateScope === true && cap.scopeId === scope;
 }
 
+function hasCronPatchField(req: CronPatchRequest): boolean {
+  return (
+    req.title !== undefined ||
+    req.action !== undefined ||
+    req.text !== undefined ||
+    req.schedule !== undefined ||
+    req.enabled !== undefined ||
+    req.archived !== undefined ||
+    req.unfurlLinks !== undefined ||
+    req.runAs !== undefined ||
+    req.unattendedGrants !== undefined
+  );
+}
+
+function cronPatchChanges(before: Cron, patch: CronPatch): boolean {
+  return (Object.entries(patch) as Array<[keyof CronPatch, unknown]>).some(
+    ([key, value]) => !isDeepStrictEqual(before[key as keyof Cron], value),
+  );
+}
+
 export async function resolveRunAsChange(
   app: Pick<App, "samePerson">,
   before: Cron,
@@ -201,27 +225,16 @@ async function patchFromCronPatchRequest(
   req: CronPatchRequest,
   capability: CapabilityClaims,
 ): Promise<CronPatch | ControlErr<"bad_request" | "forbidden">> {
-  const mode = await resolveRunAsChange(app, before, req.runAs, capability);
-  if (!mode.ok) return mode;
-  const changesMode = mode.patch.runAs !== undefined;
-  if (
-    req.title === undefined &&
-    req.action === undefined &&
-    req.text === undefined &&
-    req.schedule === undefined &&
-    req.enabled === undefined &&
-    req.archived === undefined &&
-    req.unfurlLinks === undefined &&
-    req.unattendedGrants === undefined &&
-    !changesMode
-  ) {
+  if (!hasCronPatchField(req)) {
     return {
       ok: false,
       code: "bad_request",
-      message:
-        "nothing to change — pass title, task, schedule, enabled, archived, unfurlLinks, runAs, or unattendedGrants",
+      message: CRON_PATCH_NOTHING_TO_CHANGE,
     };
   }
+  const mode = await resolveRunAsChange(app, before, req.runAs, capability);
+  if (!mode.ok) return mode;
+  const changesMode = mode.patch.runAs !== undefined;
   if (req.unfurlLinks !== undefined && !before.destination) {
     return {
       ok: false,
@@ -531,6 +544,11 @@ export function createControlService(app: App, scheduler?: Scheduler, admin?: Ad
         const invalid = validateUnattendedGrants(req.unattendedGrants);
         if (invalid) return { ok: false, code: "bad_request", message: invalid };
       }
+      const patch = await patchFromCronPatchRequest(app, before, req, capability);
+      if ("ok" in patch) return patch;
+      if (req.unattendedGrants !== undefined) patch.unattendedGrants = req.unattendedGrants;
+      else if ((before.unattendedGrants?.length ?? 0) > 0) patch.unattendedGrants = before.unattendedGrants;
+      if (!cronPatchChanges(before, patch)) return { ok: true, cron: before };
       if ((before.unattendedGrants?.length ?? 0) > 0 || req.unattendedGrants !== undefined) {
         const refusal = await unattendedGrantRefusal(
           app,
@@ -547,10 +565,6 @@ export function createControlService(app: App, scheduler?: Scheduler, admin?: Ad
           return { ok: false, code, message: refusal };
         }
       }
-      const patch = await patchFromCronPatchRequest(app, before, req, capability);
-      if ("ok" in patch) return patch;
-      if (req.unattendedGrants !== undefined) patch.unattendedGrants = req.unattendedGrants;
-      else if ((before.unattendedGrants?.length ?? 0) > 0) patch.unattendedGrants = before.unattendedGrants;
       try {
         const cron = await app.updateCron(id, patch);
         if (!cron) return { ok: false, code: "not_found", message: `no cron ${id}` };

--- a/src/api/routes/crons.ts
+++ b/src/api/routes/crons.ts
@@ -7,6 +7,7 @@ import { sendJson } from "../http.ts";
 import { isObj } from "./shared.ts";
 import { decideRecipientConsent } from "../../triggers/trigger-store.ts";
 import { canAdministerCron } from "../control-service.ts";
+import { CRON_PATCH_NOTHING_TO_CHANGE } from "../control-service.ts";
 import { type ApiCtx, type Route } from "./route.ts";
 
 function defaultTimezoneFor(capability: CapabilityClaims | null): string {
@@ -131,6 +132,7 @@ function isCronPatch(b: unknown): b is {
   unattendedGrants?: string[];
 } {
   if (!isObj(b)) return false;
+  if (!hasCronPatchFields(b)) return true;
   const hasTitle = b.title !== undefined;
   const hasAction = b.action !== undefined;
   const hasTask = b.task !== undefined;
@@ -140,18 +142,6 @@ function isCronPatch(b: unknown): b is {
   const hasUnfurlLinks = b.unfurlLinks !== undefined;
   const hasRunAs = b.runAs !== undefined;
   const hasUnattendedGrants = b.unattendedGrants !== undefined;
-  if (
-    !hasTitle &&
-    !hasAction &&
-    !hasTask &&
-    !hasSchedule &&
-    !hasEnabled &&
-    !hasArchived &&
-    !hasUnfurlLinks &&
-    !hasRunAs &&
-    !hasUnattendedGrants
-  )
-    return false;
   if (hasTitle && typeof b.title !== "string") return false;
   if (hasAction && typeof b.action !== "string") return false;
   if (hasTask && typeof b.task !== "string") return false;
@@ -166,6 +156,20 @@ function isCronPatch(b: unknown): b is {
     return false;
   if (hasSchedule && scheduleFromBody(b.schedule) === null) return false;
   return true;
+}
+
+function hasCronPatchFields(b: Record<string, unknown>): boolean {
+  return (
+    b.title !== undefined ||
+    b.action !== undefined ||
+    b.task !== undefined ||
+    b.schedule !== undefined ||
+    b.enabled !== undefined ||
+    b.archived !== undefined ||
+    b.unfurlLinks !== undefined ||
+    b.runAs !== undefined ||
+    b.unattendedGrants !== undefined
+  );
 }
 
 const CRON_ERROR_STATUS: Record<string, number> = {
@@ -348,7 +352,7 @@ async function cronRuns(ctx: ApiCtx): Promise<void> {
 }
 
 const CRON_PATCH_BAD_REQUEST =
-  "expected a cron patch: title (string), task (string), schedule, enabled (boolean), archived (boolean), unfurlLinks (boolean), and/or runAs (owner/scopeFloor/scopeShared)";
+  "expected a cron patch: title (string), task (string), schedule, enabled (boolean), archived (boolean), unfurlLinks (boolean), runAs (owner/scopeFloor/scopeShared), and/or unattendedGrants (string[])";
 
 async function cronById(ctx: ApiCtx): Promise<void> {
   const { res, app, pathname, method, body, capability } = ctx;
@@ -367,6 +371,9 @@ async function cronById(ctx: ApiCtx): Promise<void> {
         : sendJson(res, CRON_ERROR_STATUS[r.code] ?? 400, { error: r.code, message: r.message });
     }
     if (!isCronPatch(body)) return sendJson(res, 400, { error: "bad_request", message: CRON_PATCH_BAD_REQUEST });
+    if (!hasCronPatchFields(body)) {
+      return sendJson(res, 400, { error: "bad_request", message: CRON_PATCH_NOTHING_TO_CHANGE });
+    }
     const schedule =
       body.schedule !== undefined ? scheduleFromBody(body.schedule, defaultTimezoneFor(capability))! : undefined;
     const task = body.action ?? body.task;
@@ -406,6 +413,9 @@ async function cronById(ctx: ApiCtx): Promise<void> {
     });
   }
   if (!isCronPatch(body)) return sendJson(res, 400, { error: "bad_request", message: CRON_PATCH_BAD_REQUEST });
+  if (!hasCronPatchFields(body)) {
+    return sendJson(res, 400, { error: "bad_request", message: CRON_PATCH_NOTHING_TO_CHANGE });
+  }
   if (body.runAs !== undefined)
     return sendJson(res, 403, {
       error: "forbidden",

--- a/test/capability-routes.test.ts
+++ b/test/capability-routes.test.ts
@@ -70,8 +70,8 @@ describe("capability-token control plane (crons + SOUL)", () => {
       config: built.config,
       admin: built.admin,
     });
-    await new Promise<void>((resolve) => server.listen(0, resolve));
-    base = `http://localhost:${(server.address() as AddressInfo).port}`;
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   });
 
   after(async () => {
@@ -607,6 +607,15 @@ describe("capability-token control plane (crons + SOUL)", () => {
     assert.equal(patched.cron.id, id);
     assert.equal(patched.cron.action, "edited");
     assert.equal(patched.cron.schedule.cron, "0 9 * * *");
+    const same = (await (
+      await patch(
+        `/v1/crons/${id}`,
+        { action: "edited", schedule: { cron: "0 9 * * *", timezone: "America/Los_Angeles" } },
+        { "x-agent-capability": await capFor("U1") },
+      )
+    ).json()) as any;
+    assert.equal(same.cron.id, id);
+    assert.equal(same.cron.action, "edited");
     const list = (await (await get("/v1/crons", { "x-agent-capability": await capFor("U1") })).json()) as any;
     assert.equal(list.crons.filter((c: any) => c.id === id).length, 1);
 
@@ -643,11 +652,16 @@ describe("capability-token control plane (crons + SOUL)", () => {
         { "x-agent-capability": await capFor("U1") },
       )
     ).json()) as any;
-    assert.equal(
-      (await patch(`/v1/crons/${created.cron.id}`, { nonsense: true }, { "x-agent-capability": await capFor("U1") }))
-        .status,
-      400,
+    const nonsense = await patch(
+      `/v1/crons/${created.cron.id}`,
+      { nonsense: true },
+      { "x-agent-capability": await capFor("U1") },
     );
+    assert.equal(nonsense.status, 400);
+    assert.match(((await nonsense.json()) as any).message, /nothing to change/);
+    const empty = await patch(`/v1/crons/${created.cron.id}`, {}, { "x-agent-capability": await capFor("U1") });
+    assert.equal(empty.status, 400);
+    assert.match(((await empty.json()) as any).message, /nothing to change/);
   });
 
   it("creates a scopeFloor cron when the token carries a member snapshot", async () => {

--- a/test/control-service.test.ts
+++ b/test/control-service.test.ts
@@ -102,6 +102,10 @@ test("unattended cron grants require a live org-admin owner and protect later pa
   assert.equal(tamper.ok, false);
   assert.match(tamper.ok ? "" : tamper.message, /live turn/);
 
+  const privilegedNoop = await control.patchCron(created.cron.id, { enabled: true }, claims("admin-alice"));
+  assert.ok(privilegedNoop.ok, "a privileged cron no-op does not need a live grant reaffirmation");
+  assert.deepEqual(privilegedNoop.ok ? privilegedNoop.cron.unattendedGrants : undefined, grant);
+
   const unattendedRun = await control.runCron(created.cron.id, claims("admin-alice"));
   assert.equal(unattendedRun.ok, false);
   assert.match(unattendedRun.ok ? "" : unattendedRun.message, /live turn/);
@@ -572,8 +576,16 @@ test("scopeShared is explicit: shared-scope crons default to owner, while collab
   assert.equal(afterMemberEdit.length, 1, "non-owner edit via control service notifies the owner");
   assert.equal(afterMemberEdit[0]!.destination.target, "U1");
 
+  const memberNoop = await control.patchCron(ok.cron.id, { title: "expo digest v2" }, chanClaims("U2"));
+  assert.ok(memberNoop.ok, JSON.stringify(memberNoop));
+  assert.equal((await editNotices()).length, 1, "same-value member edit produces no notice");
+
+  const memberChange = await control.patchCron(ok.cron.id, { title: "expo digest v3" }, chanClaims("U2"));
+  assert.ok(memberChange.ok, JSON.stringify(memberChange));
+  assert.equal((await editNotices()).length, 2, "a later real member edit still notifies the owner");
+
   await control.patchCron(ok.cron.id, { title: "owner tweak" }, chanClaims("U1"));
-  assert.equal((await editNotices()).length, 1, "owner self-edit produces no notice");
+  assert.equal((await editNotices()).length, 2, "owner self-edit produces no notice");
 
   const byOutsider = await control.patchCron(
     ok.cron.id,
@@ -718,7 +730,13 @@ test("app.turn forwards ownerKeychainUnion onto the persisted run request (else 
 });
 
 test("cron list / get / patch / delete / run round-trip with owner authz", async () => {
-  const { control } = setup();
+  const { built, control } = setup();
+  const updateCron = built.app.updateCron.bind(built.app);
+  let updateCalls = 0;
+  built.app.updateCron = async (id, patch) => {
+    updateCalls += 1;
+    return updateCron(id, patch);
+  };
   const created = await control.createCron(
     { title: "orig", schedule: { everyMs: 3_600_000 }, action: "do x" },
     claims("U1"),
@@ -743,6 +761,20 @@ test("cron list / get / patch / delete / run round-trip with owner authz", async
   assert.equal(patched.cron.title, "renamed");
   assert.equal(patched.cron.schedule.cron, "0 9 * * 1-5");
   assert.equal(patched.cron.destination?.unfurlLinks, false);
+  assert.equal(updateCalls, 1);
+
+  const same = await control.patchCron(
+    id,
+    { title: "renamed", schedule: { cron: "0 9 * * 1-5", timezone: "America/Los_Angeles" }, unfurlLinks: false },
+    claims("U1"),
+  );
+  assert.ok(same.ok, JSON.stringify(same));
+  assert.equal(same.cron.id, id);
+  assert.equal(updateCalls, 1, "same-value patches return the cron without writing");
+
+  const sameMode = await control.patchCron(id, { runAs: "owner" }, claims("U1"));
+  assert.ok(sameMode.ok, JSON.stringify(sameMode));
+  assert.equal(updateCalls, 1, "the current effective mode is a recognized no-op");
 
   const tooFrequent = await control.patchCron(id, { schedule: { everyMs: 1 } }, claims("U1"));
   assert.equal(tooFrequent.ok, false);
@@ -754,6 +786,7 @@ test("cron list / get / patch / delete / run round-trip with owner authz", async
   const empty = await control.patchCron(id, {}, claims("U1"));
   assert.equal(empty.ok, false);
   assert.equal(empty.ok ? "" : empty.code, "bad_request");
+  assert.match(empty.ok ? "" : empty.message, /nothing to change/);
 
   const disabled = await control.setCronEnabled(id, false, claims("U1"));
   assert.ok(disabled.ok);


### PR DESCRIPTION
PATCH /v1/crons/:id failed with 'nothing to change' whenever the caller sent values equal to the cron's current state — re-disabling an already-disabled cron, for instance — even though the request expressed a perfectly reasonable desired state. The error is now reserved for requests that carry no patchable field at all; a patch whose fields deep-equal the current record succeeds as a no-op and returns the unchanged cron, making retries and declarative callers safe.

Stacked on #460 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789246148&installation_model_id=19911&pr_number=461&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F461&signature=c62865c81fc859e0293d18d350ea45f61787e9cd11bf8d09eff7f9bc521d747a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->