### PR TITLE
[codex] Make deployment activation failures durable

### DIFF
--- a/plugins/web-ui/src/deploy-view.ts
+++ b/plugins/web-ui/src/deploy-view.ts
@@ -13,6 +13,7 @@ export interface DeploymentView {
   createdInScope?: string;
   currentVersion?: number;
   appliedVersion?: number;
+  deployingVersion?: number;
   webUrl?: string;
   gitUrl?: string;
   name?: string;
@@ -79,9 +80,13 @@ export function deploymentSlug(d: DeploymentView): string {
   return d.name?.trim() || d.id;
 }
 
+export function deploymentLiveVersion(d: DeploymentView): number | undefined {
+  return d.appliedVersion;
+}
+
 export function deploymentLatestAt(d: DeploymentView): number {
-  const applied = d.versions?.find((version) => version.version === (d.appliedVersion ?? d.currentVersion));
-  return applied?.createdAt ?? d.versions?.at(-1)?.createdAt ?? 0;
+  const liveVersion = deploymentLiveVersion(d);
+  return d.versions?.find((version) => version.version === liveVersion)?.createdAt ?? 0;
 }
 
 export function deploymentTab(d: DeploymentView, viewer: string | undefined): DeploymentTab {

--- a/plugins/web-ui/src/deploys.ts
+++ b/plugins/web-ui/src/deploys.ts
@@ -25,6 +25,7 @@ import {
   deploymentListRefreshCanRedraw,
   deploymentListAfterRestoreRefresh,
   deploymentLatestAt,
+  deploymentLiveVersion,
   deploymentSlug,
   deploymentTab,
   deploymentTabEmptyMessage,
@@ -81,6 +82,8 @@ function statusClass(d: DeploymentView): string {
   )
     return "deploying";
   if (d.status === "running") return "running";
+  if (d.status === "deploying") return "deploying";
+  if (d.status === "failed") return "failed";
   if (d.status === "archived") return "archived";
   return "stopped";
 }
@@ -97,7 +100,11 @@ function permissionBadge(d: DeploymentView): TemplateResult {
 
 function versionLabel(d: DeploymentView): string {
   if (d.currentVersion === undefined) return "Version unknown";
-  if (d.appliedVersion !== undefined && d.appliedVersion !== d.currentVersion)
+  if (d.status === "deploying" && d.deployingVersion !== undefined && d.deployingVersion !== d.appliedVersion)
+    return d.appliedVersion === undefined
+      ? `v${d.deployingVersion} pending`
+      : `v${d.appliedVersion} live · v${d.deployingVersion} pending`;
+  if (d.status === "deploying" && d.appliedVersion !== undefined && d.appliedVersion !== d.currentVersion)
     return `v${d.appliedVersion} live · v${d.currentVersion} pending`;
   return `v${d.currentVersion}`;
 }
@@ -390,8 +397,8 @@ function drawDeployDetail(d: DeploymentView, loading = false): void {
           <h3>Overview</h3>
           <div class="deploy-facts">
             <div><span>Status</span><strong>${statusLabel(d)}</strong></div>
-            <div><span>Live version</span><strong>${d.appliedVersion ?? d.currentVersion ?? "—"}</strong></div>
-            <div><span>Latest version</span><strong>${d.currentVersion ?? "—"}</strong></div>
+            <div><span>Live version</span><strong>${deploymentLiveVersion(d) ?? "—"}</strong></div>
+            <div><span>Current version</span><strong>${d.currentVersion ?? "—"}</strong></div>
             <div>
               <span>Last deployed</span
               ><strong>${deploymentLatestAt(d) ? new Date(deploymentLatestAt(d)).toLocaleString() : "—"}</strong>
@@ -491,7 +498,7 @@ function drawDeployDetail(d: DeploymentView, loading = false): void {
                       <div class="deploy-version-row">
                         <div>
                           <strong>v${version.version}</strong
-                          >${version.version === d.appliedVersion ? html`<span class="badge ok">Live</span>` : nothing}${version.version === d.currentVersion && version.version !== d.appliedVersion ? html`<span class="badge">Latest</span>` : nothing}
+                          >${version.version === d.appliedVersion ? html`<span class="badge ok">Live</span>` : nothing}
                         </div>
                         <div>
                           <span>${new Date(version.createdAt).toLocaleString()}</span

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5731,6 +5731,9 @@ a.chat-row-open {
 .deploy-status.deploying > span {
   background: #b78528;
 }
+.deploy-status.failed > span {
+  background: var(--destructive);
+}
 .deploy-status.archived > span {
   background: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
 }

--- a/plugins/web-ui/test/deploy-view.test.ts
+++ b/plugins/web-ui/test/deploy-view.test.ts
@@ -10,6 +10,7 @@ import {
   deploymentListAfterRestoreRefresh,
   deploymentListRefreshCanRedraw,
   deploymentLatestAt,
+  deploymentLiveVersion,
   deploymentSlug,
   deploymentTab,
   deploymentTabEmptyMessage,
@@ -26,6 +27,7 @@ function deployment(patch: Partial<DeploymentView>): DeploymentView {
     ownerScopeId: "personal:blair@example.com",
     createdBy: "blair@example.com",
     currentVersion: 1,
+    appliedVersion: 1,
     permission: "write",
     versions: [{ version: 1, createdAt: 100 }],
     ...patch,
@@ -161,6 +163,15 @@ test("last deployed uses the applied version instead of a pending version", () =
   assert.equal(deploymentLatestAt(d), 200);
 });
 
+test("a deployment that has never applied has no live version or deployed timestamp", () => {
+  const failed = deployment({ status: "failed", appliedVersion: undefined });
+  assert.equal(deploymentLiveVersion(failed), undefined);
+  assert.equal(deploymentLatestAt(failed), 0);
+  const archived = deployment({ status: "archived", appliedVersion: undefined });
+  assert.equal(deploymentLiveVersion(archived), undefined);
+  assert.equal(deploymentLatestAt(archived), 0);
+});
+
 test("list filtering composes tab, context, search, and newest-first sorting", () => {
   const deployments = [
     deployment({
@@ -217,7 +228,13 @@ test("list filtering composes tab, context, search, and newest-first sorting", (
 
 test("sorting supports newest, name, and status without changing the filtered set", () => {
   const deployments = [
-    deployment({ id: "z", displayName: "Zulu", status: "stopped", versions: [{ version: 1, createdAt: 300 }] }),
+    deployment({
+      id: "z",
+      displayName: "Zulu",
+      status: "stopped",
+      appliedVersion: 1,
+      versions: [{ version: 1, createdAt: 300 }],
+    }),
     deployment({ id: "a", displayName: "Alpha", status: "running", versions: [{ version: 1, createdAt: 200 }] }),
   ];
   const options = { tab: "yours" as const, scope: null, query: "", viewer: "blair@example.com" };

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -107,6 +107,7 @@ export interface DeploymentView {
   displayName?: string;
   currentVersion: number;
   appliedVersion?: number;
+  deployingVersion?: number;
   status: Deployment["status"];
   lastAccessAt?: number;
   createdAt?: number;
@@ -134,6 +135,7 @@ export function deploymentView(d: Deployment): DeploymentView {
     ...(d.displayName ? { displayName: d.displayName } : {}),
     currentVersion: d.currentVersion,
     ...(d.appliedVersion !== undefined ? { appliedVersion: d.appliedVersion } : {}),
+    ...(d.deployingVersion !== undefined ? { deployingVersion: d.deployingVersion } : {}),
     status: d.status,
     ...(d.lastAccessAt !== undefined ? { lastAccessAt: d.lastAccessAt } : {}),
     ...(versions[0] ? { createdAt: versions[0].createdAt } : {}),

--- a/src/api/routes/deployments.ts
+++ b/src/api/routes/deployments.ts
@@ -23,6 +23,7 @@ import { APP_SHELL_PATH_PREFIX, appShellHtml } from "../../deploy/app-shell.ts";
 import { principalDestination } from "../../reach/reach.ts";
 import { portalSessionSub } from "../../deploy/viewer-session.ts";
 import { proxyHeaders } from "../../util/http-proxy.ts";
+import { deployPushGitNamespace } from "../../deploy/deploy-store.ts";
 
 function isDeployInput(b: unknown): b is DeployInput {
   return (
@@ -757,7 +758,7 @@ export async function proxyDeploymentSubdomain(ctx: BaseCtx): Promise<boolean> {
     if (pathname === "/__claw__/version") {
       const d = await app.getDeployment(slug);
       if (!d) sendJson(res, 404, { error: "not_found" });
-      else sendJson(res, 200, { version: d.appliedVersion ?? d.currentVersion });
+      else sendJson(res, 200, { version: d.appliedVersion ?? null });
       return true;
     }
     sendJson(res, 404, { error: "not_found" });
@@ -985,6 +986,23 @@ function gitQueryString(url: URL): string {
   return qs.toString();
 }
 
+function receivePackCommands(body: Buffer): Array<{ ref: string; newOid: string }> {
+  const commands: Array<{ ref: string; newOid: string }> = [];
+  for (let offset = 0; offset + 4 <= body.length;) {
+    const lengthText = body.subarray(offset, offset + 4).toString("ascii");
+    if (!/^[0-9a-f]{4}$/i.test(lengthText)) break;
+    const length = Number.parseInt(lengthText, 16);
+    if (length === 0) break;
+    if (length < 4 || offset + length > body.length) break;
+    const line = body.subarray(offset + 4, offset + length).toString("utf8");
+    const command = /^[0-9a-f]{40} ([0-9a-f]{40}) ([^\0\n]+)/.exec(line);
+    if (!command) break;
+    commands.push({ newOid: command[1]!, ref: command[2]! });
+    offset += length;
+  }
+  return commands;
+}
+
 function headerEnd(buf: Buffer): { headEnd: number; bodyStart: number } | null {
   const crlf = buf.indexOf("\r\n\r\n");
   if (crlf >= 0) return { headEnd: crlf, bodyStart: crlf + 4 };
@@ -1000,6 +1018,7 @@ async function runGitHttpBackend(input: {
   query: string;
   contentType?: string;
   body: Buffer;
+  namespace?: string;
 }): Promise<{ status: number; headers: Record<string, string>; body: Buffer }> {
   const repoRoot = dirname(input.repoPath);
   const repoName = basename(input.repoPath);
@@ -1013,6 +1032,7 @@ async function runGitHttpBackend(input: {
     CONTENT_TYPE: input.contentType ?? "",
     CONTENT_LENGTH: String(input.body.length),
     REMOTE_USER: "deployment-git",
+    ...(input.namespace ? { GIT_NAMESPACE: input.namespace } : {}),
   };
   return new Promise((resolve, reject) => {
     const child = spawn("git", ["-c", "http.receivepack=true", "http-backend"], {
@@ -1081,6 +1101,12 @@ async function serveDeploymentGit(ctx: BaseCtx): Promise<void> {
   if (!repoPath) return sendJson(ctx.res, 404, { error: "not_found" });
   try {
     const body = ctx.method === "POST" ? await readRequestBytes(ctx.req) : Buffer.alloc(0);
+    if (
+      isPush &&
+      receivePackCommands(body).some(({ ref, newOid }) => ref !== "refs/heads/current" || /^0+$/.test(newOid))
+    ) {
+      return sendJson(ctx.res, 403, { error: "forbidden", message: "deployment pushes must update current" });
+    }
     const runBackend = () =>
       runGitHttpBackend({
         repoPath,
@@ -1089,6 +1115,7 @@ async function serveDeploymentGit(ctx: BaseCtx): Promise<void> {
         query: gitQueryString(ctx.url),
         contentType: typeof ctx.req.headers["content-type"] === "string" ? ctx.req.headers["content-type"] : undefined,
         body,
+        ...(isPush ? { namespace: deployPushGitNamespace } : {}),
       });
     const result = isPush
       ? await ctx.app.runDeploymentGitPush(parts.id, async () => {
@@ -1109,7 +1136,10 @@ async function serveDeploymentGit(ctx: BaseCtx): Promise<void> {
             };
           }
           const r = await runBackend();
-          return { result: r, ok: r.status >= 200 && r.status < 300 };
+          return {
+            result: r,
+            ok: r.status >= 200 && r.status < 300,
+          };
         })
       : await runBackend();
     ctx.res.writeHead(result.status, result.headers);

--- a/src/deploy/aws-deploy-provider.ts
+++ b/src/deploy/aws-deploy-provider.ts
@@ -655,10 +655,14 @@ export function createAwsDeployProvider(opts: AwsDeployProviderOptions): DeployP
       bumpResolveGen(d.id);
       const stored = await store.get(d.id);
       if (stored) {
-        await api.terminate(stored.microvmId).catch((e) => swallow("aws-deploy: destroy terminate", e));
+        try {
+          await api.terminate(stored.microvmId);
+        } catch (error) {
+          if (!(error instanceof AwsApiError && error.status === 404)) throw error;
+        }
         evict(stored.microvmId);
       }
-      await store.delete(d.id).catch((e) => swallow("aws-deploy: destroy clear pointer", e));
+      await store.delete(d.id);
     },
   };
 }

--- a/src/deploy/deploy-service.ts
+++ b/src/deploy/deploy-service.ts
@@ -1,6 +1,6 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join, dirname, resolve, relative, isAbsolute } from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { Grant, Permission, ScopeId } from "../types.ts";
 import { isManageableCreationScope, parseScopeId, scopeId } from "../types.ts";
 import type { AclStore } from "../acl/acl-store.ts";
@@ -8,13 +8,7 @@ import { deployRef, encodeRef } from "../acl/resource-ref.ts";
 import { normalizeRelPath } from "./deploy-fs.ts";
 import { samePerson } from "../directory/person.ts";
 import type { AuditLog } from "../audit/audit-log.ts";
-import {
-  deployCurrentGitRef,
-  type DeployStore,
-  type Deployment,
-  type DeployEndpoint,
-  type DeploymentVersion,
-} from "./deploy-store.ts";
+import { type DeployStore, type Deployment, type DeployEndpoint, type DeploymentVersion } from "./deploy-store.ts";
 import type { DeployProfile, DeployProvider } from "./deploy-provider.ts";
 import { createNoopLeaderLease, type LeaderLease } from "../persistence/leader-lease.ts";
 import { createNoopAdvisoryLock, type AdvisoryLock } from "../persistence/advisory-lock.ts";
@@ -139,6 +133,32 @@ function requiredEntrypoint(input: string | undefined, d: Deployment | null): st
   return entrypoint;
 }
 
+function deploymentSourceHash(input: {
+  entrypoint: string;
+  files: DeployFile[];
+  homeFiles?: DeployFile[];
+  env?: Record<string, string>;
+}): string {
+  const files = (input.files ?? [])
+    .map((file) => [file.path, Buffer.from(file.data).toString("base64")])
+    .sort(([a], [b]) => a!.localeCompare(b!));
+  const homeFiles = (input.homeFiles ?? [])
+    .map((file) => [file.path, Buffer.from(file.data).toString("base64")])
+    .sort(([a], [b]) => a!.localeCompare(b!));
+  const env = Object.fromEntries(Object.entries(input.env ?? {}).sort(([a], [b]) => a.localeCompare(b)));
+  return createHash("sha256")
+    .update(JSON.stringify({ entrypoint: input.entrypoint, files, homeFiles, env }))
+    .digest("hex");
+}
+
+async function removeSnapshot(root: string, path: string | undefined): Promise<void> {
+  if (!path) return;
+  const target = resolve(path);
+  const rel = relative(resolve(root), target);
+  if (!rel || rel.startsWith("..") || isAbsolute(rel)) return;
+  await rm(target, { recursive: true, force: true });
+}
+
 export function createDeployService(deps: DeployServiceDeps): DeployService {
   const leaderLease = deps.leaderLease ?? createNoopLeaderLease();
   const advisoryLock = deps.advisoryLock ?? createNoopAdvisoryLock();
@@ -167,39 +187,86 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
     } else {
       endpoint = await deps.provider.apply(d, version);
     }
-    if (endpoint.image && endpoint.image !== version.image) {
-      await deps.deployStore.setVersionImage(id, version.version, endpoint.image);
-    }
     return endpoint;
   };
 
-  const markVersionRunning = async (id: string, version: number, endpoint: DeployEndpoint): Promise<void> => {
-    await deps.deployStore.setEndpoint(id, endpoint);
-    await deps.deployStore.setStatus(id, "running");
-    await deps.deployStore.setAppliedVersion(id, version);
+  const activateVersion = async (id: string, version: DeploymentVersion): Promise<DeployEndpoint> => {
+    const before = await deps.deployStore.get(id);
+    await deps.deployStore.markDeploying(id, version.version);
+    try {
+      const endpoint = await applyVersion(id, version, before?.appliedVersion);
+      if (endpoint.image && endpoint.image !== version.image) {
+        await deps.deployStore.setVersionImage(id, version.version, endpoint.image);
+      }
+      await deps.deployStore.markApplied(id, version.version, endpoint);
+      return endpoint;
+    } catch (error) {
+      const persistFailure =
+        before?.status === "archived" ? deps.deployStore.markArchived : deps.deployStore.markFailed;
+      await persistFailure(id).catch((cleanupError) => swallow("deploy failure persistence", cleanupError));
+      if (before) {
+        try {
+          await deps.provider.destroy(before);
+          await deps.deployStore.markRuntimeClean(id);
+        } catch (cleanupError) {
+          swallow("deploy runtime cleanup", cleanupError);
+        }
+      }
+      throw error;
+    }
   };
 
-  const liveEndpoint = async (d: Deployment): Promise<DeployEndpoint> => {
-    if (!deps.provider.resolveEndpoint || d.endpoint == null) return d.endpoint!;
-    const version = d.versions.find((v) => v.version === d.currentVersion);
+  const cleanupPending = (d: Deployment): boolean =>
+    d.status === "deploying" ||
+    d.deployingVersion !== undefined ||
+    ((d.status === "archived" || d.status === "stopped") && d.endpoint != null);
+
+  const cleanInterruptedRuntime = async (d: Deployment): Promise<Deployment> => {
+    if (d.status === "deploying") await deps.deployStore.markFailed(d.id);
+    await deps.provider.destroy(d);
+    await deps.deployStore.markRuntimeClean(d.id);
+    return (await deps.deployStore.get(d.id)) ?? d;
+  };
+
+  const liveEndpoint = async (d: Deployment): Promise<DeployEndpoint | null> => {
+    const reapply = (): Promise<DeployEndpoint | null> =>
+      withDeployLock(d.id, async () => {
+        let cur = (await deps.deployStore.get(d.id)) ?? d;
+        if (cleanupPending(cur)) {
+          cur = await cleanInterruptedRuntime(cur);
+        }
+        if (
+          cur.status !== "running" &&
+          !(cur.status === "failed" && cur.appliedVersion !== undefined) &&
+          !(cur.status === "deploying" && cur.deployingVersion !== undefined)
+        )
+          return null;
+        const liveVersion =
+          cur.status === "deploying" ? (cur.deployingVersion ?? cur.appliedVersion) : cur.appliedVersion;
+        const selectedVersion = liveVersion ?? cur.currentVersion;
+        const v = cur.versions.find((x) => x.version === selectedVersion);
+        if (!v) return cur.endpoint;
+        if (cur.status === "running" && cur.endpoint != null) {
+          if (!deps.provider.resolveEndpoint) return cur.endpoint;
+          const again = await deps.provider.resolveEndpoint(cur, v);
+          if (again) {
+            if (!endpointsEqual(again, cur.endpoint)) await deps.deployStore.setEndpoint(cur.id, again);
+            return again;
+          }
+        }
+        return activateVersion(cur.id, v);
+      });
+    if (d.endpoint == null) return reapply();
+    if (!deps.provider.resolveEndpoint) return d.endpoint;
+    const liveVersion = d.appliedVersion ?? d.currentVersion;
+    const version = d.versions.find((v) => v.version === liveVersion);
     if (!version) return d.endpoint;
     const resolved = await deps.provider.resolveEndpoint(d, version);
     if (resolved) {
       if (!endpointsEqual(resolved, d.endpoint)) await deps.deployStore.setEndpoint(d.id, resolved);
       return resolved;
     }
-    return withDeployLock(d.id, async () => {
-      const cur = (await deps.deployStore.get(d.id)) ?? d;
-      const v = cur.versions.find((x) => x.version === cur.currentVersion) ?? version;
-      const again = await deps.provider.resolveEndpoint!(cur, v);
-      if (again) {
-        if (!endpointsEqual(again, cur.endpoint)) await deps.deployStore.setEndpoint(cur.id, again);
-        return again;
-      }
-      const fresh = await applyVersion(cur.id, v, cur.appliedVersion ?? cur.currentVersion);
-      await markVersionRunning(cur.id, v.version, fresh);
-      return fresh;
-    });
+    return reapply();
   };
 
   const deploymentRef = (id: string): string => encodeRef(deployRef(id));
@@ -343,9 +410,9 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
         ...(input.name !== undefined ? { name: input.name } : {}),
         ...(input.createdInScope !== undefined ? { createdInScope: input.createdInScope } : {}),
         ...(input.env ? { env: input.env } : {}),
+        sourceHash: deploymentSourceHash(input),
       });
-      const endpoint = await applyVersion(d.id, d.versions[0]!);
-      await markVersionRunning(d.id, d.versions[0]!.version, endpoint);
+      await withDeployLock(d.id, () => activateVersion(d.id, d.versions[0]!));
       deps.auditLog.record({
         at: Date.now(),
         principalId: input.createdBy,
@@ -358,7 +425,15 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
 
     async redeploy(id, input) {
       return withDeployLock(id, async () => {
-        const before = await deps.deployStore.get(id);
+        const sourceHash = deploymentSourceHash(input);
+        let before = await deps.deployStore.get(id);
+        if (before && cleanupPending(before)) before = await cleanInterruptedRuntime(before);
+        const retry =
+          before && (before.status === "failed" || before.status === "deploying")
+            ? [...before.versions]
+                .reverse()
+                .find((candidate) => candidate.version !== before.appliedVersion && candidate.sourceHash === sourceHash)
+            : undefined;
         const snapshotDir = await snapshotFiles(deps.deployDir, input.files);
         const homeDir = input.homeFiles?.length ? await snapshotFiles(deps.deployDir, input.homeFiles) : undefined;
         const v = await deps.deployStore.addVersion(id, {
@@ -367,11 +442,18 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
           files: input.files,
           ...(homeDir ? { homeDir } : {}),
           ...(input.env ? { env: input.env } : {}),
+          sourceHash,
         });
+        if (retry?.version === v.version) {
+          await removeSnapshot(deps.deployDir, retry.snapshotDir);
+          await removeSnapshot(deps.deployDir, retry.homeDir);
+        } else if (v.snapshotDir !== snapshotDir) {
+          await removeSnapshot(deps.deployDir, snapshotDir);
+          await removeSnapshot(deps.deployDir, homeDir);
+        }
         const d = await deps.deployStore.get(id);
         if (!d) throw new Error(`unknown deployment: ${id}`);
-        const endpoint = await applyVersion(id, v, before?.appliedVersion ?? before?.currentVersion);
-        await markVersionRunning(id, v.version, endpoint);
+        await activateVersion(id, v);
         deps.auditLog.record({
           at: Date.now(),
           principalId: d.createdBy,
@@ -394,12 +476,11 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
     async rollbackDeployment(id, version) {
       return withDeployLock(id, async () => {
         const before = await deps.deployStore.get(id);
-        await deps.deployStore.setCurrentVersion(id, version);
+        if (before && cleanupPending(before)) await cleanInterruptedRuntime(before);
         const v = await deps.deployStore.versionOf(id, version);
         const d = await deps.deployStore.get(id);
         if (!d || !v) return;
-        const endpoint = await applyVersion(id, v, before?.appliedVersion ?? before?.currentVersion);
-        await markVersionRunning(id, v.version, endpoint);
+        await activateVersion(id, v);
         deps.auditLog.record({
           at: Date.now(),
           principalId: d.createdBy,
@@ -414,35 +495,27 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
       return withDeployLock(id, async () => {
         const d = await deps.deployStore.get(id);
         if (!d) return;
-        await deps.provider.destroy(d);
-        await deps.deployStore.setStatus(id, "archived");
-        await deps.deployStore.setEndpoint(id, null);
+        await deps.deployStore.markArchived(id);
+        try {
+          await deps.provider.destroy(d);
+          await deps.deployStore.markRuntimeClean(id);
+        } catch (error) {
+          swallow("deploy archive cleanup", error);
+        }
       });
     },
 
     async restoreDeployment(id, actorId) {
       return withDeployLock(id, async () => {
-        const d = await deps.deployStore.get(id);
+        let d = await deps.deployStore.get(id);
         if (!d) throw new Error(`unknown deployment: ${id}`);
         if (d.status === "running") return d;
         if (d.status !== "archived") throw new Error(`deployment is not archived: ${id}`);
-        const version = d.versions.find((v) => v.version === d.currentVersion);
-        if (!version) throw new Error(`no such version ${d.currentVersion}`);
-        try {
-          const endpoint = await applyVersion(id, version, d.appliedVersion);
-          await markVersionRunning(id, version.version, endpoint);
-        } catch (error) {
-          await deps.provider
-            .destroy(d)
-            .catch((cleanupError) => swallow("deploy restore runtime cleanup", cleanupError));
-          await deps.deployStore
-            .setStatus(id, "archived")
-            .catch((cleanupError) => swallow("deploy restore status cleanup", cleanupError));
-          await deps.deployStore
-            .setEndpoint(id, null)
-            .catch((cleanupError) => swallow("deploy restore endpoint cleanup", cleanupError));
-          throw error;
-        }
+        if (cleanupPending(d)) d = await cleanInterruptedRuntime(d);
+        const liveVersion = d.appliedVersion ?? d.currentVersion;
+        const version = d.versions.find((v) => v.version === liveVersion);
+        if (!version) throw new Error(`no such version ${liveVersion}`);
+        await activateVersion(id, version);
         deps.auditLog.record({
           at: Date.now(),
           principalId: actorId ?? d.createdBy,
@@ -492,9 +565,18 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
 
     async reachDeployment(idOrName, principalId, opts = {}): Promise<Reach> {
       const d = (await deps.deployStore.get(idOrName)) ?? (await deps.deployStore.getByName(idOrName));
-      if (!d || d.status !== "running" || d.endpoint == null) return { status: "not_found" };
+      if (
+        !d ||
+        !(
+          (d.status === "running" && d.endpoint != null) ||
+          (d.status === "failed" && d.appliedVersion !== undefined) ||
+          (d.status === "deploying" && d.deployingVersion !== undefined)
+        )
+      )
+        return { status: "not_found" };
       if (!opts.bypassAcl && !(await reachAllowed(d, principalId))) return { status: "denied" };
       const endpoint = await liveEndpoint(d);
+      if (!endpoint) return { status: "not_found" };
       await deps.deployStore.touch(d.id, Date.now());
       return { status: "ok", endpoint };
     },
@@ -506,19 +588,28 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
 
     async pushGit(id, runReceivePack) {
       return withDeployLock(id, async () => {
-        const { result, ok } = await runReceivePack();
-        if (!ok) return result;
+        const beforePush = await deps.deployStore.get(id);
+        if (beforePush && cleanupPending(beforePush)) await cleanInterruptedRuntime(beforePush);
+        const baseline = await deps.deployStore.preparePush(id);
+        let received: Awaited<ReturnType<typeof runReceivePack>>;
+        try {
+          received = await runReceivePack();
+        } catch (error) {
+          await deps.deployStore
+            .takePushedCommit(id, baseline)
+            .catch((cleanupError) => swallow("deploy pushed ref cleanup", cleanupError));
+          throw error;
+        }
+        const pushed = await deps.deployStore.takePushedCommit(id, baseline);
+        if (!received.ok || !pushed) return received.result;
         let ownerScopeId = "unknown";
         try {
           const before = await deps.deployStore.get(id);
-          if (!before) return result;
+          if (!before) return received.result;
           ownerScopeId = before.ownerScopeId;
-          const pushed = await deps.deployStore.refOf(id, deployCurrentGitRef);
-          if (!pushed) return result;
           const v = await deps.deployStore.addVersionFromCommit(id, pushed);
-          if (!v) return result;
-          const endpoint = await applyVersion(id, v, before.appliedVersion ?? before.currentVersion);
-          await markVersionRunning(id, v.version, endpoint);
+          if (!v) return received.result;
+          await activateVersion(id, v);
           deps.auditLog.record({
             at: Date.now(),
             principalId: before.createdBy,
@@ -537,26 +628,38 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
             status: "error",
           });
         }
-        return result;
+        return received.result;
       });
     },
 
     async reapIdleDeployments(ttlMs, now = Date.now()) {
       const result = await leaderLease.hold("deployments:reaper", async () => {
-        if (deps.provider.profile.managedScaleToZero) return 0;
         let stopped = 0;
         for (const d of await deps.deployStore.list()) {
-          if (d.status !== "running") continue;
-          const last = d.lastAccessAt ?? d.versions[d.versions.length - 1]?.createdAt ?? 0;
-          if (now - last < ttlMs) continue;
-          await withDeployLock(d.id, async () => {
-            const cur = await deps.deployStore.get(d.id);
-            if (!cur || cur.status !== "running") return;
-            await deps.provider.destroy(cur);
-            await deps.deployStore.setStatus(d.id, "stopped");
-            await deps.deployStore.setEndpoint(d.id, null);
-            stopped++;
-          });
+          try {
+            if (cleanupPending(d)) {
+              await withDeployLock(d.id, async () => {
+                const cur = await deps.deployStore.get(d.id);
+                if (!cur || !cleanupPending(cur)) return;
+                await cleanInterruptedRuntime(cur);
+              });
+              continue;
+            }
+            if (deps.provider.profile.managedScaleToZero) continue;
+            if (d.status !== "running") continue;
+            const last = d.lastAccessAt ?? d.versions[d.versions.length - 1]?.createdAt ?? 0;
+            if (now - last < ttlMs) continue;
+            await withDeployLock(d.id, async () => {
+              const cur = await deps.deployStore.get(d.id);
+              if (!cur || cur.status !== "running") return;
+              await deps.deployStore.markStopped(d.id);
+              await deps.provider.destroy(cur);
+              await deps.deployStore.markRuntimeClean(d.id);
+              stopped++;
+            });
+          } catch (error) {
+            swallow(`deploy reaper: ${d.id}`, error);
+          }
         }
         return stopped;
       });

--- a/src/deploy/deploy-store.ts
+++ b/src/deploy/deploy-store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { ScopeId } from "../types.ts";
 import { createMemoryMap, type DurableMap } from "../persistence/durable-map.ts";
+import { swallow } from "../util/errors.ts";
 import {
   createDeployGitStore,
   type DeployGitDiff,
@@ -17,6 +18,7 @@ export interface DeploymentVersion {
   snapshotDir: string;
   homeDir?: string;
   image?: string;
+  sourceHash?: string;
   commit?: string;
   parentCommit?: string;
   env?: Record<string, string>;
@@ -44,7 +46,7 @@ export function publicUrlOf(endpoint: DeployEndpoint | null | undefined): string
   }
 }
 
-type DeploymentStatus = "running" | "stopped" | "archived";
+type DeploymentStatus = "deploying" | "running" | "stopped" | "failed" | "archived";
 
 interface DefaultAudienceSnapshot {
   sourceScopeId: ScopeId;
@@ -65,6 +67,7 @@ export interface Deployment {
   endpoint: DeployEndpoint | null;
   lastAccessAt?: number;
   appliedVersion?: number;
+  deployingVersion?: number;
   versions: DeploymentVersion[];
 }
 
@@ -74,6 +77,7 @@ interface VersionInput {
   homeDir?: string;
   env?: Record<string, string>;
   files?: DeployGitInputFile[];
+  sourceHash?: string;
 }
 
 export interface DeployStore {
@@ -89,6 +93,12 @@ export interface DeployStore {
   setVersionImage(id: string, version: number, image: string): Promise<void>;
   setStatus(id: string, status: DeploymentStatus): Promise<void>;
   setEndpoint(id: string, endpoint: DeployEndpoint | null): Promise<void>;
+  markDeploying(id: string, version: number): Promise<void>;
+  markFailed(id: string): Promise<void>;
+  markApplied(id: string, version: number, endpoint: DeployEndpoint): Promise<void>;
+  markArchived(id: string): Promise<void>;
+  markStopped(id: string): Promise<void>;
+  markRuntimeClean(id: string): Promise<void>;
   setName(id: string, name: string): Promise<void>;
   setOwnerScope(id: string, ownerScopeId: ScopeId): Promise<void>;
   setDisplayName(id: string, displayName: string | undefined): Promise<void>;
@@ -100,6 +110,8 @@ export interface DeployStore {
   filesOf(id: string, version: number, paths?: string[]): Promise<DeployGitInputFile[] | null>;
   diffVersions(id: string, fromVersion: number | undefined, toVersion: number): Promise<DeployGitDiff | null>;
   bundleOf(id: string, version: number): Promise<Uint8Array | null>;
+  preparePush(id: string): Promise<string | null>;
+  takePushedCommit(id: string, baseline: string | null): Promise<string | null>;
   refOf(id: string, ref: string): Promise<string | null>;
   repoUrl(id: string): Promise<string>;
 }
@@ -110,6 +122,8 @@ export interface DeployStoreBackings {
 }
 
 const CURRENT_REF = "refs/heads/current";
+export const deployPushGitNamespace = "pending";
+const PUSH_REF = `refs/namespaces/${deployPushGitNamespace}/refs/heads/current`;
 const versionRef = (version: number): string => `refs/versions/${version}`;
 
 function normalizeBackings(backing?: DurableMap<Deployment> | DeployStoreBackings): {
@@ -126,6 +140,18 @@ function normalizeBackings(backing?: DurableMap<Deployment> | DeployStoreBacking
 
 export function createDeployStore(backing?: DurableMap<Deployment> | DeployStoreBackings): DeployStore {
   const { deployments: backingMap, git } = normalizeBackings(backing);
+
+  async function updateDeployment(
+    id: string,
+    update: (deployment: Deployment) => Deployment,
+  ): Promise<Deployment | null> {
+    if (backingMap.update) return backingMap.update(id, update);
+    const current = await backingMap.get(id);
+    if (!current) return null;
+    const next = update(current);
+    await backingMap.put(id, next);
+    return next;
+  }
 
   async function makeVersion(
     deploymentId: string,
@@ -149,6 +175,7 @@ export function createDeployStore(backing?: DurableMap<Deployment> | DeployStore
       snapshotDir: input.snapshotDir,
       ...(input.homeDir ? { homeDir: input.homeDir } : {}),
       ...(input.env ? { env: input.env } : {}),
+      ...(input.sourceHash ? { sourceHash: input.sourceHash } : {}),
       ...(commit ? { commit } : {}),
       ...(parentCommit ? { parentCommit } : {}),
     };
@@ -160,9 +187,84 @@ export function createDeployStore(backing?: DurableMap<Deployment> | DeployStore
     await git.setRef(deploymentId, `refs/deploy-commits/${version.commit}`, version.commit);
   }
 
-  async function updateAppliedRef(deploymentId: string, version: DeploymentVersion): Promise<void> {
-    if (version.commit) await git.setRef(deploymentId, CURRENT_REF, version.commit);
-    else await git.deleteRef(deploymentId, CURRENT_REF);
+  function sameSource(a: DeploymentVersion, b: DeploymentVersion): boolean {
+    return (
+      a.entrypoint === b.entrypoint &&
+      a.homeDir === b.homeDir &&
+      JSON.stringify(a.env ?? {}) === JSON.stringify(b.env ?? {})
+    );
+  }
+
+  function sameRuntime(a: DeploymentVersion, b: DeploymentVersion): boolean {
+    return sameSource(a, b) && a.image === b.image;
+  }
+
+  async function resolveAppliedVersion(deploymentId: string, deployment?: Deployment): Promise<number | undefined> {
+    const d = deployment ?? (await backingMap.get(deploymentId));
+    if (!d || d.appliedVersion !== undefined) return d?.appliedVersion;
+    const currentRef = await git.refOf(deploymentId, CURRENT_REF);
+    if (!currentRef) return undefined;
+    const matches = d.versions.filter((version) => version.commit === currentRef);
+    if (!matches.length || !matches.every((version) => sameRuntime(version, matches[0]!))) return undefined;
+    const inferred = matches.find((version) => version.version === d.currentVersion) ?? matches.at(-1)!;
+    const updated = await updateDeployment(deploymentId, (current) =>
+      current.appliedVersion === undefined
+        ? { ...current, appliedVersion: inferred.version, currentVersion: inferred.version }
+        : current,
+    );
+    return updated?.appliedVersion;
+  }
+
+  async function syncAppliedRef(deploymentId: string, deployment?: Deployment): Promise<void> {
+    const d = deployment ?? (await backingMap.get(deploymentId));
+    if (!d) return;
+    const appliedVersion = d.appliedVersion ?? (await resolveAppliedVersion(deploymentId, d));
+    if (appliedVersion === undefined) return;
+    const version = d.versions.find((candidate) => candidate.version === appliedVersion);
+    const expected = version?.commit;
+    if (!expected) {
+      await git.deleteRef(deploymentId, CURRENT_REF);
+      return;
+    }
+    const actual = await git.refOf(deploymentId, CURRENT_REF);
+    if (actual === expected) return;
+    await git.setRef(deploymentId, CURRENT_REF, expected);
+  }
+
+  async function normalizeLegacy(deployment: Deployment): Promise<Deployment> {
+    if (deployment.status === "running" && deployment.deployingVersion !== undefined) {
+      deployment =
+        (await updateDeployment(deployment.id, (current) => {
+          if (current.status !== "running" || current.deployingVersion === undefined) return current;
+          const { deployingVersion: _, ...rest } = current;
+          return rest;
+        })) ?? deployment;
+    }
+    if (
+      deployment.appliedVersion !== undefined &&
+      deployment.status !== "deploying" &&
+      deployment.currentVersion !== deployment.appliedVersion
+    ) {
+      deployment =
+        (await updateDeployment(deployment.id, (current) =>
+          current.appliedVersion !== undefined &&
+          current.status !== "deploying" &&
+          current.currentVersion !== current.appliedVersion
+            ? { ...current, currentVersion: current.appliedVersion }
+            : current,
+        )) ?? deployment;
+    }
+    if (deployment.appliedVersion !== undefined) return deployment;
+    const appliedVersion = await resolveAppliedVersion(deployment.id, deployment);
+    if (appliedVersion !== undefined) return (await backingMap.get(deployment.id)) ?? deployment;
+    if (deployment.status !== "stopped") return deployment;
+    return (
+      (await updateDeployment(deployment.id, (current) =>
+        current.appliedVersion === undefined && current.status === "stopped"
+          ? { ...current, status: "failed", deployingVersion: current.currentVersion }
+          : current,
+      )) ?? deployment
+    );
   }
 
   return {
@@ -187,20 +289,63 @@ export function createDeployStore(backing?: DurableMap<Deployment> | DeployStore
     async addVersion(id, input) {
       const d = await backingMap.get(id);
       if (!d) throw new Error(`unknown deployment: ${id}`);
+      const retry =
+        (d.status === "failed" || d.status === "deploying") && input.sourceHash
+          ? [...d.versions]
+              .reverse()
+              .find((candidate) => candidate.version !== d.appliedVersion && candidate.sourceHash === input.sourceHash)
+          : undefined;
+      if (retry) {
+        const refreshed = {
+          ...retry,
+          snapshotDir: input.snapshotDir,
+          ...(input.homeDir ? { homeDir: input.homeDir } : {}),
+        };
+        await updateDeployment(id, (current) => ({
+          ...current,
+          status: "deploying",
+          endpoint: null,
+          deployingVersion: retry.version,
+          versions: current.versions.map((candidate) => (candidate.version === retry.version ? refreshed : candidate)),
+        }));
+        return refreshed;
+      }
       const version = d.versions.length + 1;
       const parentCommit = d.versions.find((x) => x.version === d.currentVersion)?.commit;
       const v = await makeVersion(id, version, input, parentCommit);
-      d.versions.push(v);
-      d.currentVersion = version;
-      await backingMap.put(id, d);
+      await updateDeployment(id, (current) => {
+        if (current.versions.length + 1 !== version) throw new Error(`deployment version changed: ${id}`);
+        return {
+          ...current,
+          status: "deploying",
+          endpoint: null,
+          deployingVersion: version,
+          versions: [...current.versions, v],
+        };
+      });
       await updateVersionRef(id, v);
       return v;
     },
     async addVersionFromCommit(id, commit) {
-      const d = await backingMap.get(id);
-      if (!d) throw new Error(`unknown deployment: ${id}`);
+      const raw = await backingMap.get(id);
+      if (!raw) throw new Error(`unknown deployment: ${id}`);
+      const d = await normalizeLegacy(raw);
+      const appliedVersion = await resolveAppliedVersion(id, d);
       const current = d.versions.find((x) => x.version === d.currentVersion);
-      if (current?.commit === commit) return null;
+      const applied = d.versions.find((x) => x.version === appliedVersion);
+      if (applied?.commit === commit && d.status === "running") return null;
+      const existing = d.versions
+        .filter((candidate) => candidate.commit === commit && (!current || sameSource(candidate, current)))
+        .at(-1);
+      if (existing) {
+        await updateDeployment(id, (latest) => ({
+          ...latest,
+          status: "deploying",
+          endpoint: null,
+          deployingVersion: existing.version,
+        }));
+        return existing;
+      }
       const version = d.versions.length + 1;
       const v: DeploymentVersion = {
         version,
@@ -212,89 +357,131 @@ export function createDeployStore(backing?: DurableMap<Deployment> | DeployStore
         commit,
         ...(current?.commit ? { parentCommit: current.commit } : {}),
       };
-      d.versions.push(v);
-      d.currentVersion = version;
-      await backingMap.put(id, d);
+      await updateDeployment(id, (latest) => {
+        if (latest.versions.length + 1 !== version) throw new Error(`deployment version changed: ${id}`);
+        return {
+          ...latest,
+          status: "deploying",
+          endpoint: null,
+          deployingVersion: version,
+          versions: [...latest.versions, v],
+        };
+      });
       await updateVersionRef(id, v);
       return v;
     },
-    get: (id) => backingMap.get(id),
-    getByName: async (name) => (await backingMap.all()).find((d) => d.name === name) ?? null,
-    list: () => backingMap.all(),
-    async setCurrentVersion(id, version) {
+    async get(id) {
       const d = await backingMap.get(id);
-      if (!d) return;
-      const v = d.versions.find((x) => x.version === version);
-      if (!v) throw new Error(`no such version ${version}`);
-      d.currentVersion = version;
-      await backingMap.put(id, d);
+      if (!d) return null;
+      return normalizeLegacy(d);
+    },
+    async getByName(name) {
+      const d = (await backingMap.all()).find((candidate) => candidate.name === name) ?? null;
+      if (!d) return null;
+      return normalizeLegacy(d);
+    },
+    async list() {
+      const deployments = await backingMap.all();
+      await Promise.all(deployments.map(normalizeLegacy));
+      return backingMap.all();
+    },
+    async setCurrentVersion(id, version) {
+      await updateDeployment(id, (d) => {
+        if (!d.versions.some((candidate) => candidate.version === version))
+          throw new Error(`no such version ${version}`);
+        return { ...d, currentVersion: version };
+      });
     },
     async setVersionImage(id, version, image) {
-      const d = await backingMap.get(id);
-      if (!d) return;
-      const v = d.versions.find((x) => x.version === version);
-      if (!v) throw new Error(`no such version ${version}`);
-      v.image = image;
-      await backingMap.put(id, d);
+      await updateDeployment(id, (d) => {
+        if (!d.versions.some((candidate) => candidate.version === version))
+          throw new Error(`no such version ${version}`);
+        return {
+          ...d,
+          versions: d.versions.map((candidate) =>
+            candidate.version === version ? { ...candidate, image } : candidate,
+          ),
+        };
+      });
     },
     async setStatus(id, status) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.status = status;
-        await backingMap.put(id, d);
-      }
+      await backingMap.merge(id, { status });
     },
     async setEndpoint(id, endpoint) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.endpoint = endpoint;
-        await backingMap.put(id, d);
-      }
+      await backingMap.merge(id, { endpoint });
     },
-    async setName(id, name) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.name = name;
-        await backingMap.put(id, d);
-      }
-    },
-    async setOwnerScope(id, ownerScopeId) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.ownerScopeId = ownerScopeId;
-        await backingMap.put(id, d);
-      }
-    },
-    async setDisplayName(id, displayName) {
-      const d = await backingMap.get(id);
-      if (d) {
-        if (displayName) d.displayName = displayName;
-        else delete d.displayName;
-        await backingMap.put(id, d);
-      }
-    },
-    async setDefaultAudience(id, snapshot) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.defaultAudience = snapshot;
-        await backingMap.put(id, d);
-      }
-    },
-    async setAppliedVersion(id, version) {
+    async markDeploying(id, version) {
       const d = await backingMap.get(id);
       if (!d) return;
-      const v = d.versions.find((x) => x.version === version);
-      if (!v) throw new Error(`no such version ${version}`);
-      d.appliedVersion = version;
-      await backingMap.put(id, d);
-      await updateAppliedRef(id, v);
+      const appliedVersion = await resolveAppliedVersion(id, d);
+      await updateDeployment(id, (current) => {
+        if (!current.versions.some((candidate) => candidate.version === version))
+          throw new Error(`no such version ${version}`);
+        return {
+          ...current,
+          status: current.status === "archived" ? "archived" : "deploying",
+          endpoint: null,
+          deployingVersion: version,
+          ...(current.appliedVersion === undefined && appliedVersion !== undefined ? { appliedVersion } : {}),
+        };
+      });
+    },
+    async markFailed(id) {
+      const d = await backingMap.get(id);
+      if (!d) return;
+      const appliedVersion = await resolveAppliedVersion(id, d);
+      await updateDeployment(id, (current) => {
+        return {
+          ...current,
+          status: "failed",
+          endpoint: null,
+          ...(current.appliedVersion === undefined && appliedVersion !== undefined ? { appliedVersion } : {}),
+        };
+      });
+    },
+    async markApplied(id, version, endpoint) {
+      const d = await updateDeployment(id, (current) => {
+        if (!current.versions.some((candidate) => candidate.version === version))
+          throw new Error(`no such version ${version}`);
+        const { deployingVersion: _, ...rest } = current;
+        return { ...rest, endpoint, currentVersion: version, status: "running", appliedVersion: version };
+      });
+      if (d) await syncAppliedRef(id, d).catch((error) => swallow("deploy applied ref sync", error));
+    },
+    async markArchived(id) {
+      await updateDeployment(id, (current) => ({ ...current, status: "archived" }));
+    },
+    async markStopped(id) {
+      await updateDeployment(id, (current) => ({ ...current, status: "stopped" }));
+    },
+    async markRuntimeClean(id) {
+      await updateDeployment(id, (current) => {
+        const { deployingVersion: _, ...rest } = current;
+        return { ...rest, endpoint: null };
+      });
+    },
+    async setName(id, name) {
+      await backingMap.merge(id, { name });
+    },
+    async setOwnerScope(id, ownerScopeId) {
+      await backingMap.merge(id, { ownerScopeId });
+    },
+    async setDisplayName(id, displayName) {
+      await backingMap.merge(id, { displayName });
+    },
+    async setDefaultAudience(id, snapshot) {
+      await backingMap.merge(id, { defaultAudience: snapshot });
+    },
+    async setAppliedVersion(id, version) {
+      const d = await updateDeployment(id, (current) => {
+        if (!current.versions.some((candidate) => candidate.version === version))
+          throw new Error(`no such version ${version}`);
+        return { ...current, appliedVersion: version };
+      });
+      if (d) await syncAppliedRef(id, d);
     },
     async touch(id, at) {
-      const d = await backingMap.get(id);
-      if (d) {
-        d.lastAccessAt = at;
-        await backingMap.put(id, d);
-      }
+      await backingMap.merge(id, { lastAccessAt: at });
     },
     async versionOf(id, version) {
       return (await backingMap.get(id))?.versions.find((v) => v.version === version) ?? null;
@@ -318,8 +505,28 @@ export function createDeployStore(backing?: DurableMap<Deployment> | DeployStore
       const v = (await backingMap.get(id))?.versions.find((x) => x.version === version);
       return v?.commit ? git.bundle(id, v.commit) : null;
     },
-    refOf: (id, ref) => git.refOf(id, ref),
-    repoUrl: (id) => git.repoUrl(id),
+    async preparePush(id) {
+      await syncAppliedRef(id);
+      const d = await backingMap.get(id);
+      const applied = d?.versions.find((version) => version.version === d.appliedVersion)?.commit;
+      if (applied) await git.setRef(id, PUSH_REF, applied);
+      else await git.deleteRef(id, PUSH_REF);
+      return applied ?? null;
+    },
+    async takePushedCommit(id, baseline) {
+      const pushed = await git.refOf(id, PUSH_REF);
+      if (pushed && pushed !== baseline) await git.setRef(id, `refs/deploy-commits/${pushed}`, pushed);
+      await git.deleteRef(id, PUSH_REF);
+      return pushed === baseline ? null : pushed;
+    },
+    async refOf(id, ref) {
+      if (ref === CURRENT_REF) await syncAppliedRef(id);
+      return git.refOf(id, ref);
+    },
+    async repoUrl(id) {
+      await syncAppliedRef(id);
+      return git.repoUrl(id);
+    },
   };
 }
 

--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -79,7 +79,9 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
     },
 
     async destroy(d: Deployment): Promise<void> {
-      await dexec(["rm", "-f", name(d)]);
+      const result = await dexec(["rm", "-f", name(d)]);
+      if (result.code !== 0 && !result.stderr.includes("No such container"))
+        throw new Error(`deploy destroy failed: ${result.stderr.trim()}`);
       freePort(name(d));
     },
   };

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -1353,7 +1353,10 @@ export function buildApp(
         leaderLease,
       })
     : null;
-  const deployIdleTtlMs = deployProvider.profile.managedScaleToZero ? undefined : config.deployIdleTtlMs;
+  const deployIdleTtlMs =
+    config.deployIdleTtlMs !== undefined && config.deployIdleTtlMs > 0
+      ? config.deployIdleTtlMs
+      : Number.POSITIVE_INFINITY;
   const BLOB_TTL_MS = 6 * 60 * 60_000;
   const blobSweeper = createSweeper(() => blobTransfer.sweep(BLOB_TTL_MS), 30 * 60_000);
   const BLOB_TRANSFER_EXPIRY_DAYS = 1;
@@ -1362,10 +1365,12 @@ export function buildApp(
     .catch((e) =>
       console.error("[blob-transfer] S3 lifecycle expiry install failed (sweep remains the fallback):", errMessage(e)),
     );
-  const idleSweeper =
-    deployIdleTtlMs && deployIdleTtlMs > 0
-      ? createSweeper(() => app.reapIdleDeployments(deployIdleTtlMs), Math.max(5_000, Math.floor(deployIdleTtlMs / 4)))
-      : null;
+  const idleSweeper = createSweeper(
+    () => app.reapIdleDeployments(deployIdleTtlMs),
+    Number.isFinite(deployIdleTtlMs)
+      ? Math.max(5_000, Math.floor(deployIdleTtlMs / 4))
+      : config.processReaperIntervalMs,
+  );
   const deepIdleMachineMs = config.deepIdleMachineMs;
   const devIdleMachineMs = config.devIdleMachineMs;
   const sweepFractions = [deepIdleMachineMs, devIdleMachineMs]
@@ -1391,7 +1396,7 @@ export function buildApp(
       monitorPoller?.start(config.monitorPollMs);
       if (config.skillSyncPollMs > 0) skillSyncEngine.start(config.skillSyncPollMs);
       blobSweeper.start();
-      idleSweeper?.start();
+      idleSweeper.start();
       deepIdleSweeper?.start();
       reachDeniedNotifier?.start(config.insightsIntervalMs);
       wakeSweep.start();
@@ -1406,7 +1411,7 @@ export function buildApp(
       processReaper?.stop();
       monitorPoller?.stop();
       skillSyncEngine.stop();
-      idleSweeper?.stop();
+      idleSweeper.stop();
       deepIdleSweeper?.stop();
       reachDeniedNotifier?.stop();
       blobSweeper.stop();

--- a/test/aws-deploy-provider.test.ts
+++ b/test/aws-deploy-provider.test.ts
@@ -595,6 +595,36 @@ test("destroy: terminates the body and clears its pointer", async () => {
   assert.equal(await store.get(ID), null, "the pointer is cleared");
 });
 
+test("destroy: a termination failure retains the body pointer for retry", async () => {
+  const { api } = fakeApi();
+  const { fetchImpl } = fakeDaemon();
+  const store = createMemoryMap<StoredDeployBody>();
+  const p = provider(api, fetchImpl, store);
+  const d = deployment(ID);
+  await p.apply(d, version(localSnapshot("a", "1")));
+  api.terminate = async () => {
+    throw new Error("termination failed");
+  };
+
+  await assert.rejects(p.destroy(d), /termination failed/);
+  assert.notEqual(await store.get(ID), null);
+});
+
+test("destroy: an already-missing body clears its pointer", async () => {
+  const { api } = fakeApi();
+  const { fetchImpl } = fakeDaemon();
+  const store = createMemoryMap<StoredDeployBody>();
+  const p = provider(api, fetchImpl, store);
+  const d = deployment(ID);
+  await p.apply(d, version(localSnapshot("a", "1")));
+  api.terminate = async () => {
+    throw new AwsApiError("not found", 404);
+  };
+
+  await p.destroy(d);
+  assert.equal(await store.get(ID), null);
+});
+
 test("profile: scale-to-zero is platform-managed and reconcile is in place", () => {
   const { api } = fakeApi();
   const { fetchImpl } = fakeDaemon();

--- a/test/deploy-artifact-image.test.ts
+++ b/test/deploy-artifact-image.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -161,12 +162,13 @@ test("a reconcile-capable provider receives the git diff and marks the applied v
   assert.equal((await deployStore.get(d.id))!.appliedVersion, 2);
 });
 
-test("applied version is marked only after endpoint metadata is persisted", async () => {
+test("applied version is marked only after activation metadata is persisted", async () => {
   const baseStore = createDeployStore();
+  let destroys = 0;
   const deployStore: DeployStore = {
     ...baseStore,
-    setEndpoint: async () => {
-      throw new Error("endpoint write failed");
+    markApplied: async () => {
+      throw new Error("activation write failed");
     },
   };
   const deploy = createDeployService({
@@ -177,7 +179,9 @@ test("applied version is marked only after endpoint metadata is persisted", asyn
     provider: {
       profile: { managedScaleToZero: false },
       apply: async () => ({ host: "127.0.0.1", port: 9200 }),
-      destroy: async () => {},
+      destroy: async () => {
+        destroys++;
+      },
     },
   });
 
@@ -189,13 +193,16 @@ test("applied version is marked only after endpoint metadata is persisted", asyn
         entrypoint: "node s.js",
         files: [{ path: "s.js", data: "x" }],
       }),
-    /endpoint write failed/,
+    /activation write failed/,
   );
   const [d] = await baseStore.list();
   assert.equal(d!.appliedVersion, undefined);
+  assert.equal(d!.status, "failed");
+  assert.equal(d!.endpoint, null);
+  assert.equal(destroys, 1);
 });
 
-test("a failed redeploy does not move the hosted git current ref", async () => {
+test("a failed redeploy neither selects the candidate nor moves the hosted git current ref", async () => {
   const deployStore = createDeployStore();
   let applies = 0;
   const deploy = createDeployService({
@@ -228,7 +235,106 @@ test("a failed redeploy does not move the hosted git current ref", async () => {
     /apply failed/,
   );
   const after = (await deployStore.get(d.id))!;
-  assert.equal(after.currentVersion, 2, "the failed candidate remains recorded as the desired version");
+  assert.equal(after.status, "failed");
+  assert.equal(after.currentVersion, 1, "the failed candidate is recorded without becoming current");
   assert.equal(after.appliedVersion, 1);
   assert.equal(await deployStore.refOf(d.id, "refs/heads/current"), v1.commit);
+});
+
+test("a failed git-push deploy restores the hosted current ref", async () => {
+  const deployStore = createDeployStore();
+  let applies = 0;
+  const deploy = createDeployService({
+    deployStore,
+    acl: createAclStore(),
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    deployDir: mkdtempSync(join(tmpdir(), "deploy-push-current-ref-")),
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async () => {
+        const attempt = ++applies;
+        if (attempt === 2) throw new Error("apply failed");
+        return { host: "127.0.0.1", port: 9200, image: `image:${attempt}` };
+      },
+      destroy: async () => {},
+    },
+  });
+  const d = await deploy.deploy({
+    ownerScopeId: owner,
+    createdBy: "U1",
+    entrypoint: "node s.js",
+    files: [{ path: "s.js", data: "v1" }],
+  });
+  const v1 = (await deployStore.versionOf(d.id, 1))!;
+  const work = mkdtempSync(join(tmpdir(), "deploy-push-current-work-"));
+  const repo = await deployStore.repoUrl(d.id);
+  execFileSync("git", ["clone", "--quiet", repo, work]);
+  writeFileSync(join(work, "s.js"), "v2");
+  execFileSync("git", ["add", "s.js"], { cwd: work });
+  execFileSync("git", ["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-qm", "v2"], { cwd: work });
+  const v2Commit = execFileSync("git", ["rev-parse", "HEAD"], { cwd: work }).toString().trim();
+  const push = (ref: string) =>
+    deploy.pushGit(d.id, async () => {
+      execFileSync("git", ["push", "--quiet", "--force", repo, `${ref}:refs/heads/current`], {
+        cwd: work,
+        env: { ...process.env, GIT_NAMESPACE: "pending" },
+      });
+      return { result: undefined, ok: true };
+    });
+
+  await push("HEAD");
+
+  const after = (await deployStore.get(d.id))!;
+  assert.equal(after.status, "failed");
+  assert.equal(after.currentVersion, 1);
+  assert.equal(after.appliedVersion, 1);
+  assert.equal(after.versions.length, 2);
+  assert.equal(await deployStore.refOf(d.id, "refs/heads/current"), v1.commit);
+
+  await push("HEAD");
+  const retried = (await deployStore.get(d.id))!;
+  assert.equal(retried.status, "running");
+  assert.equal(retried.currentVersion, 2);
+  assert.equal(retried.appliedVersion, 2);
+  assert.equal(retried.versions.length, 2);
+  assert.equal(await deployStore.refOf(d.id, "refs/heads/current"), v2Commit);
+
+  await push(v1.commit!);
+  const rolledBack = (await deployStore.get(d.id))!;
+  assert.equal(rolledBack.status, "running");
+  assert.equal(rolledBack.currentVersion, 1);
+  assert.equal(rolledBack.appliedVersion, 1);
+  assert.equal(rolledBack.versions.length, 2);
+  assert.equal(await deployStore.refOf(d.id, "refs/heads/current"), v1.commit);
+});
+
+test("receive-pack discovery does not activate an archived deployment", async () => {
+  const deployStore = createDeployStore();
+  let applies = 0;
+  const deploy = createDeployService({
+    deployStore,
+    acl: createAclStore(),
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    deployDir: mkdtempSync(join(tmpdir(), "deploy-push-discovery-")),
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async () => {
+        applies++;
+        return { host: "127.0.0.1", port: 9200 };
+      },
+      destroy: async () => {},
+    },
+  });
+  const d = await deploy.deploy({
+    ownerScopeId: owner,
+    createdBy: "U1",
+    entrypoint: "node s.js",
+    files: [{ path: "s.js", data: "v1" }],
+  });
+  await deploy.archiveDeployment(d.id);
+
+  await deploy.pushGit(d.id, async () => ({ result: undefined, ok: true }));
+
+  assert.equal(applies, 1);
+  assert.equal((await deployStore.get(d.id))!.status, "archived");
 });

--- a/test/deploy-concurrency.test.ts
+++ b/test/deploy-concurrency.test.ts
@@ -75,6 +75,76 @@ test("reaper: the leader (default no-op lease) reaps as before", async () => {
   assert.equal((await deployStore.get(d.id))!.endpoint, null);
 });
 
+test("archive succeeds durably and reaper retries terminal runtime cleanup after provider failure", async () => {
+  const deployStore = createDeployStore();
+  let destroys = 0;
+  const deploy = createDeployService({
+    deployStore,
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async () => ({ host: "127.0.0.1", port: 5000 }),
+      destroy: async () => {
+        if (++destroys === 1) throw new Error("destroy failed");
+      },
+    },
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    acl: createAclStore(),
+    deployDir: mkdtempSync(join(tmpdir(), "reaper-cleanup-")),
+  });
+  const d = await deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "x",
+    files: [],
+  });
+
+  await deploy.archiveDeployment(d.id);
+  const pending = (await deployStore.get(d.id))!;
+  assert.equal(pending.status, "archived");
+  assert.notEqual(pending.endpoint, null);
+
+  assert.equal(await deploy.reapIdleDeployments(60_000, future), 0);
+  const cleaned = (await deployStore.get(d.id))!;
+  assert.equal(cleaned.status, "archived");
+  assert.equal(cleaned.endpoint, null);
+  assert.equal(destroys, 2);
+});
+
+test("reaper continues after one deployment cleanup fails", async () => {
+  const deployStore = createDeployStore();
+  let blockedId = "";
+  const deploy = createDeployService({
+    deployStore,
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async () => ({ host: "127.0.0.1", port: 5000 }),
+      destroy: async (deployment) => {
+        if (deployment.id === blockedId) throw new Error("destroy failed");
+      },
+    },
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    acl: createAclStore(),
+    deployDir: mkdtempSync(join(tmpdir(), "reaper-continues-")),
+  });
+  const first = await deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "one",
+    files: [],
+  });
+  const second = await deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "two",
+    files: [],
+  });
+  blockedId = first.id;
+
+  assert.equal(await deploy.reapIdleDeployments(60_000, future), 1);
+  assert.notEqual((await deployStore.get(first.id))!.endpoint, null);
+  assert.equal((await deployStore.get(second.id))!.endpoint, null);
+});
+
 function spyLock(): { lock: AdvisoryLock; keys: string[] } {
   const keys: string[] = [];
   const lock: AdvisoryLock = {
@@ -95,14 +165,14 @@ test("withDeployLock: redeploy/rollback/archive each acquire the advisory mutex 
     entrypoint: "x",
     files: [],
   });
-  assert.deepEqual(keys, [], "the initial create takes no deploy lock");
+  const want = `deploy:${d.id}`;
+  assert.deepEqual(keys, [want], "the initial activation locks deploy:<id>");
 
   await deploy.redeploy(d.id, { entrypoint: "y", files: [] });
   await deploy.rollbackDeployment(d.id, 1);
   await deploy.archiveDeployment(d.id);
 
-  const want = `deploy:${d.id}`;
-  assert.deepEqual(keys, [want, want, want], "redeploy, rollback, archive each lock deploy:<id>");
+  assert.deepEqual(keys, [want, want, want, want], "every activation and archive locks deploy:<id>");
 });
 
 test("withDeployLock: same-instance lifecycle ops still serialize (no overlap)", async () => {

--- a/test/deploy-failure.test.ts
+++ b/test/deploy-failure.test.ts
@@ -1,0 +1,308 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAclStore } from "../src/acl/acl-store.ts";
+import { createDeployService } from "../src/deploy/deploy-service.ts";
+import { createDeployStore, type Deployment } from "../src/deploy/deploy-store.ts";
+import type { DeployProvider } from "../src/deploy/deploy-provider.ts";
+import { createMemoryMap } from "../src/persistence/durable-map.ts";
+import { scopeId } from "../src/types.ts";
+
+const deployInput = (entrypoint: string) => ({
+  ownerScopeId: scopeId("personal", "U1"),
+  createdBy: "U1",
+  entrypoint,
+  files: [{ path: "app.js", data: entrypoint }],
+});
+
+function service(provider: DeployProvider) {
+  const deployments = createMemoryMap<Deployment>();
+  const deployStore = createDeployStore(deployments);
+  const deploy = createDeployService({
+    deployStore,
+    provider,
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    acl: createAclStore(),
+    deployDir: mkdtempSync(join(tmpdir(), "deploy-failure-")),
+  });
+  return { deploy, deployStore, deployments };
+}
+
+test("an initial provider failure is durably represented and can be retried", async () => {
+  let fail = true;
+  const { deploy, deployments } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => {
+      if (fail) throw new Error("provider apply failed");
+      return { host: "127.0.0.1", port: 5000 };
+    },
+    destroy: async () => {},
+  });
+
+  await assert.rejects(deploy.deploy(deployInput("v1")), /provider apply failed/);
+  const failed = (await deployments.all())[0]!;
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.endpoint, null);
+  assert.equal(failed.currentVersion, 1);
+  assert.equal(failed.appliedVersion, undefined);
+  assert.equal(failed.versions.length, 1);
+
+  fail = false;
+  const retried = await deploy.redeploy(failed.id, deployInput("v2"));
+  assert.equal(retried.status, "running");
+  assert.equal(retried.currentVersion, 2);
+  assert.equal(retried.appliedVersion, 2);
+});
+
+test("a legacy never-applied stopped deployment is normalized to failed", async () => {
+  let destroys = 0;
+  const { deploy, deployStore } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => ({ host: "127.0.0.1", port: 5000 }),
+    destroy: async () => {
+      destroys++;
+    },
+  });
+  const orphan = await deployStore.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/legacy/v1",
+    files: [{ path: "app.js", data: "v1" }],
+  });
+
+  const normalized = (await deployStore.get(orphan.id))!;
+
+  assert.equal(normalized.status, "failed");
+  assert.equal(normalized.appliedVersion, undefined);
+  assert.equal(normalized.deployingVersion, 1);
+  assert.equal(await deploy.reapIdleDeployments(60_000), 0);
+  assert.equal(destroys, 1);
+  assert.equal((await deployStore.get(orphan.id))!.deployingVersion, undefined);
+});
+
+test("a legacy stopped deployment with an endpoint is cleaned as interrupted", async () => {
+  let destroys = 0;
+  const { deploy, deployStore } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => ({ host: "127.0.0.1", port: 5000 }),
+    destroy: async () => {
+      destroys++;
+    },
+  });
+  const orphan = await deployStore.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/legacy/v1",
+    files: [{ path: "app.js", data: "v1" }],
+  });
+  await deployStore.setEndpoint(orphan.id, { host: "127.0.0.1", port: 5000 });
+
+  assert.equal(await deploy.reapIdleDeployments(60_000), 0);
+  assert.equal(destroys, 1);
+  const cleaned = (await deployStore.get(orphan.id))!;
+  assert.equal(cleaned.status, "failed");
+  assert.equal(cleaned.endpoint, null);
+  assert.equal(cleaned.deployingVersion, undefined);
+});
+
+test("repeated reconcile failures never select an unusable version and a later retry succeeds", async () => {
+  let reconciles = 0;
+  const { deploy } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => assert.fail("reconcile should handle committed versions"),
+    reconcile: async (_deployment, version) => {
+      reconciles++;
+      if (reconciles === 2 || reconciles === 3) throw new Error("provider reconcile failed");
+      if (reconciles === 4) {
+        assert.equal(readFileSync(join(version.snapshotDir, "app.js"), "utf8"), "v2");
+        assert.equal(readFileSync(join(version.homeDir!, ".provider/session"), "utf8"), "same");
+      }
+      return { host: "127.0.0.1", port: 5000 + reconciles };
+    },
+    destroy: async () => {},
+  });
+
+  const initial = await deploy.deploy(deployInput("v1"));
+  const retryInput = {
+    ...deployInput("v2"),
+    homeFiles: [{ path: ".provider/session", data: "same" }],
+  };
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await assert.rejects(deploy.redeploy(initial.id, retryInput), /provider reconcile failed/);
+    const failed = (await deploy.getDeployment(initial.id))!;
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.endpoint, null);
+    assert.equal(failed.currentVersion, 1);
+    assert.equal(failed.appliedVersion, 1);
+    assert.equal(failed.versions.length, 2);
+    const candidate = failed.versions.find((version) => version.version === 2)!;
+    rmSync(candidate.snapshotDir, { recursive: true, force: true });
+    rmSync(candidate.homeDir!, { recursive: true, force: true });
+  }
+
+  const retried = await deploy.redeploy(initial.id, retryInput);
+  assert.equal(retried.status, "running");
+  assert.equal(retried.currentVersion, 2);
+  assert.equal(retried.appliedVersion, 2);
+  assert.equal(retried.versions.length, 2);
+});
+
+test("archive persists terminal state before destroying an interrupted runtime", async () => {
+  const holder: { deployStore?: ReturnType<typeof createDeployStore> } = {};
+  const stateDuringDestroy: Partial<Deployment> = {};
+  const setup = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => ({ host: "127.0.0.1", port: 5000 }),
+    destroy: async (deployment) => {
+      Object.assign(stateDuringDestroy, await holder.deployStore!.get(deployment.id));
+    },
+  });
+  holder.deployStore = setup.deployStore;
+  const interrupted = await setup.deployStore.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/interrupted/v1",
+    files: [{ path: "app.js", data: "v1" }],
+  });
+  await setup.deployStore.markDeploying(interrupted.id, 1);
+
+  await setup.deploy.archiveDeployment(interrupted.id);
+
+  assert.equal(stateDuringDestroy?.status, "archived");
+  assert.equal(stateDuringDestroy?.endpoint, null);
+  assert.equal(stateDuringDestroy?.deployingVersion, 1);
+  assert.equal((await setup.deployStore.get(interrupted.id))!.deployingVersion, undefined);
+});
+
+test("reach cleans an interrupted activation without replaying ephemeral inputs", async () => {
+  let applies = 0;
+  const { deploy, deployStore } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => {
+      applies++;
+      return { host: "127.0.0.1", port: 5000 };
+    },
+    destroy: async () => {},
+  });
+  const interrupted = await deployStore.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/interrupted/v1",
+    files: [{ path: "app.js", data: "v1" }],
+  });
+  await deployStore.markDeploying(interrupted.id, 1);
+
+  const reached = await deploy.reachDeployment(interrupted.id, "U1");
+
+  assert.equal(reached.status, "not_found");
+  assert.equal(applies, 0);
+  const recovered = (await deploy.getDeployment(interrupted.id))!;
+  assert.equal(recovered.status, "failed");
+  assert.equal(recovered.appliedVersion, undefined);
+  assert.equal(recovered.deployingVersion, undefined);
+});
+
+test("reach recovers the applied version after cleaning an interrupted redeploy", async () => {
+  let applies = 0;
+  const { deploy, deployStore } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => ({ host: "127.0.0.1", port: 5000 + ++applies }),
+    destroy: async () => {},
+  });
+  const initial = await deploy.deploy(deployInput("v1"));
+  await deployStore.addVersion(initial.id, {
+    entrypoint: "v2",
+    snapshotDir: "/interrupted/v2",
+    files: [{ path: "app.js", data: "v2" }],
+  });
+
+  const reached = await deploy.reachDeployment(initial.id, "U1");
+
+  assert.equal(reached.status, "ok");
+  assert.equal(applies, 2);
+  const recovered = (await deploy.getDeployment(initial.id))!;
+  assert.equal(recovered.status, "running");
+  assert.equal(recovered.currentVersion, 1);
+  assert.equal(recovered.appliedVersion, 1);
+  assert.equal(recovered.deployingVersion, undefined);
+});
+
+test("reaper retries cleanup of an endpoint-less partial activation", async () => {
+  let destroys = 0;
+  const { deploy, deployments } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => {
+      throw new Error("partial provider failure");
+    },
+    destroy: async () => {
+      if (++destroys === 1) throw new Error("cleanup failure");
+    },
+  });
+
+  await assert.rejects(deploy.deploy(deployInput("v1")), /partial provider failure/);
+  const pending = (await deployments.all())[0]!;
+  assert.equal(pending.status, "failed");
+  assert.equal(pending.endpoint, null);
+  assert.equal(pending.deployingVersion, 1);
+
+  assert.equal(await deploy.reapIdleDeployments(60_000), 0);
+  const cleaned = (await deployments.all())[0]!;
+  assert.equal(cleaned.status, "failed");
+  assert.equal(cleaned.deployingVersion, undefined);
+  assert.equal(destroys, 2);
+});
+
+test("a transient lazy restart failure is retried on the next reach", async () => {
+  let applies = 0;
+  const { deploy } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => {
+      applies++;
+      if (applies === 2) throw new Error("restart failed");
+      return { host: "127.0.0.1", port: 5000 + applies };
+    },
+    resolveEndpoint: async () => null,
+    destroy: async () => {},
+  });
+  const initial = await deploy.deploy(deployInput("v1"));
+
+  await assert.rejects(deploy.reachDeployment(initial.id, "U1"), /restart failed/);
+  assert.equal((await deploy.getDeployment(initial.id))!.status, "failed");
+
+  const reached = await deploy.reachDeployment(initial.id, "U1");
+  assert.equal(reached.status, "ok");
+  assert.equal(applies, 3);
+  assert.equal((await deploy.getDeployment(initial.id))!.status, "running");
+});
+
+test("a failed update backfills the applied version of a legacy running deployment", async () => {
+  let fail = false;
+  const { deploy, deployments } = service({
+    profile: { managedScaleToZero: false },
+    apply: async () => {
+      if (fail) throw new Error("provider apply failed");
+      return { host: "127.0.0.1", port: 5000 };
+    },
+    destroy: async () => {},
+  });
+  const legacy = await deploy.deploy(deployInput("v1"));
+  await deployments.merge(legacy.id, { appliedVersion: undefined });
+  fail = true;
+
+  await assert.rejects(deploy.redeploy(legacy.id, deployInput("v2")), /provider apply failed/);
+  const failed = (await deploy.getDeployment(legacy.id))!;
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.currentVersion, 1);
+  assert.equal(failed.appliedVersion, 1);
+
+  fail = false;
+  const reached = await deploy.reachDeployment(legacy.id, "U1");
+  assert.equal(reached.status, "ok");
+  assert.equal((await deploy.getDeployment(legacy.id))!.status, "running");
+});

--- a/test/deploy-git-rw.test.ts
+++ b/test/deploy-git-rw.test.ts
@@ -33,11 +33,15 @@ const GIT_ENV = {
 function fixture() {
   const deployStore = createDeployStore({ git: { repoRoot: mkdtempSync(join(tmpdir(), "git-rw-repo-")) } });
   const acl: AclStore = createAclStore();
+  let applies = 0;
   const deploy = createDeployService({
     deployStore,
     provider: {
       profile: { managedScaleToZero: false },
-      apply: async () => ({ host: "127.0.0.1", port: 19998 }),
+      apply: async () => {
+        applies++;
+        return { host: "127.0.0.1", port: 19998 };
+      },
       destroy: async () => {},
     },
     auditLog: { record() {}, events: async () => [], tail: async () => [] },
@@ -55,7 +59,17 @@ function fixture() {
   const server: Server = createServer(app, { signingSecret: SECRET, identity });
   server.listen(0);
   const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
-  return { app, deploy, acl, identity, base, close: () => new Promise<void>((r) => server.close(() => r())) };
+  return {
+    app,
+    deploy,
+    acl,
+    identity,
+    base,
+    get applies() {
+      return applies;
+    },
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
 }
 
 async function gitUrl(base: string, deploymentId: string, permission: "read" | "write"): Promise<string> {
@@ -155,6 +169,56 @@ test("a write token can push, and the push registers a new immutable version", a
     const v2 = fresh.versions.find((v) => v.version === 2)!;
     assert.equal(v2.commit, pushedSha.trim());
     assert.equal(v2.entrypoint, "node server.js");
+  } finally {
+    await f.close();
+  }
+});
+
+test("a stale write clone cannot overwrite a newer deployment version", async () => {
+  const f = fixture();
+  try {
+    const d = await f.app.deploy({
+      ownerScopeId: scopeId("personal", "U1"),
+      createdBy: "U1",
+      entrypoint: "node server.js",
+      files: [{ path: "server.js", data: "console.log('v1')" }],
+    });
+    const url = await gitUrl(f.base, d.id, "write");
+    const first = mkdtempSync(join(tmpdir(), "git-rw-first-"));
+    const stale = mkdtempSync(join(tmpdir(), "git-rw-stale-"));
+    await Promise.all([
+      execFileP("git", ["clone", "--quiet", url, first], { env: GIT_ENV }),
+      execFileP("git", ["clone", "--quiet", url, stale], { env: GIT_ENV }),
+    ]);
+
+    for (const [work, contents] of [
+      [first, "console.log('v2')"],
+      [stale, "console.log('stale')"],
+    ] as const) {
+      await writeFile(join(work, "server.js"), contents);
+      await execFileP("git", ["add", "-A"], { cwd: work, env: GIT_ENV });
+      await execFileP("git", ["commit", "-q", "-m", "update"], { cwd: work, env: GIT_ENV });
+    }
+
+    await execFileP("git", ["push", "origin", "HEAD:current"], { cwd: first, env: GIT_ENV });
+    await assert.rejects(
+      execFileP("git", ["push", "origin", ":current"], { cwd: first, env: GIT_ENV }),
+      /403|forbidden|current/i,
+    );
+    await assert.rejects(
+      execFileP("git", ["push", "origin", "HEAD:current"], { cwd: stale, env: GIT_ENV }),
+      /non-fast-forward|fetch first|rejected/i,
+    );
+    await assert.rejects(
+      execFileP("git", ["push", "origin", "HEAD:other"], { cwd: stale, env: GIT_ENV }),
+      /403|forbidden|current/i,
+    );
+
+    const current = (await f.deploy.listDeployments())[0]!;
+    assert.equal(current.currentVersion, 2);
+    assert.equal(current.appliedVersion, 2);
+    assert.equal(current.versions.length, 2);
+    assert.equal(f.applies, 2);
   } finally {
     await f.close();
   }

--- a/test/deploy-reap.test.ts
+++ b/test/deploy-reap.test.ts
@@ -68,3 +68,20 @@ test("managed provider: reap is a no-op — the platform sleeps/wakes it, endpoi
   assert.equal((await deployStore.get(d.id))!.status, "running");
   assert.deepEqual((await deployStore.get(d.id))!.endpoint, { host: "127.0.0.1", port: 5000 });
 });
+
+test("managed provider: reap still cleans an interrupted runtime", async () => {
+  const setup = svc(true);
+  const d = await setup.deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "x",
+    files: [],
+  });
+  await setup.deployStore.markDeploying(d.id, 1);
+
+  assert.equal(await setup.deploy.reapIdleDeployments(60_000, future), 0);
+  assert.equal(setup.destroys, 1);
+  const cleaned = (await setup.deployStore.get(d.id))!;
+  assert.equal(cleaned.status, "failed");
+  assert.equal(cleaned.deployingVersion, undefined);
+});

--- a/test/deploy-restore.test.ts
+++ b/test/deploy-restore.test.ts
@@ -31,7 +31,7 @@ function harness(failRestore = false) {
   return { deploy, counts: () => ({ applies, destroys }) };
 }
 
-function persistenceFailureHarness(failMethod: "setVersionImage" | "setEndpoint" | "setStatus" | "setAppliedVersion") {
+function persistenceFailureHarness(failMethod: "setVersionImage" | "markApplied") {
   const base = createDeployStore();
   let armed = false;
   let failed = false;
@@ -90,7 +90,7 @@ test("restore reapplies the archived current version before marking it running",
 });
 
 test("a failed restore leaves the deployment archived and unreachable", async () => {
-  const { deploy } = harness(true);
+  const { deploy, counts } = harness(true);
   const d = await deploy.deploy({
     ownerScopeId: scopeId("personal", "U1"),
     createdBy: "U1",
@@ -103,6 +103,39 @@ test("a failed restore leaves the deployment archived and unreachable", async ()
   const after = (await deploy.listDeployments()).find((row) => row.id === d.id)!;
   assert.equal(after.status, "archived");
   assert.equal(after.endpoint, null);
+  assert.deepEqual(counts(), { applies: 2, destroys: 2 });
+  assert.equal((await deploy.reachDeployment(d.id, "U1")).status, "not_found");
+});
+
+test("an interrupted restore remains archived while cleanup is retried", async () => {
+  const deployStore = createDeployStore();
+  const deploy = createDeployService({
+    deployStore,
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async () => ({ host: "127.0.0.1", port: 20200 }),
+      destroy: async () => {},
+    },
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    acl: createAclStore(),
+    deployDir: mkdtempSync(join(tmpdir(), "deploy-restore-interrupted-")),
+  });
+  const d = await deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "server.js",
+    files: [],
+  });
+  await deploy.archiveDeployment(d.id);
+  await deployStore.markDeploying(d.id, 1);
+
+  const interrupted = (await deployStore.get(d.id))!;
+  assert.equal(interrupted.status, "archived");
+  assert.equal(interrupted.deployingVersion, 1);
+  assert.equal(await deploy.reapIdleDeployments(60_000), 0);
+  const cleaned = (await deployStore.get(d.id))!;
+  assert.equal(cleaned.status, "archived");
+  assert.equal(cleaned.deployingVersion, undefined);
   assert.equal((await deploy.reachDeployment(d.id, "U1")).status, "not_found");
 });
 
@@ -121,7 +154,41 @@ test("restore is idempotent for retries and concurrent callers", async () => {
   assert.equal((await deploy.restoreDeployment(d.id)).status, "running");
 });
 
-for (const failMethod of ["setVersionImage", "setEndpoint", "setStatus", "setAppliedVersion"] as const) {
+test("restore uses the applied version when a legacy failed candidate was selected", async () => {
+  const deployStore = createDeployStore();
+  const applied: number[] = [];
+  const deploy = createDeployService({
+    deployStore,
+    provider: {
+      profile: { managedScaleToZero: false },
+      apply: async (_deployment, version) => {
+        applied.push(version.version);
+        return { host: "127.0.0.1", port: 20200 + version.version };
+      },
+      destroy: async () => {},
+    },
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+    acl: createAclStore(),
+    deployDir: mkdtempSync(join(tmpdir(), "deploy-restore-legacy-")),
+  });
+  const d = await deploy.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    files: [],
+  });
+  await deployStore.addVersion(d.id, { entrypoint: "v2", snapshotDir: "/legacy/v2" });
+  await deployStore.setCurrentVersion(d.id, 2);
+  await deploy.archiveDeployment(d.id);
+
+  const restored = await deploy.restoreDeployment(d.id);
+
+  assert.deepEqual(applied, [1, 1]);
+  assert.equal(restored.currentVersion, 1);
+  assert.equal(restored.appliedVersion, 1);
+});
+
+for (const failMethod of ["setVersionImage", "markApplied"] as const) {
   test(`restore destroys the runtime and remains archived when ${failMethod} fails`, async () => {
     const { deploy, arm, destroys } = persistenceFailureHarness(failMethod);
     const d = await deploy.deploy({

--- a/test/deploy-store.test.ts
+++ b/test/deploy-store.test.ts
@@ -12,7 +12,7 @@ import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 import { scopeId } from "../src/types.ts";
 
-test("deploy versions are immutable and rollback flips the pointer", async () => {
+test("deploy versions are immutable and selecting one flips the pointer", async () => {
   const s = createDeployStore();
   const d = await s.create({
     ownerScopeId: scopeId("personal", "U1"),
@@ -26,9 +26,11 @@ test("deploy versions are immutable and rollback flips the pointer", async () =>
   await s.addVersion(d.id, { entrypoint: "v2", snapshotDir: "/snap/v2" });
   const after = (await s.get(d.id))!;
   assert.equal(after.versions.length, 2, "v1 is retained — versions are append-only");
-  assert.equal(after.currentVersion, 2);
+  assert.equal(after.currentVersion, 1, "recording a version does not select it before apply succeeds");
   assert.equal((await s.versionOf(d.id, 1))!.snapshotDir, "/snap/v1");
 
+  await s.setCurrentVersion(d.id, 2);
+  assert.equal((await s.get(d.id))!.currentVersion, 2);
   await s.setCurrentVersion(d.id, 1);
   assert.equal((await s.get(d.id))!.currentVersion, 1);
   assert.equal((await s.get(d.id))!.versions.length, 2, "rollback doesn't drop versions");
@@ -39,6 +41,59 @@ test("deploy versions are immutable and rollback flips the pointer", async () =>
 test("addVersion on an unknown deployment throws", async () => {
   const s = createDeployStore();
   await assert.rejects(s.addVersion("nope", { entrypoint: "x", snapshotDir: "/x" }), /unknown deployment/);
+});
+
+test("an interrupted candidate is reused without advancing version history", async () => {
+  const s = createDeployStore();
+  const d = await s.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/snap/v1",
+  });
+  await s.setAppliedVersion(d.id, 1);
+  const first = await s.addVersion(d.id, {
+    entrypoint: "v2",
+    snapshotDir: "/snap/v2-first",
+    homeDir: "/home/v2-first",
+    sourceHash: "v2-source",
+  });
+  const retry = await s.addVersion(d.id, {
+    entrypoint: "v2",
+    snapshotDir: "/snap/v2-retry",
+    homeDir: "/home/v2-retry",
+    sourceHash: "v2-source",
+  });
+
+  assert.equal(first.version, 2);
+  assert.equal(retry.version, 2);
+  assert.equal(retry.snapshotDir, "/snap/v2-retry");
+  assert.equal(retry.homeDir, "/home/v2-retry");
+  assert.equal((await s.get(d.id))!.versions.length, 2);
+});
+
+test("legacy live state selects the applied version before inheriting runtime metadata", async () => {
+  const s = createDeployStore();
+  const d = await s.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "v1",
+    snapshotDir: "/snap/v1",
+    env: { MODE: "live" },
+  });
+  await s.setAppliedVersion(d.id, 1);
+  await s.addVersion(d.id, {
+    entrypoint: "v2-failed",
+    snapshotDir: "/snap/v2",
+    env: { MODE: "failed" },
+  });
+  await s.setCurrentVersion(d.id, 2);
+  await s.setStatus(d.id, "running");
+
+  const normalized = (await s.get(d.id))!;
+
+  assert.equal(normalized.currentVersion, 1);
+  assert.equal(normalized.deployingVersion, undefined);
 });
 
 test("addVersionFromCommit registers a pushed commit as a new version inheriting entrypoint/env", async () => {
@@ -69,13 +124,15 @@ test("addVersionFromCommit registers a pushed commit as a new version inheriting
   assert.equal(v2.commit, pushed);
   assert.equal(v2.entrypoint, "node server.js");
   assert.deepEqual(v2.env, { FOO: "bar" });
-  assert.equal((await s.get(d.id))!.currentVersion, 2);
+  assert.equal((await s.get(d.id))!.currentVersion, 1);
 
   const v2bundle = await s.bundleOf(d.id, 2);
   assert.ok((v2bundle?.byteLength ?? 0) > 0, "a push-deployed version can be exported as a git bundle");
 
-  assert.equal(await s.addVersionFromCommit(d.id, pushed), null);
+  assert.equal((await s.addVersionFromCommit(d.id, pushed))?.version, 2);
   assert.equal((await s.get(d.id))!.versions.length, 2);
+  await s.setCurrentVersion(d.id, 2);
+  assert.equal((await s.get(d.id))!.currentVersion, 2);
 });
 
 test("homeDir (resident-auth snapshot) round-trips through create + addVersion", async () => {
@@ -182,6 +239,7 @@ test("deploy versions carry git commits for app files and rollback moves the cur
     null,
     "the hosted current ref is not moved before a version is applied",
   );
+  await s2.setCurrentVersion(d.id, 2);
   await s2.setAppliedVersion(d.id, 2);
   assert.equal(await s2.refOf(d.id, deployCurrentGitRef), v2.commit);
   assert.ok(existsSync(await s2.repoUrl(d.id)), "a real bare git repo backs the deployment");
@@ -362,6 +420,7 @@ test("deploy git repos restore from the durable archive into a fresh repo root",
     git: { repoRoot: mkdtempSync(join(tmpdir(), "deploy-git-b-")), archiveStore },
   });
   const v2 = (await s2.versionOf(d.id, 2))!;
+  await s2.setCurrentVersion(d.id, 2);
   await s2.setAppliedVersion(d.id, 2);
   assert.equal(
     await s2.refOf(d.id, deployCurrentGitRef),

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDockerDeployProvider } from "../src/deploy/docker-deploy-provider.ts";
+import type { Deployment } from "../src/deploy/deploy-store.ts";
+import { scopeId } from "../src/types.ts";
+
+function deployment(): Deployment {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    currentVersion: 1,
+    status: "failed",
+    endpoint: null,
+    versions: [],
+  };
+}
+
+function fakeDocker(stderr: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), "fake-docker-")), "docker");
+  writeFileSync(path, `#!/bin/sh\nprintf '%s' '${stderr}' >&2\nexit 1\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+test("destroy rejects a Docker failure so cleanup remains retryable", async () => {
+  const provider = createDockerDeployProvider({ docker: fakeDocker("daemon unavailable") });
+  await assert.rejects(provider.destroy(deployment()), /deploy destroy failed: daemon unavailable/);
+});
+
+test("destroy treats an already-missing Docker container as clean", async () => {
+  const provider = createDockerDeployProvider({
+    docker: fakeDocker("Error response from daemon: No such container: agent-deploy-550e8400-e29"),
+  });
+  await provider.destroy(deployment());
+});

--- a/test/durable-stores.test.ts
+++ b/test/durable-stores.test.ts
@@ -78,6 +78,7 @@ test("deployments persist with immutable versions across store instances", async
     snapshotDir: "/snap/1",
   });
   await s1.addVersion(d.id, { entrypoint: "node server.js --v2", snapshotDir: "/snap/2" });
+  await s1.setCurrentVersion(d.id, 2);
 
   const s2 = createDeployStore(map);
   const got = await s2.get(d.id);


### PR DESCRIPTION
Closes #210

## Summary

- represent provider activation as a durable `deploying`/`failed` transition and advance the live version only after activation succeeds
- keep failed candidates retryable without inflating version history, including after another instance must recapture ephemeral app and home snapshots
- isolate Git receive-pack candidates from the hosted `current` ref, reject unrelated refs, and promote only an actually changed candidate after activation succeeds
- report failed, live, current, and pending versions consistently through the API and web UI

## Validation

- 385 caller-derived deploy, publish, Git transport, restore, API, and web UI tests
- root and web UI TypeScript checks
- full ESLint and targeted Prettier checks
- production-shaped local core, Postgres, and web UI QA in Firefox with a synthetic failed deployment

## Screenshot

Synthetic failed-deployment state in Firefox:

![Failed deployment state in Firefox](https://raw.githubusercontent.com/time-attack/qm/ebf6e1a19c2530244c4466993b0096763c94b67d/pr-assets/issue-210-failed-deployment.png)
