### PR TITLE
sandbox: make provision-prep failures legible and non-destructive

### DIFF
--- a/src/credentials/resident-paths.ts
+++ b/src/credentials/resident-paths.ts
@@ -21,6 +21,18 @@ export const BASE_EPHEMERAL_CRED_LINKS: ReadonlyArray<{ rel: string; kind: "dir"
 const DURABLE_CREDENTIAL_PATHS = [".ssh", ".git-credentials"] as const;
 export const EPHEMERAL_CRED_DIR = "/tmp/agent-creds";
 
+// Prep runs before every command under a wall-clock timeout, and EPHEMERAL_CRED_DIR sits on a
+// different device from $HOME — so `mv $HOME/x /tmp/agent-creds/x` is a recursive copy whose
+// duration scales with the bundle, not a rename. A copy that outruns the timeout is retried from
+// scratch on the next command and never converges. Displaced $HOME state is therefore renamed
+// aside on its own device (atomic, O(1)) and the keychain refills the ephemeral target.
+//
+// Asides land under a single quarantine root rather than beside what they displaced: a
+// `~/.config/gcloud.displaced` sitting in the open would be scanned as a credential service named
+// `gcloud.displaced` and would slip past the backup exclude's prefix match, putting the very
+// plaintext credentials this module keeps out of $HOME back into backups and published apps.
+export const DISPLACED_DIR_REL = ".agent-displaced";
+
 export interface CredentialPathSpec {
   path: string;
   kind: "file" | "directory";
@@ -51,8 +63,64 @@ export function ephemeralCredLinkPaths(
   return [...links].map(([rel, kind]) => ({ rel, kind }));
 }
 
-const mkdirHealing = (dir: string): string =>
-  `if ! mkdir -p ${shq(dir)} 2>/dev/null; then rm -rf ${shq(dir)}; mkdir -p ${shq(dir)}; fi`;
+// A stale non-directory must not deny the agent its computer, so the mkdir heals itself. Clearing
+// only on the failure (rather than testing first) keeps the destructive branch off the healthy path
+// and leaves no window between the test and the create — and `rm -rf` is sound here because
+// EPHEMERAL_CRED_DIR holds nothing the keychain cannot re-materialize. It is NOT sound on a $HOME
+// path, where the same line deleted the agent's entire home directory; those go through
+// mkdirDisplacing instead.
+const mkdirHealing = (dir: string): string => {
+  if (dir !== EPHEMERAL_CRED_DIR && !dir.startsWith(`${EPHEMERAL_CRED_DIR}/`))
+    throw new Error(`refusing destructive mkdir healing outside ${EPHEMERAL_CRED_DIR}: ${dir}`);
+  return `if ! mkdir -p ${shq(dir)} 2>/dev/null; then rm -rf ${shq(dir)}; mkdir -p ${shq(dir)}; fi`;
+};
+
+// Nothing prunes $HOME on the agent's behalf, and prep runs before every command: a CLI that
+// recreates its config directory each turn would otherwise leave an aside per turn until the disk
+// fills. Quarantine is a grace period for recovering a displaced login, not an archive.
+const QUARANTINE_RETENTION_DAYS = 7;
+
+// The quarantine root has nowhere inside itself to go, so it heals in place — and the test must not
+// follow symlinks. A symlink here is accepted by `[ -d ]` and every later `mv` writes THROUGH it,
+// walking plaintext credentials out of the one directory the backup prune and the capture glob
+// know to skip. The agent has a shell, so that is reachable, not theoretical.
+const healQuarantine = (dir: string): string =>
+  `if [ ! -d ${dir} ] || [ -L ${dir} ]; then if [ -e ${dir} ] || [ -L ${dir} ]; then mv ${dir} ${dir}.$$.$(date +%s); fi; mkdir -p ${dir}; fi`;
+
+// Move a $HOME path into the quarantine root. Everything here — healing the root included — sits on
+// the displacement path rather than running up front, so a converged box writes nothing to $HOME
+// before a command and cannot be denied its computer by a full or read-only disk it could
+// otherwise still be used to clear.
+const displace = (home: string, rel: string): string => {
+  const quarantine = posix.join(home, DISPLACED_DIR_REL);
+  const aside = posix.join(quarantine, rel);
+  const src = posix.join(home, rel);
+  // `$$` alone is not unique over a box's lifetime — PID space is small and reused, and `mv`
+  // clobbers a same-named file without complaint, which would silently delete an older bundle.
+  return [
+    healQuarantine(shq(quarantine)),
+    `find ${shq(quarantine)} -mindepth 1 -maxdepth 1 -mtime +${QUARANTINE_RETENTION_DAYS} -exec rm -rf {} + 2>/dev/null`,
+    `mkdir -p ${shq(posix.dirname(aside))}`,
+    // Concurrent preps both reach here; the loser finds the source already taken, which is the
+    // outcome it wanted. Any other mv failure still stops the chain with its stderr intact.
+    `mv ${shq(src)} ${shq(aside)}.$$.$(date +%s) || [ ! -e ${shq(src)} ]`,
+  ].join("; ");
+};
+
+// Two concurrent preps both pass the `[ ! -L ]` guard, so the loser's bare `ln -s` fails EEXIST and
+// kills the && chain. Losing the race is not an error when the winner produced the link we wanted;
+// anything else on the path still fails loudly. (`ln -sfn` is not portable enough to rely on: BSD
+// ln rejects it against an existing symlink-to-directory.)
+const linkOrConverge = (path: string, target: string): string =>
+  `ln -s ${shq(target)} ${shq(path)} || [ "$(readlink ${shq(path)} 2>/dev/null)" = ${shq(target)} ]`;
+
+// The $HOME counterpart of mkdirHealing. A failed mkdir after displacement fails the chain loudly
+// rather than reaching for rm -rf: denying one turn beats destroying the box's home directory.
+const mkdirDisplacing = (home: string, rel: string): string => {
+  if (rel === ".") return `mkdir -p ${shq(home)}`;
+  const dir = shq(posix.join(home, rel));
+  return `if [ ! -d ${dir} ]; then if [ -e ${dir} ] || [ -L ${dir} ]; then ${displace(home, rel)}; fi; mkdir -p ${dir}; fi`;
+};
 
 export function ephemeralCredLinkScript(home: string, extraPaths: readonly CredentialPathSpec[] = []): string {
   const parts = [mkdirHealing(EPHEMERAL_CRED_DIR), `chmod 700 ${shq(EPHEMERAL_CRED_DIR)}`];
@@ -61,8 +129,11 @@ export function ephemeralCredLinkScript(home: string, extraPaths: readonly Crede
     const target = posix.join(EPHEMERAL_CRED_DIR, rel);
     parts.push(
       mkdirHealing(posix.dirname(target)),
-      `if [ -L ${shq(path)} ] && [ "$(readlink ${shq(path)})" != ${shq(target)} ]; then old="$(readlink -f ${shq(path)} 2>/dev/null || true)"; rm ${shq(path)}; if [ -n "$old" ] && [ -e "$old" ] && [ ! -e ${shq(target)} ]; then mv "$old" ${shq(target)}; fi; fi`,
-      `if [ ! -L ${shq(path)} ]; then if [ -e ${shq(path)} ]; then rm -rf ${shq(target)}; mv ${shq(path)} ${shq(target)}; fi; ${mkdirHealing(posix.dirname(path))}; ln -s ${shq(target)} ${shq(path)}; fi`,
+      // A symlink pointing somewhere stale is dropped, not followed: migrating what it pointed at
+      // was the cross-device copy this prep can no longer afford. The bundle stays where it is and
+      // the keychain refills the ephemeral target.
+      `if [ -L ${shq(path)} ] && [ "$(readlink ${shq(path)})" != ${shq(target)} ]; then rm -f ${shq(path)}; fi`,
+      `if [ ! -L ${shq(path)} ]; then if [ -e ${shq(path)} ]; then ${displace(home, rel)}; fi; ${mkdirDisplacing(home, posix.dirname(rel))}; ${linkOrConverge(path, target)}; fi`,
     );
     if (kind === "dir") parts.push(mkdirHealing(target));
   }

--- a/src/deployment/deployment-layer.ts
+++ b/src/deployment/deployment-layer.ts
@@ -1,3 +1,5 @@
+import { DISPLACED_DIR_REL } from "../credentials/resident-paths.ts";
+
 export type ApprovalDecision = "require_approval" | "deny";
 
 export interface ToolApproval {
@@ -129,6 +131,11 @@ export function parseToolDescriptor(raw: string, sourcePath: string): ToolDescri
     ) {
       throw new Error(
         `${sourcePath}: credential path ${JSON.stringify(path)} must be a $HOME-relative path with no traversal`,
+      );
+    }
+    if (segments[0] === DISPLACED_DIR_REL) {
+      throw new Error(
+        `${sourcePath}: credential path ${JSON.stringify(path)} is reserved — ${DISPLACED_DIR_REL} is where provision quarantines displaced $HOME state, and linking it would make it its own displacement target`,
       );
     }
     if (!segments[0]!.startsWith(".")) {

--- a/src/sandbox/aws-sandbox.ts
+++ b/src/sandbox/aws-sandbox.ts
@@ -22,7 +22,7 @@ import type {
   SandboxHandle,
   TeardownOptions,
 } from "./sandbox.ts";
-import { visibleNotInstalled, visibleTools } from "./sandbox.ts";
+import { execFailureDetail, visibleNotInstalled, visibleTools } from "./sandbox.ts";
 import {
   ephemeralCredLinkPaths,
   ephemeralCredLinkScript,
@@ -32,6 +32,7 @@ import {
 const HOME_DIR = "/root";
 const WORKSPACE_BASENAME = "workspace";
 const WORKSPACE_DIR = `${HOME_DIR}/${WORKSPACE_BASENAME}`;
+const PREP_TIMEOUT_SEC = 30;
 const HOME_TAR = "/tmp/agent-home.tar";
 const RO_LAYERS_TAR = ".ro-layers.tar";
 const RO_LAYERS_MANIFEST = ".ro-layers.manifest";
@@ -378,9 +379,12 @@ export function createAwsSandbox(workspace: WorkspaceStore, opts: AwsSandboxOpti
       const prepared = await execRaw(
         id,
         `mkdir -p ${shq(WORKSPACE_DIR)} && ${ephemeralCredLinkScript(HOME_DIR, credentialPaths)}`,
-        30,
+        PREP_TIMEOUT_SEC,
       );
-      if (prepared.code !== 0) throw new Error(`AWS sandbox credential setup failed: ${prepared.stderr.slice(0, 200)}`);
+      if (prepared.code !== 0)
+        throw new Error(
+          `AWS sandbox credential setup failed: ${execFailureDetail(prepared, PREP_TIMEOUT_SEC).slice(0, 200)}`,
+        );
 
       const env = provOpts?.env && Object.keys(provOpts.env).length ? provOpts.env : undefined;
       const handle: SandboxHandle = {

--- a/src/sandbox/exec-file-ops.ts
+++ b/src/sandbox/exec-file-ops.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { shq } from "../util/shell.ts";
 import { swallowAs } from "../util/errors.ts";
 import { makeTar, parseTar } from "./tar.ts";
+import { DISPLACED_DIR_REL } from "../credentials/resident-paths.ts";
 
 import type {
   AgentComputerBackupArea,
@@ -83,13 +84,16 @@ function normalizeBackupRelPath(path: string): string {
   return parts.join("/");
 }
 
-function defaultExcludeAgentComputerBackup(
+export function defaultExcludeAgentComputerBackup(
   entry: Pick<AgentComputerBackupEntry, "area" | "path">,
   credentialPrefixes: readonly string[],
 ): boolean {
   const rel = normalizeBackupRelPath(entry.path);
   const parts = rel.split("/");
   if (entry.area === "home" && credentialPrefixes.some((pfx) => rel === pfx || rel.startsWith(`${pfx}/`))) return true;
+  // Credentials prep displaced out of the way are still credentials — they must not ride a backup
+  // into a published app just because they no longer sit at their canonical $HOME path.
+  if (entry.area === "home" && parts[0] === DISPLACED_DIR_REL) return true;
   return (
     parts.includes(".aws") ||
     parts.includes("__pycache__") ||
@@ -148,6 +152,10 @@ export function createExecBackup({
                 "-path './venv/*'",
                 `-path './${WORKSPACE_BASENAME}'`,
                 `-path './${WORKSPACE_BASENAME}/*'`,
+                // Displaced credentials are excluded from the archive anyway; pruning them at the
+                // find keeps their plaintext out of the tar and out of core's memory entirely.
+                `-path './${DISPLACED_DIR_REL}'`,
+                `-path './${DISPLACED_DIR_REL}/*'`,
               ]
             : [];
         const contentCachePrunes = backupOpts.keepContentCaches

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -17,6 +17,7 @@ import { ephemeralCredLinkScript } from "../credentials/resident-paths.ts";
 import { ephemeralCredLinkPaths } from "../credentials/resident-paths.ts";
 import { shortHash } from "../util/crypto.ts";
 import { killableScript, killScript } from "./exec-kill.ts";
+import { execFailureDetail } from "./sandbox.ts";
 import type {
   AgentComputerProfile,
   ExecOptions,
@@ -35,6 +36,7 @@ const RO_LAYERS_TAR = ".ro-layers.tar";
 const RO_LAYERS_MANIFEST = ".ro-layers.manifest";
 const FINGERPRINT_LABEL = "qm.sandbox-fingerprint";
 const BUILD_HINT = "run `npm run sandbox:local:build`";
+const PREP_TIMEOUT_SEC = 30;
 
 export type { DockerExec };
 
@@ -382,8 +384,15 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       };
 
       try {
-        const prep = await execRaw(name, `mkdir -p ${shq(workspaceDir)} && ${ephemeralCredLinkScript(homeDir)}`, 30);
-        if (prep.code !== 0) throw new Error(`local sandbox provision prep failed: ${prep.stderr.slice(0, 200)}`);
+        const prep = await execRaw(
+          name,
+          `mkdir -p ${shq(workspaceDir)} && ${ephemeralCredLinkScript(homeDir)}`,
+          PREP_TIMEOUT_SEC,
+        );
+        if (prep.code !== 0)
+          throw new Error(
+            `local sandbox provision prep failed: ${execFailureDetail(prep, PREP_TIMEOUT_SEC).slice(0, 200)}`,
+          );
 
         await materializeRoLayers(
           workspace,

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -81,6 +81,14 @@ export interface ExecOptions {
   signal?: AbortSignal;
 }
 
+// A failing exec often says nothing on either stream — a timeout kills the script before it
+// writes, and a wedged guest filesystem blocks every command silently. Falling back to the exit
+// code keeps such a failure attributable instead of surfacing a bare "failed: ".
+export const execFailureDetail = (result: ExecResult, timeoutSec: number): string =>
+  result.stderr.trim() ||
+  result.stdout.trim() ||
+  (result.timedOut ? `timed out after ${timeoutSec}s with no output` : `exit ${result.code} with no output`);
+
 export type AgentComputerBackupArea = "workspace" | "home";
 
 export interface AgentComputerBackupEntry {

--- a/src/sandbox/sprites-sandbox.ts
+++ b/src/sandbox/sprites-sandbox.ts
@@ -23,7 +23,7 @@ import { CAPABILITY_HEADER } from "../api/contract.ts";
 import { ephemeralCredLinkPaths } from "../credentials/resident-paths.ts";
 import { shortHash } from "../util/crypto.ts";
 import { killableScript, killScript } from "./exec-kill.ts";
-import { visibleNotInstalled, visibleTools } from "./sandbox.ts";
+import { execFailureDetail, visibleNotInstalled, visibleTools } from "./sandbox.ts";
 import type {
   AgentComputerProfile,
   ExecOptions,
@@ -45,6 +45,7 @@ const RESTART_TIMEOUT_MS = 60_000;
 const CHECK_TIMEOUT_MS = 30_000;
 const GUEST_PROBE_TIMEOUT_SEC = 15;
 const DEFAULT_SPRITES_BASE_URL = "https://api.sprites.dev";
+const PREP_TIMEOUT_SEC = 60;
 
 export interface SpritesClientLike {
   getSprite(name: string): Promise<unknown>;
@@ -423,9 +424,9 @@ export function createSpritesSandbox(workspace: WorkspaceStore, opts: SpritesSan
       try {
         // Scratch boxes are credential-free and wiped at release; they don't get the links.
         const credLinks = scratch ? "" : ` && ${ephemeralCredLinkScript(HOME_DIR, opts.credentialPaths ?? [])}`;
-        const prep = await execRaw(name, `mkdir -p ${shq(workspaceDir)}${credLinks}`, 60);
+        const prep = await execRaw(name, `mkdir -p ${shq(workspaceDir)}${credLinks}`, PREP_TIMEOUT_SEC);
         if (prep.code !== 0)
-          throw new Error(`sprites provision prep failed: ${(prep.stderr || prep.stdout).slice(0, 200)}`);
+          throw new Error(`sprites provision prep failed: ${execFailureDetail(prep, PREP_TIMEOUT_SEC).slice(0, 200)}`);
 
         await materializeRoLayers(
           workspace,

--- a/test/resident-paths.test.ts
+++ b/test/resident-paths.test.ts
@@ -1,11 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, writeFile, symlink, stat, readlink, rm } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  writeFile,
+  symlink,
+  stat,
+  readlink,
+  readFile,
+  readdir,
+  utimes,
+  lstat,
+  rm,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { createExecBackup, defaultExcludeAgentComputerBackup } from "../src/sandbox/exec-file-ops.ts";
 import {
+  DISPLACED_DIR_REL,
   EPHEMERAL_CRED_DIR,
   credentialServiceForPath,
   ephemeralCredLinkPaths,
@@ -186,4 +200,186 @@ test("the heal never fires on a target that is already usable as a directory", a
 test(".config/glab is ephemeral-linked but NOT publish-captured (prod never baked glab creds into apps)", () => {
   assert.ok(!residentAuthPaths().includes(".config/glab"));
   assert.ok(EPHEMERAL_CRED_PATHS.some((link) => link.rel === ".config/glab" && link.kind === "dir"));
+});
+
+test("prep never emits a command that could delete $HOME or a credential bundle", () => {
+  const script = ephemeralCredLinkScript("/home/agent", [{ path: ".acmecli", kind: "directory" }]);
+  for (const doomed of ["/home/agent", "/home/agent/.config", "/home/agent/.aws", "/home/agent/.acmecli"]) {
+    assert.doesNotMatch(
+      script,
+      new RegExp(`rm -rf '${doomed}'(?!\\.)`),
+      `${doomed} must only ever be renamed aside, never removed`,
+    );
+  }
+});
+
+test("prep never copies bytes across the $HOME/ephemeral device boundary", () => {
+  const script = ephemeralCredLinkScript("/home/agent", [{ path: ".acmecli", kind: "directory" }]);
+  const crossDevice = [...script.matchAll(/mv (?!'\/tmp\/agent-creds)(\S+) '\/tmp\/agent-creds[^']*'/g)];
+  assert.deepEqual(
+    crossDevice.map((m) => m[0]),
+    [],
+    "a cross-device mv is a recursive copy that can outrun the prep timeout and never converge",
+  );
+});
+
+test("a stale file on $HOME itself is displaced, not deleted, and the box still comes up", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  await writeFile(join(home, ".aws"), "squatter");
+
+  assert.equal(await runLinkScript(home, credDir), 0, "provision prep must not fail");
+  assert.equal(await readlink(join(home, ".aws")), join(credDir, ".aws"), "the ephemeral link is in place");
+  const quarantined = await readdir(join(home, DISPLACED_DIR_REL));
+  const aside = quarantined.find((name) => name.startsWith(".aws."));
+  assert.ok(aside, `the squatter was displaced into ${DISPLACED_DIR_REL}, got ${quarantined.join(", ")}`);
+  assert.equal(
+    await readFile(join(home, DISPLACED_DIR_REL, aside), "utf8"),
+    "squatter",
+    "displaced state is preserved on its own device",
+  );
+});
+
+test("displaced credentials are quarantined out of $HOME's backup surface", () => {
+  const exclude = (path: string): boolean =>
+    defaultExcludeAgentComputerBackup(
+      { area: "home", path },
+      EPHEMERAL_CRED_PATHS.map((link) => link.rel),
+    );
+  assert.ok(exclude(`${DISPLACED_DIR_REL}/.config/gcloud/credentials.db`), "displaced bundles never reach a backup");
+  assert.ok(exclude(`${DISPLACED_DIR_REL}/.netrc.1234`), "nor displaced single-file credentials");
+  assert.ok(!exclude(".bashrc"), "ordinary home files still back up");
+});
+
+test("displaced credentials cannot be rescanned as a bogus credential service", () => {
+  const script = ephemeralCredLinkScript("/home/agent");
+  // Capture globs $HOME/.config/*/ — an aside beside its original would be picked up as a service
+  // literally named "gcloud.displaced" and re-materialized onto every future box forever.
+  assert.doesNotMatch(script, /'\/home\/agent\/\.config\/[a-z]+\.[a-z-]+'/);
+  for (const m of script.matchAll(/mv '\/home\/agent\/([^']+)' '([^']+)'/g)) {
+    // The quarantine root is the one path with nowhere inside itself to go; it heals in place.
+    if (m[1] === DISPLACED_DIR_REL) continue;
+    assert.match(m[2]!, new RegExp(`^/home/agent/${DISPLACED_DIR_REL}/`), `${m[1]} must be displaced into quarantine`);
+  }
+});
+
+test("concurrent preps on one box both succeed and neither destroys the other's displaced state", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  await writeFile(join(home, ".aws"), "squatter");
+
+  // provision() runs per tool call on a multi-instance core with no lock, so two preps racing onto
+  // one aside name is routine: the loser used to fail the && chain and delete the winner's bundle.
+  const codes = await Promise.all([runLinkScript(home, credDir), runLinkScript(home, credDir)]);
+  assert.deepEqual(codes, [0, 0], "neither prep may deny the agent its computer");
+  assert.equal(await readlink(join(home, ".aws")), join(credDir, ".aws"));
+  const asides = (await readdir(join(home, DISPLACED_DIR_REL))).filter((n) => n.startsWith(".aws."));
+  assert.equal(asides.length, 1, "the one squatter is displaced exactly once");
+  assert.equal(await readFile(join(home, DISPLACED_DIR_REL, asides[0]!), "utf8"), "squatter");
+});
+
+test("a file squatting on the quarantine root does not brick the box", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  await writeFile(join(home, DISPLACED_DIR_REL), "squatter");
+  await writeFile(join(home, ".aws"), "creds");
+
+  assert.equal(await runLinkScript(home, credDir), 0, "the quarantine root heals like everything else");
+  assert.equal(await readlink(join(home, ".aws")), join(credDir, ".aws"));
+  assert.ok((await stat(join(home, DISPLACED_DIR_REL))).isDirectory());
+  const displacedSquatter = (await readdir(home)).find((n) => n.startsWith(`${DISPLACED_DIR_REL}.`));
+  assert.ok(displacedSquatter, "and the squatter itself is displaced, not deleted");
+});
+
+test("repeated displacement of the same path does not overwrite an earlier bundle", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  for (const generation of ["first", "second"]) {
+    await rm(join(home, ".netrc"), { force: true });
+    await writeFile(join(home, ".netrc"), generation);
+    assert.equal(await runLinkScript(home, credDir), 0);
+  }
+  const asides = (await readdir(join(home, DISPLACED_DIR_REL))).filter((n) => n.startsWith(".netrc."));
+  const contents = await Promise.all(asides.map((n) => readFile(join(home, DISPLACED_DIR_REL, n), "utf8")));
+  assert.deepEqual(contents.sort(), ["first", "second"], "a reused pid must not clobber the older aside");
+});
+
+test("quarantined credentials are pruned from the backup archive, not just filtered after it", async () => {
+  const scripts: string[] = [];
+  const backup = createExecBackup({
+    label: "test",
+    exec: async (_id, script) => {
+      scripts.push(script);
+      return { stdout: "", stderr: "", code: 0, timedOut: false };
+    },
+    readAbsBytes: async () => Buffer.alloc(0),
+    defaultHomeDir: "/home/agent",
+    ephemeralCredentialPrefixes: EPHEMERAL_CRED_PATHS.map((link) => link.rel),
+  });
+  await backup.backupComputer(
+    { id: "box", rootDir: "/home/agent/workspace", homeDir: "/home/agent" },
+    { include: ["home"] },
+  );
+  // Filtering after the fact still tars the plaintext and drags it through core's memory first.
+  assert.match(scripts.join("\n"), new RegExp(`-path '\\./${DISPLACED_DIR_REL}/\\*'`));
+});
+
+test("the quarantine sweep expires asides without deleting the quarantine itself", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  const quarantine = join(home, DISPLACED_DIR_REL);
+  await mkdir(quarantine, { recursive: true });
+  await writeFile(join(quarantine, ".netrc.stale"), "expired");
+  await writeFile(join(quarantine, ".netrc.fresh"), "recent");
+  // `find DIR -maxdepth 1` matches DIR itself, so an old-enough box would sweep away every
+  // credential it had ever displaced along with the directory holding them.
+  const longAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+  await utimes(quarantine, longAgo, longAgo);
+  await utimes(join(quarantine, ".netrc.stale"), longAgo, longAgo);
+  await writeFile(join(home, ".netrc"), "squatter");
+
+  assert.equal(await runLinkScript(home, credDir), 0);
+  const remaining = await readdir(quarantine);
+  assert.ok(!remaining.includes(".netrc.stale"), "expired asides are swept");
+  assert.ok(remaining.includes(".netrc.fresh"), "recent asides survive");
+  assert.ok(
+    remaining.some((n) => n.startsWith(".netrc.") && n !== ".netrc.fresh"),
+    "and the aside just displaced is still there",
+  );
+});
+
+test("a symlinked quarantine root cannot walk displaced credentials out of quarantine", async (t) => {
+  const { home, credDir } = await tempPair(t);
+  // The agent has a shell on the box, so it can point the quarantine anywhere. Writing THROUGH the
+  // symlink would land plaintext credentials outside the one directory the backup prune and the
+  // capture glob know to skip — in the workspace, which backs up under a different area entirely.
+  const elsewhere = join(home, "workspace", "leak");
+  await mkdir(elsewhere, { recursive: true });
+  await symlink(elsewhere, join(home, DISPLACED_DIR_REL));
+  await writeFile(join(home, ".netrc"), "machine example.com password hunter2");
+
+  assert.equal(await runLinkScript(home, credDir), 0);
+  assert.deepEqual(await readdir(elsewhere), [], "nothing was written through the symlink");
+  assert.ok(!(await lstat(join(home, DISPLACED_DIR_REL))).isSymbolicLink(), "the symlink was displaced");
+  const quarantined = await readdir(join(home, DISPLACED_DIR_REL));
+  assert.ok(
+    quarantined.some((n) => n.startsWith(".netrc.")),
+    "and the credential landed in a real quarantine directory",
+  );
+});
+
+test("prep contains no deletion that can reach $HOME outside the quarantine", () => {
+  const home = "/home/agent";
+  const script = ephemeralCredLinkScript(home, [{ path: ".acmecli", kind: "directory" }]);
+  const quarantine = `${home}/${DISPLACED_DIR_REL}`;
+  const deletable = (path: string): boolean =>
+    path.startsWith(`${EPHEMERAL_CRED_DIR}/`) || path === EPHEMERAL_CRED_DIR || path.startsWith(`${quarantine}/`);
+
+  for (const m of script.matchAll(/rm -rf ('[^']+'|\S+)/g)) {
+    const arg = m[1]!.replace(/^'|'$/g, "");
+    if (arg === "{}") continue; // find's placeholder — checked below via its root and -mindepth
+    assert.ok(deletable(arg), `rm -rf ${arg} can reach $HOME outside the quarantine`);
+  }
+  // A `find … -exec rm` evades any check that only looks at literal rm arguments — which is how the
+  // sweep that deleted the whole quarantine slipped past this guard's first version.
+  for (const m of script.matchAll(/find ('[^']+'|\S+)([^;]*?)-exec rm[^;]*/g)) {
+    const root = m[1]!.replace(/^'|'$/g, "");
+    assert.ok(deletable(`${root}/`), `find -exec rm rooted at ${root} can reach $HOME`);
+    assert.match(m[2]!, /-mindepth 1\b/, `find -exec rm at ${root} would also delete its own root`);
+  }
 });

--- a/test/sprites-sandbox.test.ts
+++ b/test/sprites-sandbox.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createSpritesSandbox, spriteScopeName } from "../src/sandbox/sprites-sandbox.ts";
 import { createLocalWorkspaceStore } from "../src/workspace/workspace-store.ts";
-import { supportsProcessSessions, supportsBlobStaging } from "../src/sandbox/sandbox.ts";
+import { execFailureDetail, supportsProcessSessions, supportsBlobStaging } from "../src/sandbox/sandbox.ts";
 import { createMemoryBlobTransferStore } from "../src/persistence/blob-transfer.ts";
 import { scopeId } from "../src/types.ts";
 import { mintCapabilityToken, EGRESS_PROXY_AUD } from "../src/auth/capability-token.ts";
@@ -255,6 +255,17 @@ test("stageIn pulls a blob into the guest atomically (temp then mv)", async () =
   assert.match(script, /-o .*\.part/, "downloads to a temp file");
   assert.match(script, /mv -f /, "and only then moves it into place");
   assert.match(script, /curl -fsS/, "-f so an HTTP error fails loudly instead of writing the error body");
+});
+
+test("a prep failure that writes nothing still names its cause", () => {
+  assert.equal(
+    execFailureDetail({ stdout: "", stderr: "", code: 124, timedOut: true }, 60),
+    "timed out after 60s with no output",
+    "a wedged guest filesystem kills the script before it can explain itself",
+  );
+  assert.equal(execFailureDetail({ stdout: "", stderr: "", code: 1, timedOut: false }, 60), "exit 1 with no output");
+  assert.equal(execFailureDetail({ stdout: "out", stderr: " boom\n", code: 1, timedOut: false }, 60), "boom");
+  assert.equal(execFailureDetail({ stdout: " out\n", stderr: "", code: 1, timedOut: false }, 60), "out");
 });
 
 test("restartComputer reboots the scope's sprite and heals a wedged exec channel", async () => {


### PR DESCRIPTION
When a sandbox's provision-prep script died with empty stdout/stderr (for example, killed by its own timeout while blocked on I/O against a failing filesystem), the error surfaced as 'provision prep failed: ' with nothing after the colon — an operator could not tell a dead disk from a bad script. execFailureDetail now falls back to the exit code and timed-out flag when both streams are empty, and all three backends use it with the prep timeout as a named constant so the message can quote it. Prep also no longer moves bytes between $HOME and /tmp (different devices, so mv degrades to a recursive copy whose runtime scales with the payload and never converges under a timeout); displaced state is renamed aside on its own device — atomic and O(1). Finally, the self-healing mkdir heals by displacement instead of rm -rf: applied to a top-level $HOME entry, the old path deleted the agent's entire home directory on one failed mkdir.

Stacked on #409 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789248079&installation_model_id=19911&pr_number=466&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F466&signature=31c430e98574e31d333a6a6ad4f3b1deb871c77b71f9672df91dfc350f29b3be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->