### PR TITLE
Withhold tape coverage for a stopped turn until its partial is imported

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2466,6 +2466,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           !result.silent
         ) {
           const firstTapeWriteFailed = !!result.tapeWriteFailed;
+          const primaryStopped = !!result.stopped;
           // The model already wrote a reply as plain assistant text — deliver that text
           // directly instead of nudging it to re-post (a nudge here re-sends near-identical
           // text, which surfaces that render assistant entries show twice).
@@ -2538,6 +2539,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               { history: nudgeHistory, ...(nudgeTape ? { tape: nudgeTape } : {}) },
             );
             if (firstTapeWriteFailed || result.tapeWriteFailed) result = { ...result, tapeWriteFailed: true };
+            if (primaryStopped && !result.stopped) result = { ...result, stopped: true };
             if (spine.surfaceOutboundCount === 0 && spine.staySilentReason === undefined && !result.silent) {
               const fallback = stripAckPrefix(result.reply ?? "", spineAckText).trim();
               if (fallback && defaultDestination && deps.deliveries) {
@@ -2676,7 +2678,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             -1,
           );
           const preTurnCovered = tapeRows ? tapeRows.covered : false;
-          if (lastSeq >= 0 && preTurnCovered && !result.tapeWriteFailed && !compactionMirrorFailed) {
+          if (lastSeq >= 0 && preTurnCovered && !result.stopped && !result.tapeWriteFailed && !compactionMirrorFailed) {
             await withManagedRosterVersion(() =>
               deps.sessions.appendTape(lease, {
                 kind: "annotation",

--- a/test/tape-nudge-continuation.test.ts
+++ b/test/tape-nudge-continuation.test.ts
@@ -53,7 +53,13 @@ function fakeSandbox(): Sandbox {
 }
 
 async function runScenario(
-  options: { failPrimaryTapeMessage?: boolean; omitPrimaryCheckpoint?: boolean; staleNudgeRead?: boolean } = {},
+  options: {
+    failDirectDelivery?: boolean;
+    failPrimaryTapeMessage?: boolean;
+    omitPrimaryCheckpoint?: boolean;
+    staleNudgeRead?: boolean;
+    stoppedPartial?: boolean;
+  } = {},
 ) {
   const modes: Array<"shadow" | "serve" | undefined> = [];
   const folds: unknown[][] = [];
@@ -130,7 +136,30 @@ async function runScenario(
           });
           return { reply: "posted", modelCalls: 2 };
         }
-        const reply = turn.input === "needs nudge" ? "worklog without a post" : "primed";
+        const stopAgain = options.stoppedPartial && turn.input.startsWith("keep stopping");
+        let reply = "primed";
+        if (turn.input === "needs nudge") reply = "worklog without a post";
+        else if (stopAgain) reply = `partial: ${turn.input}`;
+        if ((options.stoppedPartial && turn.input === "needs nudge") || stopAgain) {
+          if (!options.failPrimaryTapeMessage) {
+            await turn.tape?.({
+              kind: "message",
+              harness: "pi",
+              payload: {
+                role: "assistant",
+                content: [{ type: "text", text: reply }],
+                stopReason: "aborted",
+              },
+              scopeLabel: turn.scopeLabel,
+            });
+          }
+          await turn.emit({
+            type: "assistant",
+            payload: { text: reply },
+            scopeLabel: turn.scopeLabel,
+          });
+          return { reply, stopped: true, modelCalls: 1 };
+        }
         const failTapeMessage = options.failPrimaryTapeMessage && turn.input === "needs nudge";
         if (!failTapeMessage) {
           await turn.tape?.({
@@ -190,6 +219,13 @@ async function runScenario(
     acl,
   });
   const deliveries = createDeliveryStore();
+  if (options.failDirectDelivery) {
+    const enqueue = deliveries.enqueue.bind(deliveries);
+    deliveries.enqueue = async (delivery) => {
+      if (delivery.text === "worklog without a post") throw new Error("surface rejected the direct reply");
+      return enqueue(delivery);
+    };
+  }
   const orchestrator = createOrchestrator({
     identity: createIdentityService(),
     resolution: createResolutionService(ORG, createMemoryConfigStore(ORG), acl),
@@ -319,6 +355,80 @@ test("a coverage gap self-heals at the next read: one legacy_import, served the 
     await sessions.tapeCoverage(session.id),
     entries.at(-1)!.seq,
     "the watermark advances again — the latch is gone",
+  );
+});
+
+test("a stopped partial withholds coverage until its saved text is imported for replay", async () => {
+  const { modes, folds, sessions, session, entries, orchestrator, input } = await runScenario({ stoppedPartial: true });
+  const partial = entries.find(
+    (entry) =>
+      entry.type === "assistant" && (entry.payload as { text?: unknown } | null)?.text === "worklog without a post",
+  );
+  assert.ok(partial);
+  assert.ok((await sessions.tapeCoverage(session.id)) < partial.seq);
+
+  await orchestrator.handleTurn(input("continue after stop"));
+  assert.equal(modes.at(-1), "serve");
+  assert.ok(JSON.stringify(folds.at(-1)).includes("worklog without a post"));
+  const imports = (await sessions.getTape(session.id)).filter(
+    (row) => row.kind === "context_event" && (row.payload as { event?: unknown }).event === "legacy_import",
+  );
+  assert.equal(imports.length, 1);
+});
+
+test("consecutive stopped turns heal one import each and converge once a turn completes", async () => {
+  const { modes, folds, sessions, session, orchestrator, input } = await runScenario({ stoppedPartial: true });
+  await orchestrator.handleTurn(input("keep stopping one"));
+  await orchestrator.handleTurn(input("keep stopping two"));
+  await orchestrator.handleTurn(input("continue after stops"));
+  const countImports = async () =>
+    (await sessions.getTape(session.id)).filter(
+      (row) => row.kind === "context_event" && (row.payload as { event?: unknown }).event === "legacy_import",
+    ).length;
+  assert.equal(await countImports(), 3, "one heal per stopped predecessor — no compounding within a turn");
+  assert.equal(modes.at(-1), "serve");
+  const foldText = JSON.stringify(folds.at(-1));
+  assert.ok(foldText.includes("worklog without a post"));
+  assert.ok(foldText.includes("partial: keep stopping two"), "every stopped partial reaches the final fold");
+  const entries = await sessions.getEntries(session.id);
+  assert.equal(await sessions.tapeCoverage(session.id), entries.at(-1)!.seq, "the completed turn re-arms coverage");
+
+  await orchestrator.handleTurn(input("one more"));
+  assert.equal(await countImports(), 3, "no further imports once coverage is restored");
+});
+
+test("a stopped partial keeps withholding coverage when the direct delivery fails and the nudge replaces the result", async () => {
+  const { sessions, session, entries, orchestrator, input } = await runScenario({
+    stoppedPartial: true,
+    failDirectDelivery: true,
+  });
+  const partial = entries.find(
+    (entry) =>
+      entry.type === "assistant" && (entry.payload as { text?: unknown } | null)?.text === "worklog without a post",
+  );
+  assert.ok(partial);
+  assert.ok(
+    (await sessions.tapeCoverage(session.id)) < partial.seq,
+    "the nudge result must not launder the stopped primary into an advanced watermark",
+  );
+
+  await orchestrator.handleTurn(input("continue after stop"));
+  const imports = (await sessions.getTape(session.id)).filter(
+    (row) => row.kind === "context_event" && (row.payload as { event?: unknown }).event === "legacy_import",
+  );
+  assert.equal(imports.length, 1, "the stopped partial still reaches the replay via the heal");
+});
+
+test("a stopped partial whose tape message write ALSO failed still reaches the replay via the heal", async () => {
+  const { modes, folds, orchestrator, input } = await runScenario({
+    stoppedPartial: true,
+    failPrimaryTapeMessage: true,
+  });
+  await orchestrator.handleTurn(input("continue after stop"));
+  assert.equal(modes.at(-1), "serve");
+  assert.ok(
+    JSON.stringify(folds.at(-1)).includes("worklog without a post"),
+    "the saved session entry supplies the partial even though its tape mirror never landed",
   );
 });
 


### PR DESCRIPTION
A stopped (aborted) reply saves its partial text to session history, but the turn could still advance tape coverage. On the next replay of a tape-served session, aborted assistant entries are dropped before the tape seed becomes provider context, so the saved partial silently disappearedfromwhatthemodelseeswhiletheperson'stranscriptstillshoweditTheturnend disappeared from what the model sees while the persons transcript still showed it. The turn-end coverage watermark is no longer written for a stopped turn; the next turn finds the session uncovered and the existing self-heal path imports saved history — including the stopped partial — as a replay-safe legacy import, after which tape serve resumes with the partial present. Tests cover consecutive stops, the stopped-plus-failed-mirror case, and a nudge replacing the stopped primary's result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789244912&installation_model_id=19911&pr_number=438&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F438&signature=b4e3e94cad36a7d7347902c137dbba3c4ed1eb5bbb4b2735dbf7f776a9a714fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->