### PR TITLE
Grant conversation-scope read on files posted in group/DM sessions

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1647,16 +1647,25 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               ownerId: actor.id,
             }).grantees
           : [];
+        // Files posted into a group/DM conversation (e.g. a project web session) get no
+        // per-member grants from defaultPublishAudience ("auto-share deferred"), which left
+        // other members unable to load them. Grant the conversation scope itself read access
+        // so everyone party to the conversation can fetch what was posted into it.
+        const fileOwnerScopeId = toScopeId("personal", actor.id);
+        const fileGrantees = [...fileAudience];
+        if ((conversation.kind === "group" || conversation.kind === "dm") && scopeId !== fileOwnerScopeId) {
+          fileGrantees.push(scopeId);
+        }
         const fileRegistration: ArtifactRegistration = {
           store: deps.files,
-          ownerScopeId: toScopeId("personal", actor.id),
+          ownerScopeId: fileOwnerScopeId,
           createdBy: actor.id,
           createdInScope: scopeId,
           seed: input.runId ?? `${session.id}:${Date.now()}`,
-          ...(fileAudience.length
+          ...(fileGrantees.length
             ? {
                 onRegistered: async ({ ownerScopeId, path }) => {
-                  for (const granteeScopeId of fileAudience) {
+                  for (const granteeScopeId of fileGrantees) {
                     await deps.acl.grant({
                       ownerScopeId,
                       ref: path,

--- a/src/harness/mock-harness.ts
+++ b/src/harness/mock-harness.ts
@@ -32,6 +32,7 @@ const READ_ONLY_BLOCKED_PREFIXES = [
   "!postthread ",
   "!broadcast ",
   "!post ",
+  "!postfiles ",
   "!react ",
   "!edit ",
   "!delete ",
@@ -496,6 +497,20 @@ export function createMockHarness(): Harness {
           });
           usedTool = true;
           reply = r.ok ? "(posted)" : `[not sent] ${r.message ?? "failed"}`;
+        } else if (command0.startsWith("!postfiles ")) {
+          // !postfiles <path>[,<path>...] <message>
+          const rest = cmd.slice(cmd.indexOf("!postfiles ") + "!postfiles ".length);
+          const sp = rest.indexOf(" ");
+          const paths = (sp === -1 ? rest : rest.slice(0, sp)).split(",").filter(Boolean);
+          const msg = sp === -1 ? "" : rest.slice(sp + 1);
+          const r = await turn.tools.post(msg, undefined, paths);
+          await turn.emit({
+            type: "tool_result",
+            payload: { tool: "post", ok: r.ok, ...(r.deliveryId ? { deliveryId: r.deliveryId } : {}) },
+            scopeLabel: turn.scopeLabel,
+          });
+          usedTool = true;
+          reply = r.ok ? "(posted files)" : `[not sent] ${r.message ?? "failed"}`;
         } else if (command0.startsWith("!react ")) {
           const [, ts, emoji] = command0.split(/\s+/);
           const r = await turn.tools.react({ ts: ts ?? "", emoji: emoji ?? "" });

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1308,9 +1308,21 @@ test("a file posted in a GROUP conversation is granted read to the conversation 
     channelRef: "G9",
     audience: [internalActor, { externalId: "U2" }],
   };
-  await app.turn(dm('!run printf FLAG > flag.png', { surface: "slack", conversation: grp, deliveryTarget: "slack:G9:files", surfaceTools: true }));
+  await app.turn(
+    dm("!run printf FLAG > flag.png", {
+      surface: "slack",
+      conversation: grp,
+      deliveryTarget: "slack:G9:files",
+      surfaceTools: true,
+    }),
+  );
   const t = await app.turn(
-    dm("!postfiles flag.png here you go", { surface: "slack", conversation: grp, deliveryTarget: "slack:G9:files", surfaceTools: true }),
+    dm("!postfiles flag.png here you go", {
+      surface: "slack",
+      conversation: grp,
+      deliveryTarget: "slack:G9:files",
+      surfaceTools: true,
+    }),
   );
   assert.notEqual(t.status, "error");
   const handles = await acl.handlesFor([scopeId("group", "G9")]);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1300,6 +1300,25 @@ test("a delivered file is recorded as a durable entry and surfaced to the next t
   assert.doesNotMatch(t3.reply ?? "", /you delivered to this conversation in your previous turn/);
 });
 
+test("a file posted in a GROUP conversation is granted read to the conversation scope", async () => {
+  const { app, acl } = freshApp();
+  const grp = {
+    kind: "group" as const,
+    threadRef: "grp:G9:files",
+    channelRef: "G9",
+    audience: [internalActor, { externalId: "U2" }],
+  };
+  await app.turn(dm('!run printf FLAG > flag.png', { surface: "slack", conversation: grp, deliveryTarget: "slack:G9:files", surfaceTools: true }));
+  const t = await app.turn(
+    dm("!postfiles flag.png here you go", { surface: "slack", conversation: grp, deliveryTarget: "slack:G9:files", surfaceTools: true }),
+  );
+  assert.notEqual(t.status, "error");
+  const handles = await acl.handlesFor([scopeId("group", "G9")]);
+  const fileHandle = handles.find((h) => h.ownerPath.endsWith("/flag.png"));
+  assert.ok(fileHandle, "the posted file is granted to the conversation scope");
+  assert.equal(fileHandle!.ownerScopeId, scopeId("personal", "U1"));
+});
+
 test("a file shared with the session is LISTED in the cached system prompt — without provisioning a sandbox", async () => {
   const built = freshApp();
   const { app, acl } = built;


### PR DESCRIPTION
Files an agent posts via post(files) in a group conversation registered artifacts owned by the posting turn's actor, but defaultPublishAudience defers auto-share for groups — so no grant was issued and every other member got 404s on /files/:id/content, rendering as broken images in the web UI. Grant the conversation scope itself read access at registration time, mirroring what uploadFileForViewer already does for composer uploads, so everyone party to the conversation can fetch what was posted into it.

**Deployment notes**

No schema change: writes ordinary ACL grants (conversation scope → read) at file registration
through the existing grant store, mirroring uploadFileForViewer.
Files posted BEFORE the upgrade keep their 404s — no backfill of grants for existing artifacts;
only newly posted files are shared. Fork PR body should be checked for a manual grant backfill;
upstream gets none, which is acceptable (old broken images stay broken) but worth a release-
note line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245117&installation_model_id=19911&pr_number=445&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F445&signature=4455437c6f2b2e7374f0b0b92098bb1bb142f9b7aeeabffc02a7f639667d419c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->