### PR TITLE
cli: close hosting-target abstraction leaks behind the HostingProvider seam

### DIFF
--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -55,8 +55,32 @@ import {
   deploymentLayerBody,
   syncDeploymentLayerBody,
   type DeploymentLayerSyncResult,
+  httpDeploymentLayerTransport,
+  type DeploymentLayerTransport,
 } from "../deployment-layer.ts";
 
+/**
+ * Deployment-layer transport for AWS: signed HTTP to the public core URL,
+ * with a Secrets Manager fallback for CORE_SIGNING_SECRET and a 60s timeout.
+ */
+export const awsDeploymentLayerTransport: DeploymentLayerTransport = httpDeploymentLayerTransport({
+  secretFallback: (config) =>
+    config.aws
+      ? capture(process.env.AWS_BIN ?? "aws", [
+          "secretsmanager",
+          "get-secret-value",
+          "--secret-id",
+          `${config.aws.secretsPrefix}CORE_SIGNING_SECRET`,
+          "--query",
+          "SecretString",
+          "--output",
+          "text",
+          "--region",
+          config.aws.region,
+        ]).trim()
+      : undefined,
+  timeoutMs: 60_000,
+});
 export interface AwsUpOpts {
   dryRun?: boolean;
   yes?: boolean;
@@ -1727,7 +1751,7 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
       if (current || before.counts.core !== 0) {
         const previousState = await currentDeploymentLayerState({
           config,
-          target: "aws",
+          transport: awsDeploymentLayerTransport,
           configDir: _configDir,
           ...(opts.envFile ? { envFile: opts.envFile } : {}),
         });
@@ -1753,7 +1777,7 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
       if (!layerChanged) {
         const state = await currentDeploymentLayerState({
           config,
-          target: "aws",
+          transport: awsDeploymentLayerTransport,
           configDir: _configDir,
           ...(opts.envFile ? { envFile: opts.envFile } : {}),
         });
@@ -1825,7 +1849,12 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
     if (desiredLayerBody) {
       layerAttempted = true;
       await syncAwsLayerAfterRoll(
-        { config, target: "aws", configDir: _configDir, ...(opts.envFile ? { envFile: opts.envFile } : {}) },
+        {
+          config,
+          transport: awsDeploymentLayerTransport,
+          configDir: _configDir,
+          ...(opts.envFile ? { envFile: opts.envFile } : {}),
+        },
         desiredLayerBody,
         desiredLayer!,
       );
@@ -1876,7 +1905,12 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
     if (layerAttempted && previousLayerBody && !previousLayerBootstrapped) {
       try {
         await syncAwsLayerAfterRoll(
-          { config, target: "aws", configDir: _configDir, ...(opts.envFile ? { envFile: opts.envFile } : {}) },
+          {
+            config,
+            transport: awsDeploymentLayerTransport,
+            configDir: _configDir,
+            ...(opts.envFile ? { envFile: opts.envFile } : {}),
+          },
           previousLayerBody,
           createHash("sha256").update(previousLayerBody).digest("hex"),
         );
@@ -2069,7 +2103,7 @@ export async function awsRollback(
         await syncAwsLayerAfterRoll(
           {
             config,
-            target: "aws",
+            transport: awsDeploymentLayerTransport,
             configDir: layerOpts.configDir,
             ...(layerOpts.envFile ? { envFile: layerOpts.envFile } : {}),
           },
@@ -2096,7 +2130,7 @@ export async function awsRollback(
         await syncAwsLayerAfterRoll(
           {
             config,
-            target: "aws",
+            transport: awsDeploymentLayerTransport,
             configDir: layerOpts.configDir,
             ...(layerOpts.envFile ? { envFile: layerOpts.envFile } : {}),
           },
@@ -3206,7 +3240,7 @@ async function checkLive(
       await retryLiveProbe(async () => {
         const state = await currentDeploymentLayerState({
           config,
-          target: "aws",
+          transport: awsDeploymentLayerTransport,
           configDir,
           ...(opts.envFile ? { envFile: opts.envFile } : {}),
         });
@@ -3313,7 +3347,7 @@ export async function awsPinSandbox(
       await assertAwsPublicNetwork(config);
       const liveLayer = await currentDeploymentLayerState({
         config,
-        target: "aws",
+        transport: awsDeploymentLayerTransport,
         configDir: layerOpts.configDir,
         ...(layerOpts.envFile ? { envFile: layerOpts.envFile } : {}),
       });
@@ -3373,7 +3407,7 @@ export async function awsPinSandbox(
       await syncAwsLayerAfterRoll(
         {
           config,
-          target: "aws",
+          transport: awsDeploymentLayerTransport,
           configDir: layerOpts.configDir,
           ...(layerOpts.envFile ? { envFile: layerOpts.envFile } : {}),
         },
@@ -3408,7 +3442,7 @@ export async function awsPinSandbox(
         await syncAwsLayerAfterRoll(
           {
             config,
-            target: "aws",
+            transport: awsDeploymentLayerTransport,
             configDir: layerOpts.configDir,
             ...(layerOpts.envFile ? { envFile: layerOpts.envFile } : {}),
           },

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -1,3 +1,5 @@
+import { httpDeploymentLayerTransport, type DeploymentLayerTransport } from "../deployment-layer.ts";
+
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -32,6 +34,11 @@ import { dockerBasePort, sandboxCoreEnv, securityScreenEnv, type QmConfig } from
 import { discoverPlugins, type ResolvedPlugin } from "../plugins.ts";
 import { computedSecrets, runtimeSecretNames, secretsForService } from "../secrets.ts";
 import { readDeploymentState, withDeploymentLock, writeDeploymentState, type DeploymentState } from "../state.ts";
+
+/** Deployment-layer transport for docker: signed HTTP to the locally published core port. */
+export const dockerDeploymentLayerTransport: DeploymentLayerTransport = httpDeploymentLayerTransport({
+  urlOf: (config) => new URL(`http://127.0.0.1:${dockerBasePort(config)}/v1/deployment-layer`),
+});
 
 const safe = (s: string): string => s.replace(/[^A-Za-z0-9_.-]/g, "-");
 const ORG_LABEL_KEY = "qm.org";

--- a/cli/src/backends/fly.ts
+++ b/cli/src/backends/fly.ts
@@ -22,7 +22,7 @@ import {
   runnableServices,
   serviceDef,
   virtualServiceEnv,
-  type FlyServiceCtx,
+  type ServiceCtx,
   type LogOpts,
   type ServiceName,
 } from "../services.ts";
@@ -38,6 +38,63 @@ import { discoverPlugins, type ResolvedPlugin } from "../plugins.ts";
 import { computedSecrets, runtimeSecretNames, secretDestinations, secretsForService } from "../secrets.ts";
 import { flySandboxRepository, imageRepository, pinnedByDigest, recordSandboxPin } from "../commands/sandbox.ts";
 import { manifestRef } from "../manifest.ts";
+import { CONNECTIVITY_CODES, CoreUnreachableError, type DeploymentLayerTransport } from "../deployment-layer.ts";
+
+const flyServiceCtx = (config: QmConfig, appPrefix: string, deployAppPrefix: string): ServiceCtx => ({
+  appPrefix,
+  orgId: config.orgId,
+  deployAppPrefix,
+  publicUrl: config.publicUrl,
+  hasPortal: config.services.includes("portal"),
+  hasAuth: config.services.includes("auth"),
+  ...(config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN
+    ? { authAllowedEmailDomain: config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN }
+    : {}),
+  coreUrl: `http://${appPrefix}-core.internal:8080`,
+  authUrl: `http://${appPrefix}-auth.flycast`,
+});
+
+const FLY_RESPONSE = "QM_LAYER_RESPONSE=";
+const FLY_REMOTE_ERROR = "QM_LAYER_ERROR=";
+const FLY_REQUEST_TIMEOUT_MS = 120_000;
+
+function flyRequest(config: QmConfig, method: "GET" | "PUT", body: string): { status: number; body: string } {
+  const app = `${appPrefixOf(config)}-core`;
+  const script = `const fs=require("node:fs"),{createHmac}=require("node:crypto");const fail=error=>{const code=error&&(error.cause&&error.cause.code||error.code);console.log(${JSON.stringify(FLY_REMOTE_ERROR)}+JSON.stringify({message:error&&error.message?error.message:String(error),...(typeof code==="string"?{code}:{})}))};try{const method=${JSON.stringify(method)},path="/v1/deployment-layer",body=fs.readFileSync(0,"utf8"),timestamp=Math.floor(Date.now()/1000),canonical=method+"\\n"+path+"\\n"+body,secret=process.env.CORE_SIGNING_SECRET;if(!secret)throw new Error("CORE_SIGNING_SECRET is not set on core");const signature=createHmac("sha256",secret).update("v0:"+timestamp+":"+canonical).digest("hex");fetch("http://127.0.0.1:"+(process.env.PORT||8080)+path,{method,headers:{"content-type":"application/json","x-timestamp":String(timestamp),"x-signature":"v0="+signature},...(method==="PUT"?{body}: {})}).then(async response=>console.log(${JSON.stringify(FLY_RESPONSE)}+JSON.stringify({status:response.status,body:await response.text()}))).catch(fail)}catch(error){fail(error)}`;
+  const encoded = Buffer.from(script).toString("base64");
+  const command = `node -e "eval(Buffer.from('${encoded}','base64').toString())"`;
+  let output: string;
+  try {
+    output = execFileSync(flyBin(), ["ssh", "console", "-a", app, "-C", command], {
+      encoding: "utf8",
+      input: body,
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: FLY_REQUEST_TIMEOUT_MS,
+    });
+  } catch (error) {
+    const detail = error as { stdout?: string; stderr?: string; message?: string };
+    const text = `${detail.stderr ?? ""}${detail.stdout ?? ""}`.trim() || detail.message || "fly ssh failed";
+    if (/could not find app|app not found/i.test(text)) throw new CliError(`Fly app ${app} not found: ${text}`);
+    throw new CoreUnreachableError(`could not reach the Fly core: ${text}`);
+  }
+  const remoteError = output.split("\n").find((value) => value.startsWith(FLY_REMOTE_ERROR));
+  if (remoteError) {
+    const detail = JSON.parse(remoteError.slice(FLY_REMOTE_ERROR.length)) as { message?: string; code?: string };
+    const message = detail.message ?? "deployment-layer request failed on the core";
+    if (detail.code && CONNECTIVITY_CODES.has(detail.code)) {
+      throw new CoreUnreachableError(`the core process on ${app} is not accepting connections: ${message}`);
+    }
+    throw new CliError(`deployment-layer request failed on ${app}: ${message}`);
+  }
+  const line = output.split("\n").find((value) => value.startsWith(FLY_RESPONSE));
+  if (!line) throw new CliError(`Fly core returned no deployment-layer response`);
+  return JSON.parse(line.slice(FLY_RESPONSE.length)) as { status: number; body: string };
+}
+
+/** Deployment-layer transport for Fly: a signed request executed on the core VM over fly ssh. */
+export const flyDeploymentLayerTransport: DeploymentLayerTransport = (opts) =>
+  Promise.resolve(flyRequest(opts.config, opts.method, opts.body));
+
 import { doctorCommon, localDoctorSecrets, requireFlyAuth } from "./doctor.ts";
 
 export interface FlyUpOpts {
@@ -62,7 +119,7 @@ interface FlyCtx {
   orgId: string;
   region: string;
   flyOrg: string;
-  serviceCtx: FlyServiceCtx;
+  serviceCtx: ServiceCtx;
 }
 
 interface DeployTiming {
@@ -287,17 +344,7 @@ export function derivedTomlFor(config: QmConfig, service: ServiceName, repoRoot:
     orgId: config.orgId,
     region: config.region ?? "",
     flyOrg: config.flyOrg ?? "",
-    serviceCtx: {
-      appPrefix,
-      orgId: config.orgId,
-      deployAppPrefix,
-      publicUrl: config.publicUrl,
-      hasPortal: config.services.includes("portal"),
-      hasAuth: config.services.includes("auth"),
-      ...(config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN
-        ? { authAllowedEmailDomain: config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN }
-        : {}),
-    },
+    serviceCtx: flyServiceCtx(config, appPrefix, deployAppPrefix),
   };
   return deriveToml(ctx, service);
 }
@@ -711,17 +758,7 @@ function buildCtx(config: QmConfig, configDir: string, opts: Pick<FlyUpOpts, "bu
     orgId: config.orgId,
     region: config.region,
     flyOrg: config.flyOrg,
-    serviceCtx: {
-      appPrefix,
-      orgId: config.orgId,
-      deployAppPrefix,
-      publicUrl: config.publicUrl,
-      hasPortal: config.services.includes("portal"),
-      hasAuth: config.services.includes("auth"),
-      ...(config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN
-        ? { authAllowedEmailDomain: config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN }
-        : {}),
-    },
+    serviceCtx: flyServiceCtx(config, appPrefix, deployAppPrefix),
   };
 }
 

--- a/cli/src/backends/registry.ts
+++ b/cli/src/backends/registry.ts
@@ -1,7 +1,10 @@
 import { awsWorkloadArchitecture, loadConfigAt, sandboxImagePinErrors, type QmConfig } from "../config.ts";
 import { CliError, errMessage, note } from "../log.ts";
 import type { Target } from "../providers.ts";
-import { syncDeploymentLayer } from "../deployment-layer.ts";
+import { syncDeploymentLayer, type DeploymentLayerTransport } from "../deployment-layer.ts";
+import { TARGET_ENV_DEFAULTS, type TargetEnvDefaults } from "../target-env-defaults.ts";
+import { renderTerraformVars } from "../terraform.ts";
+import { buildAwsMicrovmImage, deleteAwsMicrovmImage, deleteAwsTaskDefinitions } from "../commands/infra.ts";
 import { runSandboxPublish, type SandboxPublishOpts } from "../commands/sandbox.ts";
 import { awsScaffold, dockerScaffold, flyScaffold, type ProviderScaffold } from "../provider-scaffold.ts";
 import type { ResolvedPlugin } from "../plugins.ts";
@@ -17,8 +20,9 @@ import {
   awsSecretsPush,
   awsStatus,
   awsUp,
+  awsDeploymentLayerTransport,
 } from "./aws.ts";
-import { dockerDown, dockerLogs, dockerStatus, dockerUp } from "./docker.ts";
+import { dockerDeploymentLayerTransport, dockerDown, dockerLogs, dockerStatus, dockerUp } from "./docker.ts";
 import { doctorCommon, localDoctorSecrets } from "./doctor.ts";
 import {
   flyCheckLive,
@@ -30,6 +34,7 @@ import {
   flySecretsPush,
   flyStatus,
   flyUp,
+  flyDeploymentLayerTransport,
 } from "./fly.ts";
 import type { Backend, BackendUpOptions } from "./types.ts";
 
@@ -42,8 +47,16 @@ export interface DeployContext {
   target: Target;
 }
 
+type InfraOperation = "render" | "build-image" | "delete-image" | "delete-task-definitions";
+
 export interface HostingProvider {
   id: Target;
+  /** How this target's CLI reaches the deployed core's /v1/deployment-layer endpoint. */
+  deploymentLayerTransport: DeploymentLayerTransport;
+  /** Per-target env defaults applied when a service env var is not set explicitly. */
+  envDefaults: TargetEnvDefaults;
+  /** Optional `qm infra` operations; targets without managed infra omit this. */
+  infra?: Partial<Record<InfraOperation, (ctx: DeployContext) => void | Promise<void>>>;
   upFlags: readonly string[];
   upOptions(ctx: DeployContext, flags: Readonly<Record<string, string | boolean>>, dryRun: boolean): BackendUpOptions;
   createBackend(ctx: DeployContext): Backend;
@@ -90,7 +103,7 @@ async function publishFlySandbox(ctx: DeployContext, opts: SandboxPublishOpts, p
   const config = loadConfigAt(ctx.configPath, { target: ctx.target }).config;
   await syncDeploymentLayer({
     config,
-    target: ctx.target,
+    transport: hostingProvider(ctx.target).deploymentLayerTransport,
     configDir: ctx.configDir,
     sandboxDir: ctx.sandboxDir,
     ...(ctx.envFile ? { envFile: ctx.envFile } : {}),
@@ -104,6 +117,8 @@ async function publishFlySandbox(ctx: DeployContext, opts: SandboxPublishOpts, p
 
 const docker: HostingProvider = {
   id: "docker",
+  deploymentLayerTransport: dockerDeploymentLayerTransport,
+  envDefaults: TARGET_ENV_DEFAULTS.docker,
   scaffold: dockerScaffold,
   upFlags: ["build-from", "only"],
   upOptions: (_ctx, flags, dryRun) => {
@@ -127,7 +142,7 @@ const docker: HostingProvider = {
       if (!opts.dryRun) {
         await syncDeploymentLayer({
           config: ctx.config,
-          target: ctx.target,
+          transport: hostingProvider(ctx.target).deploymentLayerTransport,
           configDir: ctx.configDir,
           sandboxDir: ctx.sandboxDir,
           ...(ctx.envFile ? { envFile: ctx.envFile } : {}),
@@ -160,6 +175,8 @@ const docker: HostingProvider = {
 
 const fly: HostingProvider = {
   id: "fly",
+  deploymentLayerTransport: flyDeploymentLayerTransport,
+  envDefaults: TARGET_ENV_DEFAULTS.fly,
   scaffold: flyScaffold,
   upFlags: ["build-from", "only", "image-label", "image-from", "image-repo-prefix", "build-only"],
   upOptions: (_ctx, flags, dryRun) => {
@@ -193,7 +210,7 @@ const fly: HostingProvider = {
       if (!opts.dryRun && !opts.buildOnly && (!opts.only || opts.only.includes("core"))) {
         await syncDeploymentLayer({
           config: ctx.config,
-          target: ctx.target,
+          transport: hostingProvider(ctx.target).deploymentLayerTransport,
           configDir: ctx.configDir,
           sandboxDir: ctx.sandboxDir,
           ...(ctx.envFile ? { envFile: ctx.envFile } : {}),
@@ -242,6 +259,16 @@ const fly: HostingProvider = {
 
 const aws: HostingProvider = {
   id: "aws",
+  deploymentLayerTransport: awsDeploymentLayerTransport,
+  envDefaults: TARGET_ENV_DEFAULTS.aws,
+  infra: {
+    render: (ctx) => renderTerraformVars(ctx.config, ctx.configDir),
+    "build-image": async (ctx) => {
+      await buildAwsMicrovmImage(ctx.config, ctx.configPath);
+    },
+    "delete-image": (ctx) => deleteAwsMicrovmImage(ctx.config),
+    "delete-task-definitions": (ctx) => deleteAwsTaskDefinitions(ctx.config),
+  },
   scaffold: awsScaffold,
   upFlags: ["build-from", "only", "yes", "image-label"],
   upOptions: (ctx, flags, dryRun) => {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -18,7 +18,6 @@ import { HOSTING_PROVIDER_IDS, hostingProviderChoices, isTarget, type Target } f
 import { type LogOpts } from "./services.ts";
 import { runInit } from "./commands/init.ts";
 import { runSetup } from "./commands/setup.ts";
-import { buildAwsMicrovmImage, deleteAwsMicrovmImage, deleteAwsTaskDefinitions } from "./commands/infra.ts";
 import { runSandboxBuild } from "./commands/sandbox.ts";
 import { runChecks, runCheckCommand } from "./commands/check.ts";
 import { assertNodeEngine } from "./preflight.ts";
@@ -448,18 +447,14 @@ async function dispatch(argv: string[]): Promise<void> {
         throw new CliError(`usage: ${CLI_NAME} infra render|build-image|delete-image|delete-task-definitions`);
       }
       const ctx = deployContext(flags);
-      if (ctx.target !== "aws") throw new CliError(`infra ${operation} is only available for target aws`);
+      const run = hostingProvider(ctx.target).infra?.[operation];
+      if (!run) throw new CliError(`infra ${operation} is not available for target ${ctx.target}`);
       if (operation === "delete-image" || operation === "delete-task-definitions") {
         if (!boolFlag(flags, "yes"))
           throw new CliError(`infra ${operation} requires --yes`, { clause: "cli.invocation" });
-        if (operation === "delete-image") await deleteAwsMicrovmImage(ctx.config);
-        else await deleteAwsTaskDefinitions(ctx.config);
-      } else if (operation === "build-image") {
-        await buildAwsMicrovmImage(ctx.config, ctx.configPath);
-      } else {
-        runChecks(ctx.config, ctx.configDir, ctx.sandboxDir, { report: false });
-        renderTerraformVars(ctx.config, ctx.configDir);
       }
+      if (operation === "render") runChecks(ctx.config, ctx.configDir, ctx.sandboxDir, { report: false });
+      await run(ctx);
       return;
     }
 

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -5,6 +5,7 @@ import { CliError, errMessage, header, ok, step } from "../log.ts";
 import { parseToolDescriptor, type ToolDescriptor } from "../sandbox-layer.ts";
 import { canonicalJson } from "../util.ts";
 import { runChecks } from "./check.ts";
+import { hostingProvider } from "../backends/registry.ts";
 
 export function expectedDescriptors(bundle: DeploymentLayerBundle): ToolDescriptor[] {
   return bundle.tools.map((file) => parseToolDescriptor(file.content, file.path));
@@ -36,8 +37,8 @@ export async function runConformance(
   try {
     response = await deploymentLayerRequest({
       config,
-      target,
       configDir,
+      transport: hostingProvider(target).deploymentLayerTransport,
       method: "GET",
       ...(envFile ? { envFile } : {}),
     });

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -478,9 +478,41 @@ export function readConfigOrgId(path: string): string | undefined {
   }
 }
 
+const VALID_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
+  "contract",
+  "orgId",
+  "publicUrl",
+  "apiUrl",
+  "target",
+  "model",
+  "modelProvider",
+  "basePort",
+  "services",
+  "plugins",
+  "skills",
+  "env",
+  "secretEnv",
+  "securityScreen",
+  "vms",
+  "imageOverrides",
+  "sandbox",
+  "appPrefix",
+  "region",
+  "flyOrg",
+  "imageFrom",
+  "deployAppPrefix",
+  "aws",
+]);
+
 function validate(raw: unknown, path: string): QmConfig {
   if (!isPlainObject(raw)) throw new CliError(`${path}: expected a JSON object`);
   const o = raw;
+
+  for (const key of Object.keys(o)) {
+    if (!VALID_TOP_LEVEL_KEYS.has(key)) {
+      throw new CliError(`${path}: unknown top-level field ${JSON.stringify(key)}`);
+    }
+  }
 
   const contract = o["contract"];
   if (contract !== CONTRACT_VERSION) {
@@ -499,13 +531,18 @@ function validate(raw: unknown, path: string): QmConfig {
 
   const publicUrl = o["publicUrl"];
   if (typeof publicUrl !== "string" || !publicUrl.trim()) {
-    throw new CliError(`${path}: "publicUrl" must be a non-empty http(s) URL`);
+    throw new CliError(`${path}: "publicUrl" must be a non-empty http(s) origin URL`);
   }
   try {
     const parsed = new URL(publicUrl);
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("protocol");
+    if (parsed.pathname !== "/" || parsed.search || parsed.hash || parsed.username || parsed.password)
+      throw new Error("origin");
+    if (parsed.hostname.endsWith(".")) throw new Error("trailing dot");
   } catch {
-    throw new CliError(`${path}: "publicUrl" must be a non-empty http(s) URL`);
+    throw new CliError(
+      `${path}: "publicUrl" must be a non-empty http(s) origin URL without credentials, a path, query, fragment, or trailing hostname dot`,
+    );
   }
 
   const apiUrl = o["apiUrl"];
@@ -796,13 +833,22 @@ function validateBrokerTrust(config: QmConfig, path: string, secrets?: ReadonlyM
   }
 }
 
+function isSlackIssuer(issuer: string): boolean {
+  try {
+    const host = new URL(issuer).hostname;
+    return host === "slack.com" || host.endsWith(".slack.com");
+  } catch {
+    return false;
+  }
+}
+
 export function validatePortalTrust(config: QmConfig, path = "config", secrets?: ReadonlyMap<string, string>): void {
   if (!config.services.includes("portal")) return;
   if (config.services.includes("auth")) return validateBrokerTrust(config, path, secrets);
   const env = config.env.portal ?? {};
   const issuer = env.OIDC_ISSUER?.trim() || "https://slack.com";
   const jwksUri = env.OIDC_JWKS_URI?.trim();
-  if (issuer !== "https://slack.com" && isMissingOrPlaceholder(jwksUri)) {
+  if (!isSlackIssuer(issuer) && isMissingOrPlaceholder(jwksUri)) {
     throw new CliError(`${path}: portal requires env.portal.OIDC_JWKS_URI when using a non-Slack OIDC issuer`);
   }
   if (jwksUri !== undefined) {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -13,7 +13,13 @@ import {
   type DeclaredServiceName,
   type ServiceName,
 } from "./services.ts";
-import { hostingProviderChoices, isTarget, type Target } from "./providers.ts";
+import {
+  hostingProviderChoices,
+  isTarget,
+  type Target,
+  SANDBOX_BACKEND_POLICY,
+  targetsAllowingSandboxBackend,
+} from "./providers.ts";
 import { envNum, isEnvVarName, isMissingOrPlaceholder } from "./util.ts";
 
 export const CONFIG_FILENAME = "qm.config.jsonc";
@@ -1335,10 +1341,14 @@ function validateSandbox(raw: unknown, path: string, target: Target): SandboxCon
     for (const name of se) assertEnvName(name, `"sandbox.secretEnv" entry`);
     out.secretEnv = se;
   }
+  if (out.backend !== undefined && !SANDBOX_BACKEND_POLICY[target].allowed.includes(out.backend)) {
+    const targets = targetsAllowingSandboxBackend(out.backend)
+      .map((allowed) => JSON.stringify(allowed))
+      .join(" or ");
+    const label = out.backend === "aws" ? " (Lambda MicroVM sandboxes)" : "";
+    throw new CliError(`${path}: "sandbox.backend": ${JSON.stringify(out.backend)}${label} requires target ${targets}`);
+  }
   if (out.backend === "aws") {
-    if (target !== "aws") {
-      throw new CliError(`${path}: "sandbox.backend": "aws" (Lambda MicroVM sandboxes) requires target "aws"`);
-    }
     const stray = (["app", "image", "baseImage", "env", "secretEnv"] as const).filter((key) => out[key] !== undefined);
     if (stray.length) {
       throw new CliError(
@@ -1354,9 +1364,9 @@ function validateSandbox(raw: unknown, path: string, target: Target): SandboxCon
       `${path}: "sandbox.backend": ${JSON.stringify(out.backend)} requires "sandbox.app" (the Fly app agents execute in)`,
     );
   }
-  if (target === "aws" && out.backend === undefined) {
+  if (SANDBOX_BACKEND_POLICY[target].requireExplicit && out.backend === undefined) {
     throw new CliError(
-      `${path}: target "aws" requires an explicit "sandbox.backend" — "sprites" boots the operator-published layer image in "sandbox.app"; "aws" runs Lambda MicroVM sandboxes (or omit the whole "sandbox" block for the MicroVM default)`,
+      `${path}: target ${JSON.stringify(target)} requires an explicit "sandbox.backend" — "sprites" boots the operator-published layer image in "sandbox.app"; "aws" runs Lambda MicroVM sandboxes (or omit the whole "sandbox" block for the MicroVM default)`,
     );
   }
   return out;

--- a/cli/src/deployment-layer.ts
+++ b/cli/src/deployment-layer.ts
@@ -1,10 +1,9 @@
-import { execFileSync } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { join, relative, sep } from "node:path";
-import { appPrefixOf, dockerBasePort, type Target, type QmConfig } from "./config.ts";
+import type { QmConfig } from "./config.ts";
 import { CliError, errMessage, step, warn } from "./log.ts";
-import { capture, deploymentSecretValue, flyBin, readEnvFile } from "./util.ts";
+import { deploymentSecretValue, readEnvFile } from "./util.ts";
 
 interface DeploymentLayerFile {
   path: string;
@@ -135,16 +134,15 @@ function signingHeaders(secret: string, method: string, path: string, body: stri
   };
 }
 
-function coreUrl(config: QmConfig, target: Target): URL {
-  if (target === "docker") return new URL(`http://127.0.0.1:${dockerBasePort(config)}/v1/deployment-layer`);
+function defaultCoreUrl(config: QmConfig): URL {
   const url = new URL(config.publicUrl);
   url.pathname = `${url.pathname.replace(/\/+$/, "")}/v1/deployment-layer`;
   return url;
 }
 
-class CoreUnreachableError extends CliError {}
+export class CoreUnreachableError extends CliError {}
 
-const CONNECTIVITY_CODES = new Set([
+export const CONNECTIVITY_CODES = new Set([
   "ECONNREFUSED",
   "ECONNRESET",
   "ENOTFOUND",
@@ -168,84 +166,67 @@ function isCoreUnreachable(error: unknown): boolean {
   return false;
 }
 
-const FLY_RESPONSE = "QM_LAYER_RESPONSE=";
-const FLY_REMOTE_ERROR = "QM_LAYER_ERROR=";
-const FLY_REQUEST_TIMEOUT_MS = 120_000;
+interface DeploymentLayerTransportOpts {
+  config: QmConfig;
+  configDir: string;
+  method: "GET" | "PUT";
+  body: string;
+  envFile?: string;
+}
 
-function flyRequest(config: QmConfig, method: "GET" | "PUT", body: string): { status: number; body: string } {
-  const app = `${appPrefixOf(config)}-core`;
-  const script = `const fs=require("node:fs"),{createHmac}=require("node:crypto");const fail=error=>{const code=error&&(error.cause&&error.cause.code||error.code);console.log(${JSON.stringify(FLY_REMOTE_ERROR)}+JSON.stringify({message:error&&error.message?error.message:String(error),...(typeof code==="string"?{code}:{})}))};try{const method=${JSON.stringify(method)},path="/v1/deployment-layer",body=fs.readFileSync(0,"utf8"),timestamp=Math.floor(Date.now()/1000),canonical=method+"\\n"+path+"\\n"+body,secret=process.env.CORE_SIGNING_SECRET;if(!secret)throw new Error("CORE_SIGNING_SECRET is not set on core");const signature=createHmac("sha256",secret).update("v0:"+timestamp+":"+canonical).digest("hex");fetch("http://127.0.0.1:"+(process.env.PORT||8080)+path,{method,headers:{"content-type":"application/json","x-timestamp":String(timestamp),"x-signature":"v0="+signature},...(method==="PUT"?{body}: {})}).then(async response=>console.log(${JSON.stringify(FLY_RESPONSE)}+JSON.stringify({status:response.status,body:await response.text()}))).catch(fail)}catch(error){fail(error)}`;
-  const encoded = Buffer.from(script).toString("base64");
-  const command = `node -e "eval(Buffer.from('${encoded}','base64').toString())"`;
-  let output: string;
-  try {
-    output = execFileSync(flyBin(), ["ssh", "console", "-a", app, "-C", command], {
-      encoding: "utf8",
-      input: body,
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: FLY_REQUEST_TIMEOUT_MS,
+/**
+ * How a hosting target reaches its core's /v1/deployment-layer endpoint.
+ * Each HostingProvider supplies one; nothing in this file knows about targets.
+ */
+export type DeploymentLayerTransport = (
+  opts: DeploymentLayerTransportOpts,
+) => Promise<{ status: number; body: string }>;
+
+/** Signed-HTTP transport used by providers whose core is reachable over plain HTTPS. */
+export function httpDeploymentLayerTransport(
+  o: {
+    urlOf?: (config: QmConfig) => URL;
+    secretFallback?: (config: QmConfig) => string | undefined;
+    timeoutMs?: number;
+  } = {},
+): DeploymentLayerTransport {
+  return async (opts) => {
+    const envPath = opts.envFile ?? join(opts.configDir, ".env");
+    const env = existsSync(envPath) ? readEnvFile(envPath) : new Map<string, string>();
+    let secret = deploymentSecretValue("CORE_SIGNING_SECRET", env.get("CORE_SIGNING_SECRET"));
+    if (!secret && o.secretFallback) secret = o.secretFallback(opts.config);
+    if (!secret) throw new CliError(`CORE_SIGNING_SECRET is required locally to access the deployment layer`);
+    const url = (o.urlOf ?? defaultCoreUrl)(opts.config);
+    const response = await fetch(url, {
+      method: opts.method,
+      headers: signingHeaders(secret, opts.method, url.pathname + url.search, opts.body),
+      ...(opts.method === "PUT" ? { body: opts.body } : {}),
+      ...(o.timeoutMs ? { signal: AbortSignal.timeout(o.timeoutMs) } : {}),
     });
-  } catch (error) {
-    const detail = error as { stdout?: string; stderr?: string; message?: string };
-    const text = `${detail.stderr ?? ""}${detail.stdout ?? ""}`.trim() || detail.message || "fly ssh failed";
-    if (/could not find app|app not found/i.test(text)) throw new CliError(`Fly app ${app} not found: ${text}`);
-    throw new CoreUnreachableError(`could not reach the Fly core: ${text}`);
-  }
-  const remoteError = output.split("\n").find((value) => value.startsWith(FLY_REMOTE_ERROR));
-  if (remoteError) {
-    const detail = JSON.parse(remoteError.slice(FLY_REMOTE_ERROR.length)) as { message?: string; code?: string };
-    const message = detail.message ?? "deployment-layer request failed on the core";
-    if (detail.code && CONNECTIVITY_CODES.has(detail.code)) {
-      throw new CoreUnreachableError(`the core process on ${app} is not accepting connections: ${message}`);
-    }
-    throw new CliError(`deployment-layer request failed on ${app}: ${message}`);
-  }
-  const line = output.split("\n").find((value) => value.startsWith(FLY_RESPONSE));
-  if (!line) throw new CliError(`Fly core returned no deployment-layer response`);
-  return JSON.parse(line.slice(FLY_RESPONSE.length)) as { status: number; body: string };
+    return { status: response.status, body: await response.text() };
+  };
 }
 
 export async function deploymentLayerRequest(opts: {
   config: QmConfig;
-  target: Target;
   configDir: string;
   method: "GET" | "PUT";
   body?: string;
   envFile?: string;
+  transport: DeploymentLayerTransport;
 }): Promise<{ status: number; body: string }> {
-  const body = opts.body ?? "";
-  if (opts.target === "fly") return flyRequest(opts.config, opts.method, body);
-  const envPath = opts.envFile ?? join(opts.configDir, ".env");
-  const env = existsSync(envPath) ? readEnvFile(envPath) : new Map<string, string>();
-  let secret = deploymentSecretValue("CORE_SIGNING_SECRET", env.get("CORE_SIGNING_SECRET"));
-  if (!secret && opts.target === "aws" && opts.config.aws) {
-    secret = capture(process.env.AWS_BIN ?? "aws", [
-      "secretsmanager",
-      "get-secret-value",
-      "--secret-id",
-      `${opts.config.aws.secretsPrefix}CORE_SIGNING_SECRET`,
-      "--query",
-      "SecretString",
-      "--output",
-      "text",
-      "--region",
-      opts.config.aws.region,
-    ]).trim();
-  }
-  if (!secret) throw new CliError(`CORE_SIGNING_SECRET is required locally to access the deployment layer`);
-  const url = coreUrl(opts.config, opts.target);
-  const response = await fetch(url, {
+  return opts.transport({
+    config: opts.config,
+    configDir: opts.configDir,
     method: opts.method,
-    headers: signingHeaders(secret, opts.method, url.pathname + url.search, body),
-    ...(opts.method === "PUT" ? { body } : {}),
-    ...(opts.target === "aws" ? { signal: AbortSignal.timeout(60_000) } : {}),
+    body: opts.body ?? "",
+    ...(opts.envFile ? { envFile: opts.envFile } : {}),
   });
-  return { status: response.status, body: await response.text() };
 }
 
 export async function syncDeploymentLayer(opts: {
   config: QmConfig;
-  target: Target;
+  transport: DeploymentLayerTransport;
   configDir: string;
   sandboxDir: string;
   envFile?: string;
@@ -261,7 +242,7 @@ export async function syncDeploymentLayer(opts: {
 
 export async function currentDeploymentLayerState(opts: {
   config: QmConfig;
-  target: Target;
+  transport: DeploymentLayerTransport;
   configDir: string;
   envFile?: string;
 }): Promise<DeploymentLayerState> {
@@ -303,7 +284,7 @@ export async function currentDeploymentLayerState(opts: {
 export async function syncDeploymentLayerBody(
   opts: {
     config: QmConfig;
-    target: Target;
+    transport: DeploymentLayerTransport;
     configDir: string;
     envFile?: string;
     allowUnavailable?: boolean;
@@ -314,10 +295,10 @@ export async function syncDeploymentLayerBody(
   try {
     response = await deploymentLayerRequest({
       config: opts.config,
-      target: opts.target,
       configDir: opts.configDir,
       method: "PUT",
       body,
+      transport: opts.transport,
       ...(opts.envFile ? { envFile: opts.envFile } : {}),
     });
   } catch (error) {

--- a/cli/src/providers.ts
+++ b/cli/src/providers.ts
@@ -5,5 +5,24 @@ export type Target = (typeof HOSTING_PROVIDER_IDS)[number];
 export const isTarget = (value: unknown): value is Target =>
   typeof value === "string" && (HOSTING_PROVIDER_IDS as readonly string[]).includes(value);
 
+export type SandboxBackendId = "sprites" | "aws";
+
+export interface SandboxBackendPolicy {
+  /** Sandbox backends this hosting target can run. */
+  allowed: readonly SandboxBackendId[];
+  /** Whether the target requires "sandbox.backend" to be set explicitly in config. */
+  requireExplicit: boolean;
+}
+
+/** Keyed by hosting target so adding a target forces a sandbox-backend decision. */
+export const SANDBOX_BACKEND_POLICY: Record<Target, SandboxBackendPolicy> = {
+  docker: { allowed: ["sprites"], requireExplicit: false },
+  fly: { allowed: ["sprites"], requireExplicit: false },
+  aws: { allowed: ["sprites", "aws"], requireExplicit: true },
+};
+
+export const targetsAllowingSandboxBackend = (backend: SandboxBackendId): Target[] =>
+  HOSTING_PROVIDER_IDS.filter((target) => SANDBOX_BACKEND_POLICY[target].allowed.includes(backend));
+
 export const hostingProviderChoices = (): string =>
   `${HOSTING_PROVIDER_IDS.slice(0, -1).join(", ")}, or ${HOSTING_PROVIDER_IDS.at(-1)}`;

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -1,5 +1,6 @@
 import { isVirtualService, type DeclaredServiceName } from "./services.ts";
 import type { ModelProvider, QmConfig } from "./config.ts";
+import { TARGET_ENV_DEFAULTS } from "./target-env-defaults.ts";
 
 type SecretCondition =
   | { kind: "env-equals"; service: DeclaredServiceName; name: string; value: string }
@@ -385,21 +386,8 @@ function conditionMatches(config: QmConfig, condition: SecretCondition): boolean
   return value === condition.value;
 }
 
-export const FLY_TEMPLATE_ENV_DEFAULTS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  core: { HARNESS: "pi" },
-};
-
-const AWS_RENDER_ENV_DEFAULTS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
-  core: { SANDBOX_BACKEND: "aws" },
-};
-
 function targetEnvDefault(config: QmConfig, service: string, name: string): string | undefined {
-  if (config.target === "fly") return FLY_TEMPLATE_ENV_DEFAULTS[service]?.[name];
-  if (config.target !== "aws") return undefined;
-  const rendered = AWS_RENDER_ENV_DEFAULTS[service]?.[name];
-  if (rendered === undefined) return undefined;
-  if (name === "SANDBOX_BACKEND") return config.sandbox?.backend ?? rendered;
-  return rendered;
+  return TARGET_ENV_DEFAULTS[config.target](config, service, name);
 }
 
 function requirementFor(config: QmConfig, spec: SecretSpec): boolean | null {

--- a/cli/src/services.ts
+++ b/cli/src/services.ts
@@ -38,7 +38,7 @@ export interface LogOpts {
   tail?: number;
 }
 
-export interface FlyServiceCtx {
+export interface ServiceCtx {
   appPrefix: string;
   orgId: string;
   deployAppPrefix: string;
@@ -46,10 +46,14 @@ export interface FlyServiceCtx {
   hasPortal: boolean;
   hasAuth: boolean;
   authAllowedEmailDomain?: string;
+  /** Provider-supplied internal URL other services use to reach core. */
+  coreUrl: string;
+  /** Provider-supplied internal base URL of the auth service. */
+  authUrl: string;
 }
 
 interface FlyServiceSpec {
-  managed: (s: FlyServiceCtx) => Record<string, string>;
+  managed: (s: ServiceCtx) => Record<string, string>;
   stackKeys: string[];
   deployFlags: string[];
   flycast?: boolean;
@@ -134,16 +138,13 @@ export function brokerWiring(
   return {};
 }
 
-const flyCoreUrl = (s: FlyServiceCtx): string => `http://${s.appPrefix}-core.internal:8080`;
-const flyAuthUrl = (s: FlyServiceCtx): string => `http://${s.appPrefix}-auth.flycast`;
-
-const pluginWiring = (service: string, s: FlyServiceCtx): Record<string, string> => ({
-  CORE_API_URL: flyCoreUrl(s),
+const pluginWiring = (service: string, s: ServiceCtx): Record<string, string> => ({
+  CORE_API_URL: s.coreUrl,
   ...orgEnv(service, s.orgId, s.publicUrl, s.hasPortal),
   ...(s.hasAuth
     ? brokerWiring(service, {
         publicUrl: s.publicUrl,
-        authBaseUrl: flyAuthUrl(s),
+        authBaseUrl: s.authUrl,
         ...(s.authAllowedEmailDomain ? { allowedEmailDomain: s.authAllowedEmailDomain } : {}),
       })
     : {}),

--- a/cli/src/slack-manifests.ts
+++ b/cli/src/slack-manifests.ts
@@ -32,10 +32,20 @@ export interface SlackManifests {
   sso: string;
 }
 
+function isSlackHost(value: string | undefined): boolean {
+  if (!value) return false;
+  try {
+    const host = new URL(value).hostname;
+    return host === "slack.com" || host.endsWith(".slack.com");
+  } catch {
+    return false;
+  }
+}
+
 export function usesSlackOidc(config: QmConfig): boolean {
   const portal = config.env.portal ?? {};
   return ["OIDC_AUTH_ENDPOINT", "OIDC_TOKEN_ENDPOINT", "OIDC_USERINFO_ENDPOINT", "OIDC_ISSUER"].some((name) =>
-    portal[name]?.includes("slack.com"),
+    isSlackHost(portal[name]),
   );
 }
 

--- a/cli/src/target-env-defaults.ts
+++ b/cli/src/target-env-defaults.ts
@@ -1,0 +1,27 @@
+import type { QmConfig } from "./config.ts";
+import type { Target } from "./providers.ts";
+
+/**
+ * Per-target env defaults applied when a service env var is not set explicitly.
+ * Keyed by hosting target so the compiler enumerates every gap when a target is added.
+ */
+export type TargetEnvDefaults = (config: QmConfig, service: string, name: string) => string | undefined;
+
+export const FLY_TEMPLATE_ENV_DEFAULTS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  core: { HARNESS: "pi" },
+};
+
+const AWS_RENDER_ENV_DEFAULTS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  core: { SANDBOX_BACKEND: "aws" },
+};
+
+export const TARGET_ENV_DEFAULTS: Record<Target, TargetEnvDefaults> = {
+  docker: () => undefined,
+  fly: (_config, service, name) => FLY_TEMPLATE_ENV_DEFAULTS[service]?.[name],
+  aws: (config, service, name) => {
+    const rendered = AWS_RENDER_ENV_DEFAULTS[service]?.[name];
+    if (rendered === undefined) return undefined;
+    if (name === "SANDBOX_BACKEND") return config.sandbox?.backend ?? rendered;
+    return rendered;
+  },
+};

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -213,16 +213,37 @@ export function isInvalidSecret(name: string, value: string | undefined): boolea
   );
 }
 
+// One line of a dotenv file, following Node's --env-file semantics for the
+// `export ` prefix and quoted values ('', "", ``: the quotes are stripped and
+// \n expands to a newline inside double quotes). Two deliberate divergences
+// from Node, both pinned by tests: a `#` inside an unquoted value is part of
+// the value (tokens and URL fragments), and a quoted value ends on its own
+// line (writeEnvValue never emits multi-line values).
+function parseEnvLine(raw: string): [key: string, value: string] | undefined {
+  let line = raw.trim();
+  if (!line || line.startsWith("#")) return undefined;
+  if (line.startsWith("export ")) line = line.slice("export ".length).trimStart();
+  const eq = line.indexOf("=");
+  if (eq <= 0) return undefined;
+  const key = line.slice(0, eq).trim();
+  let value = line.slice(eq + 1).trim();
+  const quote = value[0];
+  if (quote === '"' || quote === "'" || quote === "`") {
+    const end = value.indexOf(quote, 1);
+    if (end > 0) {
+      value = value.slice(1, end);
+      if (quote === '"') value = value.replaceAll("\\n", "\n");
+    }
+  }
+  return [key, value];
+}
+
 export function readEnvFile(path: string): Map<string, string> {
   const out = new Map<string, string>();
   if (!existsSync(path)) return out;
   for (const raw of readFileSync(path, "utf8").split("\n")) {
-    const line = raw.trim();
-    if (!line || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq <= 0) continue;
-    const key = line.slice(0, eq).trim();
-    if (isEnvVarName(key)) out.set(key, line.slice(eq + 1));
+    const entry = parseEnvLine(raw);
+    if (entry && isEnvVarName(entry[0])) out.set(entry[0], entry[1]);
   }
   return out;
 }

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -62,6 +62,12 @@ test("required fields: orgId, target, services (must include core), valid servic
     const { config } = loadConfigAt(path);
     assert.deepEqual(config.services, ["core", "web-ui", "admin", "portal"]);
   });
+  withConfig({ unknownField: "bad" }, ({ path }) =>
+    assert.throws(() => loadConfigAt(path), /unknown top-level field "unknownField"/),
+  );
+  withConfig({ org_id: "acme" }, ({ path }) =>
+    assert.throws(() => loadConfigAt(path), /unknown top-level field "org_id"/),
+  );
 });
 
 test("apiUrl must be an http(s) origin URL; the trailing slash is stripped", () => {
@@ -80,6 +86,25 @@ test("apiUrl must be an http(s) origin URL; the trailing slash is stripped", () 
   ]) {
     withConfig({ apiUrl }, ({ path }) =>
       assert.throws(() => loadConfigAt(path), /"apiUrl" must be a non-empty http\(s\) origin URL/),
+    );
+  }
+});
+
+test("publicUrl must be an http(s) origin URL on every target", () => {
+  withConfig({ publicUrl: "https://acme.example/" }, ({ path }) =>
+    assert.equal(loadConfigAt(path).config.publicUrl, "https://acme.example"),
+  );
+  for (const publicUrl of [
+    "",
+    "not a url",
+    "ftp://acme.example",
+    "https://acme.example/subpath",
+    "https://acme.example?x=1",
+    "https://user:pw@acme.example",
+    "https://acme.example.",
+  ]) {
+    withConfig({ publicUrl }, ({ path }) =>
+      assert.throws(() => loadConfigAt(path), /"publicUrl" must be a non-empty http\(s\) origin URL/),
     );
   }
 });

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -6,6 +6,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CONFIG_FILENAME, loadConfigInDir, type QmConfig } from "../src/config.ts";
 import { currentDeploymentLayerState, deploymentLayerBundle, syncDeploymentLayer } from "../src/deployment-layer.ts";
+import { dockerDeploymentLayerTransport } from "../src/backends/docker.ts";
+import { flyDeploymentLayerTransport } from "../src/backends/fly.ts";
+import { awsDeploymentLayerTransport } from "../src/backends/aws.ts";
 import { expectedDescriptors, runConformance } from "../src/commands/conformance.ts";
 
 const SECRET = "conformance-test-secret";
@@ -93,7 +96,13 @@ test("the deployment layer sync rejects a bundle over the core's 1 MB limit befo
     process.env.CORE_SIGNING_SECRET = SECRET;
     try {
       await assert.rejects(
-        () => syncDeploymentLayer({ config, target: "docker", configDir: dir, sandboxDir: join(dir, "sandbox") }),
+        () =>
+          syncDeploymentLayer({
+            config,
+            transport: dockerDeploymentLayerTransport,
+            configDir: dir,
+            sandboxDir: join(dir, "sandbox"),
+          }),
         /1 MB/,
       );
     } finally {
@@ -111,7 +120,7 @@ test("a missing sandbox directory skips sync instead of replacing the deployed l
   try {
     await syncDeploymentLayer({
       config: makeConfig("http://example.invalid"),
-      target: "docker",
+      transport: dockerDeploymentLayerTransport,
       configDir: dir,
       sandboxDir: join(dir, "sandbox"),
     });
@@ -212,7 +221,7 @@ test("the docker sync PUTs the bundle to the base port with verifiable v0 HMAC s
     await withEnv({ CORE_SIGNING_SECRET: "wrong-ambient-secret", QM_BASE_PORT: String(port) }, () =>
       syncDeploymentLayer({
         config: makeConfig("http://example.invalid"),
-        target: "docker",
+        transport: dockerDeploymentLayerTransport,
         configDir: dir,
         sandboxDir: join(dir, "sandbox"),
       }),
@@ -408,7 +417,7 @@ test("a successful memory-backed sync warns that the layer will not survive rest
     await withEnv({ CORE_SIGNING_SECRET: SECRET, QM_BASE_PORT: String(port) }, () =>
       syncDeploymentLayer({
         config: makeConfig("http://example.invalid"),
-        target: "docker",
+        transport: dockerDeploymentLayerTransport,
         configDir: dir,
         sandboxDir: join(dir, "sandbox"),
       }),
@@ -429,7 +438,7 @@ test("a publicUrl with a base path keeps it in the request path and the signed c
     await withEnv({ CORE_SIGNING_SECRET: SECRET }, () =>
       syncDeploymentLayer({
         config: makeConfig(`http://127.0.0.1:${port}/base`),
-        target: "aws",
+        transport: awsDeploymentLayerTransport,
         configDir: dir,
         sandboxDir: join(dir, "sandbox"),
       }),
@@ -456,7 +465,7 @@ test("a non-2xx sync response is a CliError carrying the status and body", async
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
           }),
@@ -479,7 +488,7 @@ test("a 2xx response with unparseable JSON is a CliError with a body snippet, no
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
           }),
@@ -503,7 +512,7 @@ test("a 2xx response with an invalid durability shape fails instead of suppressi
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
           }),
@@ -516,7 +525,7 @@ test("a 2xx response with an invalid durability shape fails instead of suppressi
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
           }),
@@ -537,7 +546,7 @@ test("allowUnavailable swallows an unreachable core but NOT a local config error
     await withEnv({ CORE_SIGNING_SECRET: SECRET, QM_BASE_PORT: String(port) }, () =>
       syncDeploymentLayer({
         config: makeConfig("http://example.invalid"),
-        target: "docker",
+        transport: dockerDeploymentLayerTransport,
         configDir: dir,
         sandboxDir: join(dir, "sandbox"),
         allowUnavailable: true,
@@ -548,7 +557,7 @@ test("allowUnavailable swallows an unreachable core but NOT a local config error
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
           }),
@@ -560,7 +569,7 @@ test("allowUnavailable swallows an unreachable core but NOT a local config error
         () =>
           syncDeploymentLayer({
             config: makeConfig("http://example.invalid"),
-            target: "docker",
+            transport: dockerDeploymentLayerTransport,
             configDir: dir,
             sandboxDir: join(dir, "sandbox"),
             allowUnavailable: true,
@@ -583,7 +592,7 @@ function fakeFly(dir: string, body: string): string {
 function flySyncOpts(dir: string, allowUnavailable?: boolean): Parameters<typeof syncDeploymentLayer>[0] {
   return {
     config: makeConfig("http://example.invalid"),
-    target: "fly",
+    transport: flyDeploymentLayerTransport,
     configDir: dir,
     sandboxDir: join(dir, "sandbox"),
     ...(allowUnavailable !== undefined ? { allowUnavailable } : {}),
@@ -743,7 +752,7 @@ test("a core with no durable layer record bootstraps as empty regardless of its 
     await withEnv({ CORE_SIGNING_SECRET: SECRET }, async () => {
       const state = await currentDeploymentLayerState({
         config: makeConfig("http://localhost:8080"),
-        target: "docker",
+        transport: dockerDeploymentLayerTransport,
         configDir: dir,
       });
       assert.equal(state.body, JSON.stringify({ contract: 1, tools: [], skills: [] }));
@@ -779,7 +788,11 @@ test("a durable record whose bundle is missing still fails the read", async () =
   try {
     await withEnv({ CORE_SIGNING_SECRET: SECRET }, async () => {
       await assert.rejects(
-        currentDeploymentLayerState({ config: makeConfig("http://localhost:8080"), target: "docker", configDir: dir }),
+        currentDeploymentLayerState({
+          config: makeConfig("http://localhost:8080"),
+          transport: dockerDeploymentLayerTransport,
+          configDir: dir,
+        }),
         /did not return a restorable bundle/,
       );
     });

--- a/cli/test/secrets.test.ts
+++ b/cli/test/secrets.test.ts
@@ -4,8 +4,8 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { sandboxCoreEnv, type QmConfig } from "../src/config.ts";
+import { FLY_TEMPLATE_ENV_DEFAULTS } from "../src/target-env-defaults.ts";
 import {
-  FLY_TEMPLATE_ENV_DEFAULTS,
   computedSecrets,
   renderEnvExample,
   runtimeSecretNames,

--- a/cli/test/slack-manifests.test.ts
+++ b/cli/test/slack-manifests.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { usesSlackOidc } from "../src/slack-manifests.ts";
+import type { QmConfig } from "../src/config.ts";
+
+function configWithPortalEnv(env: Record<string, string>): QmConfig {
+  return { env: { portal: env } } as unknown as QmConfig;
+}
+
+test("usesSlackOidc matches by hostname, not substring", () => {
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "https://slack.com" })), true);
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "https://enterprise.slack.com" })), true);
+  assert.equal(
+    usesSlackOidc(configWithPortalEnv({ OIDC_AUTH_ENDPOINT: "https://slack.com/openid/connect/authorize" })),
+    true,
+  );
+  // substring lookalikes must not count as Slack
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "https://not-slack.com.example/idp" })), false);
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "https://evil-slack.com/auth" })), false);
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "https://slack.com.evil.example" })), false);
+  // malformed values fail closed
+  assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "slack.com" })), false);
+  assert.equal(usesSlackOidc(configWithPortalEnv({})), false);
+});

--- a/cli/test/util.test.ts
+++ b/cli/test/util.test.ts
@@ -104,6 +104,39 @@ test("writeEnvValue rejects invalid keys and multi-line values", (t) => {
   assert.throws(() => writeEnvValue(file, "GOOD_KEY", "a\nb"));
 });
 
+test("readEnvFile matches Node --env-file for export prefixes and quoted values", (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = join(dir, ".env");
+  writeFileSync(
+    file,
+    [
+      'DQ="wrapped#value"',
+      "SQ='single'",
+      "BT=`tick`",
+      "export EXPORTED=yes",
+      'ESCAPED="line1\\nline2"',
+      'TRAILING="abc" rest is ignored',
+      'UNCLOSED="keeps raw',
+      "SPACED=  padded  ",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(
+    [...readEnvFile(file)],
+    [
+      ["DQ", "wrapped#value"],
+      ["SQ", "single"],
+      ["BT", "tick"],
+      ["EXPORTED", "yes"],
+      ["ESCAPED", "line1\nline2"],
+      ["TRAILING", "abc"],
+      ["UNCLOSED", '"keeps raw'],
+      ["SPACED", "padded"],
+    ],
+  );
+});
+
 async function withFakeStdin<T>(fn: (emit: (bytes: Buffer) => void) => Promise<T>): Promise<T> {
   const { EventEmitter } = await import("node:events");
   const fake = Object.assign(new EventEmitter(), {

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -118,6 +118,15 @@ const UPSTREAMS: Record<string, string> = {
 };
 const COOKIE_FOR: Record<string, string> = { "web-ui": "webuiuser", admin: "admin" };
 
+function isSlackIssuer(issuer: string): boolean {
+  try {
+    const host = new URL(issuer).hostname;
+    return host === "slack.com" || host.endsWith(".slack.com");
+  } catch {
+    return false;
+  }
+}
+
 const OIDC: OidcConfig = {
   authEndpoint: process.env.OIDC_AUTH_ENDPOINT ?? "https://slack.com/openid/connect/authorize",
   tokenEndpoint: process.env.OIDC_TOKEN_ENDPOINT ?? "https://slack.com/api/openid.connect.token",
@@ -1260,7 +1269,7 @@ export function bootChecks(): void {
     if (OIDC.expectedTeamId !== undefined && isMissingOrPlaceholder(OIDC.expectedTeamId)) {
       problems.push("PORTAL_EXPECTED_TEAM_ID is optional, but may not be a placeholder when configured");
     }
-    if (OIDC.issuer !== "https://slack.com" && !OIDC_JWKS_CONFIGURED) {
+    if (!isSlackIssuer(OIDC.issuer) && !OIDC_JWKS_CONFIGURED) {
       problems.push("OIDC_JWKS_URI is required for a non-Slack issuer");
     }
     if (SESSION_SECRET && CORE_SIGNING_SECRET && SESSION_SECRET === CORE_SIGNING_SECRET) {

--- a/scripts/dev/lib/pool.ts
+++ b/scripts/dev/lib/pool.ts
@@ -50,15 +50,13 @@ export interface SlotTokens {
   extra: Record<string, string>;
 }
 
-const unquote = (value: string): string => value.replace(/^(['"])(.*)\1$/, "$2");
-
 export function slotTokens(slot: string, store = poolStore()): SlotTokens {
   const env = readEnvFile(join(store, `${slot}.env`));
   return {
-    botToken: unquote(env.SLACK_BOT_TOKEN ?? ""),
-    appToken: unquote(env.SLACK_APP_TOKEN ?? ""),
-    handle: unquote(env.HANDLE ?? ""),
-    canaryChannel: unquote(env.CANARY_CHANNEL ?? ""),
+    botToken: env.SLACK_BOT_TOKEN ?? "",
+    appToken: env.SLACK_APP_TOKEN ?? "",
+    handle: env.HANDLE ?? "",
+    canaryChannel: env.CANARY_CHANNEL ?? "",
     extra: env,
   };
 }

--- a/scripts/dev/lib/util.ts
+++ b/scripts/dev/lib/util.ts
@@ -29,6 +29,26 @@ export function fileMtimeEpoch(path: string): number {
   }
 }
 
+// Mirrors parseEnvLine in cli/src/util.ts — keep the two in agreement.
+function parseEnvLine(raw: string): [key: string, value: string] | undefined {
+  let line = raw.trim();
+  if (!line || line.startsWith("#")) return undefined;
+  if (line.startsWith("export ")) line = line.slice("export ".length).trimStart();
+  const eq = line.indexOf("=");
+  if (eq <= 0) return undefined;
+  const key = line.slice(0, eq).trim();
+  let value = line.slice(eq + 1).trim();
+  const quote = value[0];
+  if (quote === '"' || quote === "'" || quote === "`") {
+    const end = value.indexOf(quote, 1);
+    if (end > 0) {
+      value = value.slice(1, end);
+      if (quote === '"') value = value.replaceAll("\\n", "\n");
+    }
+  }
+  return [key, value];
+}
+
 export function readEnvFile(path: string): Record<string, string> {
   let raw: string;
   try {
@@ -38,10 +58,8 @@ export function readEnvFile(path: string): Record<string, string> {
   }
   const out: Record<string, string> = {};
   for (const line of raw.split("\n")) {
-    const eq = line.indexOf("=");
-    if (eq <= 0) continue;
-    const key = line.slice(0, eq);
-    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) out[key] = line.slice(eq + 1);
+    const entry = parseEnvLine(line);
+    if (entry && /^[A-Za-z_][A-Za-z0-9_]*$/.test(entry[0])) out[entry[0]] = entry[1];
   }
   return out;
 }

--- a/src/runs/postgres-run-store.ts
+++ b/src/runs/postgres-run-store.ts
@@ -6,6 +6,7 @@ import type { OrchestratorInput } from "../core/orchestrator.ts";
 import { resolveTurnOrigin } from "../core/turn-origin.ts";
 import type { EnqueueInput, EnqueueResult, ReapEvent, Run, RunDeliveryState, RunStore } from "./run-store.ts";
 import { isTerminal } from "./run-store.ts";
+import { errMessage } from "../util/errors.ts";
 import type { LedgerBegin, ToolLedger } from "./tool-ledger.ts";
 
 export interface PostgresRuntime {
@@ -75,8 +76,35 @@ export function createPostgresRunStore(connectionString: string, opts?: { maxCla
         PRIMARY KEY(run_id, attempt, call_index)
       )`,
     `ALTER TABLE tool_calls ADD COLUMN IF NOT EXISTS attempt INT NOT NULL DEFAULT 1`,
-    `ALTER TABLE tool_calls DROP CONSTRAINT IF EXISTS tool_calls_pkey`,
-    `ALTER TABLE tool_calls ADD PRIMARY KEY (run_id, attempt, call_index)`,
+    // One-time migration to the (run_id, attempt, call_index) key. The whole
+    // DO block is a single transaction, so a crash mid-migration can't leave
+    // the table without a primary key the way the old unconditional
+    // DROP CONSTRAINT + ADD PRIMARY KEY pair could (each ALTER autocommitted
+    // separately). It runs only while the PK is still the legacy shape, keeps
+    // the newest duplicate row if a keyless window let any in, and is a no-op
+    // on every later boot.
+    `DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = 'tool_calls'::regclass AND c.contype = 'p'
+            AND (SELECT array_agg(a.attname::text ORDER BY k.ord)
+                 FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+                 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+                ) <> ARRAY['run_id','attempt','call_index']
+        ) OR NOT EXISTS (
+          SELECT 1 FROM pg_constraint c
+          WHERE c.conrelid = 'tool_calls'::regclass AND c.contype = 'p'
+        ) THEN
+          DELETE FROM tool_calls t USING (
+            SELECT ctid, row_number() OVER (
+              PARTITION BY run_id, attempt, call_index ORDER BY created_at DESC, ctid DESC
+            ) AS rn FROM tool_calls
+          ) dup WHERE t.ctid = dup.ctid AND dup.rn > 1;
+          ALTER TABLE tool_calls DROP CONSTRAINT IF EXISTS tool_calls_pkey;
+          ALTER TABLE tool_calls ADD PRIMARY KEY (run_id, attempt, call_index);
+        END IF;
+      END $$`,
   ]);
 
   async function getRun(id: string): Promise<Run | null> {
@@ -305,6 +333,7 @@ export function createPostgresRunStore(connectionString: string, opts?: { maxCla
           if (done) return;
           done = true;
           clearInterval(poll);
+          clearTimeout(timer);
           events.off(runId, onSettle);
           resolve(r);
         };
@@ -313,9 +342,13 @@ export function createPostgresRunStore(connectionString: string, opts?: { maxCla
         }
         events.once(runId, onSettle);
         const poll = setInterval(() => {
-          void getRun(runId).then((r) => {
-            if (r && isTerminal(r.status)) finish(r);
-          });
+          void getRun(runId)
+            .then((r) => {
+              if (r && isTerminal(r.status)) finish(r);
+            })
+            .catch((err: unknown) => {
+              console.error(`[postgres-run-store] waitFor poll for run ${runId} failed transiently:`, errMessage(err));
+            });
         }, 250);
         poll.unref?.();
         const timer = setTimeout(() => {

--- a/test/dev-cli-lib.test.ts
+++ b/test/dev-cli-lib.test.ts
@@ -87,10 +87,10 @@ test("pool token parsing accepts quoted dotenv values", () => {
     handle: "bot1",
     canaryChannel: "C0TEST",
     extra: {
-      SLACK_BOT_TOKEN: '"xoxb-quoted"',
-      SLACK_APP_TOKEN: "'xapp-quoted'",
-      HANDLE: '"bot1"',
-      CANARY_CHANNEL: "'C0TEST'",
+      SLACK_BOT_TOKEN: "xoxb-quoted",
+      SLACK_APP_TOKEN: "xapp-quoted",
+      HANDLE: "bot1",
+      CANARY_CHANNEL: "C0TEST",
     },
   });
   assert.equal(slotValid("pool1", store), true);

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -923,6 +923,27 @@ test("pg run store: enqueue dedup, atomic one-per-session claim, fencing, ledger
   }
 });
 
+test("pg run store: waitFor survives a transient poll failure without an unhandled rejection", { skip }, async () => {
+  const { runs, close } = createPostgresRunStore(URL!);
+  let unhandled: unknown;
+  const onUnhandledRejection = (err: unknown): void => {
+    unhandled = err;
+  };
+  process.once("unhandledRejection", onUnhandledRejection);
+  try {
+    const r = (await runs.enqueue({ sessionId: "sWaitFor", request: turn("x") })).run;
+    const pending = runs.waitFor(r.id, 800);
+    // Kill the pool mid-poll: the next getRun() tick will reject, exercising the
+    // catch path instead of leaking an unhandled rejection out of setInterval.
+    await new Promise((res) => setTimeout(res, 50));
+    await close();
+    await assert.rejects(pending, /did not finish within 800ms/, "still settles via its own timeout, not a crash");
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandledRejection);
+  }
+  assert.equal(unhandled, undefined, "a transient poll failure must not escape as an unhandled rejection");
+});
+
 test(
   "pg run store: releaseLease (deploy drain) hands the run back as a retry without spending budget; stale token is a no-op",
   { skip },

--- a/test/postgres-toolcalls-migration.test.ts
+++ b/test/postgres-toolcalls-migration.test.ts
@@ -1,0 +1,90 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { createPostgresRunStore } from "../src/runs/postgres-run-store.ts";
+
+const URL = process.env.DATABASE_URL;
+const skip = URL ? false : "set DATABASE_URL (a Postgres) to run the tool_calls migration tests";
+
+type Pg = {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+  end: () => Promise<void>;
+};
+async function pool(): Promise<Pg> {
+  const pg = (await import("pg")).default;
+  return new pg.Pool({ connectionString: URL }) as unknown as Pg;
+}
+
+async function pkColumns(p: Pg): Promise<{ oid: string; columns: string[] } | undefined> {
+  const { rows } = await p.query(`
+    SELECT c.oid::text AS oid,
+           (SELECT array_agg(a.attname::text ORDER BY k.ord)
+            FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+            JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum) AS columns
+    FROM pg_constraint c
+    WHERE c.conrelid = 'tool_calls'::regclass AND c.contype = 'p'`);
+  const row = rows[0];
+  return row ? { oid: row.oid as string, columns: row.columns as string[] } : undefined;
+}
+
+async function bootAndClose(): Promise<void> {
+  const { runs, close } = createPostgresRunStore(URL!);
+  await runs.enqueue({ sessionId: "sMigrationPing", request: { text: "ping" } as never }).catch(() => undefined);
+  await close();
+}
+
+before(async () => {
+  if (!URL) return;
+  const p = await pool();
+  await p.query("DROP TABLE IF EXISTS runs, tool_calls CASCADE");
+  await p.end();
+});
+
+// leave a clean slate for suites sharing this database
+after(async () => {
+  if (!URL) return;
+  const p = await pool();
+  await p.query("DROP TABLE IF EXISTS runs, tool_calls CASCADE");
+  await p.end();
+});
+
+test("tool_calls: a keyless table with duplicates heals on boot, keeping the newest row", { skip }, async () => {
+  const p = await pool();
+  // the mid-crash state the old migration could leave: attempt column present, no PK, duplicates written
+  await p.query(`CREATE TABLE tool_calls(
+      run_id TEXT NOT NULL, attempt INT NOT NULL DEFAULT 1, call_index INT NOT NULL,
+      output TEXT NOT NULL, created_at BIGINT NOT NULL)`);
+  await p.query(`INSERT INTO tool_calls VALUES
+      ('r1', 1, 0, 'older', 100), ('r1', 1, 0, 'newer', 200), ('r1', 1, 1, 'only', 150)`);
+  await bootAndClose();
+  const pk = await pkColumns(p);
+  assert.deepEqual(pk?.columns, ["run_id", "attempt", "call_index"], "primary key restored");
+  const { rows } = await p.query("SELECT output FROM tool_calls WHERE run_id='r1' AND attempt=1 AND call_index=0");
+  assert.deepEqual(rows, [{ output: "newer" }], "newest duplicate survives");
+  await p.end();
+});
+
+test("tool_calls: a legacy two-column key migrates to (run_id, attempt, call_index)", { skip }, async () => {
+  const p = await pool();
+  await p.query("DROP TABLE IF EXISTS tool_calls");
+  await p.query(`CREATE TABLE tool_calls(
+      run_id TEXT NOT NULL, call_index INT NOT NULL, output TEXT NOT NULL, created_at BIGINT NOT NULL,
+      PRIMARY KEY(run_id, call_index))`);
+  await p.query("INSERT INTO tool_calls VALUES ('r2', 0, 'kept', 100)");
+  await bootAndClose();
+  const pk = await pkColumns(p);
+  assert.deepEqual(pk?.columns, ["run_id", "attempt", "call_index"]);
+  const { rows } = await p.query("SELECT output FROM tool_calls WHERE run_id='r2'");
+  assert.deepEqual(rows, [{ output: "kept" }], "existing row survives the migration");
+  await p.end();
+});
+
+test("tool_calls: a boot with the current key leaves the constraint untouched", { skip }, async () => {
+  const p = await pool();
+  const beforePk = await pkColumns(p);
+  assert.ok(beforePk, "previous test left the migrated key in place");
+  await bootAndClose();
+  const afterPk = await pkColumns(p);
+  assert.deepEqual(afterPk?.columns, ["run_id", "attempt", "call_index"]);
+  assert.equal(afterPk?.oid, beforePk?.oid, "constraint not dropped and recreated on a routine boot");
+  await p.end();
+});

--- a/test/secret-schema-conformance.test.ts
+++ b/test/secret-schema-conformance.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CORE_SECRET_SPECS } from "../src/deployment/secret-schema.ts";
+import { FIRST_PARTY_SECRET_SPECS } from "../cli/src/secrets.ts";
+
+// The runtime schema (src/deployment/secret-schema.ts, validated on core boot) and the CLI
+// provisioning schema (cli/src/secrets.ts, driving `qm secrets`) are maintained separately by
+// design — the CLI never imports core. This test keeps them from drifting apart silently:
+// every secret the runtime can demand must be one the CLI knows how to provision.
+
+// The env name a CLI spec ultimately delivers to the core process.
+const cliCoreEnvNames = new Set(
+  FIRST_PARTY_SECRET_SPECS.filter((spec) => spec.service === "core").map((spec) => spec.envName ?? spec.name),
+);
+
+test("every runtime-validated core secret is provisionable through the CLI schema", () => {
+  const missing = CORE_SECRET_SPECS.map((spec) => spec.name).filter((name) => !cliCoreEnvNames.has(name));
+  assert.deepEqual(
+    missing,
+    [],
+    `runtime secret-schema names with no matching CLI secret spec (name or envName, service "core"): ${missing.join(
+      ", ",
+    )} — add a spec to cli/src/secrets.ts or drop it from src/deployment/secret-schema.ts`,
+  );
+});
+
+test("runtime schema conditions reference env vars the CLI schema also conditions on", () => {
+  // Env vars the runtime's requiredWhen rules read. Each must also drive a CLI spec condition,
+  // so `qm secrets` and core boot validation agree about when a secret becomes required.
+  const runtimeConditionEnv = [
+    "SANDBOX_BACKEND",
+    "DEPLOY_PROVIDER",
+    "AWS_DEPLOY_APPS_DOMAIN",
+    "GOOGLE_OAUTH_CLIENT_ID",
+    "DROPBOX_OAUTH_CLIENT_ID",
+    "LINEAR_OAUTH_CLIENT_ID",
+  ];
+  const cliConditionEnv = new Set<string>();
+  for (const spec of FIRST_PARTY_SECRET_SPECS) {
+    if (typeof spec.required === "boolean") continue;
+    const when = spec.required.when as { name?: string; names?: string[] };
+    if (when.name) cliConditionEnv.add(when.name);
+    for (const name of when.names ?? []) cliConditionEnv.add(name);
+  }
+  const missing = runtimeConditionEnv.filter((name) => !cliConditionEnv.has(name));
+  assert.deepEqual(
+    missing,
+    [],
+    `runtime schema conditions use env vars the CLI schema never conditions on: ${missing.join(", ")}`,
+  );
+});


### PR DESCRIPTION
Target-specific behavior had leaked out of the hosting backends into shared CLI code, so adding a new hosting target meant touching switches scattered across the tree. Deployment-layer push routing no longer switches on target: each HostingProvider supplies a deploymentLayerTransport (fly's ssh-console transport, the signed-HTTP transport with secrets-manager fallback, docker's local-port transport) in its own backend file. Per-target env-default tables move into target-env-defaults.ts exposed as HostingProvider.envDefaults, service context URLs become provider-supplied fields, infra becomes an optional per-provider capability map instead of a hard gate, and sandbox-backend rules come from a policy table keyed by target. A secret-schema conformance test enumerates the gaps, so a new target is one registry entry plus one backend file and the compiler finds everything else.

**Deployment notes**

Pure CLI refactor moving target-specific transport/env-default/sandbox-policy logic behind the
HostingProvider seam; commit states no behavior change intended for fly/aws/docker and adds a
secret-schema conformance test — residual risk is regression-only, no DB/config/contract
surface

Stacked on #468 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249120&installation_model_id=19911&pr_number=480&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F480&signature=aa886550348b04d0e235ecf22c6a9676913d82f7b8c12bac59a274291626b795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->