### PR TITLE
Build deployment git URLs from the API origin

### DIFF
--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -69,6 +69,7 @@ export interface ServerDeps {
   oauthEnv?: NodeJS.ProcessEnv;
   resolveClient?: OAuthClientResolver;
   consentLinks?: ConsentLinkStore;
+  apiBaseUrl?: string;
   publicUrl?: string;
   portalUrl?: string;
   config?: ScopedConfigStore;

--- a/src/api/routes/deployments.ts
+++ b/src/api/routes/deployments.ts
@@ -1121,10 +1121,15 @@ async function serveDeploymentGit(ctx: BaseCtx): Promise<void> {
 }
 
 function gitUrlBase(ctx: ApiCtx): string {
-  if (ctx.deps.publicUrl) return ctx.deps.publicUrl;
-  const host = (ctx.req.headers["x-forwarded-host"] as string) ?? ctx.req.headers.host ?? "localhost";
-  const proto = (ctx.req.headers["x-forwarded-proto"] as string) ?? "http";
-  return `${proto}://${host}`;
+  if (ctx.deps.apiBaseUrl) {
+    return ctx.deps.apiBaseUrl;
+  } else if (ctx.deps.publicUrl) {
+    return ctx.deps.publicUrl;
+  } else {
+    const host = (ctx.req.headers["x-forwarded-host"] as string) ?? ctx.req.headers.host ?? "localhost";
+    const proto = (ctx.req.headers["x-forwarded-proto"] as string) ?? "http";
+    return `${proto}://${host}`;
+  }
 }
 
 async function deploymentGitUrl(ctx: ApiCtx): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ const server = createServer(built.app, {
   consentLinks: built.consentLinks,
   secretDrops: built.secretDrops,
   ...(built.fireDropResolution ? { fireDropResolution: built.fireDropResolution } : {}),
+  ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
   ...(config.publicUrl ? { publicUrl: config.publicUrl } : {}),
   ...(config.publicWebUrl ? { portalUrl: config.publicWebUrl } : {}),
   admin: built.admin,

--- a/test/deploy-git-rw.test.ts
+++ b/test/deploy-git-rw.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
-import type { Server } from "node:http";
+import { createServer as createHttpServer, request as httpRequest, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,7 +30,7 @@ const GIT_ENV = {
   GIT_COMMITTER_EMAIL: "t@t",
 };
 
-function fixture() {
+function fixture(urls: { apiBaseUrl?: string; publicUrl?: string } = {}) {
   const deployStore = createDeployStore({ git: { repoRoot: mkdtempSync(join(tmpdir(), "git-rw-repo-")) } });
   const acl: AclStore = createAclStore();
   const deploy = createDeployService({
@@ -52,7 +52,7 @@ function fixture() {
     sessions: createMemorySessionStore(),
     identity,
   } as unknown as Parameters<typeof createApp>[0]);
-  const server: Server = createServer(app, { signingSecret: SECRET, identity });
+  const server: Server = createServer(app, { signingSecret: SECRET, identity, ...urls });
   server.listen(0);
   const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   return { app, deploy, acl, identity, base, close: () => new Promise<void>((r) => server.close(() => r())) };
@@ -234,6 +234,45 @@ test("git-url endpoint: write for the owner, read for a read-grantee, 403 for no
     assert.equal(anon.status, 401);
   } finally {
     await f.close();
+  }
+});
+
+test("git-url endpoint returns a clonable API URL when web and API origins differ", async () => {
+  let coreBase = "";
+  const ingress = createHttpServer((req, res) => {
+    const upstream = httpRequest(
+      new URL(req.url ?? "/", coreBase),
+      { method: req.method, headers: req.headers },
+      (upstreamResponse) => {
+        res.writeHead(upstreamResponse.statusCode ?? 500, upstreamResponse.headers);
+        upstreamResponse.pipe(res);
+      },
+    );
+    upstream.on("error", (error) => res.destroy(error));
+    req.pipe(upstream);
+  });
+  ingress.listen(0);
+  const apiBaseUrl = `http://127.0.0.1:${(ingress.address() as AddressInfo).port}`;
+  const f = fixture({ apiBaseUrl, publicUrl: "https://web.example" });
+  coreBase = f.base;
+  try {
+    const deployment = await f.app.deploy({
+      ownerScopeId: scopeId("personal", "U1"),
+      createdBy: "U1",
+      entrypoint: "x",
+      files: [{ path: "server.js", data: "1" }],
+    });
+    const response = await fetch(`${f.base}/v1/deployments/${encodeURIComponent(deployment.id)}/git-url`, {
+      headers: { "x-agent-capability": await capFor("U1") },
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { url: string };
+    assert.equal(new URL(body.url).origin, apiBaseUrl);
+    const work = mkdtempSync(join(tmpdir(), "git-url-clone-"));
+    await execFileP("git", ["clone", "--quiet", body.url, work], { env: GIT_ENV });
+  } finally {
+    await f.close();
+    await new Promise<void>((resolve) => ingress.close(() => resolve()));
   }
 });
 

--- a/test/reach-deployment.test.ts
+++ b/test/reach-deployment.test.ts
@@ -268,7 +268,11 @@ test("HTTP: each /v1/deployments row carries an authed, clonable gitUrl when ing
     [{ channelId: "C1", principalId: "U2" }],
   );
   const secret = "deployments-list-secret".repeat(3);
-  const server = createServer(app, { signingSecret: secret, publicUrl: "https://core.test" });
+  const server = createServer(app, {
+    signingSecret: secret,
+    apiBaseUrl: "https://core.test",
+    publicUrl: "https://web.test",
+  });
   server.listen(0);
   try {
     const base = `http://localhost:${(server.address() as AddressInfo).port}`;

--- a/test/share-deployment.test.ts
+++ b/test/share-deployment.test.ts
@@ -105,7 +105,7 @@ function callDetail(app: ReturnType<typeof createApp>, capability: CapabilityCla
     params: { id },
     capability,
     secret: "test-secret",
-    deps: {},
+    deps: { apiBaseUrl: "https://api.example", publicUrl: "https://web.example" },
     url: new URL(`http://localhost/v1/deployments/${id}`),
     req: { headers: { host: "localhost" } },
   } as unknown as ApiCtx;
@@ -153,6 +153,7 @@ test("deployment detail is viewer-gated and fixes the permission/gitUrl wire con
   assert.equal(visible.status, 200);
   assert.equal(visible.body.deployment.permission, "write");
   assert.equal(typeof visible.body.deployment.gitUrl, "string");
+  assert.equal(new URL(visible.body.deployment.gitUrl).origin, "https://api.example");
   assert.equal(visible.body.deployment.currentVersion, 1);
   assert.equal(typeof visible.body.deployment.versions[0].createdAt, "number");
   assert.equal(visible.body.deployment.versions[0].snapshotDir, undefined);


### PR DESCRIPTION
When the web UI and the API are served from different origins, deployment git URLs were built from the web origin, where the git smart-HTTP route is not served — cloning the returned URL failed with "repository not found". The configured API origin is now passed into the HTTP server and preferred when building git URLs, covering the dedicated git-url endpoint and the gitUrl fields on deployment list and detail; the existing header-derived fallbacks are unchanged. An integration test starts separate loopback API and web servers, fetches the git URL, and clones it directly. COAUTHORS l ⚠i t l

**Deployment notes**

Adds optional config.apiBaseUrl consulted first when building deployment git URLs; falls back to
publicUrl then Host headers, so existing configs behave identically until the new field is set.
Orgs whose deployments currently clone via publicUrl keep working; setting apiBaseUrl changes
URLs handed to NEW clone/push operations only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249181&installation_model_id=19911&pr_number=482&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F482&signature=a29f271338fa09610cf18c51d70b44fee6c9425d3351b06265f4707fb29c3899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->