### PR TITLE
web-ui: session top bar follow-ups — fork badge, and apps/skills/keychain join the quick tools

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1063,7 +1063,7 @@ export function createChatSurface(
                 </div>`
               : nothing
           }
-          ${glanceTier ? nothing : sessionTopbar(agent)}
+          ${glanceTier ? nothing : sessionTopbar()}
           ${
             glanceTier
               ? paneGlance(agent, messages, glanceTier)
@@ -1125,12 +1125,7 @@ export function createChatSurface(
     return null;
   }
 
-  function pillState(needsYou: boolean, working: boolean): "needs-you" | "working" | null {
-    if (needsYou) return "needs-you";
-    return working ? "working" : null;
-  }
-
-  function sessionTopbar(agent: Agent): TemplateResult {
+  function sessionTopbar(): TemplateResult {
     const scope = chatState.scopeId;
     const session = sessionsState.list.find((s) =>
       chatState.sessionId
@@ -1139,13 +1134,20 @@ export function createChatSurface(
     );
     const title = session?.title?.trim() || "New chat";
     const crumb = scope && !scope.startsWith("personal:") ? scopeTitle(scope, chatState.contextName) : null;
-    const needsYou = activePendingApprovals().length > 0;
-    const working = !needsYou && (agent.state.isStreaming || chatState.resolvingApprovals.size > 0);
+    const forkedFrom =
+      chatState.forkSession && chatState.sessionId === chatState.forkSession.id
+        ? chatState.forkSession.forkedFrom
+        : undefined;
     return sessionTopbarTpl({
       crumb,
       title,
+      fork: forkedFrom
+        ? {
+            title: forkedFrom.title?.trim() || "another conversation",
+            onClick: () => void forkOriginController.navigate(),
+          }
+        : null,
       onCrumb: crumb && scope ? () => openProjectPage(scope) : null,
-      pill: pillState(needsYou, working),
       cronCount: scope ? scopeCronCount(scope, () => drawActiveChat()) : null,
       onTool: (tool) => {
         setScopedSession({
@@ -1155,8 +1157,8 @@ export function createChatSurface(
           title,
           crumb,
         });
-        if (scope && tool !== "memory") contextsState.selected = scope;
-        switchView(tool);
+        if (scope && (tool === "crons" || tool === "files" || tool === "apps")) contextsState.selected = scope;
+        switchView(tool === "apps" ? "deploys" : tool);
       },
     });
   }

--- a/plugins/web-ui/src/connectors.ts
+++ b/plugins/web-ui/src/connectors.ts
@@ -4,6 +4,7 @@ import { api } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
 import { icon } from "./ui";
 import { appState, replacePanePreservingFocus } from "./shell";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 import { focusDialogCancel, restoreDialogFocus, trapDialogFocus } from "./dialog-focus";
 import { isActiveGrant, isExpiredCredential, KeychainOperations, keychainSummary } from "./keychain-state";
 
@@ -500,9 +501,10 @@ function drawConnectors(loading = false): void {
   });
   if (!appState.mainEl) return;
   const host = document.createElement("div");
-  host.className = "pane keychain-page";
+  host.className = scopedSession.active ? "pane keychain-page scoped-view" : "pane keychain-page";
   render(
     html`
+      ${scopedViewTopbar("keychain", () => drawConnectors())}
       <div class="kc-page-content" ?inert=${Boolean(confirmation)}>
         <header class="kc-hero">
           <div class="kc-hero-copy">

--- a/plugins/web-ui/src/deploys.ts
+++ b/plugins/web-ui/src/deploys.ts
@@ -6,6 +6,7 @@ import { errMessage } from "../../chassis/src/errors";
 import { copyText, fieldSelect, icon, relTime } from "./ui";
 import { listBackLink, listPageTpl } from "./list-page";
 import { contextsState, ensureContexts, scopeChip } from "./contexts";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 import { appState } from "./shell";
 import { mainConversation } from "./conversations";
 import { focusDialogCancel, restoreDialogFocus, trapDialogFocus } from "./dialog-focus";
@@ -293,15 +294,20 @@ function drawDeploysPage(): void {
           : [html`<div class="empty compact cron-filter-empty">${empty}</div>`]),
       ]
     : [];
+  const scoped = Boolean(scopedSession.active);
+  deployPageHost.classList.toggle("scoped-view", scoped);
   render(
     html`
+      ${scopedViewTopbar("apps", drawDeploysPage)}
       ${listPageTpl({
         title: "Apps",
         scope: deployScope,
-        onScope: (scope) => {
-          deployScope = scope;
-          drawDeploysPage();
-        },
+        onScope: scoped
+          ? undefined
+          : (scope) => {
+              deployScope = scope;
+              drawDeploysPage();
+            },
         onRefresh: () => void renderDeploys(),
         action: { label: "Deploy with Agent", onClick: deployWithAgent },
         controls: html`<label class="deploy-sort"
@@ -883,7 +889,10 @@ export async function renderDeploys(): Promise<void> {
   archiveCandidate = null;
   archiveFocusTarget = null;
   setDeployBackgroundInert(false);
-  if (contextsState.selected) {
+  if (scopedSession.active) {
+    deployScope = scopedSession.active.scopeId;
+    contextsState.selected = null;
+  } else if (contextsState.selected) {
     deployScope = contextsState.selected;
     contextsState.selected = null;
   }

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -1,5 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { Brain, Clock3, Files } from "lucide";
+import { Box, Brain, Clock3, Files, GitFork, KeyRound, Rocket } from "lucide";
 import { api } from "./core-bridge";
 import { icon } from "./ui";
 
@@ -56,14 +56,14 @@ export function scopeCronCount(scope: string, onReady: () => void): number | nul
   return hit?.count ?? null;
 }
 
-export type SessionTool = "crons" | "files" | "memory";
+export type SessionTool = "crons" | "files" | "memory" | "apps" | "skills" | "keychain";
 
 export interface SessionTopbarOpts {
   crumb: string | null;
   title: string;
-  pill?: "working" | "needs-you" | null;
   activeTool?: SessionTool | null;
   cronCount?: number | null;
+  fork?: { title: string; onClick?: (() => void) | null } | null;
   onTitle?: (() => void) | null;
   onCrumb?: (() => void) | null;
   onTool: (tool: SessionTool) => void;
@@ -89,10 +89,19 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
     ${crumbTpl}
     <span class="session-title">${o.title}</span>
     ${
-      o.pill
-        ? html`<span class="session-pill ${o.pill === "needs-you" ? "needs-you" : "working"}"
-            ><span class="pill-dot"></span>${o.pill === "needs-you" ? "needs you" : "working"}</span
-          >`
+      o.fork
+        ? html`<button
+            class="session-fork-badge"
+            type="button"
+            title="Forked from ${o.fork.title}${o.fork.onClick ? " — open the original" : ""}"
+            ?disabled=${!o.fork.onClick}
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              o.fork?.onClick?.();
+            }}
+          >
+            ${icon(GitFork, 12)}<span>fork</span>
+          </button>`
         : nothing
     }
   `;
@@ -121,7 +130,10 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
       }
       <div class="topbar-actions session-tools">
         ${tool("crons", Clock3, cronLabel, "Crons in this context")}
-        ${tool("files", Files, "Files", "Files in this context")} ${tool("memory", Brain, "Memory", "Memory")}
+        ${tool("files", Files, "Files", "Files in this context")}
+        ${tool("apps", Rocket, "Apps", "Apps in this context")}
+        ${tool("skills", Box, "Skills", "Skills in this context")} ${tool("memory", Brain, "Memory", "Memory")}
+        ${tool("keychain", KeyRound, "Keychain", "Your keychain")}
       </div>
     </header>
   `;
@@ -159,7 +171,7 @@ export function scopedViewTopbar(current: SessionTool, redraw: () => void): Temp
     },
     onTool: (t) => {
       if (t === current) return;
-      void import("./shell").then(({ switchView }) => switchView(t));
+      void import("./shell").then(({ switchView }) => switchView(t === "apps" ? "deploys" : t));
     },
   });
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1094,29 +1094,27 @@ a.chat-row-open {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.session-pill {
+.session-fork-badge {
   flex: none;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 2px 9px;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
   border-radius: 999px;
-  font-size: 12px;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 11.5px;
   font-weight: 550;
+  cursor: pointer;
+  white-space: nowrap;
 }
-.session-pill .pill-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
+.session-fork-badge:hover:not(:disabled) {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--secondary) 85%, transparent);
 }
-.session-pill.working {
-  color: color-mix(in srgb, #3b82f6 85%, var(--foreground));
-  background: color-mix(in srgb, #3b82f6 12%, transparent);
-}
-.session-pill.needs-you {
-  color: color-mix(in srgb, #d97706 85%, var(--foreground));
-  background: color-mix(in srgb, #f59e0b 14%, transparent);
+.session-fork-badge:disabled {
+  cursor: default;
 }
 .session-tools {
   gap: 2px;

--- a/plugins/web-ui/src/skills.ts
+++ b/plugins/web-ui/src/skills.ts
@@ -24,6 +24,7 @@ import {
 } from "./skill-registry";
 import { listBackLink, listPageTpl } from "./list-page";
 import { scopeTitle } from "./contexts";
+import { scopedSession, scopedViewTopbar } from "./session-scope";
 import { focusDialogCancel, restoreDialogFocus, trapDialogFocus } from "./dialog-focus";
 import { SkillsRefreshSequence } from "./skills-refresh";
 import { SkillsMutationSequence } from "./skills-mutation";
@@ -483,7 +484,16 @@ function drawSkills(loading = false): void {
     return;
   }
   const filters = { query: skillSearch, scope: scopeFilter, source: sourceFilter, status: statusFilter };
-  const groups = filterSkillGroups(groupSkills(skillRows), filters);
+  const scopedScope = scopedSession.active?.scopeId ?? null;
+  skillsPageHost.classList.toggle("scoped-view", Boolean(scopedScope));
+  let groups = filterSkillGroups(groupSkills(skillRows), filters);
+  if (scopedScope)
+    groups = groups
+      .map((group) => ({
+        ...group,
+        skills: group.skills.filter((skill) => skill.scopeId === scopedScope || skill.scope === "org"),
+      }))
+      .filter((group) => group.skills.length > 0);
   const filtered = groups.flatMap((group) => group.skills);
   const counts = statusCounts(skillRows);
   const rows: TemplateResult[] = groups.map((group) => skillGroup(group.name, group.skills));
@@ -495,7 +505,7 @@ function drawSkills(loading = false): void {
     drawSkills();
   };
   const emptyState = skillEmptyState(skillRows.length, filtered.length, loading);
-  let empty: string | TemplateResult = "No skills available yet.";
+  let empty: string | TemplateResult = scopedScope ? "No skills in this context." : "No skills available yet.";
   if (emptyState === "filtered") {
     empty = html`<div class="skill-empty">
       <span>No skills match these filters.</span
@@ -505,7 +515,7 @@ function drawSkills(loading = false): void {
     empty = "Loading skills…";
   }
   render(
-    html`${listPageTpl({
+    html`${scopedViewTopbar("skills", () => drawSkills())}${listPageTpl({
       title: "Skills",
       onRefresh: () => void renderSkills(),
       action: { label: "New skill", onClick: startCreate },


### PR DESCRIPTION
Follow-ups to the session top bar. The status pill ("working" / "needs you") is removed — the transcript already shows both states. In its place, a session created by forking shows a small fork badge; clicking it opens the conversation it was forked from. The quick-tool row grows from crons/files/memory to crons, files, apps, skills, memory, and keychain, and the apps, skills, and keychain views opened from a session's bar get the scoped treatment the others already had: filtered to the session's context (skills keep org-wide entries visible), the scope picker locked, and the scoped top bar persisting with the title linking back to the chat.

**Deployment notes**

Web-UI only. One visible change: the status pill ("working" / "needs you") no longer appears in the session top bar.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249490&installation_model_id=19911&pr_number=485&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F485&signature=d9ba7f457e8235e14d8c18a927a6e0883465c2ef12df3cb35341db4bacd164ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->