### PR TITLE
projects: refresh the Slack directory on demand when a channel link misses

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/templates/slack-manifest.json
+++ b/cli/templates/slack-manifest.json
@@ -53,6 +53,9 @@
         "message.mpim",
         "member_joined_channel",
         "member_left_channel",
+        "channel_created",
+        "channel_rename",
+        "channel_unarchive",
         "reaction_added",
         "reaction_removed"
       ]

--- a/src/api/app-helpers.ts
+++ b/src/api/app-helpers.ts
@@ -54,6 +54,11 @@ export function createAppHelpers(deps: AppDeps, app: App) {
     adminBase ? `${adminBase}/admin/history?session=${encodeURIComponent(sessionId)}` : undefined;
 
   const surfaceContext = createSurfaceContextPuller(app);
+  const directoryRefresher = createSurfaceContextPuller(app, { waitMs: 4_000 });
+
+  async function refreshSurfaceDirectory(): Promise<void> {
+    await directoryRefresher.pull("slack", { syncDirectory: true, count: 1 });
+  }
   const reachDir: ReachDirectory = {
     resolveRecipient: (q) => deps.directory.resolve(q),
     resolveChannel: (q) => deps.directory.resolveChannel(q),
@@ -603,6 +608,7 @@ export function createAppHelpers(deps: AppDeps, app: App) {
     effectiveDeploymentPermission,
     principalCanReadDeployment,
     principalGitPermission,
+    refreshSurfaceDirectory,
     reconcileProjectMember,
     syncProjectChannelRoster,
     syncLinkedProjectRosters,

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -324,10 +324,20 @@ export function createSessionMethods(
       if (channel !== null) {
         const wanted = channel.trim().replace(/^#/, "");
         if (!wanted) return { status: "invalid_channel" };
-        const reachable = await deps.directory.listChannelsFor(principalId).catch(() => []);
-        const match =
-          reachable.find((c) => c.channelId === wanted) ??
-          reachable.find((c) => c.name.toLowerCase() === wanted.toLowerCase());
+        const findChannel = async () => {
+          const reachable = await deps.directory.listChannelsFor(principalId).catch(() => []);
+          return (
+            reachable.find((c) => c.channelId === wanted) ??
+            reachable.find((c) => c.name.toLowerCase() === wanted.toLowerCase())
+          );
+        };
+        let match = await findChannel();
+        if (!match) {
+          // The synced directory may not have caught up with a just-created channel;
+          // ask the surface for a fresh sync and look once more before giving up.
+          await h.refreshSurfaceDirectory().catch(() => undefined);
+          match = await findChannel();
+        }
         if (!match) return { status: "invalid_channel" };
         const channelScope = scopeId("channel", match.channelId);
         const inUse = (await deps.sessions.listAll()).some((session) => session.scopeId === channelScope);

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -193,6 +193,16 @@ export function registerSlackEvents(
     }
   });
 
+  for (const evt of ["channel_created", "channel_rename", "channel_unarchive"] as const) {
+    app.event(evt, async ({ event, body, client }: any) => {
+      const e = event as { channel?: { id?: string } | string; event_ts?: string };
+      const channel = typeof e.channel === "string" ? e.channel : e.channel?.id;
+      if (deduper.seen(dedupeKey({ event_id: (body as { event_id?: string })?.event_id, channel, ts: e.event_ts })))
+        return;
+      await forceDirectorySync(client);
+    });
+  }
+
   app.event("member_left_channel", async ({ event, body, client }: any) => {
     const e = event as { channel?: string; event_ts?: string };
     if (

--- a/src/slack/manifest.json
+++ b/src/slack/manifest.json
@@ -53,6 +53,9 @@
         "message.mpim",
         "member_joined_channel",
         "member_left_channel",
+        "channel_created",
+        "channel_rename",
+        "channel_unarchive",
         "reaction_added",
         "reaction_removed"
       ]

--- a/src/slack/surface-context.ts
+++ b/src/slack/surface-context.ts
@@ -190,6 +190,10 @@ export function createSurfaceContextFulfiller(deps: {
     };
     try {
       const q = r.query ?? {};
+      if (q.syncDirectory) {
+        await directory.forceDirectorySync(client).catch(swallowAs("slack: on-demand directory sync", undefined));
+        return await post({ messages: [] });
+      }
       if (q.openGroup) return await post(await openGroupDm(client, q.openGroup.participants ?? []));
       if (typeof q.searchAll === "string" && q.searchAll) {
         return fulfillLiveSearch(

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ export interface SurfaceContextQuery {
   viewerToken?: string;
   file?: { ts: string; threadTs?: string; name?: string };
   openGroup?: { participants: string[] };
+  syncDirectory?: boolean;
 }
 
 export interface SurfaceContextResult {

--- a/test/projects.test.ts
+++ b/test/projects.test.ts
@@ -837,6 +837,40 @@ test("leaving a Project still cuts off everything after the member left", async 
   assert.equal(await built.app.getSessionForViewer(session.id, "member"), null);
   assert.deepEqual(await built.app.listSessions("member"), []);
 });
+test("linking a just-created channel refreshes the surface directory and retries", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "projects-fresh-chan-")) }));
+  await built.app.upsertDirectory([{ principalId: "owner", displayName: "Owner", type: "internal" }]);
+  await built.app.upsertChannels(
+    [{ channelId: "C-OLD", name: "old", isPrivate: false }],
+    [{ channelId: "C-OLD", principalId: "owner" }],
+  );
+  const project = await built.app.createProject("owner", "Fresh");
+  assert.ok(project);
+  // Fulfil the on-demand sync the way the Slack surface would: push the new channel.
+  const unlisten = built.app.onContextRequestCreated((r) => {
+    if (!r.query.syncDirectory) return;
+    void built.app
+      .upsertChannels(
+        [
+          { channelId: "C-OLD", name: "old", isPrivate: false },
+          { channelId: "C-NEW", name: "brand-new", isPrivate: false },
+        ],
+        [
+          { channelId: "C-OLD", principalId: "owner" },
+          { channelId: "C-NEW", principalId: "owner" },
+        ],
+      )
+      .then(() => built.app.fulfillContextRequest(r.id, { result: { messages: [] } }));
+  });
+  try {
+    const linked = await built.app.setProjectSlackChannel(project!.id, "owner", "#brand-new");
+    assert.equal(linked.status, "ok");
+    assert.equal(linked.status === "ok" && linked.project.slackChannel?.channelId, "C-NEW");
+  } finally {
+    unlisten();
+  }
+});
+
 test("Project slack-channel routes gate on visibility and workspace use, and sync the channel roster", async (t) => {
   const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "projects-slack-")) }));
   const server = createInsecureTestServer(built.app, {});


### PR DESCRIPTION
Linking a just-created Slack channel to a project failed with 'channel not found among the channels you can see' because the check runs against the synced directory copy, which only refreshes on timers and a few membership events — a brand-new channel isn't there yet. On a channel-link miss, core now parks a syncDirectory surface-context request; the Slack surface fulfils it with a forced directory sync and the lookup retries once before failing. The Slack surface also refreshes proactively on channel_created, channel_rename, and channel_unarchive events, which are added to the app manifest.

**Deployment notes**

Release-note: re-apply the Slack app manifest to enable proactive channel-lifecycle refresh
Slack app manifest gains channel_created / channel_rename / channel_unarchive bot events —
the proactive directory refresh only works after an org re-applies its Slack app manifest; the on-
demand syncDirectory retry path works without it, so nothing regresses if they don't
New surface-context request type syncDirectory: in the blue-green window a new core parking
the request against an old Slack surface just goes unfulfilled and the lookup fails exactly as it did
pre-change (no worse)
No DB or config changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249502&installation_model_id=19911&pr_number=487&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F487&signature=a5a577ad3cc045f4681fd7e77faf004c2afe0f596f5bcec38e1bdcb67928f629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->