### PR TITLE
web-ui: hover popover labels the session top-bar icon buttons

### DIFF
--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -157,9 +157,9 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")}
-        ${tool("apps", Rocket, "Apps")} ${tool("skills", Box, "Skills")}
-        ${tool("memory", Brain, "Memory")} ${tool("keychain", KeyRound, "Your keychain")}
+        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")} ${tool("apps", Rocket, "Apps")}
+        ${tool("skills", Box, "Skills")} ${tool("memory", Brain, "Memory")}
+        ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>
   `;

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -139,10 +139,11 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
       <button
         class="session-tool ${o.activeTool === t ? "active" : ""}"
         type="button"
-        title=${hint}
+        aria-label=${hint}
         @click=${() => o.onTool(t)}
       >
         ${icon(glyph, 15)}${count ? html`<span class="session-tool-count">${count}</span>` : nothing}
+        <span class="session-tool-hint" role="tooltip">${hint}</span>
       </button>
     `;
   };
@@ -156,8 +157,8 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, "Crons in this context")} ${tool("files", Files, "Files in this context")}
-        ${tool("apps", Rocket, "Apps in this context")} ${tool("skills", Box, "Skills in this context")}
+        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")}
+        ${tool("apps", Rocket, "Apps")} ${tool("skills", Box, "Skills")}
         ${tool("memory", Brain, "Memory")} ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1158,6 +1158,34 @@ a.chat-row-open {
 .session-tool:hover .session-tool-count {
   color: var(--foreground);
 }
+.session-tool {
+  position: relative;
+}
+.session-tool-hint {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 11.5px;
+  font-weight: 550;
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+.session-tool:hover .session-tool-hint,
+.session-tool:focus-visible .session-tool-hint {
+  opacity: 1;
+  transform: translateY(0);
+}
 .session-heading.as-link {
   border: 0;
   background: transparent;


### PR DESCRIPTION
The session top bar's tool icons (crons, files, apps, skills, memory, keychain) relied on the native title attribute, which is slow to appear and invisible to keyboard users. Each button now gets a styled tooltip pill: right-aligned to avoid clipping, no show delay, and shown on keyboard focus as well as hover. The native title is replaced with aria-label plus a role=tooltip span.

Depends on #486 — do not merge until it lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249509&installation_model_id=19911&pr_number=489&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F489&signature=c3d17ba2a7313c5bd5873c8e390e24293b78db795e135ab6f7cd3b1372796c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->