### PR TITLE
Chat search follow-ups: archived results, clearer copy, and a visible failure state

### DIFF
--- a/plugins/web-ui/src/search.ts
+++ b/plugins/web-ui/src/search.ts
@@ -24,6 +24,7 @@ interface ChatSearchHit {
   author?: string;
   snippet: string;
   createdAt: number;
+  archived?: boolean;
 }
 
 const MIN_QUERY_LEN = 2;
@@ -35,6 +36,7 @@ const searchState = {
   open: false,
   query: "",
   hits: [] as ChatSearchHit[],
+  failed: false,
   loading: false,
   /** Selection over hits (0..hits.length-1) plus the trailing ask-QM row. */
   sel: 0,
@@ -110,6 +112,7 @@ function onQueryInput(e: InputEvent): void {
     inflight?.abort();
     inflight = null;
     searchState.hits = [];
+    searchState.failed = false;
     searchState.loading = false;
     draw();
     return;
@@ -128,9 +131,11 @@ async function runSearch(q: string): Promise<void> {
     const r = await api<{ hits: ChatSearchHit[] }>(`/api/search?q=${encodeURIComponent(q)}`, { signal: ctl.signal });
     if (seq !== fetchSeq || !searchState.open) return;
     searchState.hits = groupHitsBySession(r.hits ?? []);
+    searchState.failed = false;
   } catch {
     if (seq !== fetchSeq || ctl.signal.aborted) return;
     searchState.hits = [];
+    searchState.failed = true;
   }
   searchState.loading = false;
   clampSel();
@@ -150,7 +155,9 @@ function groupHitsBySession(hits: ChatSearchHit[]): ChatSearchHit[] {
       bySession.set(hit.sessionId, [hit]);
     }
   }
-  return order.flatMap((id) => bySession.get(id)!);
+  const live = order.filter((id) => !bySession.get(id)![0]!.archived);
+  const archived = order.filter((id) => bySession.get(id)![0]!.archived);
+  return [...live, ...archived].flatMap((id) => bySession.get(id)!);
 }
 
 function onPaletteKeydown(e: KeyboardEvent): void {
@@ -199,7 +206,9 @@ function askQm(): void {
   closeChatSearch();
   const conv = mainConversation();
   conv.newChat();
-  void conv.state.agent?.prompt(q);
+  void conv.state.agent?.prompt(
+    `Find my previous session based on the following search query, give me a link when you've identified it: ${q}`,
+  );
 }
 
 function highlight(text: string): TemplateResult {
@@ -226,13 +235,18 @@ function resultRows(): TemplateResult[] {
     if (hit.sessionId !== lastSession) {
       lastSession = hit.sessionId;
       rows.push(
-        html`<div class="chat-search-group"><b>${hitTitle(hit)}</b><span>${recencyGroup(hit.createdAt)}</span></div>`,
+        html`<div class="chat-search-group ${hit.archived ? "archived" : ""}">
+          <b>${hitTitle(hit)}</b
+          >${hit.archived ? html`<em class="chat-search-archived-tag">Archived</em>` : nothing}<span
+            >${recencyGroup(hit.createdAt)}</span
+          >
+        </div>`,
       );
     }
     rows.push(html`
       <button
         type="button"
-        class="chat-search-row ${i === searchState.sel ? "selected" : ""}"
+        class="chat-search-row ${i === searchState.sel ? "selected" : ""} ${hit.archived ? "archived" : ""}"
         @click=${() => void openHit(hit)}
         @pointermove=${() => {
           if (searchState.sel !== i) {
@@ -273,8 +287,8 @@ function askRow(): TemplateResult {
     >
       <span class="chat-search-who ask">+</span>
       <span class="chat-search-text">
-        <span class="chat-search-snippet">Ask QM in a new chat: <b>“${searchState.query.trim()}”</b></span>
-        <span class="chat-search-meta">starts a fresh session with this as the prompt</span>
+        <span class="chat-search-snippet">Ask QM to find it: <b>“${searchState.query.trim()}”</b></span>
+        <span class="chat-search-meta">starts a new chat where QM hunts down the matching session and links it</span>
       </span>
       <span class="chat-search-kbd">${isMac ? "⌘" : "Ctrl"}${icon(CornerDownLeft, 11)}</span>
     </button>
@@ -288,6 +302,10 @@ function paletteTpl(): TemplateResult {
     body = html`<div class="chat-search-empty">Search every chat you can see — messages, not just titles.</div>`;
   } else if (searchState.loading && !searchState.hits.length) {
     body = html`<div class="chat-search-empty">Searching…</div>`;
+  } else if (searchState.failed) {
+    body = html`<div class="chat-search-empty chat-search-failed">
+      Search failed — check the connection and try again.
+    </div>`;
   } else if (!searchState.hits.length) {
     body = html`<div class="chat-search-empty">No messages match “${q}”.</div>`;
   } else {
@@ -300,13 +318,13 @@ function paletteTpl(): TemplateResult {
         if (e.target === e.currentTarget) closeChatSearch();
       }}
     >
-      <div class="chat-search-palette" role="dialog" aria-label="Search chats" @keydown=${onPaletteKeydown}>
+      <div class="chat-search-palette" role="dialog" aria-label="Search your chats" @keydown=${onPaletteKeydown}>
         <div class="chat-search-inputrow">
           ${icon(Search, 16)}
           <input
             class="chat-search-input"
             type="text"
-            placeholder="Search all chats…"
+            placeholder="Search your chats…"
             autocomplete="off"
             spellcheck="false"
             .value=${searchState.query}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -7310,3 +7310,23 @@ h3.ambient-field-label {
   font-size: 11px;
   color: var(--muted-foreground);
 }
+.chat-search-group.archived b {
+  color: var(--muted-foreground, #8a8a8a);
+}
+.chat-search-archived-tag {
+  font-style: normal;
+  font-size: 10px;
+  padding: 1px 5px;
+  margin-left: 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted-foreground, #8a8a8a);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.chat-search-row.archived {
+  opacity: 0.65;
+}
+.chat-search-failed {
+  color: var(--destructive, #b42318);
+}

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -542,14 +542,14 @@ export function renderSidebarTop(): void {
                 <button
                   class="chat-search-open"
                   type="button"
-                  aria-label="Search chats"
+                  aria-label="Search your chats"
                   @click=${() => {
               hideTooltip();
               openChatSearch();
             }}
-                  @mouseenter=${(e: Event) => showTooltip(e.currentTarget as Element, `Search chats · ${SEARCH_HOTKEY_LABEL}`)}
+                  @mouseenter=${(e: Event) => showTooltip(e.currentTarget as Element, `Search your chats · ${SEARCH_HOTKEY_LABEL}`)}
                   @mouseleave=${(e: Event) => hideTooltip(e.currentTarget as Element)}
-                  @focus=${(e: Event) => showTooltip(e.currentTarget as Element, `Search chats · ${SEARCH_HOTKEY_LABEL}`)}
+                  @focus=${(e: Event) => showTooltip(e.currentTarget as Element, `Search your chats · ${SEARCH_HOTKEY_LABEL}`)}
                   @blur=${(e: Event) => hideTooltip(e.currentTarget as Element)}
                 >
                   ${icon(Search, 13)}

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -221,6 +221,7 @@ export function createSessionMethods(
             ...(hit.author ? { author: hit.author } : {}),
             snippet: searchSnippet(hit.text, terms),
             createdAt: hit.createdAt,
+            ...(session.archived ? { archived: true } : {}),
           },
         ];
       });

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -225,6 +225,7 @@ export interface SessionSearchHit {
   author?: string;
   snippet: string;
   createdAt: number;
+  archived?: boolean;
 }
 
 export interface App {


### PR DESCRIPTION
Four refinements to the chat-search palette. Copy now reads "Search your chats" across placeholder, tooltip, and aria labels. Archived chats are included in results, always grouped below live chats with an Archived badge and dimmed rows. The ask-the-agent row starts the new chat with an explicit find-my-previous-session prompt instead of the raw query. And a failed /api/search no longer masquerades as "no matches" — the palette shows a distinct search-failed state, so real errors stop hiding behind an empty-results message.

Depends on #474 — do not merge until it lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249510&installation_model_id=19911&pr_number=490&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F490&signature=8953c4efe14dfee1d8ebe90390a9ddeb882aa276ce1cd69ce8f88b54c1c879a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->