### PR TITLE
web-ui: keep the device safe-area under the composer on mid-width surfaces

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2290,7 +2290,7 @@ a.chat-row-open {
 .composer-wrap {
   position: relative;
   width: min(var(--content-w), calc(100% - 32px));
-  margin: 0 auto 18px;
+  margin: 0 auto max(18px, calc(10px + env(safe-area-inset-bottom)));
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: 24px;
@@ -6948,6 +6948,15 @@ h3.ambient-field-label {
   .custom-chat-shell {
     --content-w: 100%;
   }
+  /* Mid-width surfaces: the floating composer/dock hug the full-width column with 16px
+     side margins, but must still clear the device safe areas — the 10px variant below
+     only kicks in at <=470px, so the insets need a floor here too. */
+  .composer-wrap,
+  .live-work-dock {
+    width: auto;
+    margin-right: max(16px, calc(10px + env(safe-area-inset-right)));
+    margin-left: max(16px, calc(10px + env(safe-area-inset-left)));
+  }
 }
 @container chat (max-width: 470px) {
   .custom-chat-shell {
@@ -6956,14 +6965,12 @@ h3.ambient-field-label {
   /* The floating composer/dock margins pair with the full-bleed 14px chat pad and must
      follow the surface's width too, or a window resize misaligns them with the column. */
   .composer-wrap {
-    width: auto;
     margin-right: calc(10px + env(safe-area-inset-right));
     margin-bottom: calc(10px + env(safe-area-inset-bottom));
     margin-left: calc(10px + env(safe-area-inset-left));
     border-radius: 18px;
   }
   .live-work-dock {
-    width: auto;
     margin-right: calc(10px + env(safe-area-inset-right));
     margin-left: calc(10px + env(safe-area-inset-left));
   }

--- a/plugins/web-ui/test/responsive-source.test.ts
+++ b/plugins/web-ui/test/responsive-source.test.ts
@@ -110,12 +110,17 @@ test("touch layouts expose row actions and preserve readable composer choices", 
     compactCss,
     /padding: calc\(20px \+ var\(--surface-safe-top\)\) max\(14px, env\(safe-area-inset-right\)\) calc\(32px \+ env\(safe-area-inset-bottom\)\) max\(14px, env\(safe-area-inset-left\)\)/,
   );
+  assert.match(compactCss, /margin: 0 auto max\(18px, calc\(10px \+ env\(safe-area-inset-bottom\)\)\)/);
   assert.match(
     compactCss,
-    /\.composer-wrap \{\s*width: auto;\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);[\s\S]*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
+    /\.composer-wrap,\s*\.live-work-dock \{\s*width: auto;\s*margin-right: max\(16px, calc\(10px \+ env\(safe-area-inset-right\)\)\);\s*margin-left: max\(16px, calc\(10px \+ env\(safe-area-inset-left\)\)\)/,
   );
   assert.match(
     compactCss,
-    /\.live-work-dock \{\s*width: auto;\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
+    /\.composer-wrap \{\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-bottom: calc\(10px \+ env\(safe-area-inset-bottom\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
+  );
+  assert.match(
+    compactCss,
+    /\.live-work-dock \{\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
   );
 });


### PR DESCRIPTION
On mid-width surfaces (tablets and panes between the phone breakpoint and full width), the floating composer and live-work dock hugged the column with fixed 16px side margins and an 18px bottom margin, ignoring device safe-area insets — on notched or home-indicator devices the composer sat under the system UI. Give those margins an inset floor (max of the design margin and 10px plus the corresponding env(safe-area-inset-*)), matching the treatment the narrowest breakpoint already had.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249512&installation_model_id=19911&pr_number=491&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F491&signature=d7d2a57299ed50dd24c246f9a5e773c8c8096030fd10c53a6949e064fc241532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->