### PR TITLE
Sidebar: always show Sessions, collapse

### DIFF
--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -30,7 +30,7 @@ import {
 import { UI_BASE } from "./deep-link";
 import { errMessage } from "../../chassis/src/errors";
 import { actionSnippet, closeFormMenus, fieldSelect, formatBytes, icon, initials, relTime, toggleFormMenu } from "./ui";
-import { appState, renderSidebarTop, replacePanePreservingFocus, switchView, syncUrlFromState } from "./shell";
+import { appState, replacePanePreservingFocus, switchView, syncUrlFromState } from "./shell";
 import { mainConversation } from "./conversations";
 import { groupDmTitle, openSession, refreshSessions, sessionsState, slackLogo, surfaceOf } from "./sessions";
 import { activityOf } from "./session-list";
@@ -1443,7 +1443,5 @@ function startChatIn(c: CoreContext): void {
 }
 
 async function openFromContext(s: CoreSession): Promise<void> {
-  appState.currentView = "chats";
-  renderSidebarTop();
   await openSession(s);
 }

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -256,7 +256,7 @@ function visibleSessions(): CoreSession[] {
 }
 
 export function renderList(): void {
-  if (!appState.listEl || appState.currentView !== "chats") return;
+  if (!appState.listEl) return;
   const visible = visibleSessions();
   const active = visible.filter((s) => !s.archived);
   const archived = visible.filter((s) => s.archived);

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -72,7 +72,7 @@ import {
 } from "./contexts";
 import { groupDmLabel, groupDmText } from "./group-dm-label";
 import { transcriptModel } from "./model-options";
-import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty } from "./shell";
+import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, syncUrlFromState } from "./shell";
 import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
@@ -81,6 +81,7 @@ import {
   endSessionDrag,
   notifySessionsChanged,
   closeSessionSurfaces,
+  drawCanvas,
   sessionInCanvas,
   splitInterceptsOpen,
   splitState,
@@ -1181,6 +1182,14 @@ export async function refreshSessions(
 }
 
 export async function openSession(s: CoreSession, entriesPrefetch?: Promise<TranscriptPage | null>): Promise<void> {
+  if (appState.currentView !== "chats") {
+    appState.currentView = "chats";
+    appState.viewRenderSeq++;
+    renderSidebarTop();
+    renderList();
+    if (splitState.active) drawCanvas();
+    syncUrlFromState(s.id || null);
+  }
   if (splitInterceptsOpen(s)) return;
   closeSidebarOnNarrowView();
   if (projectName(s.scopeId) && sessionsState.collapsedProjectScopes.delete(s.scopeId)) renderList();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -86,9 +86,11 @@ export const ADMIN_BASE = (() => {
 })();
 export const ADMIN_HOME_URL = `${ADMIN_BASE}/`;
 
-export function syncUrlFromState(): void {
+export function syncUrlFromState(sessionOverride?: string | null): void {
   const chatState = mainConversation().state;
-  const sessionId = splitState.active ? null : (chatState.sessionId ?? chatState.rememberedSessionId);
+  const fromState =
+    sessionOverride !== undefined ? sessionOverride : (chatState.sessionId ?? chatState.rememberedSessionId);
+  const sessionId = splitState.active ? null : fromState;
   const next = deepLinkPath(UI_BASE, appState.currentView, sessionId, contextsState.selected);
   if (`${location.pathname}${location.search}` !== next) history.replaceState(null, "", next);
 }

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -14,6 +14,7 @@ import {
   Plus,
   RefreshCw,
   Rocket,
+  ShieldCheck,
   type IconNode,
 } from "lucide";
 import "@mariozechner/mini-lit/dist/ThemeToggle.js";
@@ -65,7 +66,7 @@ import { renderDeploys } from "./deploys";
 import { renderMemory, resetMemoryState } from "./memory";
 import { renderSkills } from "./skills";
 import { contextsState, ensureContexts, renderContexts, resetContextsState, resolveProjectScope } from "./contexts";
-import { appState, isView, type AuthMode, type Me, type View } from "./shell-state";
+import { appState, can, isView, type AuthMode, type Me, type View } from "./shell-state";
 import { trapDialogFocus } from "./dialog-focus";
 export { appState, can, type Me, type View } from "./shell-state";
 
@@ -144,9 +145,9 @@ const NAV_WORKSPACE_KEY = "web-ui:nav-workspace";
 
 function loadNavOpen(key: string): boolean {
   try {
-    return localStorage.getItem(key) !== "0";
+    return localStorage.getItem(key) === "1";
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -527,12 +528,18 @@ export function renderSidebarTop(): void {
             ${navRow("files", ICON.files, "Files")} ${navRow("crons", ICON.crons, "Crons")}
             ${navRow("keychain", ICON.keychain, "Keychain")} ${navRow("deploys", ICON.deploys, "Apps")}
             ${navRow("memory", ICON.memory, "Memory")} ${navRow("skills", ICON.skills, "Skills")}
+            ${
+              can("admin")
+                ? html`<a class="navrow" href=${ADMIN_HOME_URL} title="Admin">
+                    ${icon(ShieldCheck, 17)}<span>Admin</span>
+                  </a>`
+                : nothing
+            }
           `,
         )}
       </nav>
       ${
-        appState.currentView === "chats"
-          ? html`
+        html`
               <div class="section-label recents-label">
                 <span>Sessions</span>
                 <button
@@ -547,7 +554,6 @@ export function renderSidebarTop(): void {
                 </button>
               </div>
             `
-          : ""
       }
     `,
     appState.topEl,
@@ -582,7 +588,6 @@ export function switchView(v: View): void {
   }
   renderSidebarTop();
   syncUrlFromState();
-  if (v !== "chats" && appState.listEl) render(nothing, appState.listEl);
   switch (v) {
     case "chats":
       if (splitState.active) drawCanvas();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -538,23 +538,21 @@ export function renderSidebarTop(): void {
           `,
         )}
       </nav>
-      ${
-        html`
-              <div class="section-label recents-label">
-                <span>Sessions</span>
-                <button
-                  class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
-                  type="button"
-                  role="switch"
-                  aria-checked=${sessionsState.webOnly ? "true" : "false"}
-                  title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
-                  @click=${toggleWebOnly}
-                >
-                  <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
-                </button>
-              </div>
-            `
-      }
+      ${html`
+        <div class="section-label recents-label">
+          <span>Sessions</span>
+          <button
+            class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
+            type="button"
+            role="switch"
+            aria-checked=${sessionsState.webOnly ? "true" : "false"}
+            title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
+            @click=${toggleWebOnly}
+          >
+            <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
+          </button>
+        </div>
+      `}
     `,
     appState.topEl,
   );

--- a/plugins/web-ui/test/open-session-view-switch.test.ts
+++ b/plugins/web-ui/test/open-session-view-switch.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const sessions = readFileSync(new URL("../src/sessions.ts", import.meta.url), "utf8");
+const contexts = readFileSync(new URL("../src/contexts.ts", import.meta.url), "utf8");
+
+const openSessionBody = sessions.match(/export async function openSession\([^]*?\n\}/)?.[0] ?? "";
+
+test("openSession returns to the chats view before mounting (sidebar sessions are visible on every view)", () => {
+  const guard = openSessionBody.match(/if \(appState\.currentView !== "chats"\) \{[^]*?\n {2}\}/)?.[0] ?? "";
+  assert.ok(guard, "openSession must switch back to the chats view when invoked from another view");
+  assert.match(guard, /appState\.currentView = "chats"/);
+  assert.match(guard, /appState\.viewRenderSeq\+\+/, "must invalidate pending renders of the previous view");
+  assert.match(guard, /renderSidebarTop\(\)/);
+  assert.match(guard, /if \(splitState\.active\) drawCanvas\(\)/, "split canvas must be redrawn on return to chats");
+  assert.match(
+    guard,
+    /syncUrlFromState\(s\.id \|\| null\)/,
+    "URL must leave the old view — with the target session, not a stale remembered one — even when the split intercept returns early",
+  );
+  assert.ok(
+    openSessionBody.indexOf(guard) < openSessionBody.indexOf("splitInterceptsOpen"),
+    "view switch must happen before the split intercept so canvas opens intercept correctly",
+  );
+});
+
+test("openFromContext delegates the view switch to openSession", () => {
+  const body = contexts.match(/async function openFromContext\([^]*?\n\}/)?.[0] ?? "";
+  assert.ok(body, "openFromContext exists");
+  assert.match(body, /await openSession\(s\)/);
+  assert.doesNotMatch(body, /appState\.currentView = "chats"/);
+});


### PR DESCRIPTION
Browse by default, add an Admin link for admins Switching to Files, Crons, or any non-chat view blanked the sidebar's Sessions list, hiding the most-used navigation exactly when you were elsewhere. The Sessions header and list now render in the sidebar on every view. The Browse nav group starts collapsed by default (a stored preference still wins once toggled), and users with the admin permission get an Admin link at the bottom of Browse pointing at the admin home.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245659&installation_model_id=19911&pr_number=453&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F453&signature=65cf5399895a8ad2e24a57ddb0fc077030538268d47784698128885c898d489e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->