### PR TITLE
config: treat a top-level "//" key as a comment, not an unknown field

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -509,7 +509,7 @@ function validate(raw: unknown, path: string): QmConfig {
   const o = raw;
 
   for (const key of Object.keys(o)) {
-    if (!VALID_TOP_LEVEL_KEYS.has(key)) {
+    if (key !== "//" && !VALID_TOP_LEVEL_KEYS.has(key)) {
       throw new CliError(`${path}: unknown top-level field ${JSON.stringify(key)}`);
     }
   }

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -68,6 +68,9 @@ test("required fields: orgId, target, services (must include core), valid servic
   withConfig({ org_id: "acme" }, ({ path }) =>
     assert.throws(() => loadConfigAt(path), /unknown top-level field "org_id"/),
   );
+  withConfig({ "//": "comment-key convention for plain-JSON configs" }, ({ path }) => {
+    assert.ok(loadConfigAt(path).config);
+  });
 });
 
 test("apiUrl must be an http(s) origin URL; the trailing slash is stripped", () => {


### PR DESCRIPTION
Strict validation of top-level config fields rejects the conventional "//" comment key that plain- JSON configs use to carry notes (JSON proper has no comments). A config carrying such a key failed validation with "unknown top-level field", breaking deployments whose stored config used the convention. Validation now skips "//" when checking for unknown top-level fields, with a test.

Stacked on #468 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789248894&installation_model_id=19911&pr_number=473&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F473&signature=08709bcb4140db02e212a9fbb51c3ac68c1bca8b12ab94633cf67c4b37d110f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->