### PR TITLE
acl: version-checked cache for grant reads instead of re-reading the whole table

### DIFF
--- a/src/acl/postgres-grant-store.ts
+++ b/src/acl/postgres-grant-store.ts
@@ -22,15 +22,37 @@ export function createPostgresGrantStore(connectionString: string): GrantPersist
         granted_by       TEXT NOT NULL,
         PRIMARY KEY (owner_scope_id, path, grantee_scope_id, permission)
       )`,
+    `CREATE TABLE IF NOT EXISTS acl_grants_version(
+        only_row BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (only_row),
+        v        BIGINT NOT NULL
+      )`,
+    `INSERT INTO acl_grants_version(only_row, v) VALUES (TRUE, 0) ON CONFLICT (only_row) DO NOTHING`,
+    `CREATE OR REPLACE FUNCTION acl_grants_bump_version() RETURNS trigger LANGUAGE plpgsql AS $fn$
+      BEGIN
+        INSERT INTO acl_grants_version(only_row, v) VALUES (TRUE, 1)
+        ON CONFLICT (only_row) DO UPDATE SET v = acl_grants_version.v + 1;
+        RETURN NULL;
+      END
+      $fn$`,
+    `DROP TRIGGER IF EXISTS acl_grants_bump ON acl_grants`,
+    `CREATE TRIGGER acl_grants_bump
+      AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE ON acl_grants
+      FOR EACH STATEMENT EXECUTE FUNCTION acl_grants_bump_version()`,
   ]);
   const { q } = db;
+  let cache: { v: string; grants: readonly Grant[] } | null = null;
 
   return {
     async all() {
+      const versionRows = await q("SELECT v FROM acl_grants_version");
+      const version = versionRows.length ? String(versionRows[0]!.v) : null;
+      if (cache && version !== null && cache.v === version) return [...cache.grants];
       const rows = await q(
         "SELECT owner_scope_id, path, grantee_scope_id, permission, granted_by FROM acl_grants ORDER BY owner_scope_id, path, grantee_scope_id, permission",
       );
-      return rows.map(rowToGrant);
+      const grants = rows.map(rowToGrant);
+      cache = version === null ? null : { v: version, grants };
+      return [...grants];
     },
     async put(g) {
       const client = await (await db.pool()).connect();

--- a/test/postgres-grant-store.test.ts
+++ b/test/postgres-grant-store.test.ts
@@ -13,6 +13,7 @@ before(async () => {
   const pg = (await import("pg")).default;
   const p = new pg.Pool({ connectionString: URL });
   await p.query("DROP TABLE IF EXISTS acl_grants CASCADE");
+  await p.query("DROP TABLE IF EXISTS acl_grants_version CASCADE");
   await p.end();
 });
 
@@ -64,6 +65,101 @@ test("pg grant persistence survives across store instances (no per-process cache
   assert.equal(
     (await reader.all()).some((g) => g.ref === "shared-across.md"),
     true,
+  );
+});
+
+test("pg grant persistence: a warm cache sees another instance's writes and revocations", { skip }, async () => {
+  const reader = createPostgresGrantStore(URL!);
+  const writer = createPostgresGrantStore(URL!);
+  await reader.all();
+
+  await writer.put(grant({ ref: "warm-cache.md" }));
+  assert.equal(
+    (await reader.all()).some((g) => g.ref === "warm-cache.md"),
+    true,
+    "a grant written elsewhere is visible on the very next read",
+  );
+
+  await reader.all();
+  await writer.remove(grant({ ref: "warm-cache.md" }));
+  assert.equal(
+    (await reader.all()).some((g) => g.ref === "warm-cache.md"),
+    false,
+    "a revocation elsewhere is visible on the very next read",
+  );
+});
+
+test("pg grant persistence: a warm cache sees writes that bypass the store entirely", { skip }, async () => {
+  const reader = createPostgresGrantStore(URL!);
+  await reader.all();
+
+  const pg = (await import("pg")).default;
+  const p = new pg.Pool({ connectionString: URL });
+  await p.query(
+    "INSERT INTO acl_grants (owner_scope_id, path, grantee_scope_id, permission, granted_by) VALUES ($1, $2, $3, $4, $5)",
+    [owner, "out-of-band.md", carol, "read", "U1"],
+  );
+  await p.end();
+
+  assert.equal(
+    (await reader.all()).some((g) => g.ref === "out-of-band.md"),
+    true,
+    "raw SQL against acl_grants must invalidate warm caches (old instances during blue-green, scripts, manual psql)",
+  );
+});
+
+test("pg grant persistence: the snapshot is served from cache until the version moves", { skip }, async () => {
+  const reader = createPostgresGrantStore(URL!);
+  await reader.put(grant({ ref: "cached.md" }));
+  await reader.all();
+
+  const pg = (await import("pg")).default;
+  const p = new pg.Pool({ connectionString: URL });
+  try {
+    await p.query("ALTER TABLE acl_grants DISABLE TRIGGER acl_grants_bump");
+    await p.query("DELETE FROM acl_grants WHERE path = $1", ["cached.md"]);
+    assert.equal(
+      (await reader.all()).some((g) => g.ref === "cached.md"),
+      true,
+      "an unbumped delete is invisible — proof reads are served from the snapshot",
+    );
+  } finally {
+    await p.query("ALTER TABLE acl_grants ENABLE TRIGGER acl_grants_bump");
+  }
+  await p.query("UPDATE acl_grants_version SET v = v + 1");
+  assert.equal(
+    (await reader.all()).some((g) => g.ref === "cached.md"),
+    false,
+    "the next version bump refreshes the snapshot",
+  );
+  await p.end();
+});
+
+test("pg grant persistence: a conditional replacement invalidates warm caches", { skip }, async () => {
+  const reader = createPostgresGrantStore(URL!);
+  const writer = createPostgresGrantStore(URL!);
+  const before = grant({ ref: "cas-invalidate.md" });
+  await writer.put(before);
+  await reader.all();
+
+  const after = grant({ ref: "cas-invalidate.md", granteeScopeId: scopeId("personal", "U3") });
+  assert.equal(await writer.replaceForResourceIfCurrent(owner, "cas-invalidate.md", [before], [after]), true);
+  assert.equal(
+    (await reader.all()).some((g) => g.ref === "cas-invalidate.md" && g.granteeScopeId === after.granteeScopeId),
+    true,
+    "the replacement is visible on the very next read",
+  );
+});
+
+test("pg grant persistence: cached reads return independent arrays", { skip }, async () => {
+  const store = createPostgresGrantStore(URL!);
+  await store.put(grant({ ref: "aliasing.md" }));
+  const first = await store.all();
+  first.length = 0;
+  assert.equal(
+    (await store.all()).some((g) => g.ref === "aliasing.md"),
+    true,
+    "mutating one caller's result must not corrupt the cache",
   );
 });
 


### PR DESCRIPTION
Every ACL question (grantsFor, handlesFor, grantsOfKind, list) loaded the entire acl_grants table and filtered in process, on every call. At a few calls per second this full-table read becomes the single largest consumer of database time even though grant writes are rare. The grant store now keeps an in-process cache invalidated by a version counter that every write path bumps (via a trigger), so reads hit the table only when a write has actually happened. The cache is a pure read-through in front of Postgres, so multi-instance deployments stay correct: a stale instance re-reads on the next version mismatch.

**Deployment notes**

The createPgPool multi-migration refactor it depends on must be in the same PR (or already
upstream)
Release note: boot now creates a plpgsql function + trigger on acl_grants; DB role needs
those privileges
New migration acl/grants/0002 runs at boot via the createPgPool migration list (CREATE TABLE IF
NOT EXISTS acl_grants_version + INSERT ... ON CONFLICT DO NOTHING + CREATE OR REPLACE
FUNCTION + DROP/CREATE TRIGGER) — idempotent, no manual step.
Restructures createPgPool's signature from (conn, id, statements) to (conn, [{id, statements}]) —
upstream must carry the matching createPgPool change and note says 0001 is
checksummed/immutable; verify upstream's migration ledger accepts the new list form for a DB
that already ran 0001.
Blue-green is the designed-for case: the statement-level trigger bumps the version for writes
from OLD code too, so a new instance's warm cache invalidates on any writer. Safe both
directions.
Rollback caveat: rolling back leaves the trigger + version table in place; old code never reads
them and every write still fires the trigger — harmless but permanent unless dropped by hand.
Requires plpgsql available and DDL privileges (CREATE FUNCTION/TRIGGER) for the app's DB
role at boot — a locked-down deployment role without TRIGGER privilege fails boot; worth a
release-note line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789248209&installation_model_id=19911&pr_number=467&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F467&signature=4b1a4294398fff4973b6a2d77637aa190ff55e6994b35e63ea6283054f7694bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->