### PR TITLE
web-ui: hover popover labels the session top-bar icon buttons

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -83,7 +83,7 @@ import {
 import { browserRenderableImage, formatBytes, icon, relTime } from "./ui";
 import { appState, renderSidebarTop, switchView, syncUrlFromState } from "./shell";
 import { contextsState, scopeTitle } from "./contexts";
-import { openProjectPage, scopeCronCount, sessionTopbarTpl, setScopedSession } from "./session-scope";
+import { openProjectPage, scopeToolCount, sessionTopbarTpl, setScopedSession } from "./session-scope";
 import {
   addPendingSession,
   dropPendingSession,
@@ -1148,7 +1148,7 @@ export function createChatSurface(
           }
         : null,
       onCrumb: crumb && scope ? () => openProjectPage(scope) : null,
-      cronCount: scope ? scopeCronCount(scope, () => drawActiveChat()) : null,
+      toolCount: scope ? (t) => scopeToolCount(t, scope, () => drawActiveChat()) : null,
       onTool: (tool) => {
         setScopedSession({
           scopeId: scope ?? "",

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -26,30 +26,55 @@ interface CronLite {
   archived?: boolean;
 }
 
-const cronCountCache = new Map<string, { count: number; at: number }>();
-const cronCountInFlight = new Set<string>();
+const toolCountCache = new Map<string, { count: number; at: number }>();
+const toolCountInFlight = new Set<string>();
 
-/** Cached count of enabled crons owned by a scope; kicks off a refresh and
- * calls onReady when a fresh count lands. */
-export function scopeCronCount(scope: string, onReady: () => void): number | null {
-  const hit = cronCountCache.get(scope);
+const TOOL_COUNTERS: Partial<Record<SessionTool, (scope: string) => Promise<number>>> = {
+  crons: async (scope) => {
+    const r = await api<{ crons?: CronLite[]; visible?: CronLite[] }>("/api/crons");
+    const seen = new Set<string>();
+    let count = 0;
+    for (const c of [...(r.crons ?? []), ...(r.visible ?? [])]) {
+      if (seen.has(c.id)) continue;
+      seen.add(c.id);
+      if (c.ownerScopeId === scope && c.enabled && !c.archived) count++;
+    }
+    return count;
+  },
+  files: async (scope) => {
+    const q = new URLSearchParams({ limit: "100", scope });
+    const r = await api<{ owned?: unknown[]; shared?: unknown[] }>(`/api/files?${q.toString()}`);
+    return (r.owned?.length ?? 0) + (r.shared?.length ?? 0);
+  },
+  apps: async (scope) => {
+    const r = await api<{ deployments?: Array<{ status?: string; ownerScopeId?: string; createdInScope?: string }> }>(
+      "/api/deployments",
+    );
+    return (r.deployments ?? []).filter(
+      (d) => d.status !== "archived" && (d.createdInScope === scope || d.ownerScopeId === scope),
+    ).length;
+  },
+  skills: async (scope) => {
+    const r = await api<{ skills?: Array<{ scopeId?: string; status?: string }> }>("/api/skills?includeShadowed=1");
+    return (r.skills ?? []).filter((sk) => sk.scopeId === scope && sk.status !== "archived").length;
+  },
+};
+
+/** Cached count of a tool's items in a scope; kicks off a refresh and calls
+ * onReady when a fresh count lands. Tools without a counter return null. */
+export function scopeToolCount(tool: SessionTool, scope: string, onReady: () => void): number | null {
+  const counter = TOOL_COUNTERS[tool];
+  if (!counter || !scope) return null;
+  const key = `${tool}:${scope}`;
+  const hit = toolCountCache.get(key);
   if (hit && Date.now() - hit.at < 60_000) return hit.count;
-  if (!cronCountInFlight.has(scope)) {
-    cronCountInFlight.add(scope);
-    void api<{ crons?: CronLite[]; visible?: CronLite[] }>("/api/crons")
-      .then((r) => {
-        const seen = new Set<string>();
-        let count = 0;
-        for (const c of [...(r.crons ?? []), ...(r.visible ?? [])]) {
-          if (seen.has(c.id)) continue;
-          seen.add(c.id);
-          if (c.ownerScopeId === scope && c.enabled && !c.archived) count++;
-        }
-        cronCountCache.set(scope, { count, at: Date.now() });
-      })
-      .catch(() => cronCountCache.set(scope, { count: hit?.count ?? 0, at: Date.now() }))
+  if (!toolCountInFlight.has(key)) {
+    toolCountInFlight.add(key);
+    void counter(scope)
+      .then((count) => toolCountCache.set(key, { count, at: Date.now() }))
+      .catch(() => toolCountCache.set(key, { count: hit?.count ?? 0, at: Date.now() }))
       .finally(() => {
-        cronCountInFlight.delete(scope);
+        toolCountInFlight.delete(key);
         onReady();
       });
   }
@@ -62,7 +87,7 @@ export interface SessionTopbarOpts {
   crumb: string | null;
   title: string;
   activeTool?: SessionTool | null;
-  cronCount?: number | null;
+  toolCount?: ((tool: SessionTool) => number | null) | null;
   fork?: { title: string; onClick?: (() => void) | null } | null;
   onTitle?: (() => void) | null;
   onCrumb?: (() => void) | null;
@@ -108,17 +133,19 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
   const headingTitle = o.crumb
     ? `This chat runs in the ${o.crumb} context — the agent works with that context's files and memory, separate from your personal context.`
     : o.title;
-  const tool = (t: SessionTool, glyph: Parameters<typeof icon>[0], label: string, hint: string) => html`
-    <button
-      class="session-tool ${o.activeTool === t ? "active" : ""}"
-      type="button"
-      title=${hint}
-      @click=${() => o.onTool(t)}
-    >
-      ${icon(glyph, 15)}<span>${label}</span>
-    </button>
-  `;
-  const cronLabel = o.cronCount ? `${o.cronCount} ${o.cronCount === 1 ? "cron" : "crons"}` : "Crons";
+  const tool = (t: SessionTool, glyph: Parameters<typeof icon>[0], hint: string) => {
+    const count = o.toolCount?.(t) ?? null;
+    return html`
+      <button
+        class="session-tool ${o.activeTool === t ? "active" : ""}"
+        type="button"
+        title=${hint}
+        @click=${() => o.onTool(t)}
+      >
+        ${icon(glyph, 15)}${count ? html`<span class="session-tool-count">${count}</span>` : nothing}
+      </button>
+    `;
+  };
   return html`
     <header class="chat-topbar session-topbar">
       ${
@@ -129,11 +156,9 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, cronLabel, "Crons in this context")}
-        ${tool("files", Files, "Files", "Files in this context")}
-        ${tool("apps", Rocket, "Apps", "Apps in this context")}
-        ${tool("skills", Box, "Skills", "Skills in this context")} ${tool("memory", Brain, "Memory", "Memory")}
-        ${tool("keychain", KeyRound, "Keychain", "Your keychain")}
+        ${tool("crons", Clock3, "Crons in this context")} ${tool("files", Files, "Files in this context")}
+        ${tool("apps", Rocket, "Apps in this context")} ${tool("skills", Box, "Skills in this context")}
+        ${tool("memory", Brain, "Memory")} ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>
   `;
@@ -154,7 +179,7 @@ export function scopedViewTopbar(current: SessionTool, redraw: () => void): Temp
     title: active.title,
     onCrumb: active.crumb ? () => openProjectPage(active.scopeId) : null,
     activeTool: current,
-    cronCount: scopeCronCount(active.scopeId, redraw),
+    toolCount: (t) => scopeToolCount(t, active.scopeId, redraw),
     onTitle: () => {
       setScopedSession(null);
       void Promise.all([import("./shell"), import("./sessions")]).then(

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -157,9 +157,9 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")}
-        ${tool("apps", Rocket, "Apps")} ${tool("skills", Box, "Skills")}
-        ${tool("memory", Brain, "Memory")} ${tool("keychain", KeyRound, "Your keychain")}
+        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")} ${tool("apps", Rocket, "Apps")}
+        ${tool("skills", Box, "Skills")} ${tool("memory", Brain, "Memory")}
+        ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>
   `;

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -139,10 +139,11 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
       <button
         class="session-tool ${o.activeTool === t ? "active" : ""}"
         type="button"
-        title=${hint}
+        aria-label=${hint}
         @click=${() => o.onTool(t)}
       >
         ${icon(glyph, 15)}${count ? html`<span class="session-tool-count">${count}</span>` : nothing}
+        <span class="session-tool-hint" role="tooltip">${hint}</span>
       </button>
     `;
   };
@@ -156,8 +157,8 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, "Crons in this context")} ${tool("files", Files, "Files in this context")}
-        ${tool("apps", Rocket, "Apps in this context")} ${tool("skills", Box, "Skills in this context")}
+        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")}
+        ${tool("apps", Rocket, "Apps")} ${tool("skills", Box, "Skills")}
         ${tool("memory", Brain, "Memory")} ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1158,6 +1158,34 @@ a.chat-row-open {
 .session-tool:hover .session-tool-count {
   color: var(--foreground);
 }
+.session-tool {
+  position: relative;
+}
+.session-tool-hint {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 11.5px;
+  font-weight: 550;
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+.session-tool:hover .session-tool-hint,
+.session-tool:focus-visible .session-tool-hint {
+  opacity: 1;
+  transform: translateY(0);
+}
 .session-heading.as-link {
   border: 0;
   background: transparent;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1143,6 +1143,21 @@ a.chat-row-open {
   background: color-mix(in srgb, var(--secondary) 85%, transparent);
   color: var(--foreground);
 }
+.session-tool-count {
+  min-width: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--secondary) 90%, transparent);
+  color: var(--muted-foreground);
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 15px;
+  text-align: center;
+}
+.session-tool.active .session-tool-count,
+.session-tool:hover .session-tool-count {
+  color: var(--foreground);
+}
 .session-heading.as-link {
   border: 0;
   background: transparent;

--- a/plugins/web-ui/src/skills.ts
+++ b/plugins/web-ui/src/skills.ts
@@ -491,7 +491,7 @@ function drawSkills(loading = false): void {
     groups = groups
       .map((group) => ({
         ...group,
-        skills: group.skills.filter((skill) => skill.scopeId === scopedScope || skill.scope === "org"),
+        skills: group.skills.filter((skill) => skill.scopeId === scopedScope),
       }))
       .filter((group) => group.skills.length > 0);
   const filtered = groups.flatMap((group) => group.skills);


### PR DESCRIPTION
The session top bar's tool icons (crons, files, apps, skills, memory, keychain) relied on the native title attribute, which is slow to appear and invisible to keyboard users. Each button now gets a styled tooltip pill: right-aligned to avoid clipping, no show delay, and shown on keyboard focus as well as hover. The native title is replaced with aria-label plus a role=tooltip span.

Depends on #486 — do not merge until it lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249509&installation_model_id=19911&pr_number=489&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F489&signature=c3d17ba2a7313c5bd5873c8e390e24293b78db795e135ab6f7cd3b1372796c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->