### PR TITLE
sandbox: provision-time machine resources for the smolmachines backend

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -289,6 +289,9 @@ interface SmolmachinesSandboxEnv {
   baseUrl?: string;
   namePrefix?: string;
   image?: string;
+  cpus?: number;
+  memoryMb?: number;
+  diskGb?: number;
   egressProxyUrl?: string;
   defaultTimeoutSec?: number;
 }
@@ -299,6 +302,15 @@ function smolmachinesSandboxEnv(env: NodeJS.ProcessEnv): SmolmachinesSandboxEnv 
     ...(env.SMOLMACHINES_BASE_URL ? { baseUrl: env.SMOLMACHINES_BASE_URL } : {}),
     ...(env.SMOLMACHINES_NAME_PREFIX ? { namePrefix: env.SMOLMACHINES_NAME_PREFIX } : {}),
     ...(env.SMOLMACHINES_IMAGE ? { image: env.SMOLMACHINES_IMAGE } : {}),
+    ...(numEnvStrict("SMOLMACHINES_CPUS", env.SMOLMACHINES_CPUS) !== undefined
+      ? { cpus: numEnvStrict("SMOLMACHINES_CPUS", env.SMOLMACHINES_CPUS) }
+      : {}),
+    ...(numEnvStrict("SMOLMACHINES_MEMORY_MB", env.SMOLMACHINES_MEMORY_MB) !== undefined
+      ? { memoryMb: numEnvStrict("SMOLMACHINES_MEMORY_MB", env.SMOLMACHINES_MEMORY_MB) }
+      : {}),
+    ...(numEnvStrict("SMOLMACHINES_DISK_GB", env.SMOLMACHINES_DISK_GB) !== undefined
+      ? { diskGb: numEnvStrict("SMOLMACHINES_DISK_GB", env.SMOLMACHINES_DISK_GB) }
+      : {}),
     ...(env.SMOLMACHINES_EGRESS_PROXY_URL ? { egressProxyUrl: env.SMOLMACHINES_EGRESS_PROXY_URL } : {}),
     ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
       ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }

--- a/src/sandbox/smolmachines-sandbox.ts
+++ b/src/sandbox/smolmachines-sandbox.ts
@@ -70,6 +70,9 @@ export interface SmolmachinesSandboxOptions {
   baseUrl?: string;
   namePrefix?: string;
   image?: string;
+  cpus?: number;
+  memoryMb?: number;
+  diskGb?: number;
   defaultTimeoutSec?: number;
   egressProxyUrl?: string;
   blobTransfer?: BlobTransferStore;
@@ -88,6 +91,11 @@ export function createSmolmachinesSandbox(workspace: WorkspaceStore, opts: Smolm
   const baseUrl = (opts.baseUrl ?? DEFAULT_SMOLMACHINES_BASE_URL).replace(/\/+$/, "");
   const prefix = opts.namePrefix ?? "qm";
   const image = opts.image ?? DEFAULT_IMAGE;
+  const resources = {
+    ...(opts.cpus ? { cpus: opts.cpus } : {}),
+    ...(opts.memoryMb ? { memoryMb: opts.memoryMb } : {}),
+    ...(opts.diskGb ? { diskGb: opts.diskGb } : {}),
+  };
   const defaultTimeoutSec = opts.defaultTimeoutSec ?? 600;
   const workspaceDir = `${HOME_DIR}/${WORKSPACE_BASENAME}`;
   const provisionQueue = createKeyedQueue<string>();
@@ -138,6 +146,7 @@ export function createSmolmachinesSandbox(workspace: WorkspaceStore, opts: Smolm
     const res = await api("POST", "/v1/machines", {
       name,
       source: { type: "image", reference: image },
+      ...(Object.keys(resources).length ? { resources } : {}),
       network: { mode: "open" },
       workdir: HOME_DIR,
       ephemeral,
@@ -374,6 +383,9 @@ export function createSmolmachinesSandbox(workspace: WorkspaceStore, opts: Smolm
       get notInstalled() {
         return visibleNotInstalled(["gh", "aws", "gcloud", "kubectl", "flyctl", "glab"], opts.extraTools ?? []);
       },
+      ...(opts.cpus ? { cpus: opts.cpus } : {}),
+      ...(opts.memoryMb ? { memoryMb: opts.memoryMb } : {}),
+      ...(opts.diskGb ? { diskGb: opts.diskGb } : {}),
       homeDir: HOME_DIR,
       workdir: workspaceDir,
     },

--- a/test/smolmachines-sandbox.test.ts
+++ b/test/smolmachines-sandbox.test.ts
@@ -175,6 +175,15 @@ test("timeouts beyond the API's sync exec ceiling run detached and poll to compl
   assert.equal(leftovers.stdout.trim(), "0");
 });
 
+test("configured resources are requested at create and advertised in the profile", async () => {
+  const s = make({ cpus: 4, memoryMb: 8192, diskGb: 200 });
+  const h = await s.provision(layers);
+  assert.deepEqual(fake.machine(h.id)?.resources, { cpus: 4, memoryMb: 8192, diskGb: 200 });
+  assert.equal(s.profile.spec?.diskGb, 200);
+  assert.equal(s.profile.spec?.memoryMb, 8192);
+  assert.equal(s.profile.spec?.cpus, 4);
+});
+
 test("profile advertises resident disk and process sessions", () => {
   assert.equal(sandbox.profile.backend, "smolmachines");
   assert.equal(sandbox.profile.writablePersistence, "resident_disk");

--- a/test/support/fake-smolmachines.ts
+++ b/test/support/fake-smolmachines.ts
@@ -14,6 +14,7 @@ interface FakeMachine {
   name: string | null;
   state: string;
   ephemeral: boolean;
+  resources?: Record<string, number>;
   home: string;
 }
 
@@ -22,7 +23,7 @@ export interface FakeSmolmachines {
   calls: SmolCall[];
   homeDir(name: string): string;
   names(): string[];
-  machine(name: string): { state: string; ephemeral: boolean } | null;
+  machine(name: string): { state: string; ephemeral: boolean; resources?: Record<string, number> } | null;
   stop(name: string): void;
   execScripts(): string[];
   reset(): void;
@@ -40,9 +41,16 @@ export function installFakeSmolmachines(): FakeSmolmachines {
 
   const byName = (name: string): FakeMachine | undefined => [...machines.values()].find((m) => m.name === name);
 
-  const create = (name: string | null, ephemeral: boolean): FakeMachine => {
+  const create = (name: string | null, ephemeral: boolean, resources?: Record<string, number>): FakeMachine => {
     const id = `m-${nextId++}`;
-    const m: FakeMachine = { id, name, state: "stopped", ephemeral, home: join(root, id) };
+    const m: FakeMachine = {
+      id,
+      name,
+      state: "stopped",
+      ephemeral,
+      ...(resources ? { resources } : {}),
+      home: join(root, id),
+    };
     mkdirSync(m.home, { recursive: true });
     machines.set(id, m);
     return m;
@@ -90,7 +98,7 @@ export function installFakeSmolmachines(): FakeSmolmachines {
     state: m.state,
     ephemeral: m.ephemeral,
     source: { type: "image", reference: "ubuntu:24.04" },
-    resources: {},
+    resources: m.resources ?? {},
     network: { mode: "open" },
     env: {},
     createdAt: "2026-01-01T00:00:00Z",
@@ -114,9 +122,10 @@ export function installFakeSmolmachines(): FakeSmolmachines {
       const body = JSON.parse(toBuf(init?.body).toString() || "{}") as {
         name?: string | null;
         ephemeral?: boolean;
+        resources?: Record<string, number>;
       };
       if (body.name && byName(body.name)) return new Response("machine name conflict", { status: 409 });
-      return Response.json(info(create(body.name ?? null, body.ephemeral ?? false)), { status: 201 });
+      return Response.json(info(create(body.name ?? null, body.ephemeral ?? false, body.resources)), { status: 201 });
     }
     const files = /^\/v1\/machines\/([^/]+)\/files(\/.+)$/.exec(url.pathname);
     if (files) {
@@ -176,7 +185,7 @@ export function installFakeSmolmachines(): FakeSmolmachines {
     names: () => [...machines.values()].map((m) => m.name ?? m.id),
     machine: (name) => {
       const m = byName(name);
-      return m ? { state: m.state, ephemeral: m.ephemeral } : null;
+      return m ? { state: m.state, ephemeral: m.ephemeral, ...(m.resources ? { resources: m.resources } : {}) } : null;
     },
     stop: (name) => {
       const m = byName(name);


### PR DESCRIPTION
Stacked on #478 — merge that first.

New smolmachines machines were created at the platform's tiny defaults (1 vCPU / 256MB / 20GB) with no way to size them. Machines are now sized at create time via SMOLMACHINES_CPUS / SMOLMACHINES_MEMORY_MB / SMOLMACHINES_DISK_GB, and the agent-computer profile advertises the configured shape. In-place resize is not wired up because the provider's resize route is not live yet; the test fake records create-time resources and a new test covers the request and the profile.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249022&installation_model_id=19911&pr_number=479&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F479&signature=573ff11a1e890350bfea9b0b44f0ebfc3abd4c85f1212a587d70f56b333c0c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->