### PR TITLE
Wire custom providers end-to-end (admin API, boot default, model picker)

### DIFF
--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -30,9 +30,9 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
     const template = builtinModel(clone.template);
     if (template) return cloneModel(template, id, clone.name);
   }
-  if (fallback?.provider === "openrouter") {
+  if (fallback) {
     const template = getModel("openrouter", "openrouter/auto" as Parameters<typeof getModel>[1]) as PiModel | undefined;
-    if (template) return cloneModel(template, id, fallback.name);
+    if (template) return { ...cloneModel(template, id, fallback.name), provider: fallback.provider };
   }
   throw new Error(`Unsupported model: ${id}`);
 }

--- a/plugins/web-ui/test/model-options.test.ts
+++ b/plugins/web-ui/test/model-options.test.ts
@@ -197,3 +197,15 @@ test("a scope's own model list is derived without disturbing the active picker",
     "reading a scope's options never re-points the composer's picker",
   );
 });
+
+test("runtime options include custom-provider models from the catalog", () => {
+  const options = runtimeModelOptions(
+    ["pi"],
+    { pi: ["claude-opus-4-8", "acme-large"] },
+    { "acme-large": { name: "Acme Large", provider: "acme-gateway" } },
+  );
+  const acme = options.find((option) => option.value === "pi:acme-large");
+  assert.ok(acme);
+  assert.equal(acme.label, "Acme Large");
+  assert.equal(acme.model.provider, "acme-gateway");
+});

--- a/plugins/web-ui/test/pi-models.test.ts
+++ b/plugins/web-ui/test/pi-models.test.ts
@@ -40,3 +40,10 @@ test("fast-mode support is fed from core's runtime config, not a hardcoded clien
   assert.equal(modelSupportsFastMode(null, "claude-haiku-4-5"), false);
   assert.equal(modelSupportsFastMode(null, undefined), false);
 });
+
+test("a custom-provider model builds from its dynamic catalog entry", () => {
+  const custom = getBaseModel("acme-large", { name: "Acme Large", provider: "acme-gateway" });
+  assert.equal(custom.id, "acme-large");
+  assert.equal(custom.name, "Acme Large");
+  assert.equal(custom.provider, "acme-gateway");
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import { baseModelProviders, configuredModelForHarness, loadConfig, providerKeysPresent } from "./config.ts";
-import { buildApp, stopWithBackstop } from "./wiring.ts";
+import { loadConfig } from "./config.ts";
+import { buildApp, serverDeps, stopWithBackstop } from "./wiring.ts";
 import { createServer } from "./api/server.ts";
 import { errMessage } from "./util/errors.ts";
-import { defaultModelForHarness, modelProviderAvailabilityFor } from "./model/pi-models.ts";
-import { effectiveEgressEnforcement } from "./sandbox/sandbox.ts";
 import { slackPluginConfigFromEnv, startSlackPlugin } from "./slack/index.ts";
 import { createSlackRuntimeReconciler } from "./surfaces/slack-runtime.ts";
 
@@ -16,87 +14,10 @@ const envSlackAttempted = Boolean(process.env.SLACK_BOT_TOKEN || process.env.SLA
 let slackEnvironmentState: "absent" | "configured" | "partial" = "absent";
 if (slackConfig) slackEnvironmentState = "configured";
 else if (envSlackAttempted) slackEnvironmentState = "partial";
-const server = createServer(built.app, {
-  production: config.production,
-  allowUnauthenticatedCore: config.allowUnauthenticatedCore,
-  ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
-  ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
-  ...(config.portalIdentitySecret ? { portalIdentitySecret: config.portalIdentitySecret } : {}),
-  ...(config.requireSignedPortalIdentity ? { requireSignedPortalIdentity: true } : {}),
-  ...(built.replayDedupe ? { replayDedupe: built.replayDedupe } : {}),
-  config: built.config,
-  baseModelDefault: defaultModelForHarness(
-    config.harness,
-    configuredModelForHarness(config, config.harness),
-    baseModelProviders(config),
-  ),
-  modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
-  providerKeys: providerKeysPresent(config),
-  modelCredentials: built.modelCredentials,
-  mcpServers: built.mcpServers,
-  mcpToolService: built.mcpToolService,
-  ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
-  harnessId: config.harness,
-  connectorTokens: built.connectorTokens,
-  slackInstallation: built.slackInstallation,
-  slackEnvironmentState,
-  resolveClient: built.resolveClient,
-  consentLinks: built.consentLinks,
-  secretDrops: built.secretDrops,
-  ...(built.fireDropResolution ? { fireDropResolution: built.fireDropResolution } : {}),
-  ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
-  ...(config.publicUrl ? { publicUrl: config.publicUrl } : {}),
-  ...(config.publicWebUrl ? { portalUrl: config.publicWebUrl } : {}),
-  admin: built.admin,
-  rateLimiter: built.rateLimiter,
-  acl: built.acl,
-  credentialUsage: built.credentialUsage,
-  deviceFlowCutover: built.deviceFlowCutover,
-  egressAudit: built.egressAudit,
-  sessions: built.sessions,
-  auditLog: built.auditLog,
-  errors: built.errors,
-  metrics: built.metrics,
-  crons: built.crons,
-  brokeredServices: () => built.brokeredTools.map((tool) => tool.service),
-  deploymentLayer: built.deploymentLayerStore,
-  deployDialTimeoutMs: config.deployDialTimeoutMs,
-  ...(config.awsDeploy.appsDomain ? { deployAppsDomain: config.awsDeploy.appsDomain } : {}),
-  ...(config.awsDeploy.gateSecret ? { deployGateSecret: config.awsDeploy.gateSecret } : {}),
-  ...(config.deployAppsSessionSecret ? { deployAppsSessionSecret: config.deployAppsSessionSecret } : {}),
-  ...(config.deployAppsLoginUrl ? { deployAppsLoginUrl: config.deployAppsLoginUrl } : {}),
-  scheduler: built.scheduler,
-  identity: built.identity,
-  ...(built.keychain ? { keychain: built.keychain } : {}),
-  serviceCreds: built.serviceCreds,
-  deliveries: built.deliveries,
-  ...(built.fireAskResolution ? { fireAskResolution: built.fireAskResolution } : {}),
-  runs: built.runs,
-  workspace: built.workspace,
-  files: built.files,
-  memory: built.memory,
-  blobTransfer: built.blobTransfer,
-  sandboxBackend: built.sandbox.profile.backend,
-  egressDeclaredEnforcement: built.sandbox.profile.egressEnforcement ?? "none",
-  egressEnforcement: effectiveEgressEnforcement(built.sandbox.profile, {
-    signingSecret: config.signingSecret,
-    apiBaseUrl: config.apiBaseUrl,
-  }),
-  egressControlPlaneConfigured: Boolean(config.signingSecret && config.apiBaseUrl),
-  sandbox: built.sandbox,
-  advisoryLock: built.advisoryLock,
-  ...(built.processes ? { processes: built.processes } : {}),
-  ...(built.browserSessionStore ? { browserSessionStore: built.browserSessionStore } : {}),
-  directory: built.directory,
-  ...(built.ambientJudgments ? { ambientJudgments: built.ambientJudgments } : {}),
-  ...(built.ackEmojiPicks ? { ackEmojiPicks: built.ackEmojiPicks } : {}),
-  channelPolicy: built.channelPolicy,
-  uiState: built.uiState,
-  environments: built.environments,
-  sandboxMigration: built.sandboxMigration,
-});
+const server = createServer(built.app, serverDeps(config, built, slackEnvironmentState));
 
 await built.config.hydrate?.();
+await built.refreshCustomProviders();
 await built.identity.hydrate();
 await built.deploymentLayerReady;
 built.deploymentLayerRefresh.start();

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import { randomBytes, randomUUID } from "node:crypto";
 import { join, resolve } from "node:path";
 import { baseModelProviders, configuredModelForHarness, providerKeysPresent, type Config } from "./config.ts";
+import type { ServerDeps } from "./api/deps.ts";
 import { createIdentityService, type DeactivationRecord, type IdentityService } from "./identity/identity-service.ts";
 import {
   createMemoryConfigStore,
@@ -112,7 +113,7 @@ import {
   type SandboxRoute,
 } from "./sandbox/sandbox-routing.ts";
 import { createSandboxMigrationRunner, type SandboxMigrationRunner } from "./sandbox/sandbox-migration-runner.ts";
-import type { Sandbox } from "./sandbox/sandbox.ts";
+import { effectiveEgressEnforcement, type Sandbox } from "./sandbox/sandbox.ts";
 import { withOperatorTokenFallback } from "./credentials/connector-token.ts";
 import {
   createAwsSecretsManagerSource,
@@ -797,11 +798,13 @@ export function buildApp(
   const fallbackHarness = config.harness as HarnessId;
   const fallback = {
     harnessId: fallbackHarness,
-    modelId: defaultModelForHarness(
-      fallbackHarness,
-      configuredModelForHarness(config, fallbackHarness),
-      baseModelProviders(config),
-    ),
+    get modelId() {
+      return defaultModelForHarness(
+        fallbackHarness,
+        configuredModelForHarness(config, fallbackHarness),
+        baseModelProviders(config),
+      );
+    },
   };
   const judgeModelId = (): string => config.judgeModelId ?? auxiliaryModelFor(orgBaseModelId() ?? fallback.modelId);
   const harness = createHarnessRouter(adapters, adapters.get(fallbackHarness)!, (input) =>
@@ -1519,5 +1522,90 @@ export function buildApp(
     uiState: artifactMap<PersistedUiState>("web_ui_state"),
     skillSyncEngine,
     slackCore,
+  };
+}
+
+export function serverDeps(
+  config: Config,
+  built: BuiltApp,
+  slackEnvironmentState: "absent" | "configured" | "partial" = "absent",
+): Omit<ServerDeps, "control"> {
+  const configuredModel = configuredModelForHarness(config, config.harness);
+  return {
+    production: config.production,
+    allowUnauthenticatedCore: config.allowUnauthenticatedCore,
+    ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
+    ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
+    ...(config.portalIdentitySecret ? { portalIdentitySecret: config.portalIdentitySecret } : {}),
+    ...(config.requireSignedPortalIdentity ? { requireSignedPortalIdentity: true } : {}),
+    ...(built.replayDedupe ? { replayDedupe: built.replayDedupe } : {}),
+    config: built.config,
+    ...(configuredModel ? { baseModelDefault: configuredModel } : {}),
+    modelProviders: modelProviderAvailabilityFor(config.harness, providerKeysPresent(config)),
+    providerKeys: providerKeysPresent(config),
+    modelCredentials: built.modelCredentials,
+    customProviders: built.customProviders,
+    refreshCustomProviders: built.refreshCustomProviders,
+    mcpServers: built.mcpServers,
+    mcpToolService: built.mcpToolService,
+    ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
+    harnessId: config.harness,
+    connectorTokens: built.connectorTokens,
+    slackInstallation: built.slackInstallation,
+    slackEnvironmentState,
+    resolveClient: built.resolveClient,
+    consentLinks: built.consentLinks,
+    secretDrops: built.secretDrops,
+    ...(built.fireDropResolution ? { fireDropResolution: built.fireDropResolution } : {}),
+    ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
+    ...(config.publicUrl ? { publicUrl: config.publicUrl } : {}),
+    ...(config.publicWebUrl ? { portalUrl: config.publicWebUrl } : {}),
+    admin: built.admin,
+    rateLimiter: built.rateLimiter,
+    acl: built.acl,
+    credentialUsage: built.credentialUsage,
+    deviceFlowCutover: built.deviceFlowCutover,
+    egressAudit: built.egressAudit,
+    sessions: built.sessions,
+    auditLog: built.auditLog,
+    errors: built.errors,
+    metrics: built.metrics,
+    crons: built.crons,
+    brokeredServices: () => built.brokeredTools.map((tool) => tool.service),
+    deploymentLayer: built.deploymentLayerStore,
+    deployDialTimeoutMs: config.deployDialTimeoutMs,
+    ...(config.awsDeploy.appsDomain ? { deployAppsDomain: config.awsDeploy.appsDomain } : {}),
+    ...(config.awsDeploy.gateSecret ? { deployGateSecret: config.awsDeploy.gateSecret } : {}),
+    ...(config.deployAppsSessionSecret ? { deployAppsSessionSecret: config.deployAppsSessionSecret } : {}),
+    ...(config.deployAppsLoginUrl ? { deployAppsLoginUrl: config.deployAppsLoginUrl } : {}),
+    scheduler: built.scheduler,
+    identity: built.identity,
+    ...(built.keychain ? { keychain: built.keychain } : {}),
+    serviceCreds: built.serviceCreds,
+    deliveries: built.deliveries,
+    ...(built.fireAskResolution ? { fireAskResolution: built.fireAskResolution } : {}),
+    runs: built.runs,
+    workspace: built.workspace,
+    files: built.files,
+    memory: built.memory,
+    blobTransfer: built.blobTransfer,
+    sandboxBackend: built.sandbox.profile.backend,
+    egressDeclaredEnforcement: built.sandbox.profile.egressEnforcement ?? "none",
+    egressEnforcement: effectiveEgressEnforcement(built.sandbox.profile, {
+      signingSecret: config.signingSecret,
+      apiBaseUrl: config.apiBaseUrl,
+    }),
+    egressControlPlaneConfigured: Boolean(config.signingSecret && config.apiBaseUrl),
+    sandbox: built.sandbox,
+    advisoryLock: built.advisoryLock,
+    ...(built.processes ? { processes: built.processes } : {}),
+    ...(built.browserSessionStore ? { browserSessionStore: built.browserSessionStore } : {}),
+    directory: built.directory,
+    ...(built.ambientJudgments ? { ambientJudgments: built.ambientJudgments } : {}),
+    ...(built.ackEmojiPicks ? { ackEmojiPicks: built.ackEmojiPicks } : {}),
+    channelPolicy: built.channelPolicy,
+    uiState: built.uiState,
+    environments: built.environments,
+    sandboxMigration: built.sandboxMigration,
   };
 }

--- a/test/custom-provider-boot-wiring.test.ts
+++ b/test/custom-provider-boot-wiring.test.ts
@@ -1,0 +1,72 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, afterEach } from "node:test";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp, serverDeps } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+import { defaultModelForHarness } from "../src/model/pi-models.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
+
+const ADMIN = { "content-type": "application/json", "x-admin-actor": "admin-alice@default-org" };
+
+afterEach(() => setCustomProviders([]));
+
+test("serverDeps wires the custom-provider store and resolves a custom boot default lazily", async () => {
+  const config = testConfig({
+    dataDir: mkdtempSync(join(tmpdir(), "custom-provider-boot-")),
+    harness: "pi",
+    modelId: "acme-large",
+  });
+  const built = buildApp(config, { modelCredentialFetch: async () => new Response(null, { status: 200 }) });
+  const deps = serverDeps(config, built);
+  assert.equal(deps.customProviders, built.customProviders);
+  assert.equal(deps.refreshCustomProviders, built.refreshCustomProviders);
+  assert.equal(deps.baseModelDefault, "acme-large");
+
+  const server = createInsecureTestServer(built.app, deps);
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    assert.notEqual(defaultModelForHarness("pi", deps.baseModelDefault), "acme-large");
+
+    const list = await fetch(`${base}/v1/admin/custom-providers`, { headers: ADMIN });
+    assert.equal(list.status, 200);
+
+    const put = await fetch(`${base}/v1/admin/custom-providers/acme-gateway`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({
+        name: "Acme Gateway",
+        protocol: "openai",
+        baseUrl: "https://llm.acme.internal/v1",
+        models: [{ id: "acme-large", name: "Acme Large" }],
+        apiKey: "sk-acme-secret",
+        validate: false,
+      }),
+    });
+    assert.equal(put.status, 200);
+
+    assert.equal(defaultModelForHarness("pi", deps.baseModelDefault), "acme-large");
+
+    const runtime = await fetch(
+      `${base}/v1/runtime-config?principalId=admin-alice@default-org&scopeId=personal:admin-alice@default-org`,
+      { headers: ADMIN },
+    );
+    assert.equal(runtime.status, 200);
+    const body = (await runtime.json()) as {
+      effective: { modelId: string };
+      modelsByHarness: Record<string, string[]>;
+      modelCatalog: Record<string, { name: string; provider: string }>;
+    };
+    assert.equal(body.effective.modelId, "acme-large");
+    assert.ok(body.modelsByHarness.pi?.includes("acme-large"));
+    assert.equal(body.modelCatalog["acme-large"]?.provider, "acme-gateway");
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
The custom-provider subsystem (store, admin routes, runtime registry, catalog) existed but was unreachable in default production wiring. Three fixes: the server-deps assembly never passed the custom-provider store and refresher, so the admin API always 404'd — the assembly now lives next to buildApp so it cannot drift, and boot awaits the initial refresh; the boot default resolved the configured model eagerly before custom providers hydrated, so a configured custom model silently degraded to the built-in default forever — the configured model id is now passed raw and resolved lazily per call; and the web-ui picker only accepted dynamic catalog entries for the openrouter provider and threw for custom-provider slugs — any catalog-backed model now clones the dynamic template while keeping its own provider slug. An end-to-end boot-wiring test exercises production-shaped wiring from registration through the runtime-config advertisement.  marcclefas-code

**Deployment notes**

Release-note the flip: configured custom models take effect after upgrade; orgs should verify
their custom-provider config is actually valid
Deliberate behavior flip (fixes public #269/#282/#333): a configured custom default model that
previously degraded silently to the built-in default at boot is now resolved lazily and actually used
— an org with stale/broken custom-provider config will see per-call failures where it silently got
the default before
Admin custom-providers API goes from always-404 to live (routes existed, deps were never
wired); endpoints sit behind the existing admin auth
index.ts now awaits refreshCustomProviders() at boot — one extra store read at startup, same
database; no schema change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789253766&installation_model_id=19911&pr_number=512&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F512&signature=34f21e17cbe84e50ffd55de6dac221392c2ffa43322e796594a6ec37ef0b67af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->