### PR TITLE
web-ui: single-header multiview panes

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1064,7 +1064,7 @@ export function createChatSurface(
                 </div>`
               : nothing
           }
-${glanceTier || ctx.pane ? nothing : sessionTopbar()}
+          ${glanceTier || ctx.pane ? nothing : sessionTopbar()}
           ${
             glanceTier
               ? paneGlance(agent, messages, glanceTier)
@@ -1158,7 +1158,7 @@ ${glanceTier || ctx.pane ? nothing : sessionTopbar()}
           title,
           crumb,
         });
-if (scope && tool !== "memory") contextsState.selected = scope;
+        if (scope && tool !== "memory") contextsState.selected = scope;
         switchView(tool === "apps" ? "deploys" : tool);
       },
     });

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1064,7 +1064,7 @@ export function createChatSurface(
                 </div>`
               : nothing
           }
-          ${glanceTier ? nothing : sessionTopbar()}
+${glanceTier || ctx.pane ? nothing : sessionTopbar()}
           ${
             glanceTier
               ? paneGlance(agent, messages, glanceTier)

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1158,7 +1158,7 @@ ${glanceTier || ctx.pane ? nothing : sessionTopbar()}
           title,
           crumb,
         });
-        if (scope && (tool === "crons" || tool === "files" || tool === "apps")) contextsState.selected = scope;
+if (scope && tool !== "memory") contextsState.selected = scope;
         switchView(tool === "apps" ? "deploys" : tool);
       },
     });

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6776,6 +6776,45 @@ h3.ambient-field-label {
   flex: 0 0 auto;
 }
 
+/* Single-header multiview: the pane title is a scope / title breadcrumb, and the
+   chat's project tools live behind the header's own overflow menu. */
+.split-pane-crumb {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 5px;
+  font-weight: 500;
+  color: var(--muted-foreground);
+}
+
+.split-pane-crumb-sep {
+  flex: 0 0 auto;
+  margin-right: 5px;
+  font-weight: 400;
+  color: color-mix(in srgb, var(--muted-foreground) 65%, transparent);
+}
+
+.split-tools {
+  position: relative;
+  display: inline-flex;
+}
+
+.split-tools-btn.active {
+  background: color-mix(in srgb, var(--foreground) 9%, transparent);
+  color: var(--foreground);
+}
+
+.split-tools-menu {
+  z-index: 60;
+}
+
+.split-tools-menu-sep {
+  height: 1px;
+  margin: 5px 4px;
+  background: var(--border);
+}
+
 /* In the strip the shared hover wash needs to differ from the strip's own background. */
 .dockview-theme-qm .dv-tabs-and-actions-container .icon-btn:hover {
   background: color-mix(in srgb, var(--foreground) 7%, var(--secondary));

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -1,6 +1,21 @@
 import { html, nothing, render, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { Binoculars, Clock3, Cog, Expand, Maximize2, Plus, Shrink, X } from "lucide";
+import {
+  Binoculars,
+  Box,
+  Brain,
+  Clock3,
+  Cog,
+  Expand,
+  Files,
+  KeyRound,
+  Maximize2,
+  MoreHorizontal,
+  Plus,
+  Rocket,
+  Shrink,
+  X,
+} from "lucide";
 import {
   createDockview,
   type DockviewApi,
@@ -30,7 +45,7 @@ import {
 import { preservingFocus } from "./pane-focus";
 import { hideTooltip, showTooltip } from "./tooltip";
 import { icon } from "./ui";
-import { contextsState } from "./contexts";
+import { contextsState, scopeTitle } from "./contexts";
 import type { DensityTier } from "./density";
 import { appState } from "./shell-state";
 import { renderSidebarTop, switchView, syncUrlFromState } from "./shell";
@@ -54,6 +69,7 @@ import {
   syncWorkingPulse,
 } from "./sessions";
 import { conversationBackground, type RowIndicators } from "./session-list";
+import { setScopedSession, type SessionTool } from "./session-scope";
 import type { CoreSession } from "./core-bridge";
 import { fetchUiState, putUiState } from "./core-bridge";
 
@@ -727,7 +743,10 @@ export function drawCanvas(): void {
 
 function computeHeaderSignature(): string {
   return (dockApi?.panels ?? [])
-    .map((p) => `${p.id}|${paneTitle(p)}|${paneIsWorking(p)}|${paneAwaitsInput(p)}|${paneBackground(p)?.label ?? ""}`)
+    .map(
+      (p) =>
+        `${p.id}|${paneCrumb(p) ?? ""}|${paneTitle(p)}|${paneIsWorking(p)}|${paneAwaitsInput(p)}|${paneBackground(p)?.label ?? ""}`,
+    )
     .join("~");
 }
 
@@ -753,6 +772,41 @@ function paneTitle(panel: IDockviewPanel): string {
   if (session) return sessionTitle(session);
   if (panelParams(panel).sessionId) return "Conversation";
   return "New session";
+}
+
+function paneScopeId(panel: IDockviewPanel): string | null {
+  return paneSession(panel)?.scopeId || panelParams(panel).scopeId || null;
+}
+
+function paneCrumb(panel: IDockviewPanel): string | null {
+  const scope = paneScopeId(panel);
+  if (!scope || scope.startsWith("personal:")) return null;
+  const context = contextsState.list.find((c) => c.scopeId === scope);
+  return scopeTitle(scope, context?.name ?? null);
+}
+
+const PANE_TOOLS: { tool: SessionTool; glyph: Parameters<typeof icon>[0]; label: string }[] = [
+  { tool: "crons", glyph: Clock3, label: "Crons" },
+  { tool: "files", glyph: Files, label: "Files" },
+  { tool: "apps", glyph: Rocket, label: "Apps" },
+  { tool: "skills", glyph: Box, label: "Skills" },
+  { tool: "memory", glyph: Brain, label: "Memory" },
+  { tool: "keychain", glyph: KeyRound, label: "Your keychain" },
+];
+
+function openPaneTool(panel: IDockviewPanel, tool: SessionTool): void {
+  const params = panelParams(panel);
+  const session = paneSession(panel);
+  const scope = paneScopeId(panel) ?? "";
+  setScopedSession({
+    scopeId: scope,
+    sessionId: params.sessionId ?? session?.id ?? null,
+    threadRef: params.threadRef ?? null,
+    title: session?.title?.trim() || "New chat",
+    crumb: paneCrumb(panel),
+  });
+  if (scope && (tool === "crons" || tool === "files" || tool === "apps")) contextsState.selected = scope;
+  switchView(tool === "apps" ? "deploys" : tool);
 }
 
 function paneIsWorking(panel: IDockviewPanel): boolean {
@@ -919,10 +973,11 @@ class PaneTab implements ITabRenderer {
     const panel = this.panel;
     if (!panel) return;
     const title = paneTitle(panel);
+    const crumb = paneCrumb(panel);
     const working = paneIsWorking(panel);
     const awaiting = paneAwaitsInput(panel);
     const background = paneBackground(panel);
-    this.element.title = title;
+    this.element.title = crumb ? `${crumb} / ${title}` : title;
     render(
       html`
         ${working ? html`<span class="working-dot" ${ref(syncWorkingPulse)} title="Agent is working"></span>` : nothing}
@@ -938,6 +993,11 @@ class PaneTab implements ITabRenderer {
                   background.watches > 0 ? icon(Binoculars, 11) : nothing
                 }${background.crons > 0 ? icon(Clock3, 11) : nothing}</span
               >`
+            : nothing
+        }
+        ${
+          crumb
+            ? html`<span class="split-pane-crumb">${crumb}</span><span class="split-pane-crumb-sep">/</span>`
             : nothing
         }
         <span class="split-pane-title-text">${title}</span>
@@ -970,6 +1030,7 @@ class PaneTab implements ITabRenderer {
 class GroupActions implements IHeaderActionsRenderer {
   readonly element: HTMLElement;
   private props: IGroupHeaderProps | null = null;
+  private menuOpen = false;
 
   constructor() {
     this.element = document.createElement("span");
@@ -979,8 +1040,26 @@ class GroupActions implements IHeaderActionsRenderer {
   init(props: IGroupHeaderProps): void {
     this.props = props;
     groupActions.add(this);
+    document.addEventListener("click", this.onDocClick);
     this.draw();
   }
+
+  private readonly onDocClick = (e: Event): void => {
+    if (!this.menuOpen) return;
+    if (this.element.querySelector(".split-tools")?.contains(e.target as Node)) return;
+    this.menuOpen = false;
+    this.draw();
+  };
+
+  private readonly placeMenu = (el?: Element): void => {
+    if (!(el instanceof HTMLElement)) return;
+    const rect = this.element.querySelector(".split-tools-btn")?.getBoundingClientRect();
+    if (!rect) return;
+    el.style.position = "fixed";
+    el.style.top = `${rect.bottom + 6}px`;
+    el.style.right = `${Math.max(8, window.innerWidth - rect.right)}px`;
+    el.style.left = "auto";
+  };
 
   draw(): void {
     const props = this.props;
@@ -990,6 +1069,46 @@ class GroupActions implements IHeaderActionsRenderer {
       return g?.activePanel ?? g?.panels[0] ?? null;
     };
     const maximized = props.api.isMaximized();
+    const runTool = (tool: SessionTool): void => {
+      this.menuOpen = false;
+      const p = activePanel();
+      this.draw();
+      if (p) openPaneTool(p, tool);
+    };
+    const menu = this.menuOpen
+      ? html`
+          <div
+            class="session-menu-popover split-tools-menu"
+            role="menu"
+            ${ref(this.placeMenu)}
+            @click=${(e: Event) => e.stopPropagation()}
+          >
+            ${PANE_TOOLS.map(
+              (t) => html`
+                <button class="session-menu-option" type="button" role="menuitem" @click=${() => runTool(t.tool)}>
+                  ${icon(t.glyph, 15)}<span>${t.label}</span>
+                </button>
+              `,
+            )}
+            <div class="split-tools-menu-sep" role="separator"></div>
+            <button
+              class="session-menu-option"
+              type="button"
+              role="menuitem"
+              @click=${() => {
+                this.menuOpen = false;
+                this.draw();
+                if (maximized) props.api.exitMaximized();
+                else props.api.maximize();
+              }}
+            >
+              ${icon(maximized ? Shrink : Expand, 15)}<span
+                >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span
+              >
+            </button>
+          </div>
+        `
+      : nothing;
     const buttons: { label: string; glyph: TemplateResult | SVGElement; cls?: string; run: () => void }[] = [
       {
         label: "Split this pane with a new session",
@@ -998,11 +1117,6 @@ class GroupActions implements IHeaderActionsRenderer {
           const p = activePanel();
           if (p) paneSplitWithBlank(p);
         },
-      },
-      {
-        label: maximized ? "Restore to grid (Esc)" : "Focus this pane over the grid",
-        glyph: icon(maximized ? Shrink : Expand, 14),
-        run: () => (maximized ? props.api.exitMaximized() : props.api.maximize()),
       },
       {
         label: "Open full screen",
@@ -1023,23 +1137,41 @@ class GroupActions implements IHeaderActionsRenderer {
       },
     ];
     render(
-      html`${buttons.map(
-        (b) =>
-          html`<button
-            class="icon-btn subtle${b.cls ?? ""}"
+      html`<span class="split-tools">
+          <button
+            class="icon-btn subtle split-tools-btn ${this.menuOpen ? "active" : ""}"
             type="button"
-            title=${b.label}
-            aria-label=${b.label}
-            @click=${b.run}
+            title="Tools"
+            aria-label="Tools"
+            aria-haspopup="menu"
+            aria-expanded=${this.menuOpen ? "true" : "false"}
+            @click=${() => {
+              this.menuOpen = !this.menuOpen;
+              this.draw();
+            }}
           >
-            ${b.glyph}
-          </button>`,
-      )}`,
+            ${icon(MoreHorizontal, 15)}
+          </button>
+          ${menu}
+        </span>
+        ${buttons.map(
+          (b) =>
+            html`<button
+              class="icon-btn subtle${b.cls ?? ""}"
+              type="button"
+              title=${b.label}
+              aria-label=${b.label}
+              @click=${b.run}
+            >
+              ${b.glyph}
+            </button>`,
+        )}`,
       this.element,
     );
   }
 
   dispose(): void {
+    document.removeEventListener("click", this.onDocClick);
     groupActions.delete(this);
   }
 }

--- a/plugins/web-ui/test/split-single-header.test.ts
+++ b/plugins/web-ui/test/split-single-header.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("a pane renders one header: the chat's own session topbar stays out of panes", () => {
+  assert.match(chat, /\$\{glanceTier \|\| ctx\.pane \? nothing : sessionTopbar\(\)\}/);
+});
+
+test("the pane tab carries the scope / title breadcrumb", () => {
+  assert.match(split, /function paneCrumb\(panel: IDockviewPanel\): string \| null/);
+  assert.match(split, /class="split-pane-crumb"/);
+  assert.match(split, /this\.element\.title = crumb \? `\$\{crumb\} \/ \$\{title\}` : title;/);
+  // crumb changes must retrigger a header redraw
+  assert.match(split, /\$\{paneCrumb\(p\) \?\? ""\}\|\$\{paneTitle\(p\)\}/);
+  assert.match(css, /\.split-pane-crumb \{/);
+});
+
+test("project tools live behind the header overflow menu, left of the split button", () => {
+  const toolsIdx = split.indexOf("split-tools-btn");
+  const plusIdx = split.indexOf("Split this pane with a new session");
+  assert.ok(toolsIdx > 0 && plusIdx > 0 && toolsIdx < plusIdx, "tools menu renders before the + button");
+  for (const tool of ['"crons"', '"files"', '"apps"', '"skills"', '"memory"', '"keychain"']) {
+    assert.ok(split.includes(`tool: ${tool}`), `${tool} reachable from the pane menu`);
+  }
+  assert.match(split, /switchView\(tool === "apps" \? "deploys" : tool\)/);
+  assert.match(split, /setScopedSession\(\{/);
+});
+
+test("the tools menu closes on any click outside the \u22ef control \u2014 sibling buttons included", () => {
+  const cls = split.slice(split.indexOf("class GroupActions"), split.indexOf("function notePaneSession"));
+  assert.match(cls, /querySelector\("\.split-tools"\)\?\.contains\(e\.target as Node\)/);
+  // the toggle must not swallow the click, or another pane's open menu never hears it
+  const toggle = cls.slice(cls.indexOf('class="icon-btn subtle split-tools-btn'), cls.indexOf("MoreHorizontal"));
+  assert.doesNotMatch(toggle, /stopPropagation/);
+});
+
+test("inline pane chrome is exactly tools, split, full screen, close", () => {
+  const draw = split.slice(split.indexOf("class GroupActions"), split.indexOf("function notePaneSession"));
+  // focus-over-grid moved into the menu; not an inline button
+  const inlineButtons = draw.slice(draw.indexOf("const buttons"));
+  assert.doesNotMatch(inlineButtons, /Focus this pane over the grid/);
+  assert.match(draw, /Restore to grid \(Esc\)/); // still reachable via the menu
+  assert.match(inlineButtons, /Open full screen/);
+  assert.match(inlineButtons, /Close pane/);
+});

--- a/plugins/web-ui/test/split-single-header.test.ts
+++ b/plugins/web-ui/test/split-single-header.test.ts
@@ -7,7 +7,7 @@ const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 
 test("a pane renders one header: the chat's own session topbar stays out of panes", () => {
-  assert.match(chat, /\$\{glanceTier \|\| ctx\.pane \? nothing : sessionTopbar\(\)\}/);
+  assert.match(chat, /\$\{glanceTier \|\| ctx\.pane \? nothing : sessionTopbar\([^)]*\)\}/);
 });
 
 test("the pane tab carries the scope / title breadcrumb", () => {


### PR DESCRIPTION
Multiview panes rendered two stacked headers: the pane chrome plus the hosted chat's own session top bar. Panes now show one header — the pane tab carries a scope/title breadcrumb, the inner chat suppresses its own top bar when hosted in a pane, and the per-context tools (crons, files, apps, skills, memory, keychain) plus the focus-over-grid action move behind a  overflow menu next to the pane's + button, leaving  and full-screen as the only inline chrome.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245940&installation_model_id=19911&pr_number=457&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F457&signature=710e2e5704326af0facddf0f4db9c943259b9800857d829a3574aa039e669020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->