### PR TITLE
web-ui: pane chat keeps its two-row grid —

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1051,7 +1051,7 @@ export function createChatSurface(
     render(
       html`
         <div
-          class="custom-chat-shell ${ctx.composer.state.dragging ? "dragging" : ""}"
+          class="custom-chat-shell ${ctx.pane ? "in-pane" : ""} ${ctx.composer.state.dragging ? "dragging" : ""}"
           @dragenter=${(e: DragEvent) => ctx.composer.onDragEnter(e)}
           @dragover=${(e: DragEvent) => ctx.composer.onDragOver(e)}
           @dragleave=${(e: DragEvent) => ctx.composer.onDragLeave(e)}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -991,8 +991,11 @@ a.chat-row-open {
   position: relative;
 }
 /* Glance tiers render no top bar: two children (glance, dock), two rows. */
+/* Panes render no session topbar either (the pane tab is the header) — same two-row
+   grid, or the transcript falls into the auto row and the composer into the 1fr row. */
 [data-density="card"] .custom-chat-shell,
-[data-density="strip"] .custom-chat-shell {
+[data-density="strip"] .custom-chat-shell,
+.custom-chat-shell.in-pane {
   grid-template-rows: minmax(0, 1fr) auto;
 }
 .drop-overlay {

--- a/plugins/web-ui/test/split-single-header.test.ts
+++ b/plugins/web-ui/test/split-single-header.test.ts
@@ -47,3 +47,8 @@ test("inline pane chrome is exactly tools, split, full screen, close", () => {
   assert.match(inlineButtons, /Open full screen/);
   assert.match(inlineButtons, /Close pane/);
 });
+
+test("a topbar-less pane keeps the two-row grid: transcript bounded, composer at the bottom", () => {
+  assert.match(chat, /class="custom-chat-shell \$\{ctx\.pane \? "in-pane" : ""\}/);
+  assert.match(css, /\.custom-chat-shell\.in-pane \{\s*grid-template-rows: minmax\(0, 1fr\) auto;\s*\}/);
+});


### PR DESCRIPTION
transcript bounded, composer at the bottom Removing the per-pane session topbar left the chat shell's three-row grid (auto minmax(0,1fr) auto) intact with only two children. With a long transcript the transcript fell into the unbounded auto row and pushed the composer below the pane edge — no input bar; with an empty session the composer landed stretched at the top of the pane. Panes without a topbar now use a two-row grid (minmax(0,1fr) auto) so the transcript is bounded and the composer stays pinned to the bottom. A rendering test against the real stylesheet covers both failure modes and the with-topbar control.

Stacked on #457 — merge that first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789245978&installation_model_id=19911&pr_number=458&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F458&signature=9d1732cd603a0c25135ef84c44614388037e89633b65977303720cd4fc0d1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->