### PR TITLE
adr: local sandboxes on the docker target

### DIFF
--- a/adrs/local-sandboxes-on-docker-target.md
+++ b/adrs/local-sandboxes-on-docker-target.md
@@ -1,0 +1,9 @@
+# Local sandboxes on the docker target
+
+Hi — we're PipesHub. We ship a CLI that a QM agent runs with `execute`, so a working sandbox on the operator's machine is the only way someone can try the integration on a laptop without Fly Sprites.
+
+`target: docker` today runs core locally but still has no supported sandbox backend that actually executes. That's already written up in #278 and #271, and #411 looks like the implementation. We're not proposing a new design.
+
+What we're asking is a product decision: is `sandbox.backend: "local"` on `target: docker` something you want to support and document? If yes, we'd happily test a branch against a real tool. We know mounting the Docker socket into core is a security decision — that's yours.
+
+We didn't open a new issue so this wouldn't sit twice.


### PR DESCRIPTION
Following the contributing guide: a short note in `adrs/`, not code.

The gap is already in #278 and #271, and #411 looks like the implementation. This is the product question — whether `sandbox.backend: "local"` on `target: docker` is something you want to support — so it isn't a third bug report of the same thing.

Happy to test a branch.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789265158&installation_model_id=19911&pr_number=518&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F518&signature=76f94d8b44c8be8df38c3b531547607f69507843ba94f4b05732252545c330dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->