### PR TITLE
fix(sandbox): make the local backend reachable when core runs in a container

### DIFF
--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -1,7 +1,7 @@
 import { httpDeploymentLayerTransport, type DeploymentLayerTransport } from "../deployment-layer.ts";
 
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { CliError, bold, die, dim, errMessage, header, note, ok, step, warn } from "../log.ts";
@@ -319,6 +319,7 @@ function serviceEnv(ctx: DockerCtx, service: ServiceName): Record<string, string
     out.SESSION_STORE = "postgres";
     out.RUN_STORE = "postgres";
     out.DATABASE_URL = ctx.databaseUrl;
+    out.LOCAL_SANDBOX_CORE_CONTAINER = cname(ctx, "core");
     if (config.model) out.PI_MODEL = config.model;
     if (config.modelProvider) out.MODEL_PROVIDER = config.modelProvider;
     const layerSubs = existingLayerSubdirs(ctx);
@@ -390,6 +391,15 @@ function pushEnvArgs(args: string[], env: Record<string, string>, secretKeys: Se
   return file.cleanup;
 }
 
+export function dockerSocketGroupArgs(socketPath = "/var/run/docker.sock"): string[] {
+  try {
+    const gid = statSync(socketPath).gid;
+    return gid > 0 ? ["--group-add", String(gid)] : [];
+  } catch {
+    return [];
+  }
+}
+
 function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: string[]; cleanup: () => void } {
   const def = serviceDef(service);
   const args = [
@@ -407,6 +417,8 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
   ];
   const cleanup = pushEnvArgs(args, serviceEnv(ctx, service), secretEnvKeys(ctx, service));
   if (service === "core") {
+    args.push("-v", "/var/run/docker.sock:/var/run/docker.sock");
+    args.push(...dockerSocketGroupArgs());
     args.push("-v", `${ctx.prefix}-coredata:/data`);
     for (const m of layerMounts(ctx)) args.push("-v", m);
     for (const m of skillMounts(ctx)) args.push("-v", m);

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -150,6 +150,10 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
     assert.ok(!argv.includes("config-placeholder"), "non-secret config env cannot shadow or expose secret values");
     assert.ok(argv.includes("--env-file"), "secrets travel via --env-file");
     assert.ok(argv.includes("FLY_SANDBOX_APP_NAME=sekrit-sandboxes"), "non-secret env still flows as -e");
+    assert.ok(
+      argv.includes("LOCAL_SANDBOX_CORE_CONTAINER=qm-sekrit-core"),
+      "core learns its own container name so the local sandbox is reachable over the docker network",
+    );
     assert.ok(argv.includes("FLY_RESIDENT_ENV_TZ=UTC"), "sandbox.env literals are not secrets");
     assert.ok(argv.includes("LINEAR_REGION=us"), "undeclared plugin env still flows as -e");
     assert.ok(argv.includes("SECURITY_SCREEN_BACKEND=proxy"));

--- a/cli/test/docker-socket-group.test.ts
+++ b/cli/test/docker-socket-group.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dockerSocketGroupArgs } from "../src/backends/docker.ts";
+
+test("a mounted docker socket owned by a real group is joined by gid", () => {
+  const dir = mkdtempSync(join(tmpdir(), "sock-gid-"));
+  const sock = join(dir, "docker.sock");
+  writeFileSync(sock, "");
+  const gid = statSync(sock).gid;
+  const args = dockerSocketGroupArgs(sock);
+  if (gid > 0) assert.deepEqual(args, ["--group-add", String(gid)]);
+  else assert.deepEqual(args, [], "a root-group socket needs no supplementary group");
+});
+
+test("a socket owned by root's group adds nothing", () => {
+  assert.deepEqual(dockerSocketGroupArgs("/proc/1/cmdline"), []);
+});
+
+test("a missing socket adds nothing", () => {
+  assert.deepEqual(dockerSocketGroupArgs(join(tmpdir(), "definitely-absent-docker.sock")), []);
+});

--- a/deploy/core/Dockerfile
+++ b/deploy/core/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
-RUN apk add --no-cache ca-certificates curl git git-daemon
+RUN apk add --no-cache ca-certificates curl git git-daemon docker-cli
 
 WORKDIR /app
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -248,12 +248,14 @@ interface LocalSandboxEnv {
   cpus?: number;
   memoryMb?: number;
   defaultTimeoutSec?: number;
+  coreContainer?: string;
 }
 
 function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
   return {
     ...(env.LOCAL_SANDBOX_IMAGE ? { image: env.LOCAL_SANDBOX_IMAGE } : {}),
     ...(env.LOCAL_SANDBOX_DOCKER_BIN ? { dockerBin: env.LOCAL_SANDBOX_DOCKER_BIN } : {}),
+    ...(env.LOCAL_SANDBOX_CORE_CONTAINER ? { coreContainer: env.LOCAL_SANDBOX_CORE_CONTAINER } : {}),
     ...(numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) !== undefined
       ? { cpus: numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) }
       : {}),

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -48,6 +48,7 @@ export interface LocalSandboxOptions {
   repoRoot?: string;
   dockerExec?: DockerExec;
   fetchImpl?: typeof fetch;
+  coreContainer?: string;
   onError?: (e: { category: string; code: string; message: string; scopeLabel?: string }) => void;
 }
 
@@ -94,6 +95,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
   const fetchImpl = opts.fetchImpl ?? fetch;
   const defaultTimeoutSec = opts.defaultTimeoutSec ?? 600;
   const homeDir = opts.homeDir ?? HOME_DIR;
+  const coreContainer = opts.coreContainer?.trim() || undefined;
   const workspaceDir = `${homeDir}/${WORKSPACE_BASENAME}`;
   const provisionQueue = createKeyedQueue<string>();
 
@@ -165,9 +167,9 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     timeoutMs?: number,
     signal?: AbortSignal,
   ): Promise<{ status: number; text: string }> {
-    const port = await resolvePort(name);
+    const origin = coreContainer ? `http://${name}:${AGENT_PORT}` : `http://127.0.0.1:${await resolvePort(name)}`;
     const signals = [AbortSignal.timeout(timeoutMs ?? 30_000), ...(signal ? [signal] : [])];
-    const res = await fetchImpl(`http://127.0.0.1:${port}${path}`, {
+    const res = await fetchImpl(`${origin}${path}`, {
       method: body === undefined ? "GET" : "POST",
       ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
       signal: AbortSignal.any(signals),
@@ -233,7 +235,22 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
         throw new Error(`docker network create ${net} failed: ${r.stderr.trim()}`);
       }
     }
+    if (coreContainer) {
+      const r = await dexec(["network", "connect", net, coreContainer]);
+      if (r.code !== 0 && !/already exists|already connected/i.test(r.stderr)) {
+        throw new Error(`docker network connect ${net} ${coreContainer} failed: ${r.stderr.trim()}`);
+      }
+    }
     return net;
+  }
+
+  async function removeNetwork(name: string): Promise<void> {
+    const net = localNetworkName(name);
+    if (coreContainer)
+      await dexec(["network", "disconnect", net, coreContainer]).catch(
+        swallowAs("local-sandbox: network disconnect", undefined),
+      );
+    await dexec(["network", "rm", net]).catch(swallowAs("local-sandbox: network rm", undefined));
   }
 
   async function runContainer(name: string, scope: string | undefined, withVolume: boolean): Promise<void> {
@@ -273,6 +290,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       scopeByContainer.set(name, scope);
       const state = await containerState(name);
       if (state && state.imageId === imageId) {
+        if (coreContainer) await ensureNetwork(name);
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
@@ -297,6 +315,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       scratchByKey.set(key, name);
       const state = await containerState(name);
       if (state) {
+        if (coreContainer) await ensureNetwork(name);
         if (!state.running) await startContainer(name);
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
@@ -456,9 +475,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
           for (const [k, name] of scratchByKey) if (name === handle.id) scratchByKey.delete(k);
           if (tdOpts?.destroy) await dexec(["rm", "-f", handle.id]);
           else await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: scratch rm", undefined));
-          await dexec(["network", "rm", localNetworkName(handle.id)]).catch(
-            swallowAs("local-sandbox: scratch network rm", undefined),
-          );
+          await removeNetwork(handle.id);
           portByName.delete(handle.id);
           return;
         }
@@ -467,9 +484,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
 
         if (tdOpts?.destroy) {
           await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: destroy rm", undefined));
-          await dexec(["network", "rm", localNetworkName(handle.id)]).catch(
-            swallowAs("local-sandbox: destroy network rm", undefined),
-          );
+          await removeNetwork(handle.id);
           const scope = scopeByContainer.get(handle.id);
           if (scope)
             await dexec(["volume", "rm", localVolumeName(scope)]).catch(

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -255,6 +255,100 @@ test("each container runs on its own network; destroy removes it", async () => {
   await sb.teardown(hb);
 });
 
+test("a containerized core reaches the sandbox by container name over the sandbox's own network", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const seen: string[] = [];
+  const sb = makeSandbox(fake, {
+    coreContainer: "qm-acme-core",
+    fetchImpl: (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      seen.push(url);
+      return fetch(url.replace(/^http:\/\/[^/]+/, `http://127.0.0.1:${daemonPort}`), init);
+    },
+  });
+  const scope = scopeId("personal", "U30");
+  const h = await sb.provision(rw(scope));
+  const net = localNetworkName(h.id);
+
+  assert.equal(
+    seen.every((u) => u.startsWith(`http://${h.id}:8080`)),
+    true,
+    `expected every daemon call on the container name, got ${JSON.stringify(seen.slice(0, 3))}`,
+  );
+  assert.equal(fake.networkMembers.get(net)?.has("qm-acme-core"), true, "core should join the sandbox network");
+
+  const r = await sb.run(h, "echo wired");
+  assert.equal(r.stdout.trim(), "wired");
+  await sb.teardown(h);
+});
+
+test("a recreated core rejoins the network of a sandbox it is reusing warm", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const mk = () =>
+    makeSandbox(fake, {
+      coreContainer: "qm-acme-core",
+      fetchImpl: (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input);
+        return fetch(url.replace(/^http:\/\/[^/]+/, `http://127.0.0.1:${daemonPort}`), init);
+      },
+    });
+  const scope = scopeId("personal", "U33");
+  const first = mk();
+  const h = await first.provision(rw(scope));
+  const net = localNetworkName(h.id);
+  await first.teardown(h, { keepWarm: true });
+
+  fake.networkMembers.get(net)!.delete("qm-acme-core");
+
+  const second = mk();
+  const h2 = await second.provision(rw(scope));
+  assert.equal(h2.id, h.id, "the warm container is reused");
+  assert.equal(
+    fake.networkMembers.get(net)?.has("qm-acme-core"),
+    true,
+    "a core recreated by `qm up` must rejoin the network of every sandbox it reuses",
+  );
+  await second.teardown(h2, { destroy: true });
+});
+
+test("destroy disconnects the containerized core before removing the sandbox network", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake, {
+    coreContainer: "qm-acme-core",
+    fetchImpl: (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      return fetch(url.replace(/^http:\/\/[^/]+/, `http://127.0.0.1:${daemonPort}`), init);
+    },
+  });
+  const scope = scopeId("personal", "U31");
+  const h = await sb.provision(rw(scope));
+  const net = localNetworkName(h.id);
+  assert.equal(fake.networkMembers.get(net)?.has("qm-acme-core"), true);
+
+  await sb.teardown(h, { destroy: true });
+  assert.equal(fake.networks.has(net), false, "network must be removed, which requires disconnecting core first");
+});
+
+test("without a containerized core the published host port is still used", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const seen: string[] = [];
+  const sb = makeSandbox(fake, {
+    fetchImpl: (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      seen.push(url);
+      return fetch(url, init);
+    },
+  });
+  const scope = scopeId("personal", "U32");
+  const h = await sb.provision(rw(scope));
+  assert.equal(
+    seen.every((u) => u.startsWith(`http://127.0.0.1:${daemonPort}`)),
+    true,
+  );
+  assert.equal(fake.networkMembers.get(localNetworkName(h.id))?.size ?? 0, 0);
+  await sb.teardown(h);
+});
+
 test("concurrent teardown and provision for one scope serialize (no stop of a fresh user)", async () => {
   const fake = installFakeDocker(daemonPort);
   const sb = makeSandbox(fake);

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -13,6 +13,7 @@ export interface FakeDocker {
   containers: Map<string, FakeContainer>;
   volumes: Set<string>;
   networks: Set<string>;
+  networkMembers: Map<string, Set<string>>;
   runCount: number;
   daemonDown: boolean;
   imageMissing: boolean;
@@ -24,10 +25,12 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const containers = new Map<string, FakeContainer>();
   const volumes = new Set<string>();
   const networks = new Set<string>();
+  const networkMembers = new Map<string, Set<string>>();
   const self: FakeDocker = {
     containers,
     volumes,
     networks,
+    networkMembers,
     runCount: 0,
     daemonDown: false,
     imageMissing: false,
@@ -77,7 +80,26 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
           networks.add(name);
           return ok(name);
         }
-        if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        if (sub === "connect") {
+          const member = rest[2]!;
+          if (!networks.has(name)) return fail(`Error: No such network: ${name}`);
+          const members = networkMembers.get(name) ?? new Set<string>();
+          if (members.has(member)) return fail(`endpoint with name ${member} already exists in network ${name}`);
+          members.add(member);
+          networkMembers.set(name, members);
+          return ok();
+        }
+        if (sub === "disconnect") {
+          const member = rest[rest.length - 1]!;
+          const netName = rest[rest.length - 2]!;
+          if (!networkMembers.get(netName)?.delete(member)) return fail(`Error: container ${member} is not connected`);
+          return ok();
+        }
+        if (sub === "rm") {
+          if (networkMembers.get(name)?.size) return fail(`error while removing network: ${name} has active endpoints`);
+          networkMembers.delete(name);
+          return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        }
         return fail(`unknown network subcommand ${sub}`);
       }
       case "volume": {


### PR DESCRIPTION
The `docker` target supports `SANDBOX_BACKEND=local` — `checks.ts` carves out an explicit exception so it does not demand a Fly `sandbox.app`. But on a Linux host that combination cannot work today: every sandbox-backed tool fails with `SANDBOX_BACKEND=local requires a running Docker daemon (is Docker Desktop running?)` while the daemon is perfectly healthy. Peeling it apart turns up three separate walls, all reported through that one misleading message.

**1. The core image has no `docker` CLI.** `createLocalSandbox` shells out via `spawnDockerExec(opts.dockerBin ?? "docker")`, but `deploy/core/Dockerfile` installs only `ca-certificates curl git git-daemon`. `docker version` is ENOENT, and `preflight()` reports it as a stopped daemon.

**2. The mounted socket is unusable by the core process.** The docker backend bind-mounts `/var/run/docker.sock` into core, but core runs as `node` (uid/gid 1000) while the host socket is typically `root:docker` mode 0660. Connecting yields `EACCES` — the mount is there but grants nothing. This does not bite on Docker Desktop, whose socket permissions differ. Fixed by adding `--group-add` with the socket's *actual* gid, read via `statSync`, rather than a hardcoded value; a gid of 0 adds nothing.

**3. The daemon URL assumes core is a host process.** The sandbox publishes its agent port as `127.0.0.1:0:8080` — the *host* loopback — and `daemon()` connects to `http://127.0.0.1:<hostPort>`. When core is itself a container, `127.0.0.1` is its own loopback, so it can never reach the sandbox; the failure changes to `exec daemon never became reachable`. Fixed by teaching core its own container name (`LOCAL_SANDBOX_CORE_CONTAINER`, injected by the docker backend) and, when set, addressing the sandbox as `http://<container>:8080` and joining its network on demand.

**Isolation is unchanged.** Sandboxes keep their own per-scope network; core joins each one rather than sandboxes being attached to core's network, so sandboxes still cannot see each other. Nor does this widen sandbox→core reachability: sandboxes already run with `--add-host=host.docker.internal:host-gateway` and could already reach any host-published port, core included. The host-process path (Docker Desktop) is byte-for-byte unchanged — every new behaviour is behind `if (coreContainer)`.

Also: `network rm` fails while core is still attached, so teardown disconnects first; the two existing `network rm` call sites are consolidated into one `removeNetwork` helper. And the warm-reuse paths ensure the network too — a core recreated by `qm up` otherwise loses its attachment to the networks of sandboxes it later reuses, which the cold-start path alone does not cover.

Tests cover the container-name origin, core joining the network, the disconnect-before-remove ordering, warm rejoin after core recreation, unchanged host-mode behaviour, and gid probing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789274832&installation_model_id=19911&pr_number=520&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F520&signature=6548da533a6761cf15a9bca85f777c57a9f67c8655c73f2328fca6a820c74546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->