### PR TITLE
Let Enter add a new line in the composer

### DIFF
--- a/adrs/multiline-composer-enter-key.md
+++ b/adrs/multiline-composer-enter-key.md
@@ -1,0 +1,3 @@
+# Let Enter add a new line in the composer
+
+I'd like plain Enter to add a new line, with Ctrl+Enter or Cmd+Enter sending the message instead. On mobile, the send button can keep handling submission.


### PR DESCRIPTION
I would like plain Enter to add a new line, with Ctrl+Enter or Cmd+Enter sending instead. This PR adds that short proposal to the ADR folder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789284612&installation_model_id=19911&pr_number=523&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F523&signature=47456e76350505950703fbe158d256acea911900a8d8a15a96e9ff0b798ac7d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->