### PR TITLE
Use a typed controller for local Docker

### DIFF
--- a/adrs/typed-controller-for-local-docker.md
+++ b/adrs/typed-controller-for-local-docker.md
@@ -1,0 +1,3 @@
+# Use a typed controller for local Docker
+
+If a containerized Core manages local Docker sandboxes, I'd like it to use a constrained typed controller that validates images, mounts, networks, permissions, and ownership labels, rather than giving Core direct access to the Docker socket.


### PR DESCRIPTION
If containerized Core manages local Docker sandboxes, I would like it to use a constrained typed controller rather than direct Docker socket access. This PR adds that short proposal to the ADR folder.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789284701&installation_model_id=19911&pr_number=524&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F524&signature=eeea31a83100d657314e704c6e12a0770fedf39ef013ed5280738fdca6259b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->