### PR TITLE
fix(admin): normalize line endings before hashing CSP script

### DIFF
--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -29,9 +29,15 @@ const BASE_HTML = readFileSync(
   "utf8",
 ).replaceAll("__ADMIN_BASE__", () => ADMIN_BASE_PATH);
 const ADMIN_SCRIPT = BASE_HTML.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? "";
+// Browsers normalize \r\n and bare \r to \n before hashing an inline <script>'s
+// content for CSP purposes, so the hash here must be computed over the same
+// normalized form or a CRLF checkout produces a mismatch that blocks the script.
+export function hashAdminScript(script: string): string {
+  return createHash("sha256").update(script.replace(/\r\n?/g, "\n")).digest("base64");
+}
 const ADMIN_CSP = [
   "default-src 'self'",
-  `script-src 'sha256-${createHash("sha256").update(ADMIN_SCRIPT).digest("base64")}'`,
+  `script-src 'sha256-${hashAdminScript(ADMIN_SCRIPT)}'`,
   "style-src 'unsafe-inline'",
   "img-src 'self' data:",
   "connect-src 'self'",

--- a/plugins/admin/test/csp-hash.test.ts
+++ b/plugins/admin/test/csp-hash.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, request as httpRequest, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const core = createServer((req: IncomingMessage, res) => {
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+});
+await new Promise<void>((r) => core.listen(0, r));
+const corePort = (core.address() as AddressInfo).port;
+
+process.env.CORE_API_URL = `http://localhost:${corePort}`;
+process.env.CORE_SIGNING_SECRET = "admin-csp-hash-test-secret";
+
+const { server, hashAdminScript } = await import("../src/index.ts");
+
+test("hashAdminScript: LF-only script hashes stably", () => {
+  const script = "console.log('a');\nconsole.log('b');\n";
+  assert.equal(hashAdminScript(script), hashAdminScript(script));
+});
+
+test("hashAdminScript: CRLF and LF variants of the same script hash identically", () => {
+  const lf = "console.log('a');\nconsole.log('b');\n";
+  const crlf = lf.replace(/\n/g, "\r\n");
+  assert.equal(hashAdminScript(crlf), hashAdminScript(lf));
+});
+
+test("hashAdminScript: bare CR (old Mac-style) line endings also hash identically to LF", () => {
+  const lf = "console.log('a');\nconsole.log('b');\n";
+  const cr = lf.replace(/\n/g, "\r");
+  assert.equal(hashAdminScript(cr), hashAdminScript(lf));
+});
+
+test("hashAdminScript: content differences still produce different hashes", () => {
+  assert.notEqual(hashAdminScript("console.log('a');\n"), hashAdminScript("console.log('b');\n"));
+});
+
+await new Promise<void>((r) => server.listen(0, r));
+const port = (server.address() as AddressInfo).port;
+
+test.after(() => {
+  server.close();
+  if (core.listening) core.close();
+});
+
+function raw(path: string): Promise<{ status: number; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({ host: "localhost", port, path, method: "GET" }, (res) => {
+      res.on("data", () => {});
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("GET / sends a content-security-policy script-src hash that matches the real on-disk script", async () => {
+  const r = await raw("/");
+  assert.equal(r.status, 200);
+  const csp = r.headers["content-security-policy"] as string;
+  assert.ok(csp, "content-security-policy header present");
+  const match = csp.match(/script-src 'sha256-([^']+)'/);
+  assert.ok(match, "script-src sha256 directive present");
+
+  const fs = await import("node:fs");
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, join } = await import("node:path");
+  const html = fs
+    .readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../public/index.html"), "utf8")
+    .replaceAll("__ADMIN_BASE__", process.env.ADMIN_BASE_PATH ?? "");
+  const script = html.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? "";
+  assert.equal(match?.[1], hashAdminScript(script));
+});


### PR DESCRIPTION
## Summary

- Fixes #232: a CRLF checkout (e.g. Windows with `core.autocrlf=true`) breaks the admin shell's inline script, because the server hashes the raw on-disk bytes of the script for its CSP `script-src 'sha256-...'` header, while browsers normalize `\r\n`/`\r` to `\n` before hashing inline script content per spec — the two hashes never match, so the CSP silently blocks the script.
- Extracts the hash computation into an exported `hashAdminScript()` helper (`plugins/admin/src/index.ts`) that normalizes line endings before hashing, so the computed CSP hash always matches what a browser will compute regardless of on-disk line-ending style.

## Test plan

- Added `plugins/admin/test/csp-hash.test.ts`:
  - CRLF and bare-CR variants of a script hash identically to their LF equivalent.
  - Differing content still produces differing hashes (sanity check).
  - The live server's `content-security-policy` response header's `script-src` hash matches `hashAdminScript()` computed over the real on-disk script.
- Verified red-before-fix: temporarily removed the normalization and confirmed exactly the CRLF/CR-specific assertions fail (the LF-only and content-difference assertions still pass), then restored the fix and reran green.
- Full admin plugin suite: `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 npm test` → 83/83 passing, no regressions.
- `npm run typecheck` → clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789287297&installation_model_id=19911&pr_number=526&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F526&signature=29cbde7c90c11a8c48fd341fa3243899eae4cd8917835b88841e88996680996a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->