### PR TITLE
fix(admin): correct ambient-policy help text to match actual default rule

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4196,8 +4196,8 @@
                     <label for="ambient-enabled">Ambient behavior</label>
                     <p class="hint" style="margin: 2px 0 6px">
                       When off, the agent never wakes on overheard messages in this channel — it only responds to direct
-                      @mentions. Default: off, unless this channel has a standing order set below or a bot ledger
-                      entry marked <b>action</b> — either one turns "Default" on.
+                      @mentions. Default: off, unless this channel has a standing order set below or a bot ledger entry
+                      marked <b>action</b> — either one turns "Default" on.
                     </p>
                     <select id="ambient-enabled" style="margin-bottom: 14px">
                       <option value="default">Default (on with standing order or action bot)</option>
@@ -4329,8 +4329,8 @@
                       <span class="setting-copy"
                         ><strong>Allow ambient behavior</strong
                         ><small
-                          >Channels choose per-channel; without a choice, ambient defaults off unless the channel has
-                          a standing order or an action-bot ledger entry.</small
+                          >Channels choose per-channel; without a choice, ambient defaults off unless the channel has a
+                          standing order or an action-bot ledger entry.</small
                         ></span
                       >
                     </label>

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4196,10 +4196,11 @@
                     <label for="ambient-enabled">Ambient behavior</label>
                     <p class="hint" style="margin: 2px 0 6px">
                       When off, the agent never wakes on overheard messages in this channel — it only responds to direct
-                      @mentions. Default: on for channels with 8 or fewer members, off for larger ones.
+                      @mentions. Default: off, unless this channel has a standing order set below or a bot ledger
+                      entry marked <b>action</b> — either one turns "Default" on.
                     </p>
                     <select id="ambient-enabled" style="margin-bottom: 14px">
-                      <option value="default">Default (by channel size)</option>
+                      <option value="default">Default (on with standing order or action bot)</option>
                       <option value="on">On</option>
                       <option value="off">Off</option>
                     </select>

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4329,8 +4329,8 @@
                       <span class="setting-copy"
                         ><strong>Allow ambient behavior</strong
                         ><small
-                          >Channels choose per-channel; without a choice, ambient defaults off in channels with more
-                          than 8 members.</small
+                          >Channels choose per-channel; without a choice, ambient defaults off unless the channel has
+                          a standing order or an action-bot ledger entry.</small
                         ></span
                       >
                     </label>


### PR DESCRIPTION
## Summary

The admin panel's "Ambient behavior" help text claimed ambient mode defaults on/off based on channel member count ("on for channels with 8 or fewer members, off for larger ones"). No such logic exists anywhere in the codebase — it's a fictional rule. This PR corrects the copy (in two places) to describe the actual default behavior.

## Root cause

The real default logic lives in `judgeAmbientContainer` (`src/api/app-ambient.ts:89-96`): when a channel's `ambientEnabled` policy is unset ("Default"), ambient is **off** unless the channel has a non-empty standing order (`policy.orders`) or at least one bot configured with `mode: "action"`. There is no member-count check anywhere — confirmed by reading the actual logic and grepping the repo for any member-count-based ambient rule.

## Changes

- `plugins/admin/public/index.html`:
  - Per-channel "Ambient behavior" hint text and the `Default (by channel size)` dropdown option — corrected to describe the standing-order / action-bot condition.
  - Org-wide "Allow ambient behavior" toggle hint — caught during review, since it repeated the same fictional "8 members" claim in a second location.

Copy-only change; `src/api/app-ambient.ts` and all other logic are untouched.

## Validation

- Re-read `judgeAmbientContainer`'s `ambientOffReason` branches line-by-line against the new copy to confirm every claim is directly traceable to the code.
- Grepped the repo for any remaining member-count-based ambient text/logic — none found.
- Ran the changed HTML through Python's `html.parser` to confirm it still parses cleanly.
- No dev-server/browser render was performed (this sandbox has no reachable browser driver and the full dev instance requires Postgres/service setup not available here); the change is plain text content with no new interactive elements.

Fixes #270

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789287404&installation_model_id=19911&pr_number=527&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F527&signature=f58c77a50b97d03a6218e33f1a63cfd654e988e71f63b50f74c113f723ad482f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->