### PR TITLE
Retry transient admin access probes

### DIFF
--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -202,11 +202,10 @@ export function consumeState(state: string): boolean {
 
 const ADMIN_TTL_MS = 60_000;
 const ADMIN_PROBE_TIMEOUT_MS = 1500;
+const ADMIN_PROBE_ATTEMPTS = 2;
 const adminCache = new LRUCache<string, boolean>({ max: 10_000, ttl: ADMIN_TTL_MS });
 
-async function adminProbe(sub: string): Promise<{ isAdmin: boolean; failed: boolean }> {
-  const hit = adminCache.get(sub);
-  if (hit !== undefined) return { isAdmin: hit, failed: false };
+async function adminProbeAttempt(sub: string): Promise<boolean | null> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), ADMIN_PROBE_TIMEOUT_MS);
   try {
@@ -218,16 +217,26 @@ async function adminProbe(sub: string): Promise<{ isAdmin: boolean; failed: bool
       );
     }
     const r = await fetch(`${UPSTREAMS.admin}/api/whoami`, { headers, signal: ctrl.signal });
-    if (!r.ok) return { isAdmin: false, failed: true };
+    if (!r.ok) return null;
     const j = (await r.json()) as { isAdmin?: boolean };
-    const v = j.isAdmin === true;
-    adminCache.set(sub, v);
-    return { isAdmin: v, failed: false };
+    return j.isAdmin === true;
   } catch {
-    return { isAdmin: false, failed: true };
+    return null;
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function adminProbe(sub: string): Promise<{ isAdmin: boolean; failed: boolean }> {
+  const hit = adminCache.get(sub);
+  if (hit !== undefined) return { isAdmin: hit, failed: false };
+  for (let attempt = 0; attempt < ADMIN_PROBE_ATTEMPTS; attempt++) {
+    const isAdmin = await adminProbeAttempt(sub);
+    if (isAdmin === null) continue;
+    adminCache.set(sub, isAdmin);
+    return { isAdmin, failed: false };
+  }
+  return { isAdmin: false, failed: true };
 }
 
 async function isAdmin(sub: string): Promise<boolean> {

--- a/plugins/portal/test/proxy-errors.test.ts
+++ b/plugins/portal/test/proxy-errors.test.ts
@@ -5,11 +5,13 @@ import { connect } from "node:net";
 import type { AddressInfo } from "node:net";
 import { verifyPortalIdentity } from "../../chassis/src/portal-identity.ts";
 
-let whoamiMode: "ok" | "down" = "ok";
+let whoamiMode: "ok" | "down" | "fail-once" = "ok";
+let whoamiRequests = 0;
 
 const upstream = createServer((req: IncomingMessage, res) => {
   if (req.url === "/api/whoami") {
-    if (whoamiMode === "down") {
+    whoamiRequests++;
+    if (whoamiMode === "down" || (whoamiMode === "fail-once" && whoamiRequests === 1)) {
       res.writeHead(502, { "content-type": "application/json" });
       return void res.end(JSON.stringify({ error: "core_unreachable" }));
     }
@@ -126,6 +128,15 @@ test("a prototype-chain segment like /constructor/ never matches a keyed surface
     assert.equal(r.status, 200, `expected the web-ui proxy for ${p}, got ${r.status}`);
     assert.equal(((await r.json()) as { url: string }).url, p);
   }
+});
+
+test("a transient admin-probe failure is retried before denying access", async () => {
+  whoamiRequests = 0;
+  whoamiMode = "fail-once";
+  const ok = await fetch(`${base}/admin/api/me`, { headers: { cookie: sessionCookie("U-admin-transient") } });
+  assert.equal(ok.status, 200);
+  assert.equal(whoamiRequests, 2);
+  whoamiMode = "ok";
 });
 
 test("an admin-probe outage is reported as unavailable and is NOT negative-cached", async () => {


### PR DESCRIPTION
Retries transient admin access probes while preserving fail-closed behavior for sustained outages.

- verification: focused regression test, Chrome pre/post flow, lint, and typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789325050&installation_model_id=19911&pr_number=531&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F531&signature=1eea7ce709a154bb1a6a760ff04983afb185fbb8f0de47f2b83bf3a05de2ffcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->