### PR TITLE
pg-pool: enable TCP keepalive and retry once on connection-drop errors

### DIFF
--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -91,6 +91,22 @@ export function pgCaOptions(): { ssl?: { ca: string } } {
   return installedCaTrust;
 }
 
+/**
+ * Managed Postgres poolers/proxies can drop idle or in-flight connections
+ * (rebalancing, failover, idle reaping); the network can do the same. pg
+ * surfaces these as "Connection terminated" errors, ECONNRESET/EPIPE socket
+ * errors, or 57P01 (terminating connection due to administrator command).
+ * These indicate a dead connection rather than a bad statement, so a single
+ * retry on a fresh client from the pool is safe for the simple-query path.
+ */
+export function isConnectionDropError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === "57P01" || code === "ECONNRESET" || code === "EPIPE") return true;
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" && message.includes("Connection terminated");
+}
+
 export function createPgPool(connectionString: string, statements: string[]): PgPool {
   const schema = statements.map((s) => s.trim()).filter((s) => s.length > 0);
   for (const stmt of schema) assertOneStatement(stmt);
@@ -99,7 +115,7 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
     if (!poolP) {
       poolP = (async () => {
         const pg = (await import("pg")).default;
-        const p = new pg.Pool({ connectionString, ...pgCaOptions() });
+        const p = new pg.Pool({ connectionString, keepAlive: true, ...pgCaOptions() });
         p.on("error", (err) => console.error("[pg] idle client error:", errMessage(err)));
         try {
           await applyDdl(p, schema);
@@ -116,7 +132,15 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
     return poolP;
   }
   async function query(text: string, params: unknown[] = []): Promise<{ rows: Rows; rowCount: number }> {
-    const res = await (await pool()).query(text, params);
+    const p = await pool();
+    let res;
+    try {
+      res = await p.query(text, params);
+    } catch (e) {
+      if (!isConnectionDropError(e)) throw e;
+      console.error("[pg] connection dropped mid-query; retrying once:", errMessage(e));
+      res = await p.query(text, params);
+    }
     return { rows: res.rows as Rows, rowCount: res.rowCount ?? 0 };
   }
   async function q(text: string, params: unknown[] = []): Promise<Rows> {

--- a/test/pg-pool.test.ts
+++ b/test/pg-pool.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { createPgPool, assertOneStatement } from "../src/persistence/pg-pool.ts";
+import { createPgPool, assertOneStatement, isConnectionDropError } from "../src/persistence/pg-pool.ts";
 
 test("createPgPool is lazy: building it neither connects nor throws (no DB needed)", async () => {
   const pg = createPgPool("postgres://does-not-exist:0/none", ["SELECT 1"]);
@@ -70,3 +70,15 @@ test("assertOneStatement: an apostrophe in a line comment can't hide a following
 function pathToUrl(p: string): string {
   return new URL(`file://${p}`).href;
 }
+
+test("isConnectionDropError: recognizes connection-drop shapes and nothing else", () => {
+  assert.equal(isConnectionDropError(new Error("Connection terminated unexpectedly")), true);
+  assert.equal(isConnectionDropError(new Error("Connection terminated")), true);
+  assert.equal(isConnectionDropError(Object.assign(new Error("boom"), { code: "57P01" })), true);
+  assert.equal(isConnectionDropError(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })), true);
+  assert.equal(isConnectionDropError(Object.assign(new Error("write EPIPE"), { code: "EPIPE" })), true);
+  assert.equal(isConnectionDropError(Object.assign(new Error("syntax error"), { code: "42601" })), false);
+  assert.equal(isConnectionDropError(new Error("duplicate key value violates unique constraint")), false);
+  assert.equal(isConnectionDropError(null), false);
+  assert.equal(isConnectionDropError("Connection terminated"), false);
+});


### PR DESCRIPTION
## Problem

Managed Postgres poolers/proxies can drop idle or in-flight connections (rebalancing, failover, idle-connection reaping); flaky networks do the same. When a connection dies mid-query, `pg` surfaces:

- `Connection terminated unexpectedly` / `Connection terminated`
- `ECONNRESET` / `EPIPE` socket errors
- `57P01` (`terminating connection due to administrator command`)

and the request fails with a 500 even though the statement never ran anywhere.

**Repro:** kill the Postgres backend mid-query → the caller gets a 500 with `Connection terminated unexpectedly`.

## Fix

- Set `keepAlive: true` on the `pg.Pool` so dead peers are detected promptly and idle connections are less likely to be reaped by middleboxes.
- In the pool's simple-query path (`query()`), retry **once** on a fresh client when the failure is a connection-drop error, via a new exported `isConnectionDropError(err)` helper. Any other error still throws immediately.

The retry is deliberately single-shot and limited to the pool-level `query()` path, where each attempt checks out a fresh client from the pool (the dropped client is discarded by `pg`), so the retry never reuses a dead connection. Transactions (`withPgTransaction`) are untouched — replaying those is not reuse-safe.

## Tests

- New unit test covering `isConnectionDropError` (positive shapes + non-drop errors + non-object inputs).
- Existing `pg-pool`, `pg-ca-options`, and `persistence-init-retry` suites pass; `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789327601&installation_model_id=19911&pr_number=532&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F532&signature=628d297a6dbffbf82308aa3a0087c35e292ed4164239bf0cc96ceb2a1965aebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->