### PR TITLE
admin: name attached scopes on environments and tag attached scope rows

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -11540,11 +11540,17 @@
         if (environmentDir.length) {
           const environments = denseList(
             environmentDir,
-            (environment) => ({
-              name: environment.name || shortName(environment.id),
-              preview: attachedScopesLabel(environment.attachedScopes || []),
-              href: stateToUrl({ view: "history", scope: environment.id, historyKind }),
-            }),
+            (environment) => {
+              const attached = environment.attachedScopes || [];
+              const preview = document.createElement("span");
+              preview.textContent = attachedScopesLabel(attached);
+              if (attached.length) preview.title = attached.map((id) => shortName(id)).join(", ");
+              return {
+                name: environment.name || shortName(environment.id),
+                preview,
+                href: stateToUrl({ view: "history", scope: environment.id, historyKind }),
+              };
+            },
             (environment) => selectScope(environment.id),
             "No named environments.",
           );
@@ -11662,6 +11668,34 @@
             title: scopeKind(scope) !== "org" ? shortName(scope) : VIEW_TITLE.history,
             tabs,
           });
+        }
+        const environmentEntry = (environmentDir || []).find((environment) => environment.id === scope);
+        if (environmentEntry && !cronSel) {
+          const attached = environmentEntry.attachedScopes || [];
+          const chips = document.createElement("div");
+          chips.className = "history-empty-scopes";
+          attached.forEach((id) => {
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className = "history-empty-scope";
+            button.textContent = shortName(id);
+            button.title = id;
+            button.onclick = () => selectScope(id);
+            chips.appendChild(button);
+          });
+          if (!attached.length) {
+            const none = document.createElement("p");
+            none.className = "empty";
+            none.textContent = "No scopes attached.";
+            chips.appendChild(none);
+          }
+          root.appendChild(
+            dataCard(
+              "Attached scopes",
+              plural(attached.length, "scope") + " share this environment's computer and working memory.",
+              chips,
+            ),
+          );
         }
         const cronDeliveryChip = (delivered, label) => {
           if (!delivered) return null;

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -11530,12 +11530,19 @@
           actions: [sortControl],
         });
         const activityTime = (s) => (scopeSort === "human" ? s.lastConversationActivity || 0 : s.lastActivity || 0);
+        const attachedScopesLabel = (attached) => {
+          if (!attached.length) return "no scopes attached";
+          const names = attached.map((id) => shortName(id));
+          const shown = names.slice(0, 4).join(", ");
+          const extra = names.length - 4;
+          return extra > 0 ? `${shown} +${plural(extra, "more scope")}` : shown;
+        };
         if (environmentDir.length) {
           const environments = denseList(
             environmentDir,
             (environment) => ({
               name: environment.name || shortName(environment.id),
-              preview: plural(environment.attachedScopes?.length || 0, "attached scope"),
+              preview: attachedScopesLabel(environment.attachedScopes || []),
               href: stateToUrl({ view: "history", scope: environment.id, historyKind }),
             }),
             (environment) => selectScope(environment.id),
@@ -11553,6 +11560,14 @@
             counts.className = "dense-tag";
             counts.textContent = sessionCountsLabel(s.sessions || 0, s.backgroundSessions || 0);
             preview.appendChild(counts);
+            if (s.environmentAttachment) {
+              const env = document.createElement("span");
+              env.className = "dense-tag";
+              env.textContent =
+                "env: " + (s.environmentAttachment.environmentName || shortName(s.environmentAttachment.environmentId));
+              env.title = "This scope is attached to a named environment.";
+              preview.appendChild(env);
+            }
             if (s.lastMessage) preview.appendChild(document.createTextNode(s.lastMessage));
             return {
               name: shortName(s.scopeId),


### PR DESCRIPTION
The scope index's **Named environments** card showed only a count (e.g. "6 attached scopes") without saying which scopes those are. This change:

- lists the attached scopes by name in the card preview (first four, then a `+N more scopes` overflow),
- adds a small `env: <name>` tag on a scope row when that scope is attached to a named environment, so it's visible at a glance which scopes share a computer.

UI-only; uses the `attachedScopes` and `environmentAttachment` fields the scopes endpoint already returns.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789329153&installation_model_id=19911&pr_number=533&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F533&signature=9cb63bc7dc9bd9132e013d3c8657369d55018b2eb0a606a7ce7dc2bae193f062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->