### PR TITLE
Fix messages overlapping conversation headers

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1031,6 +1031,8 @@ a.chat-row-open {
   outline-offset: 2px;
 }
 .chat-topbar {
+  position: relative;
+  z-index: 1;
   height: 56px;
   box-sizing: border-box;
   display: flex;

--- a/plugins/web-ui/test/session-header-stacking.test.ts
+++ b/plugins/web-ui/test/session-header-stacking.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("the main session header paints above its composited transcript scroller", () => {
+  const block = css.match(/\.chat-topbar \{[^}]*\}/)?.[0] ?? "";
+  assert.match(block, /position: relative;/, "the header must establish a positioned stacking layer");
+  assert.match(block, /z-index: 1;/, "the header must paint above the transcript scroller");
+});


### PR DESCRIPTION
Ensures conversation headers remain above scrolling content.

- verification: Web UI tests pass
- verification: typecheck and production build pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789329343&installation_model_id=19911&pr_number=534&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F534&signature=25decb319fea0581bae769ab8bfb5efd1cc8e980fe9527cc674a13dce4f320ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->