### PR TITLE
Keep colliding custom models selectable

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -7054,6 +7054,7 @@
 
       let onboardingModels = {};
       let onboardingModelStatuses = [];
+      let customProvidersLoaded = [];
       function onboardingBadge(id, text, ready, optional = false) {
         const el = $(id);
         el.textContent = text;
@@ -7064,11 +7065,18 @@
         openai: "OpenAI",
         openrouter: "OpenRouter — hosted open models",
       };
+      function customOnboardingProvider(providerId) {
+        return customProvidersLoaded.find((provider) => provider.id === providerId);
+      }
       function onboardingProviderForModel(modelId) {
         const owning = Object.entries(onboardingModels).find(([, models]) =>
           models.some((model) => model.id === modelId),
         )?.[0];
         if (owning) return owning;
+        const custom = customProvidersLoaded.find(
+          (provider) => modelId === provider.id || modelId.startsWith(provider.id + "/"),
+        );
+        if (custom) return custom.id;
         return (
           onboardingModelStatuses.find((item) => item.configured)?.provider ||
           onboardingModelStatuses[0]?.provider ||
@@ -7102,10 +7110,17 @@
         });
         if (preferred && [...select.options].some((option) => option.value === preferred)) select.value = preferred;
         const status = onboardingModelStatuses.find((item) => item.provider === provider);
-        $("onboarding-model-delete").disabled = !status || status.source === "absent";
-        $("onboarding-model-key").placeholder = status?.configured
-          ? "•••• set — enter a replacement"
-          : "Write-only API key";
+        const custom = customOnboardingProvider(provider);
+        $("onboarding-model-delete").disabled = Boolean(custom) || !status || status.source === "absent";
+        $("onboarding-model-key").disabled = Boolean(custom);
+        $("onboarding-model-key").placeholder = custom
+          ? custom.hasKey
+            ? "Key is set on the custom provider below"
+            : "Save the custom provider key below first"
+          : status?.configured
+            ? "•••• set — enter a replacement"
+            : "Write-only API key";
+        $("onboarding-model-save").textContent = custom ? "Use as base model" : "Validate and save";
       }
       async function loadOnboarding() {
         const [models, slack, catalog, config] = await Promise.all([
@@ -7123,6 +7138,23 @@
         onboardingModels = {};
         (models.data.models || []).forEach((model) => {
           (onboardingModels[model.provider] ||= []).push(model);
+        });
+        await loadCustomProviders();
+        customProvidersLoaded.forEach((provider) => {
+          if (!onboardingModelStatuses.some((status) => status.provider === provider.id)) {
+            onboardingModelStatuses.push({
+              provider: provider.id,
+              configured: Boolean(provider.hasKey),
+              source: "admin",
+            });
+          }
+          if (!(onboardingModels[provider.id] || []).length) {
+            onboardingModels[provider.id] = (provider.models || []).map((model) => ({
+              id: provider.id + "/" + model.id,
+              name: model.name || model.id,
+              provider: provider.id,
+            }));
+          }
         });
         const baseModel = config.data.baseModel || config.data.baseModelDefault || "";
         const baseProvider = onboardingProviderForModel(baseModel);
@@ -7171,6 +7203,31 @@
         const provider = $("onboarding-model-provider").value;
         const apiKey = $("onboarding-model-key").value.trim();
         const modelId = $("onboarding-model-id").value;
+        const custom = customOnboardingProvider(provider);
+        if (custom) {
+          if (!modelId) {
+            setStatus("st-onboarding-model", "Pick a custom model.", "err");
+            return;
+          }
+          if (!custom.hasKey) {
+            setStatus("st-onboarding-model", "Save the custom provider API key below first.", "err");
+            return;
+          }
+          $("onboarding-model-save").disabled = true;
+          setStatus("st-onboarding-model", "Saving base model…", "saving", true);
+          const selected = await api("PUT", "/api/scopes/" + encodeURIComponent(orgScope()) + "/base-model", {
+            modelId,
+          });
+          $("onboarding-model-save").disabled = false;
+          await loadOnboarding();
+          setStatus(
+            "st-onboarding-model",
+            selected.ok ? "Base model saved." : selected.data?.error || "The base model could not be changed.",
+            selected.ok ? "ok" : "err",
+            !selected.ok,
+          );
+          return;
+        }
         if (!apiKey) {
           setStatus("st-onboarding-model", "Enter the provider API key.", "err");
           return;
@@ -7187,7 +7244,6 @@
         $("onboarding-model-save").disabled = false;
         $("onboarding-model-key").value = "";
         await loadOnboarding();
-        await loadCustomProviders();
         setStatus(
           "st-onboarding-model",
           selected.ok ? "Key and base model saved." : "Key saved, but the base model could not be changed.",
@@ -7197,6 +7253,10 @@
       };
       $("onboarding-model-delete").onclick = async () => {
         const provider = $("onboarding-model-provider").value;
+        if (customOnboardingProvider(provider)) {
+          setStatus("st-onboarding-model", "Remove a custom provider from the table below.", "err");
+          return;
+        }
         if (
           !confirm(
             "Disable the " + connectorName(provider) + " model key? Models from this provider will stop working.",
@@ -7209,10 +7269,8 @@
           return;
         }
         await loadOnboarding();
-        await loadCustomProviders();
         setStatus("st-onboarding-model", "Provider disabled.", "ok");
       };
-      let customProvidersLoaded = [];
       function parseCustomModels(text) {
         return text
           .split("\n")
@@ -7273,7 +7331,7 @@
               setStatus("st-custom-provider", removed.data?.message || "Could not remove this provider.", "err");
               return;
             }
-            await loadCustomProviders();
+            await loadOnboarding();
             setStatus("st-custom-provider", "Provider removed.", "ok");
           };
           actions.appendChild(edit);
@@ -7309,7 +7367,7 @@
           return;
         }
         $("custom-provider-key").value = "";
-        await loadCustomProviders();
+        await loadOnboarding();
         setStatus("st-custom-provider", "Provider saved. Its models are now in the picker.", "ok");
       };
       function openOnboardingTarget(target) {

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -7129,6 +7129,7 @@
           api("GET", "/api/connector-catalog"),
           api("GET", "/api/scopes/" + encodeURIComponent(orgScope())),
         ]);
+        await loadCustomProviders();
         if (!models.ok || !slack.ok || !catalog.ok || !config.ok) {
           setStatus("st-onboarding-model", "Setup status could not be loaded. Try again.", "err", true);
           renderOnboardingProviderOptions();
@@ -7139,7 +7140,6 @@
         (models.data.models || []).forEach((model) => {
           (onboardingModels[model.provider] ||= []).push(model);
         });
-        await loadCustomProviders();
         customProvidersLoaded.forEach((provider) => {
           if (!onboardingModelStatuses.some((status) => status.provider === provider.id)) {
             onboardingModelStatuses.push({

--- a/plugins/admin/test/default-view.test.ts
+++ b/plugins/admin/test/default-view.test.ts
@@ -41,6 +41,9 @@ test("temporary onboarding covers model credentials, Slack, and OAuth setup", ()
   assert.match(html, /api\("GET", "\/api\/model-providers"\)/);
   assert.match(html, /api\("PUT", "\/api\/model-providers\/" \+ encodeURIComponent\(provider\)/);
   assert.match(html, /models\.data\.models/);
+  assert.match(html, /customOnboardingProvider/);
+  assert.match(html, /provider\.id \+ "\/" \+ model\.id/);
+  assert.match(html, /Use as base model/);
   assert.doesNotMatch(html, /const ONBOARDING_MODELS/);
   assert.match(html, /viewLoadedAt\.onboarding = Date\.now\(\)/);
   assert.match(html, /data-onboarding-target="slack"/);

--- a/src/api/routes/admin/scope-config.ts
+++ b/src/api/routes/admin/scope-config.ts
@@ -9,6 +9,7 @@ import {
   modelServiceable,
   ALL_PROVIDERS_AVAILABLE,
   resolveModel,
+  selectableModelId,
 } from "../../../model/pi-models.ts";
 import {
   builtInModelCatalog,
@@ -305,13 +306,15 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
       ? await selectableModelCatalog(deps.modelCredentialFetch)
       : builtInModelCatalog();
   const runtime = values.runtime as { harnessId?: unknown; modelId?: unknown } | null | undefined;
-  const resolvedCurrent = runtime && typeof runtime.modelId === "string" ? resolveModel(runtime.modelId) : null;
-  const currentProvider = resolvedCurrent?.provider;
+  const runtimeModelId = runtime && typeof runtime.modelId === "string" ? runtime.modelId : null;
+  const resolvedCurrent = runtimeModelId ? resolveModel(runtimeModelId) : null;
   const currentModel =
-    runtime &&
-    typeof runtime.modelId === "string" &&
-    (currentProvider === "anthropic" || currentProvider === "openai" || currentProvider === "openrouter")
-      ? ({ id: runtime.modelId, name: resolvedCurrent!.name, provider: currentProvider } satisfies ModelCatalogEntry)
+    runtimeModelId && resolvedCurrent
+      ? ({
+          id: selectableModelId(runtimeModelId),
+          name: resolvedCurrent.name,
+          provider: String(resolvedCurrent.provider),
+        } satisfies ModelCatalogEntry)
       : null;
   const modelsFor = (harnessId: string) => {
     const models = selectableCatalogForHarness(catalog, harnessId);

--- a/src/harness/opencode-harness.ts
+++ b/src/harness/opencode-harness.ts
@@ -8,9 +8,8 @@ import { pathToFileURL } from "node:url";
 import { spawn, type ChildProcess } from "node:child_process";
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk";
 import { CONFIG_DEFAULTS, type Config } from "../config.ts";
-import { isCustomModelId } from "../model/custom-providers.ts";
 import type { CustomProviderSpec } from "../model/custom-providers.ts";
-import { DEFAULT_AGENT_MODEL_ID, resolveModel } from "../model/pi-models.ts";
+import { DEFAULT_AGENT_MODEL_ID, resolveModel, winningCustomModel } from "../model/pi-models.ts";
 import { startSignalPoll, type RunSignalStore } from "../runs/run-signal-store.ts";
 import type { LlmCallUsage } from "../sessions/session-store.ts";
 import type { ScopeId, SessionEntry } from "../types.ts";
@@ -179,13 +178,8 @@ function sessionToken(secret: string, sessionId: string): string {
 }
 
 export function modelRef(id: string): { providerID: string; modelID: string } {
-  // A registered custom model wins before slash-splitting: gateway model ids
-  // routinely contain slashes (e.g. "bedrock/claude-x" behind LiteLLM), and
-  // those must route to the registered provider, not a phantom "bedrock".
-  if (isCustomModelId(id)) {
-    const resolved = resolveModel(id);
-    if (resolved?.provider) return { providerID: String(resolved.provider), modelID: id };
-  }
+  const custom = winningCustomModel(id);
+  if (custom) return { providerID: custom.provider, modelID: custom.id };
   const slash = id.indexOf("/");
   if (slash > 0) return { providerID: id.slice(0, slash), modelID: id.slice(slash + 1) };
   const resolved = resolveModel(id);

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -1520,12 +1520,17 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
 
           const desiredModelId = turn.model ?? resolveModelId(turn.scopeLabel);
           const wantFast = wantsFastMode(turn.fastMode, desiredModelId);
-          const current = entry.agentSession.model as { id?: string; headers?: Record<string, string> } | undefined;
+          const current = entry.agentSession.model as
+            { id?: string; provider?: string; headers?: Record<string, string> } | undefined;
           const currentFast = Boolean(current?.headers?.["anthropic-beta"]?.includes(FAST_MODE_BETA));
-          if (current?.id !== desiredModelId || currentFast !== wantFast) {
+          const desired = resolveModel(desiredModelId);
+          const sameModel =
+            Boolean(desired) &&
+            current?.id === desired?.id &&
+            String(current?.provider ?? "") === String(desired?.provider ?? "");
+          if (!sameModel || currentFast !== wantFast) {
             try {
-              const base = resolveModel(desiredModelId);
-              if (base) await entry.agentSession.setModel(wantFast ? withFastModeHeaders(base) : base);
+              if (desired) await entry.agentSession.setModel(wantFast ? withFastModeHeaders(desired) : desired);
             } catch (e) {
               swallow("pi: model switch", e);
             }

--- a/src/model/custom-providers.ts
+++ b/src/model/custom-providers.ts
@@ -116,17 +116,24 @@ let registry = new Map<string, CustomRuntimeModel>();
 let providers: CustomProviderSpec[] = [];
 let version = 0;
 
+export function customModelSelectionId(providerId: string, wireId: string): string {
+  return `${providerId}/${wireId}`;
+}
+
 /**
  * Called by wiring at boot and again after every admin write, with the
- * full current set of enabled providers. Last write wins; built-in model
- * ids shadow custom ones at resolution, so a collision can't hijack a
- * built-in.
+ * full current set of enabled providers. Each model is keyed by its wire
+ * id and by provider/wireId. Built-in ids still win on the bare wire id
+ * so a collision cannot hijack a built-in; the namespaced key selects
+ * the custom model.
  */
 export function setCustomProviders(specs: CustomProviderSpec[]): void {
   const next = new Map<string, CustomRuntimeModel>();
   for (const spec of specs) {
     for (const m of spec.models) {
-      next.set(m.id, toRuntimeModel(spec, m));
+      const runtime = toRuntimeModel(spec, m);
+      next.set(m.id, runtime);
+      next.set(customModelSelectionId(spec.id, m.id), runtime);
     }
   }
   registry = next;
@@ -148,7 +155,13 @@ export function isCustomModelId(id: string): boolean {
 }
 
 export function customModelCatalog(): Array<{ id: string; name: string; provider: string }> {
-  return [...registry.values()].map((m) => ({ id: m.id, name: m.name, provider: m.provider }));
+  return providers.flatMap((spec) =>
+    spec.models.map((m) => ({
+      id: m.id,
+      name: m.name?.trim() || m.id,
+      provider: spec.id,
+    })),
+  );
 }
 
 /**

--- a/src/model/custom-providers.ts
+++ b/src/model/custom-providers.ts
@@ -112,7 +112,6 @@ function toRuntimeModel(provider: CustomProviderSpec, m: CustomModelSpec): Custo
   };
 }
 
-let registry = new Map<string, CustomRuntimeModel>();
 let providers: CustomProviderSpec[] = [];
 let version = 0;
 
@@ -120,23 +119,23 @@ export function customModelSelectionId(providerId: string, wireId: string): stri
   return `${providerId}/${wireId}`;
 }
 
+function specById(id: string): CustomProviderSpec | undefined {
+  return providers.find((spec) => spec.id === id);
+}
+
+function runtimeOnProvider(spec: CustomProviderSpec, wireId: string): CustomRuntimeModel | undefined {
+  const model = spec.models.find((entry) => entry.id === wireId);
+  return model ? toRuntimeModel(spec, model) : undefined;
+}
+
 /**
  * Called by wiring at boot and again after every admin write, with the
- * full current set of enabled providers. Each model is keyed by its wire
- * id and by provider/wireId. Built-in ids still win on the bare wire id
- * so a collision cannot hijack a built-in; the namespaced key selects
- * the custom model.
+ * full current set of enabled providers. Lookup is provider-first
+ * (`provider/wireId`, wire may itself contain slashes) and otherwise
+ * unique-wire. A shared or shadowed wire is only reachable via the
+ * namespaced id so a collision cannot hijack another model.
  */
 export function setCustomProviders(specs: CustomProviderSpec[]): void {
-  const next = new Map<string, CustomRuntimeModel>();
-  for (const spec of specs) {
-    for (const m of spec.models) {
-      const runtime = toRuntimeModel(spec, m);
-      next.set(m.id, runtime);
-      next.set(customModelSelectionId(spec.id, m.id), runtime);
-    }
-  }
-  registry = next;
   providers = specs.map((s) => ({ ...s, models: [...s.models] }));
   version += 1;
 }
@@ -147,11 +146,24 @@ export function customProvidersVersion(): number {
 }
 
 export function resolveCustomModel(id: string): CustomRuntimeModel | undefined {
-  return registry.get(id);
+  const slash = id.indexOf("/");
+  if (slash > 0) {
+    const spec = specById(id.slice(0, slash));
+    if (spec) {
+      const named = runtimeOnProvider(spec, id.slice(slash + 1));
+      if (named) return named;
+    }
+  }
+  const hits: CustomRuntimeModel[] = [];
+  for (const spec of providers) {
+    const hit = runtimeOnProvider(spec, id);
+    if (hit) hits.push(hit);
+  }
+  return hits.length === 1 ? hits[0] : undefined;
 }
 
 export function isCustomModelId(id: string): boolean {
-  return registry.has(id);
+  return resolveCustomModel(id) !== undefined;
 }
 
 export function customModelCatalog(): Array<{ id: string; name: string; provider: string }> {

--- a/src/model/model-catalog.ts
+++ b/src/model/model-catalog.ts
@@ -1,5 +1,5 @@
 import { modelSupportedByHarness, resolveModel, SELECTABLE_BASE_MODELS } from "./pi-models.ts";
-import { customModelCatalog, customProvidersVersion } from "./custom-providers.ts";
+import { customModelCatalog, customModelSelectionId, customProvidersVersion } from "./custom-providers.ts";
 
 export interface ModelCatalogEntry {
   id: string;
@@ -32,7 +32,17 @@ export function builtInModelCatalog(): ModelCatalogEntry[] {
       : [];
   });
   const known = new Set(builtIns.map((model) => model.id));
-  return [...builtIns, ...customModelCatalog().filter((model) => !known.has(model.id))];
+  const custom = customModelCatalog();
+  const wireCounts = new Map<string, number>();
+  for (const model of custom) wireCounts.set(model.id, (wireCounts.get(model.id) ?? 0) + 1);
+  return [
+    ...builtIns,
+    ...custom.map((model) =>
+      known.has(model.id) || (wireCounts.get(model.id) ?? 0) > 1
+        ? { ...model, id: customModelSelectionId(model.provider, model.id) }
+        : model,
+    ),
+  ];
 }
 
 async function boundedJson(response: Response): Promise<unknown> {

--- a/src/model/model-catalog.ts
+++ b/src/model/model-catalog.ts
@@ -1,5 +1,10 @@
-import { modelSupportedByHarness, resolveModel, SELECTABLE_BASE_MODELS } from "./pi-models.ts";
-import { customModelCatalog, customModelSelectionId, customProvidersVersion } from "./custom-providers.ts";
+import {
+  customCatalogSelectionId,
+  modelSupportedByHarness,
+  resolveModel,
+  SELECTABLE_BASE_MODELS,
+} from "./pi-models.ts";
+import { customModelCatalog, customProvidersVersion } from "./custom-providers.ts";
 
 export interface ModelCatalogEntry {
   id: string;
@@ -31,17 +36,13 @@ export function builtInModelCatalog(): ModelCatalogEntry[] {
       ? [{ ...model, provider: provider as string }]
       : [];
   });
-  const known = new Set(builtIns.map((model) => model.id));
   const custom = customModelCatalog();
-  const wireCounts = new Map<string, number>();
-  for (const model of custom) wireCounts.set(model.id, (wireCounts.get(model.id) ?? 0) + 1);
   return [
     ...builtIns,
-    ...custom.map((model) =>
-      known.has(model.id) || (wireCounts.get(model.id) ?? 0) > 1
-        ? { ...model, id: customModelSelectionId(model.provider, model.id) }
-        : model,
-    ),
+    ...custom.map((model) => ({
+      ...model,
+      id: customCatalogSelectionId(model.provider, model.id),
+    })),
   ];
 }
 

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -1,7 +1,7 @@
 import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { providerBaseUrl } from "./provider-endpoints.ts";
-import { isCustomModelId, resolveCustomModel } from "./custom-providers.ts";
+import { customModelSelectionId, resolveCustomModel, type CustomRuntimeModel } from "./custom-providers.ts";
 
 const getModel = getBuiltinModel as unknown as (provider: string, id: string) => Model<Api> | undefined;
 
@@ -152,6 +152,21 @@ export function resolveModel(id: string): PiModel | undefined {
   return builtinModel(id) ?? (resolveCustomModel(id) as unknown as PiModel | undefined);
 }
 
+export function winningCustomModel(id: string): CustomRuntimeModel | undefined {
+  const custom = resolveCustomModel(id);
+  if (!custom) return undefined;
+  if (REGISTRY_BY_ID.has(id) || builtinModel(id)) return undefined;
+  return custom;
+}
+
+export function selectableModelId(id: string): string {
+  const custom = winningCustomModel(id);
+  if (!custom) return id;
+  const wire = custom.id;
+  if (REGISTRY_BY_ID.has(wire) || builtinModel(wire)) return customModelSelectionId(custom.provider, wire);
+  return wire;
+}
+
 export function auxiliaryModelForProvider(provider: string): string | undefined {
   return MODEL_REGISTRY.find((m) => m.auxiliary && resolveModel(m.id)?.provider === provider)?.id;
 }
@@ -175,8 +190,7 @@ export function contextTokenBudgetForModel(id: string): number | undefined {
 
 export function modelSupportedByHarness(id: string | undefined, harness: string): boolean {
   if (!id) return false;
-  if (isCustomModelId(id) && !REGISTRY_BY_ID.has(id))
-    return harness === "pi" || harness === "opencode" || harness === "mock";
+  if (winningCustomModel(id)) return harness === "pi" || harness === "opencode" || harness === "mock";
   if (harness === "pi" || harness === "opencode" || harness === "mock") return Boolean(resolveModel(id));
   const provider = resolveModel(id)?.provider;
   if (harness === "claude") return provider === "anthropic" || /^claude-/i.test(id);
@@ -207,7 +221,7 @@ export interface ModelProviderAvailability {
 export function modelServiceable(id: string, providers: ModelProviderAvailability): boolean {
   const provider = resolveModel(id)?.provider;
   if (!provider) return false;
-  if (isCustomModelId(id) && !REGISTRY_BY_ID.has(id)) return true;
+  if (winningCustomModel(id)) return true;
   if (provider === "openai") return providers.openai;
   if (provider === "anthropic") return providers.anthropic;
   if (provider === "openrouter") return providers.openrouter;

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -159,12 +159,16 @@ export function winningCustomModel(id: string): CustomRuntimeModel | undefined {
   return custom;
 }
 
+export function customCatalogSelectionId(provider: string, wireId: string): string {
+  const resolved = resolveModel(wireId);
+  if (!resolved || String(resolved.provider) !== provider) return customModelSelectionId(provider, wireId);
+  return wireId;
+}
+
 export function selectableModelId(id: string): string {
   const custom = winningCustomModel(id);
   if (!custom) return id;
-  const wire = custom.id;
-  if (REGISTRY_BY_ID.has(wire) || builtinModel(wire)) return customModelSelectionId(custom.provider, wire);
-  return wire;
+  return customCatalogSelectionId(custom.provider, custom.id);
 }
 
 export function auxiliaryModelForProvider(provider: string): string | undefined {

--- a/test/custom-provider-route.test.ts
+++ b/test/custom-provider-route.test.ts
@@ -210,3 +210,49 @@ test("a colliding custom model stays selectable and can be set as the org base m
     await srv.close();
   }
 });
+
+test("two custom providers that share a wire id stay namespaced on the org picker", async () => {
+  const srv = start();
+  try {
+    for (const [id, name] of [
+      ["acme-gateway", "Acme"],
+      ["other-gw", "Other"],
+    ] as const) {
+      const put = await fetch(`${srv.base}/v1/admin/custom-providers/${id}`, {
+        method: "PUT",
+        headers: ADMIN,
+        body: JSON.stringify({
+          name,
+          protocol: "openai",
+          baseUrl: `https://${id}.example.com/v1`,
+          models: [{ id: "shared-chat", name: `${name} Shared` }],
+          apiKey: `sk-${id}`,
+          validate: false,
+        }),
+      });
+      assert.equal(put.status, 200);
+    }
+
+    const selected = await fetch(`${srv.base}/v1/admin/scopes/org:default-org/base-model`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ modelId: "acme-gateway/shared-chat" }),
+    });
+    assert.equal(selected.status, 200);
+
+    const after = await fetch(`${srv.base}/v1/admin/scopes/org:default-org`, { headers: ADMIN });
+    assert.equal(after.status, 200);
+    const body = (await after.json()) as {
+      baseModel: string | null;
+      runtime: { modelId: string } | null;
+      baseModelOptions: Array<{ id: string; provider: string }>;
+    };
+    assert.equal(body.baseModel, "acme-gateway/shared-chat");
+    assert.equal(body.runtime?.modelId, "acme-gateway/shared-chat");
+    assert.ok(body.baseModelOptions.some((m) => m.id === "acme-gateway/shared-chat" && m.provider === "acme-gateway"));
+    assert.ok(body.baseModelOptions.some((m) => m.id === "other-gw/shared-chat" && m.provider === "other-gw"));
+    assert.ok(!body.baseModelOptions.some((m) => m.id === "shared-chat"));
+  } finally {
+    await srv.close();
+  }
+});

--- a/test/custom-provider-route.test.ts
+++ b/test/custom-provider-route.test.ts
@@ -147,3 +147,66 @@ test("bad specs are refused with a reason", async () => {
     await srv.close();
   }
 });
+
+test("a colliding custom model stays selectable and can be set as the org base model", async () => {
+  const srv = start();
+  try {
+    const put = await fetch(`${srv.base}/v1/admin/custom-providers/dragonapi`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({
+        name: "DragonAPI",
+        protocol: "openai",
+        baseUrl: "https://dragon.example.com/v1",
+        models: [{ id: "gpt-5.6-terra", name: "Dragon Terra" }],
+        apiKey: "sk-dragon",
+        validate: false,
+      }),
+    });
+    assert.equal(put.status, 200);
+
+    const catalog = await fetch(`${srv.base}/v1/admin/model-providers`, { headers: ADMIN });
+    assert.equal(catalog.status, 200);
+    const catalogBody = (await catalog.json()) as { models: Array<{ id: string; provider: string }> };
+    assert.ok(catalogBody.models.some((m) => m.id === "dragonapi/gpt-5.6-terra" && m.provider === "dragonapi"));
+
+    const before = await fetch(`${srv.base}/v1/admin/scopes/org:default-org`, { headers: ADMIN });
+    assert.equal(before.status, 200);
+    const beforeBody = (await before.json()) as {
+      baseModelOptions: Array<{ id: string; provider: string }>;
+    };
+    assert.ok(
+      beforeBody.baseModelOptions.some((m) => m.id === "dragonapi/gpt-5.6-terra" && m.provider === "dragonapi"),
+    );
+
+    const bare = await fetch(`${srv.base}/v1/admin/scopes/org:default-org/base-model`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ modelId: "gpt-5.6-terra" }),
+    });
+    assert.equal(bare.status, 400);
+
+    const selected = await fetch(`${srv.base}/v1/admin/scopes/org:default-org/base-model`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ modelId: "dragonapi/gpt-5.6-terra" }),
+    });
+    assert.equal(selected.status, 200);
+    assert.equal(srv.built.config.getBaseModel("org:default-org"), "dragonapi/gpt-5.6-terra");
+
+    const after = await fetch(`${srv.base}/v1/admin/scopes/org:default-org`, { headers: ADMIN });
+    assert.equal(after.status, 200);
+    const afterBody = (await after.json()) as {
+      baseModel: string | null;
+      runtime: { harnessId: string; modelId: string } | null;
+      modelsByHarness: Record<string, Array<{ id: string; provider: string }>>;
+    };
+    assert.equal(afterBody.baseModel, "dragonapi/gpt-5.6-terra");
+    assert.equal(afterBody.runtime?.modelId, "dragonapi/gpt-5.6-terra");
+    assert.ok(
+      afterBody.modelsByHarness.pi?.some((m) => m.id === "dragonapi/gpt-5.6-terra" && m.provider === "dragonapi"),
+    );
+  } finally {
+    await srv.close();
+  }
+});

--- a/test/custom-providers.test.ts
+++ b/test/custom-providers.test.ts
@@ -5,11 +5,18 @@ import {
   resolveCustomModel,
   isCustomModelId,
   customModelCatalog,
+  customModelSelectionId,
   validateCustomProviderSpec,
 } from "../src/model/custom-providers.ts";
 import { builtInModelCatalog } from "../src/model/model-catalog.ts";
 import { createCustomProviderStore } from "../src/model/custom-provider-store.ts";
-import { modelSupportedByHarness, modelServiceable, resolveModel } from "../src/model/pi-models.ts";
+import {
+  modelSupportedByHarness,
+  modelServiceable,
+  resolveModel,
+  selectableModelId,
+  winningCustomModel,
+} from "../src/model/pi-models.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 import type { StoredCustomProvider } from "../src/model/custom-provider-store.ts";
 
@@ -54,8 +61,16 @@ test("anthropic-protocol providers produce anthropic-messages models with defaul
 test("resolveModel falls back to custom models; built-ins shadow custom ids", () => {
   setCustomProviders([{ ...GATEWAY, models: [{ id: "acme-large" }, { id: "claude-opus-5", name: "impostor" }] }]);
   assert.equal(resolveModel("acme-large")?.provider, "acme-gateway");
-  // The built-in claude-opus-5 must win over a custom model claiming its id.
   assert.equal(String(resolveModel("claude-opus-5")?.provider), "anthropic");
+  const namespaced = customModelSelectionId("acme-gateway", "claude-opus-5");
+  assert.equal(resolveModel(namespaced)?.provider, "acme-gateway");
+  assert.equal(resolveModel(namespaced)?.id, "claude-opus-5");
+  assert.equal(winningCustomModel("claude-opus-5"), undefined);
+  assert.equal(winningCustomModel(namespaced)?.provider, "acme-gateway");
+  assert.equal(selectableModelId("claude-opus-5"), "claude-opus-5");
+  assert.equal(selectableModelId(namespaced), namespaced);
+  assert.equal(selectableModelId("acme-large"), "acme-large");
+  assert.equal(selectableModelId("acme-gateway/acme-large"), "acme-large");
 });
 
 test("custom models are gated to pi and mock harnesses", () => {
@@ -125,6 +140,53 @@ test("store validates specs on upsert", async () => {
   await assert.rejects(store.upsert({ ...GATEWAY, id: "anthropic" }, "k", "a@b.c"), /reserved/);
 });
 
+test("catalog keeps colliding custom models under a provider-prefixed id", () => {
+  setCustomProviders([
+    {
+      id: "dragonapi",
+      name: "DragonAPI",
+      protocol: "openai",
+      baseUrl: "https://dragon.example.com/v1",
+      models: [
+        { id: "gpt-5.6-terra", name: "Dragon Terra" },
+        { id: "gpt-5.6-sol", name: "Dragon Sol" },
+      ],
+    },
+  ]);
+  const catalog = builtInModelCatalog();
+  assert.ok(catalog.some((m) => m.id === "gpt-5.6-terra" && m.provider === "openai"));
+  const terra = catalog.find((m) => m.id === "dragonapi/gpt-5.6-terra");
+  assert.ok(terra, "colliding custom model stays selectable");
+  assert.equal(terra!.provider, "dragonapi");
+  assert.equal(terra!.name, "Dragon Terra");
+  assert.ok(catalog.some((m) => m.id === "dragonapi/gpt-5.6-sol" && m.provider === "dragonapi"));
+  assert.equal(
+    modelServiceable("dragonapi/gpt-5.6-terra", { anthropic: false, openai: false, openrouter: false }),
+    true,
+  );
+  assert.equal(modelServiceable("gpt-5.6-terra", { anthropic: false, openai: false, openrouter: false }), false);
+  assert.equal(String(resolveModel("gpt-5.6-terra")?.provider), "openai");
+  assert.equal(resolveModel("dragonapi/gpt-5.6-terra")?.provider, "dragonapi");
+  assert.equal(resolveModel("dragonapi/gpt-5.6-terra")?.id, "gpt-5.6-terra");
+});
+
+test("catalog namespaces a wire id shared by two custom providers", () => {
+  setCustomProviders([
+    { ...GATEWAY, models: [{ id: "shared-chat", name: "Acme Shared" }] },
+    {
+      id: "other-gw",
+      name: "Other",
+      protocol: "openai",
+      baseUrl: "https://other.example.com/v1",
+      models: [{ id: "shared-chat", name: "Other Shared" }],
+    },
+  ]);
+  const catalog = builtInModelCatalog();
+  assert.ok(catalog.some((m) => m.id === "acme-gateway/shared-chat" && m.provider === "acme-gateway"));
+  assert.ok(catalog.some((m) => m.id === "other-gw/shared-chat" && m.provider === "other-gw"));
+  assert.ok(!catalog.some((m) => m.id === "shared-chat"));
+});
+
 test("registered models surface in the catalog and vanish on unregister", () => {
   setCustomProviders([
     {
@@ -156,7 +218,21 @@ test("opencode modelRef routes slashed custom model ids to the registered provid
   ]);
   try {
     assert.deepEqual(modelRef("bedrock/claude-opus-5"), { providerID: "litellm", modelID: "bedrock/claude-opus-5" });
-    // built-in slash convention untouched
+    assert.deepEqual(modelRef("litellm/bedrock/claude-opus-5"), {
+      providerID: "litellm",
+      modelID: "bedrock/claude-opus-5",
+    });
+    setCustomProviders([
+      {
+        id: "dragonapi",
+        name: "DragonAPI",
+        protocol: "openai",
+        baseUrl: "https://dragon.example.com/v1",
+        models: [{ id: "gpt-5.6-terra" }],
+      },
+    ]);
+    assert.deepEqual(modelRef("gpt-5.6-terra"), { providerID: "openai", modelID: "gpt-5.6-terra" });
+    assert.deepEqual(modelRef("dragonapi/gpt-5.6-terra"), { providerID: "dragonapi", modelID: "gpt-5.6-terra" });
     assert.deepEqual(modelRef("openrouter/auto"), { providerID: "openrouter", modelID: "auto" });
   } finally {
     setCustomProviders([]);

--- a/test/custom-providers.test.ts
+++ b/test/custom-providers.test.ts
@@ -185,6 +185,57 @@ test("catalog namespaces a wire id shared by two custom providers", () => {
   assert.ok(catalog.some((m) => m.id === "acme-gateway/shared-chat" && m.provider === "acme-gateway"));
   assert.ok(catalog.some((m) => m.id === "other-gw/shared-chat" && m.provider === "other-gw"));
   assert.ok(!catalog.some((m) => m.id === "shared-chat"));
+  assert.equal(selectableModelId("acme-gateway/shared-chat"), "acme-gateway/shared-chat");
+  assert.equal(selectableModelId("other-gw/shared-chat"), "other-gw/shared-chat");
+  assert.equal(winningCustomModel("shared-chat"), undefined);
+  assert.equal(resolveModel("shared-chat"), undefined);
+  assert.equal(resolveModel("acme-gateway/shared-chat")?.provider, "acme-gateway");
+  assert.equal(resolveModel("other-gw/shared-chat")?.provider, "other-gw");
+});
+
+test("a slashed custom wire id does not collide with another provider's namespaced id", () => {
+  setCustomProviders([
+    {
+      id: "litellm",
+      name: "LiteLLM",
+      protocol: "openai",
+      baseUrl: "https://litellm.example.com/v1",
+      models: [{ id: "bedrock/claude-opus-5", name: "Bedrock Opus via LiteLLM" }],
+    },
+    {
+      id: "bedrock",
+      name: "Bedrock",
+      protocol: "openai",
+      baseUrl: "https://bedrock.example.com/v1",
+      models: [{ id: "claude-opus-5", name: "Bedrock Opus" }],
+    },
+  ]);
+  assert.equal(resolveModel("litellm/bedrock/claude-opus-5")?.provider, "litellm");
+  assert.equal(resolveModel("litellm/bedrock/claude-opus-5")?.id, "bedrock/claude-opus-5");
+  assert.equal(resolveModel("bedrock/claude-opus-5")?.provider, "bedrock");
+  assert.equal(resolveModel("bedrock/claude-opus-5")?.id, "claude-opus-5");
+  assert.equal(String(resolveModel("claude-opus-5")?.provider), "anthropic");
+  const catalog = builtInModelCatalog();
+  assert.ok(catalog.some((m) => m.id === "litellm/bedrock/claude-opus-5" && m.provider === "litellm"));
+  assert.ok(catalog.some((m) => m.id === "bedrock/claude-opus-5" && m.provider === "bedrock"));
+  assert.equal(catalog.filter((m) => m.id === "bedrock/claude-opus-5").length, 1);
+});
+
+test("a custom model that matches a non-selectable built-in is still namespaced", () => {
+  setCustomProviders([
+    {
+      id: "shadow-gw",
+      name: "Shadow",
+      protocol: "openai",
+      baseUrl: "https://shadow.example.com/v1",
+      models: [{ id: "claude-opus-4-7", name: "Impostor Opus 4.7" }],
+    },
+  ]);
+  const catalog = builtInModelCatalog();
+  assert.ok(catalog.some((m) => m.id === "shadow-gw/claude-opus-4-7" && m.provider === "shadow-gw"));
+  assert.ok(!catalog.some((m) => m.id === "claude-opus-4-7" && m.provider === "shadow-gw"));
+  assert.equal(String(resolveModel("claude-opus-4-7")?.provider), "anthropic");
+  assert.equal(resolveModel("shadow-gw/claude-opus-4-7")?.provider, "shadow-gw");
 });
 
 test("registered models surface in the catalog and vanish on unregister", () => {


### PR DESCRIPTION
## What broke

#512 lets an admin register extra OpenAI/Anthropic-compatible providers. If a registered model reuses a built-in wire id (`gpt-5.6-terra`, `claude-opus-5`, …), or two custom providers share a wire id, the custom model was dropped from the catalog. `resolveModel` still prefers the built-in, so the custom one could not be picked as the org base model.

The admin onboarding picker only listed the three built-in connectors. Saving a custom provider as the base model went through `/model-providers`, which rejected the slug. After a custom-provider write, onboarding did not reload, so the picker looked empty until a full refresh.

OpenCode treated any registry hit as custom and sent the namespaced selection id (`provider/wireId`) as the upstream `modelID`. The pi harness compared only `session.model.id` to the desired selection id, so a provider switch that kept the same wire id did not take effect.

## What this does

- Register each custom model under both its wire id and `provider/wireId`.
- A bare colliding id still resolves to the built-in. The namespaced id selects the custom model.
- The catalog keeps colliding/shared models under the namespaced id instead of dropping them.
- `winningCustomModel` is the single “is this id a custom selection?” check. OpenCode `modelRef` sends `{ providerID, modelID: wire id }`.
- The pi harness switches when provider or wire id changes.
- Scope config reports a custom current model (not only anthropic/openai/openrouter) using the selectable id.
- Admin onboarding lists registered custom providers, saves them via `/base-model`, and reloads after a custom-provider write.

A custom provider still cannot hijack a built-in: selecting `gpt-5.6-terra` stays OpenAI. The custom copy is `your-gateway/gpt-5.6-terra`.

## Tests

```
node --experimental-test-module-mocks --test \
  test/custom-providers.test.ts \
  test/custom-provider-route.test.ts \
  test/custom-provider-boot-wiring.test.ts \
  test/custom-provider-e2e.test.ts \
  plugins/admin/test/default-view.test.ts
```

Covers colliding built-ins, two custom providers sharing a wire id, OpenCode `modelRef`, catalog cache invalidation, and a route test that registers a colliding model, rejects the bare built-in id when that provider key is absent, and accepts `provider/wireId` as the org base model.

## Admin UI

Onboarding → Models: a registered custom provider appears in the provider dropdown. The key field is disabled (the key lives on the custom-provider row below). The save button is **Use as base model** and only calls `/base-model`. Saving or removing a custom provider reloads the onboarding picker.

I did not attach a screenshot of a live instance. The change is against the existing onboarding card; the HTML contract is covered by `plugins/admin/test/default-view.test.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789330159&installation_model_id=19911&pr_number=535&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F535&signature=87985502f0446c9943d8e6be17b4e3233aa0c13d2d5e6c5ef070f9f5b7365624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->