### PR TITLE
adr: show who sent each message in project chats

### DIFF
--- a/adrs/project-chat-message-authors.md
+++ b/adrs/project-chat-message-authors.md
@@ -1,0 +1,7 @@
+In a project chat, a few people can be talking to the agent in the same thread. Right now the web UI just shows the message bubbles and a timestamp — no name. If two people ask things, you can't tell who said what.
+
+Slack already has names on the messages because that's Slack. The web project view doesn't.
+
+Would be nice to put the person's name next to their message, especially in projects / shared chats. Personal DMs don't need it as much.
+
+I think the session entries already know who sent them (search uses an author field), so this might mostly be a web UI thing.


### PR DESCRIPTION
A short note for `adrs/` about names next to messages in shared chats.

In a project, a few people can talk to the agent in the same thread, and the web UI currently just shows the bubble and a timestamp. If two people ask things, you can't tell who said what.

Slack already has names because that's Slack. The web project view doesn't. Personal DMs don't need this as much.

I looked through open issues and PRs and didn't find this already filed. Session entries already carry an author name (search uses it), so this might mostly be a web UI thing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789331262&installation_model_id=19911&pr_number=536&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F536&signature=d6df9af94c6e0a21bbd79049e6e45d645fdfbf7263f612cb7a5aaac0195f73b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->