### PR TITLE
admin: singular verb for a one-scope environment roster

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -11692,7 +11692,9 @@
           root.appendChild(
             dataCard(
               "Attached scopes",
-              plural(attached.length, "scope") + " share this environment's computer and working memory.",
+              plural(attached.length, "scope") +
+                (attached.length === 1 ? " shares" : " share") +
+                " this environment's computer and working memory.",
               chips,
             ),
           );

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -11646,6 +11646,7 @@
         });
         const tabs = [modeTab("conversation"), modeTab("cron")];
         if (countForMode("background") > 0 || historyKind === "background") tabs.push(modeTab("background"));
+        const environmentEntry = (environmentDir || []).find((environment) => environment.id === scope);
         if (cronSel) {
           pageShell({
             back: {
@@ -11665,11 +11666,15 @@
                     onClick: () => go({ view: "history", scope: "org:" + orgId, session: null, page: 1, historyKind }),
                   }
                 : undefined,
-            title: scopeKind(scope) !== "org" ? shortName(scope) : VIEW_TITLE.history,
+            title: environmentEntry?.name
+              ? environmentEntry.name
+              : scopeKind(scope) !== "org"
+                ? shortName(scope)
+                : VIEW_TITLE.history,
+            context: environmentEntry?.name ? "environment · owned by " + shortName(scope) : "",
             tabs,
           });
         }
-        const environmentEntry = (environmentDir || []).find((environment) => environment.id === scope);
         if (environmentEntry && !cronSel) {
           const attached = environmentEntry.attachedScopes || [];
           const chips = document.createElement("div");


### PR DESCRIPTION
Follow-up to #533 (this commit was pushed after the merge): the Attached scopes card subtitle now reads "1 scope shares…" / "N scopes share…".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789342727&installation_model_id=19911&pr_number=537&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F537&signature=9385446d1c25854e04f5aa7ef5c5baf76b130f7acf53c28ee3f3b6cf402172c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->