### PR TITLE
Support Foundry and Bedrock model backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@ HARNESS_SECURITY_POSTURE=auto
 #OPENAI_API_KEY=sk-...
 #OPENROUTER_API_KEY=sk-or-...
 
+# Codex through a Responses-compatible endpoint:
+#OPENAI_BASE_URL=https://example.invalid/openai/v1
+
+# Claude through Amazon Bedrock:
+#CLAUDE_CODE_USE_BEDROCK=1
+#AWS_REGION=us-west-2
+#ANTHROPIC_MODEL=us.anthropic.claude-sonnet
+#ANTHROPIC_SMALL_FAST_MODEL=us.anthropic.claude-haiku
+
 ORG_ID=acme
 PORT=8080
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ operator's own cloud account; initialization does not generate or enable deploym
 and this repository has no production deployment workflow. See
 [`deployment.md`](./deployment.md) for the details.
 
+### Alternative model backends
+
+The Codex harness can use a Responses-compatible endpoint by setting
+`OPENAI_BASE_URL` alongside `OPENAI_API_KEY`. The URL must be HTTP(S) and cannot
+contain credentials, a query, or a fragment; qm writes the matching provider config
+inside Codex's isolated home.
+
+The Claude harness can use Amazon Bedrock by setting
+`CLAUDE_CODE_USE_BEDROCK=1`, `AWS_REGION`, and the standard AWS credential-chain
+variables. `ANTHROPIC_MODEL` and `ANTHROPIC_SMALL_FAST_MODEL` can override the
+Bedrock model ids. AWS credentials are passed to Claude only when Bedrock is enabled.
+
 ## Contributing
 
 We take contributions as _human-written_ text, not code — see

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -214,26 +214,63 @@ async function baseModelCheck(config: QmConfig, secrets: Map<string, string>): P
     warn(`${name} is not available locally — skipping the live ${provider} check`);
     return;
   }
-  await modelProviderCheck(provider, key);
+  await modelProviderCheck(provider, key, config.env.core ?? {});
   step(`base model provider ${provider}: ${name} accepted`);
 }
 
 const MODEL_PROVIDER_PROBES: Readonly<
-  Record<ModelProvider, { url: string; headers: (key: string) => Record<string, string> }>
+  Record<ModelProvider, { url: string; path: string; headers: (key: string) => Record<string, string> }>
 > = {
   anthropic: {
     url: "https://api.anthropic.com/v1/models?limit=1",
+    path: "models?limit=1",
     headers: (key) => ({ "x-api-key": key, "anthropic-version": "2023-06-01" }),
   },
-  openai: { url: "https://api.openai.com/v1/models", headers: (key) => ({ authorization: `Bearer ${key}` }) },
-  openrouter: { url: "https://openrouter.ai/api/v1/key", headers: (key) => ({ authorization: `Bearer ${key}` }) },
+  openai: {
+    url: "https://api.openai.com/v1/models",
+    path: "models",
+    headers: (key) => ({ authorization: `Bearer ${key}` }),
+  },
+  openrouter: {
+    url: "https://openrouter.ai/api/v1/key",
+    path: "key",
+    headers: (key) => ({ authorization: `Bearer ${key}` }),
+  },
 };
 
-async function modelProviderCheck(provider: ModelProvider, apiKey: string): Promise<void> {
+const MODEL_PROVIDER_BASE_URLS: Readonly<Record<ModelProvider, string>> = {
+  anthropic: "ANTHROPIC_BASE_URL",
+  openai: "OPENAI_BASE_URL",
+  openrouter: "OPENROUTER_BASE_URL",
+};
+
+export function modelProviderProbeUrl(provider: ModelProvider, env: Record<string, string>): string {
+  const raw = env[MODEL_PROVIDER_BASE_URLS[provider]];
+  if (!raw?.trim()) return MODEL_PROVIDER_PROBES[provider].url;
+
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  let base: URL;
+  try {
+    base = new URL(trimmed);
+  } catch {
+    throw new CliError(`${MODEL_PROVIDER_BASE_URLS[provider]} is not a valid URL`);
+  }
+  if (base.protocol !== "http:" && base.protocol !== "https:")
+    throw new CliError(`${MODEL_PROVIDER_BASE_URLS[provider]} must be an http(s) URL`);
+  if (base.username || base.password)
+    throw new CliError(`${MODEL_PROVIDER_BASE_URLS[provider]} must not contain credentials`);
+  if (base.search) throw new CliError(`${MODEL_PROVIDER_BASE_URLS[provider]} must not contain a query string`);
+  if (base.hash) throw new CliError(`${MODEL_PROVIDER_BASE_URLS[provider]} must not contain a fragment`);
+
+  return new URL(MODEL_PROVIDER_PROBES[provider].path, `${trimmed}/`).toString();
+}
+
+async function modelProviderCheck(provider: ModelProvider, apiKey: string, env: Record<string, string>): Promise<void> {
   const probe = MODEL_PROVIDER_PROBES[provider];
+  const url = modelProviderProbeUrl(provider, env);
   let res: Response;
   try {
-    res = await fetch(probe.url, { headers: probe.headers(apiKey), signal: AbortSignal.timeout(10_000) });
+    res = await fetch(url, { headers: probe.headers(apiKey), signal: AbortSignal.timeout(10_000) });
   } catch (e) {
     throw new CliError(
       `could not reach the ${provider} API: ${errMessage(e)} — check network access (and any proxy) and retry`,

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   doctorCommon,
   localDoctorSecrets,
+  modelProviderProbeUrl,
   requiredSlackScopes,
   slackManifestBotScopes,
 } from "../src/backends/doctor.ts";
@@ -24,6 +25,25 @@ const config: QmConfig = {
   imageOverrides: {},
   sandbox: { app: "acme-sandboxes" },
 };
+
+test("doctor probes validated provider endpoint overrides", () => {
+  assert.equal(
+    modelProviderProbeUrl("openai", { OPENAI_BASE_URL: " https://foundry.example.com/openai/v1/ " }),
+    "https://foundry.example.com/openai/v1/models",
+  );
+  assert.equal(
+    modelProviderProbeUrl("anthropic", { ANTHROPIC_BASE_URL: "https://gateway.example.com/v1" }),
+    "https://gateway.example.com/v1/models?limit=1",
+  );
+  assert.throws(
+    () => modelProviderProbeUrl("openai", { OPENAI_BASE_URL: "https://user:pw@foundry.example.com/v1" }),
+    /must not contain credentials/,
+  );
+  assert.throws(
+    () => modelProviderProbeUrl("openai", { OPENAI_BASE_URL: "https://foundry.example.com/v1?api-version=x" }),
+    /must not contain a query string/,
+  );
+});
 
 test("Docker doctor rejects missing and placeholder required secrets before external probes", async () => {
   const prior = process.env.ANTHROPIC_API_KEY;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
 import { providerBaseUrlsFromEnv, type ProviderBaseUrls } from "./model/provider-endpoints.ts";
+import { claudeProviderEnv } from "./harness/claude-environment.ts";
 import { join, resolve } from "node:path";
 import {
   parseMemoryCaptureMode,
@@ -694,24 +695,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
       "CODEX_HOME",
     ].flatMap((name) => (env[name] === undefined ? [] : [[name, env[name]]])),
   ) as NodeJS.ProcessEnv;
-  const claudeProcessEnv = Object.fromEntries(
-    [
-      "PATH",
-      "TMPDIR",
-      "LANG",
-      "LC_ALL",
-      "SSL_CERT_FILE",
-      "SSL_CERT_DIR",
-      "NODE_EXTRA_CA_CERTS",
-      "HTTP_PROXY",
-      "HTTPS_PROXY",
-      "NO_PROXY",
-      "ALL_PROXY",
-      "ANTHROPIC_API_KEY",
-      "ANTHROPIC_AUTH_TOKEN",
-      "CLAUDE_CODE_OAUTH_TOKEN",
-    ].flatMap((name) => (env[name] === undefined ? [] : [[name, env[name]]])),
-  ) as NodeJS.ProcessEnv;
+  const claudeProcessEnv = claudeProviderEnv(env);
   if (providerBaseUrls.openai) codexProcessEnv.OPENAI_BASE_URL = providerBaseUrls.openai;
   if (providerBaseUrls.anthropic) claudeProcessEnv.ANTHROPIC_BASE_URL = providerBaseUrls.anthropic;
   const turnWallClockMs =

--- a/src/harness/claude-environment.ts
+++ b/src/harness/claude-environment.ts
@@ -1,0 +1,60 @@
+const CLAUDE_ENV_NAMES = [
+  "PATH",
+  "TMPDIR",
+  "LANG",
+  "LC_ALL",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NODE_EXTRA_CA_CERTS",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "NO_PROXY",
+  "ALL_PROXY",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+] as const;
+
+const BEDROCK_ENV_NAMES = [
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_PROFILE",
+  "AWS_SHARED_CREDENTIALS_FILE",
+  "AWS_CONFIG_FILE",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+  "AWS_ROLE_ARN",
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+  "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+  "AWS_EC2_METADATA_SERVICE_ENDPOINT",
+  "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "ANTHROPIC_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL",
+  "ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+  "ANTHROPIC_BEDROCK_BASE_URL",
+  "ANTHROPIC_BEDROCK_SERVICE_TIER",
+] as const;
+
+function enabled(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+export function claudeProviderEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of CLAUDE_ENV_NAMES) {
+    if (source[name] !== undefined) env[name] = source[name];
+  }
+  if (!enabled(source.CLAUDE_CODE_USE_BEDROCK)) return env;
+
+  env.CLAUDE_CODE_USE_BEDROCK = source.CLAUDE_CODE_USE_BEDROCK;
+  for (const name of BEDROCK_ENV_NAMES) {
+    if (source[name] !== undefined) env[name] = source[name];
+  }
+  return env;
+}

--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -29,6 +29,7 @@ import type { ScopeId, SessionEntry } from "../types.ts";
 import { swallow } from "../util/errors.ts";
 import { parseSecurityScreenVerdict, SECURITY_SCREEN_SYSTEM_PROMPT } from "../security/security-posture.ts";
 import { compactTranscript, deterministicCompactSummary } from "./context-compaction.ts";
+import { claudeProviderEnv } from "./claude-environment.ts";
 import { defineHarness, type Harness, type HarnessTurnInput, type HarnessTurnResult } from "./harness.ts";
 import {
   buildDetectionPrompt,
@@ -103,30 +104,8 @@ type BridgedTool = {
 
 const CHILD_TOOL_NAMES = new Set(["execute", "read", "write", "publish", "memory", "history", "background"]);
 const CLAUDE_CHILD_AGENT_TYPES = new Set(["research", "code", "consult"]);
-const CLAUDE_ENV_PASSTHROUGH = [
-  "PATH",
-  "TMPDIR",
-  "LANG",
-  "LC_ALL",
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "NODE_EXTRA_CA_CERTS",
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "NO_PROXY",
-  "ALL_PROXY",
-  "ANTHROPIC_API_KEY",
-  "ANTHROPIC_AUTH_TOKEN",
-  "ANTHROPIC_BASE_URL",
-  "CLAUDE_CODE_OAUTH_TOKEN",
-] as const;
-
 export function claudeChildEnv(source: NodeJS.ProcessEnv, jail: string): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { HOME: jail, CLAUDE_CONFIG_DIR: join(jail, ".claude") };
-  for (const name of CLAUDE_ENV_PASSTHROUGH) {
-    if (source[name] !== undefined) env[name] = source[name];
-  }
-  return env;
+  return { HOME: jail, CLAUDE_CONFIG_DIR: join(jail, ".claude"), ...claudeProviderEnv(source) };
 }
 
 export function claudeProcessIdentity(uid = process.getuid?.()): { uid: number; gid: number } | undefined {

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { CONFIG_DEFAULTS, type Config } from "../config.ts";
+import { parseProviderBaseUrl } from "../model/provider-endpoints.ts";
 import { NonRetryableTurnError } from "../core/turn-error.ts";
 import { DEFAULT_CODEX_MODEL_ID, modelSupportedByHarness } from "../model/pi-models.ts";
 import { startSignalPoll, type RunSignalStore } from "../runs/run-signal-store.ts";
@@ -205,6 +206,24 @@ export function prepareCodexHome(source: NodeJS.ProcessEnv, jail: string): strin
     writeFileSync(
       join(target, "auth.json"),
       JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: source.OPENAI_API_KEY }),
+      { mode: 0o600 },
+    );
+  }
+  if (source.OPENAI_BASE_URL) {
+    const baseUrl = parseProviderBaseUrl("OPENAI_BASE_URL", source.OPENAI_BASE_URL);
+    writeFileSync(
+      join(target, "config.toml"),
+      [
+        'model_provider = "qm-openai-compatible"',
+        "",
+        "[model_providers.qm-openai-compatible]",
+        'name = "OpenAI-compatible"',
+        `base_url = ${JSON.stringify(baseUrl)}`,
+        'env_key = "OPENAI_API_KEY"',
+        'wire_api = "responses"',
+        "supports_websockets = false",
+        "",
+      ].join("\n"),
       { mode: 0o600 },
     );
   }

--- a/test/claude-harness.test.ts
+++ b/test/claude-harness.test.ts
@@ -85,6 +85,8 @@ test("Claude child environment excludes core credentials and user homes", () => 
         CORE_SIGNING_SECRET: "signing-secret",
         DATABASE_URL: "postgres://secret",
         OPENAI_API_KEY: "openai-secret",
+        AWS_ACCESS_KEY_ID: "unrelated-aws-credential",
+        AWS_SECRET_ACCESS_KEY: "unrelated-aws-secret",
         ANTHROPIC_API_KEY: "anthropic-provider-key",
       },
       "/tmp/claude-jail",
@@ -96,6 +98,41 @@ test("Claude child environment excludes core credentials and user homes", () => 
       ANTHROPIC_API_KEY: "anthropic-provider-key",
     },
   );
+});
+
+test("Claude child environment preserves Bedrock routing and AWS credential-chain settings", () => {
+  const source = {
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    AWS_REGION: "us-west-2",
+    AWS_DEFAULT_REGION: "us-east-1",
+    AWS_ACCESS_KEY_ID: "access",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    AWS_SESSION_TOKEN: "session",
+    AWS_PROFILE: "bedrock",
+    AWS_SHARED_CREDENTIALS_FILE: "/run/aws/credentials",
+    AWS_CONFIG_FILE: "/run/aws/config",
+    AWS_WEB_IDENTITY_TOKEN_FILE: "/run/aws/token",
+    AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/bedrock",
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/abc",
+    AWS_CONTAINER_CREDENTIALS_FULL_URI: "http://169.254.170.2/credentials",
+    AWS_CONTAINER_AUTHORIZATION_TOKEN: "container-token",
+    AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE: "/run/aws/container-token",
+    AWS_EC2_METADATA_SERVICE_ENDPOINT: "http://169.254.169.254",
+    AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE: "IPv4",
+    AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
+    ANTHROPIC_MODEL: "us.anthropic.claude-sonnet",
+    ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-haiku",
+    ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION: "us-west-2",
+    ANTHROPIC_BEDROCK_BASE_URL: "https://bedrock-runtime.example.com",
+    ANTHROPIC_BEDROCK_SERVICE_TIER: "priority",
+  } as NodeJS.ProcessEnv;
+
+  const env = claudeChildEnv(source, "/tmp/claude-jail");
+  assert.deepEqual(env, {
+    HOME: "/tmp/claude-jail",
+    CLAUDE_CONFIG_DIR: "/tmp/claude-jail/.claude",
+    ...source,
+  });
 });
 
 test("Claude drops only a root parent process to the unprivileged nobody identity", () => {

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { createRequire } from "node:module";
@@ -287,6 +287,30 @@ test("Codex child environment excludes core credentials and user homes", () => {
     OPENAI_API_KEY: "openai-needed-by-provider",
     CODEX_ACCESS_TOKEN: "codex-access-token",
   });
+});
+
+test("Codex materializes an OpenAI-compatible provider in its isolated home", (t) => {
+  const jail = mkdtempSync(join(tmpdir(), "qm-codex-provider-test-"));
+  t.after(() => rmSync(jail, { recursive: true, force: true }));
+
+  const home = prepareCodexHome(
+    { OPENAI_API_KEY: "sk-test", OPENAI_BASE_URL: "https://foundry.example.com/openai/v1" },
+    jail,
+  );
+  const configPath = join(home, "config.toml");
+  assert.equal(
+    readFileSync(configPath, "utf8"),
+    `model_provider = "qm-openai-compatible"
+
+[model_providers.qm-openai-compatible]
+name = "OpenAI-compatible"
+base_url = "https://foundry.example.com/openai/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+supports_websockets = false
+`,
+  );
+  assert.equal(statSync(configPath).mode & 0o777, 0o600);
 });
 
 test("Codex materializes API-key auth into its isolated home, and never an ambient login", (t) => {
@@ -614,16 +638,21 @@ const realCodexBinary = (() => {
 })();
 
 test(
-  "the installed Codex app-server accepts the exact thread/start this adapter sends",
+  "the installed Codex app-server accepts the adapter's custom-provider config and thread/start",
   { skip: realCodexBinary && existsSync(realCodexBinary) ? false : "@openai/codex is not resolvable" },
   async (t) => {
     const jail = mkdtempSync(join(tmpdir(), "qm-codex-real-"));
-    prepareCodexHome({ CODEX_HOME: join(jail, "empty-source") }, jail);
+    const providerEnv = {
+      PATH: process.env.PATH,
+      OPENAI_API_KEY: "sk-live-test",
+      OPENAI_BASE_URL: "http://127.0.0.1:9/openai/v1",
+    };
+    prepareCodexHome(providerEnv, jail);
     const requests: string[] = [];
     const server = new CodexAppServer({
       binaryPath: realCodexBinary!,
       cwd: jail,
-      env: codexChildEnv({ PATH: process.env.PATH }, jail),
+      env: codexChildEnv(providerEnv, jail),
       onNotification: () => {},
       onRequest: async (method) => {
         requests.push(method);

--- a/test/provider-endpoints.test.ts
+++ b/test/provider-endpoints.test.ts
@@ -69,6 +69,28 @@ test("loadConfig parses provider base URLs and feeds the child harness envs", ()
   assert.equal(config.codexProcessEnv.OPENAI_BASE_URL, "https://o.example.com/v1");
 });
 
+test("loadConfig feeds Bedrock routing and AWS credential-chain settings to Claude", () => {
+  const config = loadConfig({
+    ...BASE_ENV,
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    AWS_REGION: "us-west-2",
+    AWS_ACCESS_KEY_ID: "access",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    AWS_SESSION_TOKEN: "session",
+    ANTHROPIC_MODEL: "us.anthropic.claude-sonnet",
+    ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-haiku",
+  });
+  assert.deepEqual(config.claudeProcessEnv, {
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    AWS_REGION: "us-west-2",
+    AWS_ACCESS_KEY_ID: "access",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    AWS_SESSION_TOKEN: "session",
+    ANTHROPIC_MODEL: "us.anthropic.claude-sonnet",
+    ANTHROPIC_SMALL_FAST_MODEL: "us.anthropic.claude-haiku",
+  });
+});
+
 test("loadConfig rejects an invalid provider base URL", () => {
   assert.throws(() => loadConfig({ ...BASE_ENV, OPENAI_BASE_URL: "nope" } as NodeJS.ProcessEnv));
 });


### PR DESCRIPTION
Adds Responses-compatible Codex endpoint configuration and Bedrock credential-chain routing for Claude, with endpoint-aware doctor checks.

- verification: focused harness/provider/doctor tests
- verification: typecheck, lint, Oxlint, format
- verification: real Codex app-server and live Azure Responses turn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789343695&installation_model_id=19911&pr_number=538&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F538&signature=cbfe582bec3d3b548d1c004736c9ec66e5ef1acdb91ab32a55821216b5f736b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->