### PR TITLE
dev-instance requires ANTHROPIC_API_KEY even when pi is running on another provider

### DIFF
--- a/adrs/dev-instance-provider-keys.md
+++ b/adrs/dev-instance-provider-keys.md
@@ -1,0 +1,10 @@
+# Re: dev-instance requires ANTHROPIC_API_KEY even when pi is running on another provider
+
+Tried booting a dev instance with only an OpenRouter key and it refused with ANTHROPIC_API_KEY is required: dev instances exercise real LLM calls by default.
+
+But pi handles OpenRouter ok — config.ts reads OPENROUTER_API_KEY and OPENAI_API_KEY, and modelSupportedByHarness lets pi use any registry model. It's scripts/dev/lib/envctx.ts that kind of only selects pi when an Anthropic key is given, so the dev script ends up being more strict than the runtime it configures.
+
+
+Small related thing: PI_MODEL in the worktree .env doesn't carry through to the dev instance env, which impacts when the only key is non-Anthropic, because the default model isn't workable.
+
+Happy to send the patch if needed.


### PR DESCRIPTION
Adding a note to `adrs/` per CONTRIBUTING.md — the detail is in the file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789367113&installation_model_id=19911&pr_number=541&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F541&signature=1dceafc02d200c9ca5b8f27cd9a1fd03219a2a335f31375030e6569ff2977c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->