### PR TITLE
Propose external sandbox providers

### DIFF
--- a/adrs/external-sandbox-providers.md
+++ b/adrs/external-sandbox-providers.md
@@ -1,0 +1,9 @@
+I'd like to use OpenSandbox as QM's sandbox backend. QM already has a `Sandbox` interface, but adding another implementation currently means changing `src/wiring.ts`.
+
+Could a deployment pass a custom factory that returns a `Sandbox`? That would let me keep the OpenSandbox integration in the deployment instead of modifying QM core.
+
+The same registration or factory extension-point pattern could also let deployments provide:
+
+- a new `Sandbox` implementation
+- a new `Harness` implementation
+- a new `MemoryService` implementation


### PR DESCRIPTION
I would like deployments to provide custom Sandbox factories without modifying QM core.

The proposal also suggests applying the same extension-point pattern to Harness and MemoryService implementations.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789377573&installation_model_id=19911&pr_number=543&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F543&signature=128ac2ac8ed183bd3ff7913ca58afb11d45c776a1e277300697d60a3a6c3c504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->