### PR TITLE
Gate env-delivered org credentials by service-cred grants

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -893,12 +893,6 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       });
       if (badGrantee !== undefined)
         return { error: `grantee must be this org or a valid personal:/team: scope (got ${badGrantee})` };
-      if (delivery === "env" && desired?.some((g) => g !== scope)) {
-        return {
-          error:
-            "env-delivery credentials are injected into every all-internal conversation — person/team grants don't gate them; share org-wide",
-        };
-      }
       const injection =
         b.injection && typeof b.injection === "object"
           ? ({

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -29,7 +29,11 @@ import { createBackgroundBroker } from "../connectors/background-exec-broker.ts"
 import { createMonitorBroker, readBackgroundOutputTail } from "../monitors/monitor-broker.ts";
 import { isPollSurface, isSilentPollReply } from "../triggers/run-trigger.ts";
 import { envKey } from "../credentials/connector-token.ts";
-import { renderKeychainManifest, type MaterializedEnvCred } from "../credentials/keychain.ts";
+import {
+  renderKeychainManifest,
+  type MaterializedEnvCred,
+  type PublicServiceCredential,
+} from "../credentials/keychain.ts";
 import { captureDeviceFlowLogins, deviceFlowCredOwner } from "../credentials/device-flow-persist.ts";
 import type { DeviceFlowCutoverMode } from "../credentials/device-flow-cutover.ts";
 import { type ResidentAuthConnector, RESIDENT_AUTH_CONNECTORS, mergeConnectors } from "../credentials/resident-auth.ts";
@@ -1037,28 +1041,37 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       const authoredDetection =
         input.origin.kind === "ambient" && input.origin.live === true && conversation.kind !== "dm";
       const liveAuthorTurn = (humanTurn || authoredDetection) && allInternal;
+      // Service credentials: one read of the org's credential list and one grant scan feed both
+      // the env-delivery gate (below) and the broker token mint (further down). Same grants gate both.
+      let serviceCredRecords: PublicServiceCredential[] = [];
+      let grantedCredSlugs = new Set<string>();
+      if (!strictReadOnly && deps.serviceCreds) {
+        serviceCredRecords = await deps.serviceCreds.listServiceCredentials(resolution.orgScopeId);
+        if (serviceCredRecords.length > 0) {
+          grantedCredSlugs = new Set(
+            (
+              await deps.acl.grantsOfKind(
+                "service-cred",
+                conversation.audience,
+                scopeId,
+                resolution.orgScopeId,
+                principalEntitledToScope,
+              )
+            ).map((g) => parseRef(g.ref).id),
+          );
+        }
+      }
       if (!strictReadOnly && allInternal && deps.serviceCreds) {
         const orgScope = toScopeId("org", orgId());
         // Env delivery is gated by the same service-cred grants as the broker: the env var rides
         // only when every internal participant in this conversation is entitled to the credential.
-        const envGrantedSlugs = new Set(
-          (
-            await deps.acl.grantsOfKind(
-              "service-cred",
-              conversation.audience,
-              scopeId,
-              resolution.orgScopeId,
-              principalEntitledToScope,
-            )
-          ).map((g) => parseRef(g.ref).id),
-        );
-        for (const cred of await deps.serviceCreds.listServiceCredentials(orgScope)) {
+        for (const cred of serviceCredRecords) {
           if (
             cred.delivery !== "env" ||
             !cred.envKey ||
             !cred.enabled ||
             !cred.hasSecret ||
-            !envGrantedSlugs.has(cred.slug) ||
+            !grantedCredSlugs.has(cred.slug) ||
             cred.envKey in connectorEnv
           )
             continue;
@@ -1142,19 +1155,12 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           deps.capabilitySecret ?? deps.signingSecret,
         );
         if (deps.serviceCreds) {
-          const records = await deps.serviceCreds.listServiceCredentials(resolution.orgScopeId);
+          const records = serviceCredRecords;
           const enabled = new Set(
             records.filter((r) => r.enabled && r.hasSecret && r.delivery !== "env").map((r) => r.slug),
           );
           if (enabled.size > 0) {
-            const grants = await deps.acl.grantsOfKind(
-              "service-cred",
-              conversation.audience,
-              scopeId,
-              resolution.orgScopeId,
-              principalEntitledToScope,
-            );
-            const slugs = [...new Set(grants.map((g) => parseRef(g.ref).id))].filter((s) => enabled.has(s));
+            const slugs = [...grantedCredSlugs].filter((s) => enabled.has(s));
             if (slugs.length > 0) {
               connectorEnv.AGENT_CREDENTIAL_TOKEN = await mintCapabilityToken(
                 {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1039,12 +1039,26 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       const liveAuthorTurn = (humanTurn || authoredDetection) && allInternal;
       if (!strictReadOnly && allInternal && deps.serviceCreds) {
         const orgScope = toScopeId("org", orgId());
+        // Env delivery is gated by the same service-cred grants as the broker: the env var rides
+        // only when every internal participant in this conversation is entitled to the credential.
+        const envGrantedSlugs = new Set(
+          (
+            await deps.acl.grantsOfKind(
+              "service-cred",
+              conversation.audience,
+              scopeId,
+              resolution.orgScopeId,
+              principalEntitledToScope,
+            )
+          ).map((g) => parseRef(g.ref).id),
+        );
         for (const cred of await deps.serviceCreds.listServiceCredentials(orgScope)) {
           if (
             cred.delivery !== "env" ||
             !cred.envKey ||
             !cred.enabled ||
             !cred.hasSecret ||
+            !envGrantedSlugs.has(cred.slug) ||
             cred.envKey in connectorEnv
           )
             continue;

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -15,6 +15,9 @@ import { TURN_FILES_DIR, turnFileId } from "../src/core/attachments.ts";
 import { contextSummaryPayload } from "../src/harness/context-compaction.ts";
 import { egressDecision } from "../src/resolution/egress-policy.ts";
 import { hashId } from "../src/util/crypto.ts";
+import { encodeRef, serviceCredRef } from "../src/acl/resource-ref.ts";
+import type { AclStore } from "../src/acl/acl-store.ts";
+import type { ScopeId } from "../src/types.ts";
 import type { SecurityScreener } from "../src/security/security-screener.ts";
 
 function freshApp(overrides: Partial<Config> = {}, securityScreener?: SecurityScreener) {
@@ -62,6 +65,16 @@ function channel(text: string, extra: Partial<TurnRequest> = {}): TurnRequest {
     gatewayContext: { reactionGuidance: "react with a Slack emoji short-name like :pray:" },
     ...extra,
   };
+}
+
+async function grantCred(acl: AclStore, org: ScopeId, slug: string, grantee: ScopeId = org): Promise<void> {
+  await acl.grant({
+    ownerScopeId: org,
+    ref: encodeRef(serviceCredRef(slug)),
+    granteeScopeId: grantee,
+    permission: "read",
+    grantedBy: "admin@default-org",
+  });
 }
 
 test("internal DM turn runs end-to-end and records the session", async () => {
@@ -441,7 +454,7 @@ test("org env-delivery credentials ride provision env under their envKey — rea
     signingSecret: "test-secret",
     apiBaseUrl: "https://core.example.com",
   });
-  const { app, sandbox, serviceCreds } = buildApp(config);
+  const { app, sandbox, serviceCreds, acl } = buildApp(config);
   const org = scopeId("org", "default-org");
   await serviceCreds.setServiceCredential(org, {
     slug: "browse-steel",
@@ -451,6 +464,8 @@ test("org env-delivery credentials ride provision env under their envKey — rea
     secret: "steel-org-key",
     host: "",
   });
+  await grantCred(acl, org, "browse-steel");
+  await grantCred(acl, org, "browse-model-key");
   await serviceCreds.setServiceCredential(org, {
     slug: "browse-model-key",
     name: "Browse model key",
@@ -490,8 +505,10 @@ test("a disabled or broker-delivery credential never rides provision env", async
     signingSecret: "test-secret",
     apiBaseUrl: "https://core.example.com",
   });
-  const { app, sandbox, serviceCreds } = buildApp(config);
+  const { app, sandbox, serviceCreds, acl } = buildApp(config);
   const org = scopeId("org", "default-org");
+  await grantCred(acl, org, "x-firehose");
+  await grantCred(acl, org, "browse-steel");
   await serviceCreds.setServiceCredential(org, {
     slug: "x-firehose",
     name: "X",
@@ -530,7 +547,7 @@ test("a credential flipped away from env between the metadata read and the secre
     signingSecret: "test-secret",
     apiBaseUrl: "https://core.example.com",
   });
-  const { app, sandbox, serviceCreds } = buildApp(config);
+  const { app, sandbox, serviceCreds, acl } = buildApp(config);
   const org = scopeId("org", "default-org");
   await serviceCreds.setServiceCredential(org, {
     slug: "browse-steel",
@@ -540,6 +557,7 @@ test("a credential flipped away from env between the metadata read and the secre
     secret: "steel-org-key",
     host: "",
   });
+  await grantCred(acl, org, "browse-steel");
   const realGet = serviceCreds.getServiceCredentialSecret.bind(serviceCreds);
   serviceCreds.getServiceCredentialSecret = async (scope, slug) => {
     const rec = await realGet(scope, slug);
@@ -563,7 +581,7 @@ test("env-delivery injection is all-internal only, and an existing env key (keyc
     signingSecret: "test-secret",
     apiBaseUrl: "https://core.example.com",
   });
-  const { app, sandbox, serviceCreds } = buildApp(config);
+  const { app, sandbox, serviceCreds, acl } = buildApp(config);
   const org = scopeId("org", "default-org");
   await serviceCreds.setServiceCredential(org, {
     slug: "browse-steel",
@@ -573,6 +591,7 @@ test("env-delivery injection is all-internal only, and an existing env key (keyc
     secret: "steel-org-key",
     host: "",
   });
+  await grantCred(acl, org, "browse-steel");
   const captures: ProvisionOptions[] = [];
   const realProvision = sandbox.provision.bind(sandbox);
   sandbox.provision = (layers, opts) => {
@@ -593,6 +612,48 @@ test("env-delivery injection is all-internal only, and an existing env key (keyc
   );
   assert.equal(externalRoom.status, "ok");
   assert.equal(captures.at(-1)?.env?.STEEL_API_KEY, undefined, "a room with externals gets no org env credentials");
+});
+
+test("env-delivery credentials are gated by service-cred grants — no grant, no env var; a person grant admits only that person", async () => {
+  const config = testConfig({
+    dataDir: mkdtempSync(join(tmpdir(), "ap-")),
+    signingSecret: "test-secret",
+    apiBaseUrl: "https://core.example.com",
+  });
+  const { app, sandbox, serviceCreds, acl } = buildApp(config);
+  const org = scopeId("org", "default-org");
+  await serviceCreds.setServiceCredential(org, {
+    slug: "browse-steel",
+    name: "Steel",
+    delivery: "env",
+    envKey: "STEEL_API_KEY",
+    secret: "steel-org-key",
+    host: "",
+  });
+  const captures: ProvisionOptions[] = [];
+  const realProvision = sandbox.provision.bind(sandbox);
+  sandbox.provision = (layers, opts) => {
+    if (opts) captures.push(opts);
+    return realProvision(layers, opts);
+  };
+
+  let res = await app.turn(dm("!run echo keys", { conversation: { kind: "dm", threadRef: "dm:U1:gate1" } }));
+  assert.equal(res.status, "ok");
+  assert.equal(captures.at(-1)?.env?.STEEL_API_KEY, undefined, "ungranted env credential stays home");
+
+  await grantCred(acl, org, "browse-steel", scopeId("personal", "somebody-else"));
+  res = await app.turn(dm("!run echo keys", { conversation: { kind: "dm", threadRef: "dm:U1:gate2" } }));
+  assert.equal(res.status, "ok");
+  assert.equal(captures.at(-1)?.env?.STEEL_API_KEY, undefined, "a grant to someone else does not admit this actor");
+
+  await grantCred(acl, org, "browse-steel", scopeId("personal", "U1"));
+  res = await app.turn(dm("!run echo keys", { conversation: { kind: "dm", threadRef: "dm:U1:gate3" } }));
+  assert.equal(res.status, "ok");
+  assert.equal(
+    captures.at(-1)?.env?.STEEL_API_KEY,
+    "steel-org-key",
+    "a personal grant to the actor admits the env var",
+  );
 });
 
 test("admin-configured browse step limit rides provision env (BROWSE_LAB_MAX_STEPS)", async () => {

--- a/test/service-credential-route.test.ts
+++ b/test/service-credential-route.test.ts
@@ -210,7 +210,7 @@ test("env-delivery credential: envKey validated, host refused, duplicates refuse
   }
 });
 
-test("env-delivery refuses person/team grantees — grants don't gate env injection, so the ACL must not pretend otherwise", async () => {
+test("env-delivery accepts person/team grantees — grants now gate env injection like broker calls", async () => {
   const srv = start();
   try {
     const narrowed = await putCred(srv.base, {
@@ -221,18 +221,17 @@ test("env-delivery refuses person/team grantees — grants don't gate env inject
       secret: "s1",
       grantees: ["personal:alice@default-org"],
     });
-    assert.equal(narrowed.status, 400);
-    assert.match(await narrowed.text(), /don't gate them/);
+    assert.equal(narrowed.status, 200, "a person grant on an env credential is allowed");
 
     const orgWide = await putCred(srv.base, {
-      slug: "browse-steel",
-      name: "Steel",
+      slug: "browse-steel-wide",
+      name: "Steel wide",
       delivery: "env",
-      envKey: "STEEL_API_KEY",
+      envKey: "STEEL_WIDE_API_KEY",
       secret: "s1",
       grantees: ["org:default-org"],
     });
-    assert.equal(orgWide.status, 200, "the org grant itself is fine");
+    assert.equal(orgWide.status, 200, "the org grant is fine too");
   } finally {
     await srv.close();
   }


### PR DESCRIPTION
Port of an internal change (qm-yc #1990, merged 2026-08-14).

Env-delivery org credentials previously injected into every all-internal conversation with no access gate — the only remaining gap after broker credentials were already grant-gated.

**Change**
- Orchestrator: env injection now checks the same `service-cred` ACL grants as the broker token (`grantsOfKind` + `principalEntitledToScope`; all internal participants must be entitled).
- Admin route: person/team grantees are accepted for env-delivery credentials (the 400 rejection is removed).
- Perf: duplicate service-cred lookups folded into one shared read per turn.
- Tests: no-grant → no env var; someone-else grant → no env var; personal grant → env var rides.

**Back-compat:** credentials saved through the admin route always carry a default org grant, so existing env creds keep working unchanged.

Verified on this branch: tsc clean, prettier clean, service-credential-route suite 30/30, orchestrator credential/env tests 11/11.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789415880&installation_model_id=19911&pr_number=548&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F548&signature=bebefc22ce14f3186778edbfffd99f0a75e5a9bbf77eae04a251c51313685281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->