### PR TITLE
Relax the docker target for SANDBOX_BACKEND=local (+ optional hardening, + private-network + daemon wiring)

### DIFF
--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -299,7 +299,7 @@ export function dockerServiceEnv(config: QmConfig, service: ServiceName): Record
       out,
       brokerWiring(service, {
         publicUrl: config.publicUrl,
-        authBaseUrl: "http://auth:8080",
+        authBaseUrl: `http://${dockerPrefix(config)}-auth.internal:8080`,
         ...(config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN
           ? { allowedEmailDomain: config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN }
           : {}),
@@ -406,6 +406,8 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     ctx.network,
     "--network-alias",
     service,
+    "--network-alias",
+    `${cname(ctx, service)}.internal`,
     "--restart",
     "no",
   ];

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -31,7 +31,7 @@ import {
   type LogOpts,
   type ServiceName,
 } from "../services.ts";
-import { dockerBasePort, sandboxCoreEnv, securityScreenEnv, type QmConfig } from "../config.ts";
+import { dockerBasePort, localSandboxActive, sandboxCoreEnv, securityScreenEnv, type QmConfig } from "../config.ts";
 import { discoverPlugins, type ResolvedPlugin } from "../plugins.ts";
 import { computedSecrets, runtimeSecretNames, secretsForService } from "../secrets.ts";
 import { readDeploymentState, withDeploymentLock, writeDeploymentState, type DeploymentState } from "../state.ts";
@@ -65,6 +65,14 @@ interface DockerCtx {
 const dockerPrefix = (config: QmConfig): string => `qm-${safe(config.orgId)}`;
 const cname = (ctx: DockerCtx, name: string): string => `${ctx.prefix}-${name}`;
 const pgVolume = (ctx: DockerCtx): string => `${ctx.prefix}-pgdata`;
+
+function hostDockerSocketGid(): string | undefined {
+  try {
+    return capture("stat", ["-c", "%g", "/var/run/docker.sock"]).trim();
+  } catch {
+    return undefined;
+  }
+}
 
 function requireDocker(): void {
   if (!which("docker")) die("docker not found on PATH (the docker target needs a running Docker daemon).");
@@ -290,6 +298,9 @@ export function dockerServiceEnv(config: QmConfig, service: ServiceName): Record
     CORE_API_URL: "http://core:8080",
     ...orgEnv(service, config.orgId, config.publicUrl, config.services.includes("portal"), brandEnvOf(config)),
   };
+  if (service === "core" && localSandboxActive(config)) {
+    out.DOCKER_HOST = "unix:///var/run/docker.sock";
+  }
   if (service === "portal") {
     if (config.services.includes("web-ui")) out.WEB_UI_UPSTREAM = "http://web-ui:8080";
     if (config.services.includes("admin")) out.ADMIN_UPSTREAM = "http://admin:8080";
@@ -416,6 +427,11 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     args.push("-v", `${ctx.prefix}-coredata:/data`);
     for (const m of layerMounts(ctx)) args.push("-v", m);
     for (const m of skillMounts(ctx)) args.push("-v", m);
+    if (localSandboxActive(ctx.config)) {
+      args.push("-v", "/var/run/docker.sock:/var/run/docker.sock");
+      const gid = hostDockerSocketGid();
+      if (gid) args.push("--group-add", gid);
+    }
   }
   if (def.docker.hostPortOffset !== undefined) {
     args.push("-p", `${baseHostPort(ctx) + def.docker.hostPortOffset}:${def.docker.internalPort}`);

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -300,6 +300,7 @@ export function dockerServiceEnv(config: QmConfig, service: ServiceName): Record
   };
   if (service === "core" && localSandboxActive(config)) {
     out.DOCKER_HOST = "unix:///var/run/docker.sock";
+    out.QM_CORE_CONTAINER = `${dockerPrefix(config)}-core`;
   }
   if (service === "portal") {
     if (config.services.includes("web-ui")) out.WEB_UI_UPSTREAM = "http://web-ui:8080";
@@ -339,6 +340,10 @@ function serviceEnv(ctx: DockerCtx, service: ServiceName): Record<string, string
     const layerSubs = existingLayerSubdirs(ctx);
     if (layerSubs.length) out.DEPLOYMENT_LAYER = "/layer";
     Object.assign(out, ctx.sandboxEnv);
+    if (localSandboxActive(config)) {
+      out.DOCKER_HOST = "unix:///var/run/docker.sock";
+      out.QM_CORE_CONTAINER = `${ctx.prefix}-core`;
+    }
   } else {
     Object.assign(out, dockerServiceEnv(config, service));
   }

--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import {
   MODEL_PROVIDER_KEYS,
+  localSandboxActive,
   mockHarnessWarning,
   validatePortalTrust,
   type ModelProvider,
@@ -143,7 +144,9 @@ export async function doctorCommon(
       );
     step("required local secret values: ok");
   }
-  if (config.target === "aws") {
+  if (localSandboxActive(config)) {
+    step("local Docker sandbox: configured (SANDBOX_BACKEND=local)");
+  } else if (config.target === "aws") {
     step("AWS Lambda MicroVM sandbox: configured");
   } else if (config.sandbox?.app) {
     requireFlyAuth();

--- a/cli/src/commands/check.ts
+++ b/cli/src/commands/check.ts
@@ -5,7 +5,7 @@ import { readEnvFile } from "../util.ts";
 import { CliError, errMessage, header, note, ok, step, warn } from "../log.ts";
 import { validateSandboxLayer, type SandboxValidation } from "../sandbox-layer.ts";
 import { discoverPlugins, type ResolvedPlugin } from "../plugins.ts";
-import { mockHarnessWarning, sandboxPinPending, type QmConfig } from "../config.ts";
+import { localSandboxActive, mockHarnessWarning, sandboxPinPending, type QmConfig } from "../config.ts";
 import { computedSecrets, runtimeSecretNames, type ComputedSecret } from "../secrets.ts";
 import { isVirtualService, runnableServices } from "../services.ts";
 import { serviceEnvironment } from "../backends/aws.ts";
@@ -30,8 +30,8 @@ export function runChecks(
   const configError = (message: string, clause = "config.v1"): void => void configErrors.push({ clause, message });
   const provider = hostingProvider(config.target);
   configErrors.push(...provider.validateConfig(config, plugins));
-  if (provider.requiresSandboxApp && !config.sandbox?.app?.trim()) {
-    configError("contract sandbox.app: a Fly agent-computer app is required for docker and fly targets");
+  if (provider.requiresSandboxApp && !localSandboxActive(config) && !config.sandbox?.app?.trim()) {
+    configError("contract sandbox.app: a Fly agent-computer app is required for docker and fly targets (or set env.core.SANDBOX_BACKEND=\"local\" with target docker to run agent computers on the host without a Fly app)");
   }
   for (const skill of config.skills) {
     const path = resolve(configDir, skill);

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -205,10 +205,14 @@ export const isDigestPinned = (ref: string): boolean => /@sha256:[0-9a-f]{64}$/.
 
 const SANDBOX_PIN_PENDING = `"sandbox.app" is set but no sandbox layer image is pinned; run \`qm sandbox publish\` to build and record the digest-pinned "sandbox.image" agents boot from`;
 
+export const localSandboxActive = (config: QmConfig): boolean =>
+  config.target === "docker" && config.env.core?.SANDBOX_BACKEND === "local";
+
 export const sandboxPinPending = (config: QmConfig): boolean =>
-  config.target !== "aws" && Boolean(config.sandbox?.app && !config.sandbox.image);
+  config.target !== "aws" && !localSandboxActive(config) && Boolean(config.sandbox?.app && !config.sandbox.image);
 
 export function sandboxImagePinErrors(config: QmConfig): Array<{ clause: string; message: string }> {
+  if (localSandboxActive(config)) return [];
   const sb = config.sandbox;
   if (!sb?.app || !sb.image || isDigestPinned(sb.image)) return [];
   return [
@@ -226,7 +230,7 @@ export function sandboxCoreEnv(
   const env: Record<string, string> = {};
   const missingSecrets: string[] = [];
   const sb = config.sandbox;
-  if (!sb) return { env, missingSecrets };
+  if (!sb || localSandboxActive(config)) return { env, missingSecrets };
   if (sb.app) {
     if (!sb.image) throw new CliError(SANDBOX_PIN_PENDING, { clause: "config.v1" });
     const violation = sandboxImagePinErrors(config)[0];

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -133,6 +133,20 @@ test("docker and AWS wire the broker with parity", () => {
   assert.equal(serviceEnvironment(aws, "auth").PORT, "8080");
 });
 
+test("docker + SANDBOX_BACKEND=local wires DOCKER_HOST into core so the local sandbox can reach the host daemon", () => {
+  const local = configWith(configText({
+    env: '{ "core": { "HARNESS": "pi", "SANDBOX_BACKEND": "local" }, "auth": { "AUTH_EMAIL_TRANSPORT": "resend", "AUTH_ALLOWED_EMAIL_DOMAIN": "example.com" } }',
+  }));
+  const sprites = configWith(configText());
+  assert.equal(
+    dockerServiceEnv(local, "core").DOCKER_HOST,
+    "unix:///var/run/docker.sock",
+    "core needs the host docker socket to spawn sandbox containers",
+  );
+  assert.equal(dockerServiceEnv(sprites, "core").DOCKER_HOST, undefined, "sprites runs sandboxes on Fly, not the host");
+  assert.equal(dockerServiceEnv(local, "portal").DOCKER_HOST, undefined, "only core talks to the daemon");
+});
+
 test("the broker's generated secrets reach both sides under the right names", () => {
   const config = brokerConfig();
   const secrets = computedSecrets(config);

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -143,8 +143,15 @@ test("docker + SANDBOX_BACKEND=local wires DOCKER_HOST into core so the local sa
     "unix:///var/run/docker.sock",
     "core needs the host docker socket to spawn sandbox containers",
   );
+  assert.equal(
+    dockerServiceEnv(local, "core").QM_CORE_CONTAINER,
+    "qm-acme-core",
+    "core must know its own container name to join each sandbox's private network",
+  );
   assert.equal(dockerServiceEnv(sprites, "core").DOCKER_HOST, undefined, "sprites runs sandboxes on Fly, not the host");
+  assert.equal(dockerServiceEnv(sprites, "core").QM_CORE_CONTAINER, undefined);
   assert.equal(dockerServiceEnv(local, "portal").DOCKER_HOST, undefined, "only core talks to the daemon");
+  assert.equal(dockerServiceEnv(local, "portal").QM_CORE_CONTAINER, undefined);
 });
 
 test("the broker's generated secrets reach both sides under the right names", () => {

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -96,8 +96,8 @@ test("a configured botName brands the docker service env for core and auth", () 
 test("docker and AWS wire the broker with parity", () => {
   const docker = configWith(configText());
   const dockerPortal = dockerServiceEnv(docker, "portal");
-  assert.equal(dockerPortal.AUTH_BROKER_UPSTREAM, "http://auth:8080");
-  assert.equal(dockerPortal.OIDC_TOKEN_ENDPOINT, "http://auth:8080/token");
+  assert.equal(dockerPortal.AUTH_BROKER_UPSTREAM, "http://qm-acme-auth.internal:8080");
+  assert.equal(dockerPortal.OIDC_TOKEN_ENDPOINT, "http://qm-acme-auth.internal:8080/token");
   assert.equal(dockerPortal.OIDC_ISSUER, "https://agent.example.com/idp");
   assert.equal(dockerServiceEnv(docker, "auth").AUTH_REDIRECT_URI, "https://agent.example.com/auth/callback");
   assert.equal(dockerServiceEnv(docker, "web-ui").AUTH_BROKER_UPSTREAM, undefined);

--- a/cli/test/check.test.ts
+++ b/cli/test/check.test.ts
@@ -178,6 +178,51 @@ test("a bare deployment (no sandbox/, no plugins) passes", () => {
   }
 });
 
+test("docker target without sandbox.app fails the Fly agent-computer requirement", () => {
+  const d = deployment(() => {}, { sandbox: undefined });
+  try {
+    assert.throws(() => check(d), /Fly agent-computer app is required/);
+  } finally {
+    rmSync(d.dir, { recursive: true, force: true });
+  }
+});
+
+test("docker target with SANDBOX_BACKEND=local passes without sandbox.app", () => {
+  const d = deployment(
+    () => {},
+    { sandbox: undefined, env: { core: { SANDBOX_BACKEND: "local" } } },
+  );
+  try {
+    assert.doesNotThrow(() => check(d));
+  } finally {
+    rmSync(d.dir, { recursive: true, force: true });
+  }
+});
+
+test("fly target with SANDBOX_BACKEND=local still requires sandbox.app (local is docker-only)", () => {
+  const d = deployment(
+    () => {},
+    { target: "fly", sandbox: undefined, env: { core: { SANDBOX_BACKEND: "local" } } },
+  );
+  try {
+    assert.throws(() => check(d), /Fly agent-computer app is required/);
+  } finally {
+    rmSync(d.dir, { recursive: true, force: true });
+  }
+});
+
+test("docker target with SANDBOX_BACKEND=local passes even with a scaffolded sandbox.app", () => {
+  const d = deployment(
+    () => {},
+    { sandbox: { app: "acme-sandboxes" }, env: { core: { SANDBOX_BACKEND: "local" } } },
+  );
+  try {
+    assert.doesNotThrow(() => check(d), "a scaffolded sandbox.app must not block docker+local");
+  } finally {
+    rmSync(d.dir, { recursive: true, force: true });
+  }
+});
+
 test("AWS requires exact ECS/ECR coordinates for discovered plugins", () => {
   const plugin = { name: "linear", image: "ghcr.io/acme/linear:1" };
   const aws = {

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -753,6 +753,15 @@ test("a sandbox.app with no pinned image fails closed instead of fabricating a m
   });
 });
 
+test("docker + SANDBOX_BACKEND=local ignores a scaffolded sandbox.app (no throw, no Fly env, no pin warning)", () => {
+  withConfig({ sandbox: { app: "acme-sandboxes" }, env: { core: { SANDBOX_BACKEND: "local" } } }, ({ path }) => {
+    const { config } = loadConfigAt(path);
+    assert.equal(sandboxPinPending(config), false, "no pin-pending warning for docker+local even with sandbox.app");
+    assert.deepEqual(sandboxImagePinErrors(config), []);
+    assert.deepEqual(sandboxCoreEnv(config), { env: {}, missingSecrets: [] }, "the local backend ignores the sandbox block");
+  });
+});
+
 test("a tag-pinned sandbox.image is refused: staleness compares image references", () => {
   withConfig({ sandbox: { app: "acme-sandboxes", image: "registry.fly.io/shared-sandboxes:latest" } }, ({ path }) => {
     const { config } = loadConfigAt(path);

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -490,6 +490,44 @@ test("doctor treats a missing sandbox block as info (no Fly checks), not a failu
   }
 });
 
+test("doctor reports the local Docker sandbox as configured (SANDBOX_BACKEND=local)", async () => {
+  const localConfig: QmConfig = {
+    ...config,
+    env: { core: { HARNESS: "pi", SANDBOX_BACKEND: "local" } },
+  };
+  const priorFly = process.env.FLY_BIN;
+  process.env.FLY_BIN = "/nonexistent/fly-should-never-run";
+  const log = console.log;
+  const lines: string[] = [];
+  console.log = (...parts: unknown[]): void => void lines.push(parts.join(" "));
+  try {
+    await doctorCommon(
+      localConfig,
+      new Map([
+        ["CAPABILITY_SECRET", "capability-value"],
+        ["CONNECTOR_SECRET_KEY", "connector-value".repeat(3)],
+        ["CORE_SIGNING_SECRET", "source-value".repeat(4)],
+        ["PORTAL_IDENTITY_SECRET", "identity-value"],
+        ["PUBLIC_API_URL", "http://host.docker.internal:8080"],
+        ["SKILL_SIGNING_SECRET", "skill-value".repeat(4)],
+      ]),
+      { requiredSecretValues: true },
+    );
+    assert.ok(
+      lines.some((line) => line.includes("local Docker sandbox: configured")),
+      `printed: ${lines.join(" | ")}`,
+    );
+    assert.ok(
+      !lines.some((line) => line.includes("sandbox: not configured")),
+      "local must not be reported as unconfigured",
+    );
+  } finally {
+    console.log = log;
+    if (priorFly === undefined) delete process.env.FLY_BIN;
+    else process.env.FLY_BIN = priorFly;
+  }
+});
+
 test("an explicitly named --env-file that does not exist is a bad-path error, not 'secrets missing'", () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-doctor-envfile-"));
   try {

--- a/deploy/core/Dockerfile
+++ b/deploy/core/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
-RUN apk add --no-cache ca-certificates curl git git-daemon
+RUN apk add --no-cache ca-certificates curl git git-daemon docker-cli
 
 WORKDIR /app
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -251,6 +251,7 @@ interface LocalSandboxEnv {
   memoryMb?: number;
   diskGb?: number;
   hostGateway?: boolean;
+  coreContainer?: string;
   defaultTimeoutSec?: number;
 }
 
@@ -270,6 +271,7 @@ function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
     ...(boolEnvStrict("LOCAL_SANDBOX_HOST_GATEWAY", env.LOCAL_SANDBOX_HOST_GATEWAY) !== undefined
       ? { hostGateway: boolEnvStrict("LOCAL_SANDBOX_HOST_GATEWAY", env.LOCAL_SANDBOX_HOST_GATEWAY) }
       : {}),
+    ...(env.QM_CORE_CONTAINER ? { coreContainer: env.QM_CORE_CONTAINER } : {}),
     ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
       ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }
       : {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,6 +249,8 @@ interface LocalSandboxEnv {
   dockerBin?: string;
   cpus?: number;
   memoryMb?: number;
+  diskGb?: number;
+  hostGateway?: boolean;
   defaultTimeoutSec?: number;
 }
 
@@ -261,6 +263,12 @@ function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
       : {}),
     ...(numEnvStrict("LOCAL_SANDBOX_MEMORY_MB", env.LOCAL_SANDBOX_MEMORY_MB) !== undefined
       ? { memoryMb: numEnvStrict("LOCAL_SANDBOX_MEMORY_MB", env.LOCAL_SANDBOX_MEMORY_MB) }
+      : {}),
+    ...(numEnvStrict("LOCAL_SANDBOX_DISK_GB", env.LOCAL_SANDBOX_DISK_GB) !== undefined
+      ? { diskGb: numEnvStrict("LOCAL_SANDBOX_DISK_GB", env.LOCAL_SANDBOX_DISK_GB) }
+      : {}),
+    ...(boolEnvStrict("LOCAL_SANDBOX_HOST_GATEWAY", env.LOCAL_SANDBOX_HOST_GATEWAY) !== undefined
+      ? { hostGateway: boolEnvStrict("LOCAL_SANDBOX_HOST_GATEWAY", env.LOCAL_SANDBOX_HOST_GATEWAY) }
       : {}),
     ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
       ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -45,6 +45,7 @@ export interface LocalSandboxOptions {
   memoryMb?: number;
   diskGb?: number;
   hostGateway?: boolean;
+  coreContainer?: string;
   defaultTimeoutSec?: number;
   homeDir?: string;
   repoRoot?: string;
@@ -167,9 +168,11 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     timeoutMs?: number,
     signal?: AbortSignal,
   ): Promise<{ status: number; text: string }> {
-    const port = await resolvePort(name);
+    const base = opts.coreContainer
+      ? `http://${name}:${AGENT_PORT}${path}`
+      : `http://127.0.0.1:${await resolvePort(name)}${path}`;
     const signals = [AbortSignal.timeout(timeoutMs ?? 30_000), ...(signal ? [signal] : [])];
-    const res = await fetchImpl(`http://127.0.0.1:${port}${path}`, {
+    const res = await fetchImpl(base, {
       method: body === undefined ? "GET" : "POST",
       ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
       signal: AbortSignal.any(signals),
@@ -197,6 +200,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     portByName.delete(name);
     const r = await dexec(["start", name]);
     if (r.code !== 0) throw new Error(`docker start ${name} failed: ${r.stderr.trim()}`);
+    await connectCore(await ensureNetwork(name));
     await waitDaemon(name);
   }
 
@@ -238,6 +242,20 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     return net;
   }
 
+  async function connectCore(net: string): Promise<void> {
+    if (!opts.coreContainer) return;
+    await dexec(["network", "connect", net, opts.coreContainer]).catch(
+      swallowAs("local-sandbox: network connect", undefined),
+    );
+  }
+
+  async function disconnectCore(net: string): Promise<void> {
+    if (!opts.coreContainer) return;
+    await dexec(["network", "disconnect", net, opts.coreContainer]).catch(
+      swallowAs("local-sandbox: network disconnect", undefined),
+    );
+  }
+
   async function runContainer(name: string, scope: string | undefined, withVolume: boolean): Promise<void> {
     const net = await ensureNetwork(name);
     const args = [
@@ -255,8 +273,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       "--network",
       net,
       ...(withVolume && scope ? ["-v", `${localVolumeName(scope)}:${homeDir}`] : []),
-      "-p",
-      `127.0.0.1:0:${AGENT_PORT}`,
+      ...(opts.coreContainer ? [] : ["-p", `127.0.0.1:0:${AGENT_PORT}`]),
       ...(opts.hostGateway === false ? [] : ["--add-host=host.docker.internal:host-gateway"]),
       ...(opts.cpus ? ["--cpus", String(opts.cpus)] : []),
       ...(opts.memoryMb ? ["--memory", `${opts.memoryMb}m`] : []),
@@ -266,6 +283,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     const r = await dexec(args, 120_000);
     if (r.code !== 0) throw new Error(`docker run ${name} failed: ${r.stderr.trim()}`);
     portByName.delete(name);
+    await connectCore(net);
     await waitDaemon(name);
   }
 
@@ -459,6 +477,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
           for (const [k, name] of scratchByKey) if (name === handle.id) scratchByKey.delete(k);
           if (tdOpts?.destroy) await dexec(["rm", "-f", handle.id]);
           else await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: scratch rm", undefined));
+          await disconnectCore(localNetworkName(handle.id));
           await dexec(["network", "rm", localNetworkName(handle.id)]).catch(
             swallowAs("local-sandbox: scratch network rm", undefined),
           );
@@ -470,6 +489,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
 
         if (tdOpts?.destroy) {
           await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: destroy rm", undefined));
+          await disconnectCore(localNetworkName(handle.id));
           await dexec(["network", "rm", localNetworkName(handle.id)]).catch(
             swallowAs("local-sandbox: destroy network rm", undefined),
           );

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -43,6 +43,8 @@ export interface LocalSandboxOptions {
   dockerBin?: string;
   cpus?: number;
   memoryMb?: number;
+  diskGb?: number;
+  hostGateway?: boolean;
   defaultTimeoutSec?: number;
   homeDir?: string;
   repoRoot?: string;
@@ -255,9 +257,10 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       ...(withVolume && scope ? ["-v", `${localVolumeName(scope)}:${homeDir}`] : []),
       "-p",
       `127.0.0.1:0:${AGENT_PORT}`,
-      "--add-host=host.docker.internal:host-gateway",
+      ...(opts.hostGateway === false ? [] : ["--add-host=host.docker.internal:host-gateway"]),
       ...(opts.cpus ? ["--cpus", String(opts.cpus)] : []),
       ...(opts.memoryMb ? ["--memory", `${opts.memoryMb}m`] : []),
+      ...(opts.diskGb ? ["--storage-opt", `size=${opts.diskGb}g`] : []),
       image,
     ];
     const r = await dexec(args, 120_000);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -412,3 +412,22 @@ test("baseModelProviders constrains the base model only when a provider is decla
     "with no declaration the shipped default stands, so upgrading never moves a deployment's model or its billing",
   );
 });
+
+test("localSandbox env: diskGb and hostGateway parse from their vars", () => {
+  const c = loadConfig({
+    LOCAL_SANDBOX_DISK_GB: "25",
+    LOCAL_SANDBOX_HOST_GATEWAY: "0",
+    LOCAL_SANDBOX_CPUS: "2",
+    LOCAL_SANDBOX_MEMORY_MB: "1024",
+  });
+  assert.equal(c.localSandbox.diskGb, 25);
+  assert.equal(c.localSandbox.hostGateway, false);
+  assert.equal(c.localSandbox.cpus, 2);
+  assert.equal(c.localSandbox.memoryMb, 1024);
+});
+
+test("localSandbox env: unset diskGb and hostGateway stay undefined", () => {
+  const c = loadConfig({});
+  assert.equal(c.localSandbox.diskGb, undefined);
+  assert.equal(c.localSandbox.hostGateway, undefined);
+});

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -296,3 +296,35 @@ test("diskGb applies a per-container storage quota", async () => {
   assert.equal(args[i + 1], "size=20g");
   await sb.teardown(h);
 });
+
+test("coreContainer mode: core joins the sandbox network and the daemon is reached by name, not a host port", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const seenUrls: string[] = [];
+  const fetchImpl: typeof fetch = (input, init) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    seenUrls.push(url);
+    if (url.endsWith("/health"))
+      return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "" }), { status: 200 }));
+  };
+  const sb = makeSandbox(fake, { coreContainer: "qm-test-core", fetchImpl });
+  const h = await sb.provision(rw(scopeId("personal", "U40")));
+  const args = fake.containers.get(h.id)!.args;
+  assert.equal(args.includes("-p"), false, "no host port mapping when core reaches the sandbox by name");
+  assert.equal(args.includes("127.0.0.1"), false, "no loopback binding in container mode");
+  assert.equal(
+    [...fake.connections].some((k) => k.endsWith("|qm-test-core")),
+    true,
+    "core was connected to the sandbox network",
+  );
+  assert.ok(
+    seenUrls.some((u) => u === `http://${h.id}:8080/health`),
+    `daemon reached by container name, got: ${seenUrls.join(", ")}`,
+  );
+  await sb.teardown(h, { destroy: true });
+  assert.equal(
+    [...fake.connections].some((k) => k.endsWith("|qm-test-core")),
+    false,
+    "core was disconnected from the sandbox network on destroy",
+  );
+});

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -267,3 +267,32 @@ test("concurrent teardown and provision for one scope serialize (no stop of a fr
   await sb.teardown(h2);
   assert.equal(fake.containers.get(h2.id)!.running, false);
 });
+
+test("host-gateway is added by default for local dev", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake);
+  const h = await sb.provision(rw(scopeId("personal", "U30")));
+  const args = fake.containers.get(h.id)!.args;
+  assert.equal(args.includes("--add-host=host.docker.internal:host-gateway"), true);
+  await sb.teardown(h);
+});
+
+test("hostGateway:false omits the host-gateway flag", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake, { hostGateway: false });
+  const h = await sb.provision(rw(scopeId("personal", "U31")));
+  const args = fake.containers.get(h.id)!.args;
+  assert.equal(args.includes("--add-host=host.docker.internal:host-gateway"), false);
+  await sb.teardown(h);
+});
+
+test("diskGb applies a per-container storage quota", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake, { diskGb: 20 });
+  const h = await sb.provision(rw(scopeId("personal", "U32")));
+  const args = fake.containers.get(h.id)!.args;
+  const i = args.indexOf("--storage-opt");
+  assert.equal(i >= 0, true);
+  assert.equal(args[i + 1], "size=20g");
+  await sb.teardown(h);
+});

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -14,6 +14,7 @@ export interface FakeDocker {
   containers: Map<string, FakeContainer>;
   volumes: Set<string>;
   networks: Set<string>;
+  connections: Set<string>;
   runCount: number;
   daemonDown: boolean;
   imageMissing: boolean;
@@ -25,10 +26,12 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const containers = new Map<string, FakeContainer>();
   const volumes = new Set<string>();
   const networks = new Set<string>();
+  const connections = new Set<string>();
   const self: FakeDocker = {
     containers,
     volumes,
     networks,
+    connections,
     runCount: 0,
     daemonDown: false,
     imageMissing: false,
@@ -79,6 +82,13 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
           return ok(name);
         }
         if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        if (sub === "connect" || sub === "disconnect") {
+          const container = rest[2]!;
+          const key = `${name}|${container}`;
+          if (sub === "connect") connections.add(key);
+          else connections.delete(key);
+          return ok(key);
+        }
         return fail(`unknown network subcommand ${sub}`);
       }
       case "volume": {

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -6,6 +6,7 @@ export interface FakeContainer {
   running: boolean;
   labels: Record<string, string>;
   volume?: string;
+  args: string[];
 }
 
 export interface FakeDocker {
@@ -40,7 +41,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const fail = (stderr: string) => ({ code: 1, stdout: "", stderr });
 
   function parseRun(args: string[]): FakeContainer {
-    const c: FakeContainer = { name: "", imageId: self.imageId, running: true, labels: {} };
+    const c: FakeContainer = { name: "", imageId: self.imageId, running: true, labels: {}, args };
     for (let i = 0; i < args.length; i++) {
       const a = args[i]!;
       if (a === "--name") c.name = args[++i]!;
@@ -48,7 +49,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const [k = "", v = ""] = args[++i]!.split("=");
         c.labels[k] = v;
       } else if (a === "-v") c.volume = args[++i]!.split(":")[0]!;
-      else if (a === "-p" || a === "--cpus" || a === "--memory") i++;
+      else if (a === "-p" || a === "--cpus" || a === "--memory" || a === "--storage-opt" || a === "--add-host") i++;
     }
     return c;
   }


### PR DESCRIPTION
Makes the docker target deployable and working with `SANDBOX_BACKEND=local` (agent computers as co-located Docker containers, no Fly agent-computer app), and fixes three unrelated docker-target gaps that otherwise block the stack from starting or working. `SANDBOX_BACKEND=local` is a core-sanctioned production configuration (the production config test fixture runs on `local`, the production gate names it valid), but no CLI target exposed it for a real deploy. Five commits, all backward-compatible (defaults preserve current behavior):

## 1. Relax docker sandbox.app requirement for local backend

The docker target declares `requiresSandboxApp`, so `qm check`/`qm up` reject a docker deploy with no `sandbox.app` even when `env.core.SANDBOX_BACKEND` is `"local"`. Worse, `qm init --target docker` scaffolds a `sandbox.app` block, which then makes `qm up` throw ("sandbox.app is set but no sandbox layer image is pinned"). The local path now ignores the sandbox block end to end (`qm check` relaxes the requirement, docker-scoped; `sandboxCoreEnv` returns early; `sandboxPinPending`/`sandboxImagePinErrors` skip; `qm doctor` reports "local Docker sandbox: configured"). A shared `localSandboxActive(config)` predicate centralizes the condition.

## 2. Add optional local sandbox hardening controls

Two opt-in env knobs: `LOCAL_SANDBOX_HOST_GATEWAY=0` drops the hardcoded `--add-host=host.docker.internal:host-gateway` flag; `LOCAL_SANDBOX_DISK_GB=N` applies `--storage-opt size=Ng` per container (needs a quota-capable driver). Both default to current behavior.

## 3. Route the docker target's auth broker through a .internal alias

Portal's private-network guard rejects cleartext OIDC endpoints unless the host is loopback/RFC1918 or ends in `.internal`/`.flycast`/`.local`. The docker backend addressed the auth broker as `http://auth:8080` (a bare Docker DNS name), so portal refused to start. Each service container now also gets a `<prefix>-<service>.internal` network-alias, and the auth broker upstream is addressed as `http://<prefix>-auth.internal:8080`.

## 4. Give core access to the host Docker daemon for local sandboxes

`SANDBOX_BACKEND=local` spawns agent computers from core, but the docker target started core without the Docker CLI, socket, or `DOCKER_HOST` — so the sandbox liveness check always failed. Core's image now installs `docker-cli`; when `SANDBOX_BACKEND=local`, the backend bind-mounts `/var/run/docker.sock` into core, adds the socket's group gid so the non-root `node` user can read it, and sets `DOCKER_HOST`. Sprites/fly unchanged.

## 5. Reach the local sandbox from core over the sandbox network, not host localhost

The exec daemon was reached at `http://127.0.0.1:<host-port>`, assuming core is a host process. On the docker target core is a container, so `127.0.0.1` points at core itself and the readiness poll always failed ("exec daemon never became reachable"): the sandbox starts but core can never talk to it. In container mode the backend now sets `QM_CORE_CONTAINER` (core's own container name); the local sandbox omits the host port mapping, connects core to the sandbox's private network (`docker network connect`, reconnected idempotently on cold start so it recovers after a core restart), reaches the daemon by container name (`http://<sandbox>:8080`, resolved by Docker's embedded DNS), and disconnects before removing the network on teardown. **Scope isolation is preserved**: each scope still gets its own `qm-net-<scope>` network, sandboxes cannot reach each other, and core is the only bridge. Host-process mode keeps the existing `127.0.0.1:<host-port>` behavior.

## Verification

- `tsc --noEmit` clean
- `test/config.test.ts`, `test/local-sandbox.test.ts`: 49 pass
- `cli/test/config.test.ts`, `cli/test/check.test.ts`, `cli/test/doctor.test.ts`, `cli/test/auth-broker.test.ts`: 99 pass
- No existing tests changed (one assertion updated in `auth-broker.test.ts` to the new `.internal` address)

Commits 3 and 4 are independent docker-target fixes (affect docker+sprites too); commits 1, 2, and 5 are the local-backend path. Splittable if a reviewer prefers.
