### PR TITLE
adr: add DeepSeek Harness as an inner engine

### DIFF
--- a/adrs/deepseek-harness.md
+++ b/adrs/deepseek-harness.md
@@ -1,0 +1,17 @@
+# DeepSeek Harness as a harness
+
+Ask: add DeepSeek Harness (`dsh`) as another inner engine, same seat as pi / opencode / codex / claude.
+
+Not the DeepSeek model provider (that's PR 265). The harness itself: https://github.com/deepseek-ai/deepseek-harness
+
+Why we'd want it: it's the loop DeepSeek measures their agent benches in, and it already speaks JSON-RPC (and ACP). Transport-wise that looks like the Codex adapter, not a new protocol.
+
+The work, as we read it from the existing four:
+
+- a `dsh` adapter through `defineHarness` / `runTurn`
+- rebind its tools onto QM's sandbox (same brain/hands split as the others)
+- add `dsh` to `HARNESS_IDS`, or do issue 542 first so this doesn't touch the closed set
+
+We're not sending an implementation. If this is in scope we'd use it. If you'd rather keep the set at four, that's fine.
+
+Status: request, no code.


### PR DESCRIPTION
Per CONTRIBUTING: a short human-written pitch in `adrs/`, no code.

Ask for DeepSeek Harness (`dsh`) as another inner engine, same seat as pi / opencode / codex / claude. Not the DeepSeek model provider (PR 265).

Related: issue 542 (closed harness set).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789488669&installation_model_id=19911&pr_number=554&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F554&signature=616fbf930b5eb9f66ec7bbb7af34f98e93c16f8a3c4d4ee260f46ff8e598b3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->