### PR TITLE
Request: webhook triggers

### DIFF
--- a/adrs/webhook-triggers.md
+++ b/adrs/webhook-triggers.md
@@ -1,0 +1,3 @@
+Request: Webhook triggers
+
+My company has many cases where we want to dispatch an agent on an event, not on a poll cycle (ex:  a failure in a batch analytics job, and we want an agent to go investigate). Cron and monitor cover scheduled/watched work, but there's no way to hit qm from outside and say "run now."


### PR DESCRIPTION
My company has many cases where we want to dispatch an agent on an event, not on a poll cycle (ex: a failure in a batch analytics job, and we want an agent to go investigate). Cron and monitor cover scheduled/watched work, but there's no way to hit qm from outside and say "run now."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789515211&installation_model_id=19911&pr_number=555&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F555&signature=fda57a6ddbba63b6be5467edd9175c71bd917360ca5c47a35606d7e1cd1cd962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->