### PR TITLE
Request: abstracted chat surface, not just Slack

### DIFF
--- a/adrs/chat-surface-abstraction.md
+++ b/adrs/chat-surface-abstraction.md
@@ -1,0 +1,6 @@
+Request: Abstracted chat surface, not just Slack
+
+My company uses Teams (unforgiveable, I know :) ) so a ton of the benifet of QM is locked away. I'm sure there's others out there in a similar situation.
+
+From what I can tell, chat isn't behind a generic interface the way harnesses, session stores, and sandboxes are. I'd like the chat surface itself to become a real substrate abstraction so Teams (and whatever comes after) can plug
+in easily


### PR DESCRIPTION
Request: Abstracted chat surface, not just Slack

My company uses Teams (unforgiveable, I know :) ) so a ton of the benifet of QM is locked away. I'm sure there's others out there in a similar situation.

From what I can tell, chat isn't behind a generic interface the way harnesses, session stores, and sandboxes are. I'd like the chat surface itself to become a real substrate abstraction so Teams (and whatever comes after) can plug
in easily

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789522223&installation_model_id=19911&pr_number=556&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F556&signature=3b49e0f18977ebc086f6bc53304a59ba97763971fd0292fa2c16d6cf5f7522ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->