### PR TITLE
Prepare the QM 1.0.5 rollout

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.10",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.10",
+      "version": "1.0.5",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.10",
+  "version": "1.0.5",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/src/deployment/postdeploy-smoke.ts
+++ b/src/deployment/postdeploy-smoke.ts
@@ -306,8 +306,8 @@ async function runPostdeploySmoke(config: PostdeployConfig): Promise<void> {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const config = loadConfig();
   if (process.argv[2] === "session") {
-    if (config.databaseUrl) await checkDatabase(config);
     await checkLiveSession(config, process.argv[3] ?? `http://127.0.0.1:${config.port}`);
+    if (config.databaseUrl) await checkDatabase(config);
     console.log("database and live session smoke passed");
   } else {
     await runPostdeploySmoke(config);

--- a/src/deployment/postdeploy-smoke.ts
+++ b/src/deployment/postdeploy-smoke.ts
@@ -89,21 +89,23 @@ export async function checkSlackCredentials(
 }
 
 export async function stagingApiHeaders(
-  orgId: string,
   principalId: string,
   sourceSecret: string,
   portalIdentitySecret: string,
+  method: string,
   path: string,
+  body = "",
+  base: Record<string, string> = {},
   nowMs = Date.now(),
 ): Promise<Record<string, string>> {
   const portalIdentity = await mintSignedPayload({ p: principalId, exp: nowMs + 60_000 }, portalIdentitySecret);
   return signedRequestHeaders(
     sourceSecret,
-    "GET",
+    method,
     path,
-    "",
+    body,
     {
-      "x-admin-actor": `${principalId}@${orgId}`,
+      ...base,
       [PORTAL_IDENTITY_HEADER]: portalIdentity,
     },
     Math.floor(nowMs / 1000),
@@ -125,9 +127,15 @@ export async function checkLiveSession(
   const root = baseUrl.replace(/\/+$/, "");
   const request = async (method: "GET" | "POST", path: string, body?: unknown, admin = false): Promise<unknown> => {
     const raw = body === undefined ? "" : JSON.stringify(body);
-    const headers = admin
-      ? await stagingApiHeaders(orgId, principalId, sourceSecret, portalIdentitySecret, path)
-      : signedRequestHeaders(sourceSecret, method, path, raw);
+    const headers = await stagingApiHeaders(
+      principalId,
+      sourceSecret,
+      portalIdentitySecret,
+      method,
+      path,
+      raw,
+      admin ? { "x-admin-actor": `${principalId}@${orgId}` } : {},
+    );
     const response = await fetchImpl(`${root}${path}`, {
       method,
       headers: { ...headers, ...(raw ? { "content-type": "application/json" } : {}) },
@@ -226,7 +234,9 @@ async function checkApi(
 ): Promise<void> {
   const path = `/v1/admin/sessions?scope=${encodeURIComponent(`org:${orgId}`)}&limit=5&_smoke=${randomUUID()}`;
   const response = await fetch(`http://127.0.0.1:${port}${path}`, {
-    headers: await stagingApiHeaders(orgId, principalId, sourceSecret, portalIdentitySecret, path),
+    headers: await stagingApiHeaders(principalId, sourceSecret, portalIdentitySecret, "GET", path, "", {
+      "x-admin-actor": `${principalId}@${orgId}`,
+    }),
   });
   const body = await response.text();
   if (!response.ok) throw new Error(`staging session API returned ${response.status}: ${body.slice(0, 500)}`);

--- a/src/deployment/postdeploy-smoke.ts
+++ b/src/deployment/postdeploy-smoke.ts
@@ -259,13 +259,9 @@ type PostdeployConfig = Pick<
   | "slack"
 >;
 
-async function runPostdeploySmoke(config: PostdeployConfig): Promise<void> {
-  const { databaseUrl, orgId, portalIdentitySecret, signingSecret: sourceSecret } = config;
+async function checkDatabase(config: PostdeployConfig): Promise<void> {
+  const { databaseUrl } = config;
   if (!databaseUrl) throw new Error("postdeploy smoke requires DATABASE_URL");
-  if (!orgId) throw new Error("postdeploy smoke requires ORG_ID");
-  if (!sourceSecret) throw new Error("postdeploy smoke requires CORE_SIGNING_SECRET");
-  if (!portalIdentitySecret) throw new Error("postdeploy smoke requires PORTAL_IDENTITY_SECRET");
-
   const pg = (await import("pg")).default;
   const client = new pg.Client({
     connectionString: databaseUrl,
@@ -285,6 +281,15 @@ async function runPostdeploySmoke(config: PostdeployConfig): Promise<void> {
   } finally {
     await client.end();
   }
+}
+
+async function runPostdeploySmoke(config: PostdeployConfig): Promise<void> {
+  const { orgId, portalIdentitySecret, signingSecret: sourceSecret } = config;
+  if (!orgId) throw new Error("postdeploy smoke requires ORG_ID");
+  if (!sourceSecret) throw new Error("postdeploy smoke requires CORE_SIGNING_SECRET");
+  if (!portalIdentitySecret) throw new Error("postdeploy smoke requires PORTAL_IDENTITY_SECRET");
+
+  await checkDatabase(config);
 
   await checkApi(
     orgId,
@@ -301,8 +306,9 @@ async function runPostdeploySmoke(config: PostdeployConfig): Promise<void> {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const config = loadConfig();
   if (process.argv[2] === "session") {
+    if (config.databaseUrl) await checkDatabase(config);
     await checkLiveSession(config, process.argv[3] ?? `http://127.0.0.1:${config.port}`);
-    console.log("live session smoke passed");
+    console.log("database and live session smoke passed");
   } else {
     await runPostdeploySmoke(config);
   }

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -41,11 +41,23 @@ export function assertOneStatement(stmt: string): void {
   }
 }
 
+export function concurrentIndexName(stmt: string): string | undefined {
+  return /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY\s+IF\s+NOT\s+EXISTS\s+([a-z_][a-z0-9_$]*)\b/i.exec(stmt)?.[1];
+}
+
 async function applyDdl(pool: Pool, statements: string[]): Promise<void> {
   const ddl = await pool.connect();
   try {
     await ddl.query("SELECT pg_advisory_lock(hashtext('agent-platform:schema-init'))");
     for (const stmt of statements) {
+      const indexName = concurrentIndexName(stmt);
+      if (indexName) {
+        const existing = await ddl.query(
+          "SELECT NOT indisvalid OR NOT indisready AS invalid FROM pg_index WHERE indexrelid = to_regclass($1)",
+          [indexName],
+        );
+        if (existing.rows[0]?.invalid) await ddl.query(`DROP INDEX CONCURRENTLY ${indexName}`);
+      }
       await ddl.query(stmt);
     }
   } finally {

--- a/src/sessions/postgres-session-store.ts
+++ b/src/sessions/postgres-session-store.ts
@@ -39,6 +39,10 @@ import {
   userMessagePreview,
 } from "./session-store.ts";
 
+export const SESSION_ENTRIES_SEARCH_INDEX_SQL = `CREATE INDEX CONCURRENTLY IF NOT EXISTS session_entries_search_fts
+  ON session_entries USING GIN (to_tsvector('simple', COALESCE(entry_search_text(payload), '')))
+  WHERE type IN ('user', 'assistant', 'text')`;
+
 export function rowToSession(r: Record<string, unknown>): Session {
   return {
     id: r.id as string,
@@ -269,9 +273,7 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
                       ELSE NULL END;
         EXCEPTION WHEN others THEN RETURN NULL;
         END $entry_search_text$`,
-    `CREATE INDEX IF NOT EXISTS session_entries_search_fts
-        ON session_entries USING GIN (to_tsvector('simple', COALESCE(entry_search_text(payload), '')))
-        WHERE type IN ('user', 'assistant', 'text')`,
+    SESSION_ENTRIES_SEARCH_INDEX_SQL,
     `DELETE FROM session_entries WHERE session_id IN (SELECT id FROM sessions WHERE type IN ('channel','group') AND thread_ref ~ '^[a-z0-9_]+/[^:/]+$')`,
     `DELETE FROM participants WHERE session_id IN (SELECT id FROM sessions WHERE type IN ('channel','group') AND thread_ref ~ '^[a-z0-9_]+/[^:/]+$')`,
     `DELETE FROM session_leases WHERE session_id IN (SELECT id FROM sessions WHERE type IN ('channel','group') AND thread_ref ~ '^[a-z0-9_]+/[^:/]+$')`,

--- a/test/persistence-init-retry.test.ts
+++ b/test/persistence-init-retry.test.ts
@@ -72,3 +72,27 @@ test("pg pool: an idle-client 'error' is logged, not fatal", { skip }, async () 
   assert.deepEqual((await pg.query("SELECT 1 AS one")).rows, [{ one: 1 }], "pool keeps serving queries");
   await pg.close();
 });
+
+test("pg pool: concurrent index creation recovers an invalid prior attempt", { skip }, async () => {
+  const pg = createPgPool(URL!, ["DROP TABLE IF EXISTS qm_concurrent_index_retry CASCADE"]);
+  try {
+    await pg.schema!("CREATE TABLE qm_concurrent_index_retry(value INT NOT NULL)");
+    await pg.query("INSERT INTO qm_concurrent_index_retry(value) VALUES (1), (1)");
+    await assert.rejects(
+      pg.schema!("CREATE UNIQUE INDEX CONCURRENTLY qm_concurrent_index_retry_idx ON qm_concurrent_index_retry(value)"),
+      /could not create unique index/,
+    );
+    await pg.schema!(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS qm_concurrent_index_retry_idx ON qm_concurrent_index_retry(value)",
+    );
+    assert.deepEqual(
+      await pg.q(
+        "SELECT indisvalid, indisready FROM pg_index WHERE indexrelid = to_regclass('qm_concurrent_index_retry_idx')",
+      ),
+      [{ indisvalid: true, indisready: true }],
+    );
+  } finally {
+    await pg.query("DROP TABLE IF EXISTS qm_concurrent_index_retry CASCADE");
+    await pg.close();
+  }
+});

--- a/test/pg-pool.test.ts
+++ b/test/pg-pool.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { createPgPool, assertOneStatement } from "../src/persistence/pg-pool.ts";
+import { createPgPool, assertOneStatement, concurrentIndexName } from "../src/persistence/pg-pool.ts";
 
 test("createPgPool is lazy: building it neither connects nor throws (no DB needed)", async () => {
   const pg = createPgPool("postgres://does-not-exist:0/none", ["SELECT 1"]);
@@ -65,6 +65,14 @@ test("assertOneStatement: a single-quoted literal or line comment containing ';'
 
 test("assertOneStatement: an apostrophe in a line comment can't hide a following statement's ';'", () => {
   assert.throws(() => assertOneStatement("SELECT 1 -- don't\n; SELECT 'x'"), /single statement/);
+});
+
+test("concurrentIndexName recognizes retryable concurrent index creation", () => {
+  assert.equal(
+    concurrentIndexName("CREATE INDEX CONCURRENTLY IF NOT EXISTS session_search ON sessions(id)"),
+    "session_search",
+  );
+  assert.equal(concurrentIndexName("CREATE INDEX IF NOT EXISTS session_search ON sessions(id)"), undefined);
 });
 
 function pathToUrl(p: string): string {

--- a/test/postdeploy-smoke.test.ts
+++ b/test/postdeploy-smoke.test.ts
@@ -31,11 +31,13 @@ test("deployed API smoke uses a configured real org admin", () => {
 test("deployed API smoke proves the production portal-identity boundary", async () => {
   const now = Date.now();
   const headers = await stagingApiHeaders(
-    "acme",
     "josh@example.com",
     "source-secret",
     "portal-secret",
+    "GET",
     "/v1/admin/sessions",
+    "",
+    { "x-admin-actor": "josh@example.com@acme" },
     now,
   );
   assert.equal(headers["x-admin-actor"], "josh@example.com@acme");
@@ -85,7 +87,7 @@ test("deployed staging smoke verifies its own Slack bot and Socket Mode credenti
 });
 
 test("live session smoke proves a model turn, persistence, title, error log, and cleanup", async () => {
-  const calls: Array<{ method: string; path: string; body: string }> = [];
+  const calls: Array<{ method: string; path: string; body: string; portalIdentity: string | null }> = [];
   const config = {
     adminGrants: "josh@example.com:org_admin",
     orgId: "acme",
@@ -95,7 +97,12 @@ test("live session smoke proves a model turn, persistence, title, error log, and
   await checkLiveSession(config, "http://core.internal:8080", async (input, init) => {
     const url = new URL(String(input));
     const method = init?.method ?? "GET";
-    calls.push({ method, path: `${url.pathname}${url.search}`, body: String(init?.body ?? "") });
+    calls.push({
+      method,
+      path: `${url.pathname}${url.search}`,
+      body: String(init?.body ?? ""),
+      portalIdentity: new Headers(init?.headers).get(PORTAL_IDENTITY_HEADER),
+    });
     if (url.pathname === "/v1/turns")
       return Response.json({ status: "ok", sessionId: "sess-1", reply: "QM deployment canary passed." });
     if (url.pathname === "/v1/admin/errors") return Response.json({ errors: [] });
@@ -117,6 +124,10 @@ test("live session smoke proves a model turn, persistence, title, error log, and
   assert.equal(JSON.parse(calls[0]!.body).readOnly, true);
   assert.equal(JSON.parse(calls[0]!.body).skipMemory, true);
   assert.deepEqual(JSON.parse(calls[3]!.body), { principalId: "josh@example.com", archived: true });
+  for (const call of calls) {
+    const identity = await verifyPortalIdentity(call.portalIdentity ?? "", "portal-secret", Date.now());
+    assert.equal(identity?.p, "josh@example.com", `${call.method} ${call.path} carries the canary identity`);
+  }
 
   let archivedFailedSession = false;
   await assert.rejects(

--- a/test/session-search.test.ts
+++ b/test/session-search.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import { buildApp } from "../src/wiring.ts";
 import { testConfig } from "./support/test-config.ts";
 import { createMemorySessionStore } from "../src/sessions/memory-session-store.ts";
+import { SESSION_ENTRIES_SEARCH_INDEX_SQL } from "../src/sessions/postgres-session-store.ts";
 import type { SessionStore } from "../src/sessions/session-store.ts";
 import { scopeId } from "../src/types.ts";
 
@@ -25,6 +26,10 @@ async function seed(sessions: SessionStore, threadRef: string, principal: string
   await sessions.releaseLease(lease!);
   return s.id;
 }
+
+test("Postgres builds the full-text index without blocking writes", () => {
+  assert.match(SESSION_ENTRIES_SEARCH_INDEX_SQL, /^CREATE INDEX CONCURRENTLY IF NOT EXISTS/);
+});
 
 test("memory store: searchEntries matches user and assistant text, newest first", async () => {
   const store = createMemorySessionStore();


### PR DESCRIPTION
## What changed

- Sign every live-session canary request with the configured portal identity while preserving the admin actor on admin routes.
- Build the Postgres session-search GIN index concurrently so rollout does not block writes.
- Recover an invalid index left by an interrupted concurrent build, and make Fly's live gate reject any invalid index.
- Set the CLI package version to `1.0.5`.

## Why

The deployment canary declared itself as a web surface but only attached `x-portal-identity` to admin reads. Production therefore rejected its ordinary `/v1/turns` call with `401 portal identity required`.

The session-search index was also created with plain `CREATE INDEX`, which could hold a write-blocking lock during rollout. PostgreSQL can leave an invalid same-named index after a failed concurrent build, so startup now drops that invalid index concurrently before retrying.

The latest published package is `0.1.4` and main had already advanced its unreleased source version to `0.1.10`; `1.0.5` intentionally begins the stable 1.x line requested for this release.

## Validation

- Focused identity, index, DDL, and retry tests — passed
- Root typecheck, contract typecheck, ESLint, Oxlint, Knip, and Prettier — passed
- CLI typecheck, 515 unit tests, and packed-artifact test — passed
- GitHub CI, including clean-runner CLI E2E and the real Postgres failed-index/retry test — passed
- Reviewed candidate deployed blue/green to the isolated Fly beta stack against its real Postgres database
- `qm check --live` — service identity/config, object storage, portal health, invalid-index query, real model turn, persistence, title, error check, and cleanup passed
- `qm conformance` — passed
- Production image dependency audit — 0 vulnerabilities

The local Docker E2E command was stopped because the workstation Docker daemon was unresponsive before test execution; PR CI ran the same suite successfully on a clean runner.
