### PR TITLE
Clarify admin navigation icon

### DIFF
--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -1,6 +1,5 @@
 import { html, nothing, render, type TemplateResult } from "lit";
 import {
-  ArrowLeft,
   Box,
   Brain,
   ChevronDown,
@@ -449,7 +448,7 @@ export function mountShell(): void {
               <span class="user-name">${appState.me?.user ?? ""}</span>
             </div>
             <a class="icon-btn subtle" href=${ADMIN_HOME_URL} title="Back to admin" aria-label="Back to admin"
-              >${icon(ArrowLeft, 17)}</a
+              >${icon(ShieldCheck, 17)}</a
             >
             <theme-toggle .includeSystem=${true} title="Color scheme: light / dark / system"></theme-toggle>
             <button class="icon-btn subtle" title="Sign out" aria-label="Sign out" @click=${signOut}>

--- a/plugins/web-ui/test/admin-navigation-source.test.ts
+++ b/plugins/web-ui/test/admin-navigation-source.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+
+test("admin navigation uses an admin-specific icon", () => {
+  const adminLink = shell.match(/<a class="icon-btn subtle" href=\$\{ADMIN_HOME_URL\}[\s\S]*?<\/a/);
+  assert.ok(adminLink, "admin navigation link exists");
+  assert.match(adminLink[0], /icon\(ShieldCheck, 17\)/);
+  assert.doesNotMatch(adminLink[0], /icon\(ArrowLeft, 17\)/);
+});


### PR DESCRIPTION
Replaces the generic admin back arrow with a recognizable shield-check icon while preserving the accessible label.

- verification: 551 web UI tests, typecheck, production build, and local browser render

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789581156&installation_model_id=19911&pr_number=562&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F562&signature=68b2e9c73f09269a357766d8509594de19951b5d0d80416ae084674326c94e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->