### PR TITLE
fix(web-ui): snap chat to bottom instantly on pane tab re-activation

### DIFF
--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -879,7 +879,13 @@ class PaneContent implements IContentRenderer {
     this.syncZones();
     p.api.onDidDimensionsChange(() => this.syncDensity());
     p.api.onDidVisibilityChange((e) => {
-      if (e.isVisible) void this.load();
+      if (!e.isVisible) return;
+      if (!this.loaded) {
+        void this.load();
+        return;
+      }
+      this.syncDensity();
+      this.conversation.drawActiveChat(undefined, { forceScroll: true });
     });
     if (p.api.isVisible) void this.load();
   }

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -63,7 +63,7 @@ test("a pane is an element in this document — never a second copy of the app",
     "a pane loads its transcript once, and never after it closes",
   );
   assert.match(load, /if \(this\.disposed\) return;/, "and drops the continuation if the pane closed mid-load");
-  assert.match(split, /onDidVisibilityChange\(\(e\) => \{\s*\n\s*if \(e\.isVisible\) void this\.load\(\);/);
+  assert.match(split, /onDidVisibilityChange\(\(e\) => \{\s*\n\s*if \(!e\.isVisible\) return;/);
 });
 
 test("a conversation dropped on a pane's tab strip joins that pane — and only there", () => {

--- a/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
+++ b/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+
+test("re-activating a pane tab force-scrolls the transcript (already-loaded panes snap to bottom)", () => {
+  const handler = split.match(/onDidVisibilityChange\(\(e\) => \{[\s\S]*?\}\);/)?.[0] ?? "";
+  assert.match(handler, /drawActiveChat\(undefined, \{ forceScroll: true \}\)/);
+  assert.match(handler, /if \(!this\.loaded\)/, "only already-loaded panes redraw; first show still loads");
+  const density = handler.indexOf("this.syncDensity()");
+  const draw = handler.indexOf("drawActiveChat(undefined, { forceScroll: true })");
+  assert.ok(
+    density >= 0 && density < draw,
+    "density resyncs before the forced redraw — a hidden pane measured 0\u00d70 and would render scroller-less glance UI",
+  );
+});
+
+test("a forced transcript scroll bypasses the smooth scroll-behavior (snaps instantly)", () => {
+  const fn = chat.match(/function scrollTranscript\(force = false\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
+  const setAuto = fn.indexOf('scroller.style.scrollBehavior = "auto"');
+  const write = fn.indexOf("scroller.scrollTop = scroller.scrollHeight");
+  assert.ok(setAuto >= 0, "forced path must set scroll-behavior:auto");
+  assert.ok(write > setAuto, "the snap write must come after behavior is set to auto");
+});


### PR DESCRIPTION
## Problem
Switching back to a chat tab in a split layout animates a smooth scroll from the top to the bottom of the transcript instead of opening already at the bottom.

## Root cause
dockview hides inactive tab panels with `display:none`. A re-shown pane has lost its scroll position; the ResizeObserver-driven redraw then catches up through `.chat-scroll`'s `scroll-behavior: smooth`, producing the animated scroll. A hidden pane also measures 0x0, leaving density at 'strip', so density must be resynced before the forced redraw or the snap is skipped.

## Fix
On `onDidVisibilityChange`, redraw already-loaded panes with `forceScroll: true` (after resyncing density), which snaps via `scroll-behavior: auto`. First show still loads as before.

## Tests
- New `test/tab-switch-scroll-snap.test.ts` covering the forced redraw ordering and the auto-behavior snap path.
- Updated `split-canvas-entry.test.ts` to the new handler shape.