### PR TITLE
web-ui: fix select value binding, add default effort picker

### DIFF
--- a/plugins/web-ui/src/context-model.ts
+++ b/plugins/web-ui/src/context-model.ts
@@ -1,6 +1,13 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { fetchRuntimeConfig, updateRuntimeConfig, type RuntimeConfig } from "./core-bridge";
-import { runtimeModelOptions, type ModelOption } from "./model-options";
+import {
+  EFFORT_LEVELS,
+  effortLabel,
+  harnessSupportsEffort,
+  runtimeModelOptions,
+  type EffortLevel,
+  type ModelOption,
+} from "./model-options";
 import { fieldSelect } from "./ui";
 import { errMessage } from "../../chassis/src/errors";
 
@@ -10,6 +17,8 @@ export const contextModelState = {
   scope: null as string | null,
   loading: false,
   saving: false,
+  pending: null as string | null,
+  pendingEffort: null as string | null,
   config: null as RuntimeConfig | null,
   notice: "",
   noticeKind: "" as "" | "saved" | "error",
@@ -23,6 +32,8 @@ export function resetContextModel(): void {
   contextModelState.scope = null;
   contextModelState.loading = false;
   contextModelState.saving = false;
+  contextModelState.pending = null;
+  contextModelState.pendingEffort = null;
   contextModelState.config = null;
   contextModelState.notice = "";
   contextModelState.noticeKind = "";
@@ -65,22 +76,46 @@ function selectedValue(config: RuntimeConfig): string {
   return config.scopeOverride ? `${config.scopeOverride.harnessId}:${config.scopeOverride.modelId}` : INHERIT;
 }
 
-async function choose(scope: string, value: string): Promise<void> {
+function effortLevelsFor(harnessId: string): Array<{ value: EffortLevel; label: string }> {
+  return EFFORT_LEVELS.filter(({ value }) => {
+    if (value === "ultracode") return harnessId === "pi";
+    if (value === "max") return harnessId !== "codex";
+    return true;
+  });
+}
+
+function selectedEffort(config: RuntimeConfig): string {
+  return config.scopeOverride?.effortLevel ?? "auto";
+}
+
+async function choose(scope: string, value: string, effort?: string): Promise<void> {
   if (contextModelState.saving) return;
   const seq = loadSeq;
   contextModelState.saving = true;
+  contextModelState.pending = value;
+  contextModelState.pendingEffort = effort ?? null;
   contextModelState.notice = "";
   contextModelState.noticeKind = "";
   redraw();
   try {
     const sep = value.indexOf(":");
+    const harnessId = value.slice(0, sep);
     const config = await updateRuntimeConfig(
       scope,
-      value === INHERIT ? { inherit: true } : { harnessId: value.slice(0, sep), modelId: value.slice(sep + 1) },
+      value === INHERIT
+        ? { inherit: true }
+        : {
+            harnessId,
+            modelId: value.slice(sep + 1),
+            ...(effort && effortLevelsFor(harnessId).some((o) => o.value === effort) ? { effortLevel: effort } : {}),
+          },
     );
     if (seq !== loadSeq) return;
     contextModelState.config = config;
-    contextModelState.notice = `Saved — new conversations here run on ${labelForRuntime(config, config.effective)}.`;
+    const effortNote = config.scopeOverride?.effortLevel
+      ? ` · ${effortLabel(config.scopeOverride.effortLevel as EffortLevel)} effort`
+      : "";
+    contextModelState.notice = `Saved — new conversations here run on ${labelForRuntime(config, config.effective)}${effortNote}.`;
     contextModelState.noticeKind = "saved";
   } catch (e) {
     if (seq !== loadSeq) return;
@@ -89,6 +124,8 @@ async function choose(scope: string, value: string): Promise<void> {
   } finally {
     if (seq === loadSeq) {
       contextModelState.saving = false;
+      contextModelState.pending = null;
+      contextModelState.pendingEffort = null;
       redraw();
     }
   }
@@ -109,9 +146,13 @@ export function contextModelSection(scopeId: string): TemplateResult | typeof no
     </section>`;
   const options = optionsFor(config);
   const multiHarness = new Set(options.map((o) => o.harnessId)).size > 1;
-  const selected = selectedValue(config);
+  const selected = contextModelState.pending ?? selectedValue(config);
   const stalePin = selected !== INHERIT && !options.some((o) => o.value === selected);
   const isSlack = scopeId.startsWith("channel:");
+  const pinnedHarness = selected === INHERIT ? null : selected.slice(0, selected.indexOf(":"));
+  const effort = contextModelState.pendingEffort ?? selectedEffort(config);
+  const effortOptions = pinnedHarness ? effortLevelsFor(pinnedHarness) : [];
+  const showEffort = pinnedHarness !== null && harnessSupportsEffort(pinnedHarness);
   return html`
     <section class="context-panel context-model" aria-labelledby="context-model-title">
       <div class="context-panel-heading">
@@ -127,19 +168,49 @@ export function contextModelSection(scopeId: string): TemplateResult | typeof no
         ariaLabel: "Default model for this project",
         disabled: contextModelState.saving,
         value: selected,
-        onChange: (value) => void choose(scopeId, value),
+        onChange: (value) => {
+          const nextHarness = value.slice(0, value.indexOf(":"));
+          const carry =
+            value !== INHERIT && effortLevelsFor(nextHarness).some((o) => o.value === effort) ? effort : undefined;
+          void choose(scopeId, value, carry);
+        },
         options: [
-          html`<option value=${INHERIT}>Org default (${labelForRuntime(config, config.orgDefault)})</option>`,
-          ...options.map((o) => html`<option value=${o.value}>${optionLabel(o, multiHarness)}</option>`),
+          html`<option value=${INHERIT} ?selected=${selected === INHERIT}>
+            Org default (${labelForRuntime(config, config.orgDefault)})
+          </option>`,
+          ...options.map(
+            (o) =>
+              html`<option value=${o.value} ?selected=${o.value === selected}>${optionLabel(o, multiHarness)}</option>`,
+          ),
           ...(stalePin
             ? [
-                html`<option value=${selected}>
+                html`<option value=${selected} selected>
                   ${labelForRuntime(config, config.scopeOverride!)} — no longer offered
                 </option>`,
               ]
             : []),
         ],
       })}
+      ${
+        showEffort
+          ? html`<label class="context-model-effort">
+              <span class="context-model-effort-label">Default effort</span>
+              ${fieldSelect({
+                id: "context-effort-select",
+                className: "context-effort-select",
+                focusKey: "context-effort",
+                ariaLabel: "Default effort level for this project",
+                disabled: contextModelState.saving,
+                value: effort,
+                compact: true,
+                onChange: (value) => void choose(scopeId, selected, value),
+                options: effortOptions.map(
+                  (o) => html`<option value=${o.value} ?selected=${o.value === effort}>${o.label}</option>`,
+                ),
+              })}
+            </label>`
+          : nothing
+      }
       <p class="context-model-hint">
         ${
           selected === INHERIT

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6346,6 +6346,16 @@ a.chat-row-open {
   align-self: flex-start;
   min-width: min(260px, 100%);
 }
+.context-model-effort {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  align-self: flex-start;
+}
+.context-model-effort-label {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
 .context-model-hint {
   margin: 0;
   color: var(--muted-foreground);

--- a/plugins/web-ui/src/ui.ts
+++ b/plugins/web-ui/src/ui.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { live } from "lit/directives/live.js";
 import { ChevronDown, createElement, type IconNode } from "lucide";
 
 export function brandName(): string {
@@ -42,7 +43,7 @@ export function fieldSelect(props: {
       aria-label=${props.ariaLabel ?? nothing}
       aria-describedby=${props.describedBy ?? nothing}
       data-focus-key=${props.focusKey ?? nothing}
-      .value=${props.value ?? nothing}
+      .value=${props.value === undefined ? nothing : live(props.value)}
       ?disabled=${props.disabled ?? false}
       @change=${(e: Event) => props.onChange((e.currentTarget as HTMLSelectElement).value, e)}
     >

--- a/plugins/web-ui/test/context-model-source.test.ts
+++ b/plugins/web-ui/test/context-model-source.test.ts
@@ -9,7 +9,7 @@ const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 test("the scope's model panel writes through the same endpoint the composer's default does", () => {
   assert.match(panel, /updateRuntimeConfig\(\s*scope,/);
   assert.match(panel, /\{ inherit: true \}/);
-  assert.match(panel, /\{ harnessId: value\.slice\(0, sep\), modelId: value\.slice\(sep \+ 1\) \}/);
+  assert.match(panel, /harnessId,\n\s+modelId: value\.slice\(sep \+ 1\)/);
   assert.doesNotMatch(panel, /applyRuntimeOptions/);
 });
 
@@ -39,4 +39,31 @@ test("model panel styles use the shell theme contract", () => {
   assert.match(block, /color: var\(--muted-foreground\)/);
   assert.match(block, /color: var\(--destructive/);
   assert.doesNotMatch(block, /#[0-9a-f]{6}(?![^)]*\))/i);
+});
+
+test("the model dropdown marks the pinned option selected so the first paint is honest", () => {
+  assert.match(panel, /\?selected=\$\{selected === INHERIT\}/);
+  assert.match(panel, /\?selected=\$\{o\.value === selected\}/);
+  assert.match(panel, /option value=\$\{selected\} selected/);
+});
+
+test("an in-flight pick wins the saving re-render — no snap-back while the save runs", () => {
+  assert.match(panel, /pending: null as string \| null/);
+  assert.match(panel, /contextModelState\.pending = value/);
+  assert.match(panel, /const selected = contextModelState\.pending \?\? selectedValue\(config\)/);
+  // pending is cleared with saving, in the same guarded finally
+  assert.match(panel, /contextModelState\.saving = false;\n\s+contextModelState\.pending = null;/);
+});
+
+test("a pinned model offers a default effort level on the panel", () => {
+  assert.match(panel, /harnessSupportsEffort\(pinnedHarness\)/);
+  assert.match(panel, /ariaLabel: "Default effort level for this project"/);
+  assert.match(panel, /focusKey: "context-effort"/);
+  // effort choices are filtered to what the pinned harness accepts
+  assert.match(panel, /if \(value === "ultracode"\) return harnessId === "pi"/);
+  assert.match(panel, /if \(value === "max"\) return harnessId !== "codex"/);
+  // switching models carries a still-valid effort, drops an invalid one
+  assert.match(panel, /effortLevelsFor\(nextHarness\)\.some\(\(o\) => o\.value === effort\) \? effort : undefined/);
+  // the effort styles exist
+  assert.ok(css.includes(".context-model-effort {"));
 });

--- a/plugins/web-ui/test/field-select-source.test.ts
+++ b/plugins/web-ui/test/field-select-source.test.ts
@@ -41,3 +41,11 @@ test("no page keeps its own select chrome now that one rule owns it", () => {
   assert.doesNotMatch(css, /\.list-select select \{/);
   assert.doesNotMatch(css, /\.deploy-sort select \{/);
 });
+
+test("the dropdown holds the caller's value against re-renders (live) and stale DOM state", () => {
+  // .value on a <select> commits before its <option> children exist on first render,
+  // and lit's default dirty-check skips re-asserting it when the DOM has drifted —
+  // so the caller's value must go through live(), and options mark their own selected.
+  assert.match(ui, /import \{ live \} from "lit\/directives\/live\.js"/);
+  assert.match(ui, /\.value=\$\{props\.value === undefined \? nothing : live\(props\.value\)\}/);
+});


### PR DESCRIPTION
Two fixes to the scope model panel, one small feature:

- `fieldSelect` binds `.value` through `live()` and options set `?selected`, so a `<select>` shows its saved value on first render and re-renders can't silently reset it. Previously the value committed before the options existed and was dropped.
- An in-flight pick is held until the save settles — no visual snap-back during the round-trip; reverts on error.
- When a model is pinned, the panel offers a **Default effort** dropdown, filtered to the harness's supported levels and carried across model switches when still valid.

Tests cover the binding, the pending hold, and the effort guards. Typecheck, lint, prettier clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789590786&installation_model_id=19911&pr_number=567&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F567&signature=67e040ee2b953fa1a1b44e08c9016dacfe5f7f58e2c7b7de123eab98c8296c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->