### PR TITLE
Correct release version to 0.1.5

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,7 +112,8 @@ jobs:
           base_version=$(git show "${base}:cli/package.json" | jq -r .version)
           head_version=$(git show "${HEAD_SHA}:cli/package.json" | jq -r .version)
           highest=$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)
-          if [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; then
+          if [ "$base_version:$head_version" != "1.0.5:0.1.5" ] &&
+            { [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; }; then
             printf '%s\n' "$changed" >&2
             echo "these files ship in @yc-software/qm; bump cli/package.json past $base_version" >&2
             exit 1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,7 +112,9 @@ jobs:
           base_version=$(git show "${base}:cli/package.json" | jq -r .version)
           head_version=$(git show "${HEAD_SHA}:cli/package.json" | jq -r .version)
           highest=$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)
-          if [ "$base_version:$head_version" != "1.0.5:0.1.5" ] &&
+          correction_files=$(printf '%s\n' "$changed" | sort)
+          expected_correction_files=$(printf '%s\n' cli/package-lock.json cli/package.json)
+          if { [ "$base_version:$head_version" != "1.0.5:0.1.5" ] || [ "$correction_files" != "$expected_correction_files" ]; } &&
             { [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; }; then
             printf '%s\n' "$changed" >&2
             echo "these files ship in @yc-software/qm; bump cli/package.json past $base_version" >&2

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -89,8 +89,11 @@ jobs:
               exit 1
             fi
             echo "@yc-software/qm@$version is already on npm pinning these digests; keeping it"
-            exit 0
+          else
+            npm publish --provenance --access public
           fi
-          npm publish --provenance --access public
+          if [ "$version" = 0.1.5 ]; then
+            npm deprecate @yc-software/qm@1.0.5 "Published with an incorrect version number; use 0.1.5."
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "1.0.5",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "1.0.5",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "1.0.5",
+  "version": "0.1.5",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",


### PR DESCRIPTION
## What changed

- Correct the CLI package version from `1.0.5` to `0.1.5` and align the lockfile.
- Allow only this exact correction, with only the two package manifest files changed, through the monotonic-version CI guard.
- Deprecate npm `1.0.5` from the authenticated publish job after `0.1.5` is available.

## Why

The release was intended to be the next patch after `0.1.4`. Publishing it as `1.0.5` incorrectly skipped the package onto the 1.x line.

Publishing `0.1.5` will restore npm's `latest` tag and warn anyone explicitly installing the mistaken version. The mistaken GitHub release is already a draft; after `0.1.5` is verified, its tag and draft will be deleted so a future legitimate `v1.0.5` remains available.

## Validation

- Package and lockfile versions agree at `0.1.5`.
- `npm --prefix cli run test:pack` — passed.
- Version-guard cases cover the exact correction, correction plus an extra CLI change, missing manifest changes, ordinary upgrades, equal versions, and unrelated downgrades.
- Prettier and `git diff --check` — passed.
- npm and GitHub tag slots for `0.1.5` are unused.
