### PR TITLE
Remove temporary release correction exception

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,10 +112,7 @@ jobs:
           base_version=$(git show "${base}:cli/package.json" | jq -r .version)
           head_version=$(git show "${HEAD_SHA}:cli/package.json" | jq -r .version)
           highest=$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)
-          correction_files=$(printf '%s\n' "$changed" | sort)
-          expected_correction_files=$(printf '%s\n' cli/package-lock.json cli/package.json)
-          if { [ "$base_version:$head_version" != "1.0.5:0.1.5" ] || [ "$correction_files" != "$expected_correction_files" ]; } &&
-            { [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; }; then
+          if [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; then
             printf '%s\n' "$changed" >&2
             echo "these files ship in @yc-software/qm; bump cli/package.json past $base_version" >&2
             exit 1


### PR DESCRIPTION
Removes the narrowly scoped 1.0.5 → 0.1.5 CI exception now that the correction has merged.

The one-time npm recovery will be performed locally rather than encoded in the reusable release workflows.

Validation:
- `node --test test/release-workflows.test.ts`
- `git diff --check`