### PR TITLE
Docker deploy: give apps a writable /data, and stop reissuing ports after a restart

### DIFF
--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -1,26 +1,38 @@
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import type { Deployment, DeploymentVersion } from "./deploy-store.ts";
 import type { DeployEndpoint, DeployProvider } from "./deploy-provider.ts";
 import { spawnDockerExec, type DockerExec } from "../sandbox/docker-exec.ts";
 
 const APP_PORT = 8080;
+const DATA_DIR = "/data";
 const LEGACY_NETWORK = "agent-deploynet";
 
 export interface DockerDeployProviderOptions {
   image?: string;
   docker?: string;
   basePort?: number;
+  dataRoot?: string;
   dockerExec?: DockerExec;
+  mkdir?: (path: string) => void;
 }
 
 export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {}): DeployProvider {
   const docker = opts.docker ?? "docker";
   const image = opts.image ?? "node:24-alpine";
+  const dataRoot = resolve(opts.dataRoot ?? "./data/deployments-data");
+  const mkdir = opts.mkdir ?? ((path: string) => void mkdirSync(path, { recursive: true }));
   let nextPort = opts.basePort ?? 9200;
   const ports = new Map<string, number>();
   const freed: number[] = [];
-  const allocPort = (n: string): number => {
+  const allocPort = (n: string, assigned?: number): number => {
     const existing = ports.get(n);
     if (existing !== undefined) return existing;
+    if (assigned !== undefined) {
+      ports.set(n, assigned);
+      nextPort = Math.max(nextPort, assigned + 1);
+      return assigned;
+    }
     const port = freed.pop() ?? nextPort++;
     ports.set(n, port);
     return port;
@@ -81,12 +93,14 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
   };
 
   return {
-    profile: { managedScaleToZero: false },
+    profile: { managedScaleToZero: false, dataDir: DATA_DIR },
 
     async apply(d: Deployment, version: DeploymentVersion): Promise<DeployEndpoint> {
       const net = await ensureNetwork(network(d));
       await dexec(["rm", "-f", name(d)]);
-      const hostPort = allocPort(name(d));
+      const hostPort = allocPort(name(d), d.endpoint?.port);
+      const dataPath = join(dataRoot, d.id);
+      mkdir(dataPath);
       const envArgs = Object.entries(version.env ?? {}).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
       const r = await dexec([
         "run",
@@ -105,10 +119,14 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
         `127.0.0.1:${hostPort}:${APP_PORT}`,
         "-v",
         `${version.snapshotDir}:/app:ro`,
+        "-v",
+        `${dataPath}:${DATA_DIR}`,
         "-w",
         "/app",
         "-e",
         `PORT=${APP_PORT}`,
+        "-e",
+        `DATA_DIR=${DATA_DIR}`,
         ...envArgs,
         image,
         "sh",

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -144,3 +144,71 @@ test("a transient target inspection failure does not report the deployment missi
 
   await assert.rejects(provider.resolveEndpoint!(running, running.versions[0]!), /daemon unavailable/);
 });
+
+test("deployed apps get a writable /data mount and are told where it is", async () => {
+  const calls: string[][] = [];
+  const made: string[] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    return { code: args[1] === "inspect" ? 1 : 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const d = await store.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app",
+  });
+  const provider = createDockerDeployProvider({ dockerExec, dataRoot: "/var/qm-data", mkdir: (p) => made.push(p) });
+
+  await provider.apply(d, d.versions[0]!);
+
+  const run = calls.find((args) => args[0] === "run")!;
+  const joined = run.join(" ");
+  assert.equal(provider.profile.dataDir, "/data");
+  assert.ok(made.includes(`/var/qm-data/${d.id}`), "per-deployment data directory is created on the host");
+  assert.ok(joined.includes(`-v /var/qm-data/${d.id}:/data`), "the data directory is mounted writable");
+  assert.ok(joined.includes("-v /snap/app:/app:ro"), "the snapshot stays read-only");
+  assert.ok(joined.includes("-e DATA_DIR=/data"), "the app is told where its writable directory is");
+});
+
+test("a redeploy reuses the port already recorded on the deployment", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    return { code: args[1] === "inspect" ? 1 : 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const first = await store.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/one",
+  });
+  const second = await store.create({
+    ownerScopeId: scopeId("personal", "U2"),
+    createdBy: "U2",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/two",
+  });
+
+  const before = createDockerDeployProvider({ dockerExec, mkdir: () => {} });
+  const firstEndpoint = await before.apply(first, first.versions[0]!);
+  const secondEndpoint = await before.apply(second, second.versions[0]!);
+  assert.notEqual(firstEndpoint.port, secondEndpoint.port);
+
+  // A fresh provider models a process restart: the in-memory counter is gone,
+  // but the ports the deployments already hold are still on their records.
+  const after = createDockerDeployProvider({ dockerExec, mkdir: () => {} });
+  const rebound = await after.apply({ ...second, endpoint: secondEndpoint }, second.versions[0]!);
+  assert.equal(rebound.port, secondEndpoint.port, "a restart does not re-hand out a port that is already taken");
+
+  const third = await store.create({
+    ownerScopeId: scopeId("personal", "U3"),
+    createdBy: "U3",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/three",
+  });
+  const fresh = await after.apply(third, third.versions[0]!);
+  assert.notEqual(fresh.port, secondEndpoint.port, "a new deployment does not collide with a reused port");
+});


### PR DESCRIPTION
Two defects in the Docker deploy provider. Together they make a locally deployed app that stores anything fail on first run, and then fail differently after a restart. Both are invisible from the outside: the deployment record says `running` while the container has already exited.

## 1. No writable storage

The container gets the snapshot mounted read-only at `/app` and nothing writable anywhere:

```
-v ${version.snapshotDir}:/app:ro
```

So an app that opens a database or writes a file dies on startup. `mkdirSync('/app/data')` fails, and with `{ recursive: true }` it fails the same way, just with `EROFS` instead of `ENOENT`.

The platform already has a contract for this. `aws-deploy-provider.ts` defines `DATA_DIR = "/data"` and `DATA_DB = "/data/app.db"`, and `wiring.ts` warns that an AWS deployment without a data bucket has *"NO durable /data"*. `DeployProfile` even carries a `dataDir` field. The Docker provider never implemented its half — so an app written correctly against that contract works on AWS and crashes locally, which is the wrong way round for the environment people develop in.

Now: a per-deployment directory on the host, mounted read-write at `/data`, `DATA_DIR` in the app's environment, and the path advertised on `profile.dataDir`. The directory lives outside the container, so data survives a redeploy.

## 2. Host ports are allocated in memory

```ts
let nextPort = opts.basePort ?? 9200;
const ports = new Map<string, number>();
```

Every process restart resets the counter to the base. The next `apply` then hands out a port an existing container already holds, and the second container to start fails to bind — after several restarts a set of deployments can all carry the same recorded port.

The allocation is already durable: it is on the deployment record as `endpoint.port`, and `apply` receives the `Deployment`. So this keeps no new state — `apply` prefers the recorded port and advances the counter past it, instead of maintaining a parallel copy in RAM that a restart silently invalidates.

## Tests

`dataRoot` and `mkdir` are injectable alongside the existing `dockerExec`, so both paths are covered without touching a real filesystem or daemon:

- the data directory is created, mounted read-write at `/data`, and `DATA_DIR` is set, while the snapshot stays `:ro`
- a restart, modelled as a fresh provider instance over the same records: a redeploy keeps its recorded port, and a subsequent new deployment does not collide with it

`test/docker-deploy-provider.test.ts` 7/7, `test/aws-deploy-provider.test.ts` 46/46 unaffected, `tsc --noEmit` clean.

## Not fixed here

Nothing reconciles a deployment's recorded `status` against the container's actual state, so a crashed app reports `running` indefinitely and the UI shows it as starting up. That is what made both defects above hard to see, but it needs a reconcile loop rather than a change to this file, so it is left for a separate change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789628939&installation_model_id=19911&pr_number=575&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F575&signature=f63415a2b097bd756020549b7fb72c804b072c470359ec01f0de17f023793dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->