### PR TITLE
ci: only check co-author trailers on commits the PR adds

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -139,7 +139,7 @@ jobs:
           set -euo pipefail
           base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
           offenders=""
-          for sha in $(git rev-list "$base..$HEAD_SHA"); do
+          for sha in $(git rev-list --first-parent "$base..$HEAD_SHA"); do
             if git log -1 --format='%(trailers:key=Co-authored-by,valueonly)' "$sha" \
               | grep -qi '@users\.noreply\.github\.com'; then
               offenders="$offenders $sha"
@@ -151,6 +151,7 @@ jobs:
           echo "GitHub credits them to whichever account owns that username, which may be a stranger." >&2
           echo "This repo bans all such addresses, including your own privacy address;" >&2
           echo "use the contributor's real email, or drop the trailer." >&2
+          echo "Only commits this PR itself adds are checked; commits merged in from another branch are not." >&2
           exit 1
 
   lint:


### PR DESCRIPTION
The `Co-author trailers` check walks every commit reachable from the head:

```sh
base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
for sha in $(git rev-list "$base..$HEAD_SHA"); do
```

That range is not "the commits this PR adds" — it also contains everything a merge brought in. So a PR that merges another branch into itself is checked against that branch's commits as well as its own.

The failure mode is a check that cannot be satisfied. Merge `main` into a branch and the range picks up `main`'s history, including `9ff90fc` ("credits: record co-authors the squash merges dropped"), which records 13 `@users.noreply.github.com` trailers. The check flags it, and the author's options are rewriting published history or merging red. Neither is a review signal.

`--first-parent` restricts the range to the commits on the PR's own line of development.

## It still catches what it is meant to catch

Both offending shapes sit on the first-parent path, so neither is affected:

- a commit that introduces a banned trailer
- a merge commit carrying a banned trailer in its own message

Only the *contents* of a merged-in branch are skipped, which is history that entered through whatever review that branch had. The added stderr line says so, so someone reading a failure knows the scope.

## Repro

```
* fork: own clean commit
*   Merge branch 'upstream-main' into sync
|\
| * upstream: credit contributors      <- Co-authored-by: <...@users.noreply.github.com>
* | fork: prior work
|/
* base
```

| scan | result |
| --- | --- |
| `git rev-list "$base..$HEAD_SHA"` | flags `upstream: credit contributors` |
| `git rev-list --first-parent "$base..$HEAD_SHA"` | clean |

Controls, both still flagged under `--first-parent`: a branch whose own commit adds a banned trailer, and a branch whose merge commit carries one in its own message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789630737&installation_model_id=19911&pr_number=576&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F576&signature=3b87be6b6283c599dce6d662fbfce5a079927e69b3def90f44413fd3d6e200af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->