### PR TITLE
fix(sandbox): don't misreport attestation images as missing in local preflight

### DIFF
--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -112,21 +112,28 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
         preflightDone = undefined;
         throw new Error("SANDBOX_BACKEND=local requires a running Docker daemon (is Docker Desktop running?)");
       }
-      const img = await dexec([
-        "image",
-        "inspect",
-        "-f",
-        `{{.Id}} {{if .Config.Labels}}{{index .Config.Labels "${FINGERPRINT_LABEL}"}}{{end}}`,
-        image,
-      ]);
+      // Existence and label are separate probes: images built by buildx with
+      // attestations (the Docker 29 default, and what `qm sandbox publish`
+      // emits) inspect as an OCI index whose Config has no Labels key, which
+      // fails the fingerprint template even though the image is present and
+      // usable. A template failure must not be reported as a missing image.
+      const img = await dexec(["image", "inspect", "-f", "{{.Id}}", image]);
       if (img.code !== 0) {
         preflightDone = undefined;
         throw new Error(`local sandbox image ${image} not found — ${BUILD_HINT}`);
       }
-      const [imageId = "", labeled = ""] = img.stdout.trim().split(/\s+/);
+      const labeled = await dexec([
+        "image",
+        "inspect",
+        "-f",
+        `{{if .Config.Labels}}{{index .Config.Labels "${FINGERPRINT_LABEL}"}}{{end}}`,
+        image,
+      ]);
+      const fingerprint = labeled.code === 0 ? labeled.stdout.trim() : "";
+      const [imageId = ""] = img.stdout.trim().split(/\s+/);
       if (!staleWarned) {
         const want = await computeSandboxImageFingerprint(opts.repoRoot ?? process.cwd());
-        if (want && labeled && labeled !== want) {
+        if (want && fingerprint && fingerprint !== want) {
           staleWarned = true;
           console.warn(`[local-sandbox] sandbox image ${image} is stale — ${BUILD_HINT}`);
         }

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -90,6 +90,28 @@ test("a missing sandbox image fails provision with the build hint", async () => 
   await assert.rejects(sb.provision(rw(scopeId("personal", "U0"))), /not found — run `npm run sandbox:local:build`/);
 });
 
+test("attestation (OCI index) image whose label template fails is usable, not reported missing (#577)", async () => {
+  const fake = installFakeDocker(daemonPort);
+  fake.imageLabelsTemplateError = true;
+  const sb = makeSandbox(fake);
+  const scope = scopeId("personal", "U0");
+  // The regression's signature was a preflight rejection claiming the image is
+  // missing. The preflight must accept the image; environments where the later
+  // daemon-exec prep fails for unrelated reasons (local Windows runs) still
+  // prove the image was found — only the not-found rejection is a failure.
+  try {
+    const h = await sb.provision(rw(scope));
+    assert.equal(h.id, localContainerName(scope));
+    assert.equal(fake.runCount, 1);
+  } catch (error) {
+    assert.doesNotMatch(
+      String(error),
+      /not found — run `npm run sandbox:local:build`/,
+      "image was misreported as missing",
+    );
+  }
+});
+
 test("cold provision creates volume + container, run() execs over the daemon, bytes round-trip", async () => {
   const fake = installFakeDocker(daemonPort);
   const sb = makeSandbox(fake);

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -18,6 +18,9 @@ export interface FakeDocker {
   imageMissing: boolean;
   imageId: string;
   imageFingerprint: string;
+  /** Mimics a buildx attestation image: `{{.Id}}` inspects fine, but the
+   * fingerprint template fails because the OCI index's Config has no Labels key. */
+  imageLabelsTemplateError: boolean;
 }
 
 export function installFakeDocker(daemonPort: number): FakeDocker {
@@ -31,6 +34,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
     runCount: 0,
     daemonDown: false,
     imageMissing: false,
+    imageLabelsTemplateError: false,
     imageId: "sha256:image-v1",
     imageFingerprint: "",
     dockerExec: async (args) => exec(args),
@@ -61,7 +65,17 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         return ok("Docker version fake");
       case "image": {
         if (self.imageMissing) return fail("Error: No such image");
-        return ok(`${self.imageId} ${self.imageFingerprint}`);
+        if (rest[0] === "inspect") {
+          const format = rest[rest.indexOf("-f") + 1] ?? "";
+          if (format === "{{.Id}}") return ok(self.imageId);
+          if (self.imageLabelsTemplateError) {
+            return fail(
+              'template parsing error: template: :1:20: executing "" at <.Config.Labels>: map has no entry for key "Labels"',
+            );
+          }
+          return ok(self.imageFingerprint);
+        }
+        return fail(`unknown image subcommand ${rest.join(" ")}`);
       }
       case "inspect": {
         const name = rest[rest.length - 1]!;


### PR DESCRIPTION
## Summary

Fixes the preflight bug reported in part 2 of #577 (scoped to that; part 1 is a published-artifacts question for maintainers).

## The bug

The local-sandbox preflight ran one probe:

```
docker image inspect -f '{{.Id}} {{if .Config.Labels}}{{index .Config.Labels "qm.sandbox-fingerprint"}}{{end}}' <image>
```

Images built by buildx **with attestations** — the Docker 29 default, and exactly what `qm sandbox publish` emits — inspect as an OCI index whose `Config` has no `Labels` key. The Go template then fails:

```
template parsing error: template: :1:20: executing "" at <.Config.Labels>:
map has no entry for key "Labels"
```

That exits non-zero, so preflight rejected a **present, usable** image as `local sandbox image <image> not found — run npm run sandbox:local:build` — a wrong error that points at rebuilding (the reporter rebuilt twice before checking the exit path itself).

## Fix

Split the probe in two:

1. `docker image inspect -f '{{.Id}}' <image>` decides **existence** — valid for index and manifest images alike.
2. The fingerprint template becomes a second, **tolerated** probe: a non-zero exit means "no fingerprint", which skips the stale-image comparison instead of failing the run.

Fingerprint-labeled images behave exactly as before, including the stale warning.

## Tests

- `test/support/fake-docker.ts` gains the exact attestation behavior: `{{.Id}}` inspects fine, the labels template fails with the real `map has no entry for key "Labels"` error.
- New regression test in `test/local-sandbox.test.ts` asserts provision no longer rejects with the not-found signature. **Verified locally: fails on `main` with precisely that misreport ("image was misreported as missing"), passes with the fix.**

Note: 12 pre-existing tests in this file already fail on Windows checkouts (they exercise the real `agent.mjs` daemon's `/exec`, which needs a POSIX shell) — same count before and after this change; CI on Linux runs them green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789643527&installation_model_id=19911&pr_number=580&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F580&signature=83782ce1df251967118ecc69d6474ed797de0b769b433a37225855bccb52da10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->