### PR TITLE
fix(security): point quarantine refusals at the session holding the record

### DIFF
--- a/plugins/chassis/src/security-quarantine.ts
+++ b/plugins/chassis/src/security-quarantine.ts
@@ -1,2 +1,14 @@
 export const SECURITY_QUARANTINE_REFUSAL_TEXT =
   "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review the quarantine.";
+
+/**
+ * The refusal text promises an admin review of the quarantine. The refused
+ * input and the screen's full request snapshot are stored on the session
+ * (readable via GET /v1/admin/sessions/:id/llm), so when the refusal carries a
+ * session id, surface it: that is the record an admin reviews (#574).
+ */
+export function quarantineRefusalText(sessionId?: string): string {
+  return sessionId
+    ? `${SECURITY_QUARANTINE_REFUSAL_TEXT} (quarantine record: session ${sessionId})`
+    : SECURITY_QUARANTINE_REFUSAL_TEXT;
+}

--- a/src/delivery/run-result-delivery.ts
+++ b/src/delivery/run-result-delivery.ts
@@ -2,7 +2,7 @@ import type { Destination, OutgoingAttachment } from "../types.ts";
 import type { Run, RunStore } from "../runs/run-store.ts";
 import type { DeliveryStore } from "./delivery-store.ts";
 import type { Task, TaskStore } from "../tasks/task-store.ts";
-import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../../plugins/chassis/src/security-quarantine.ts";
+import { quarantineRefusalText } from "../../plugins/chassis/src/security-quarantine.ts";
 import { resolveTurnOrigin } from "../core/turn-origin.ts";
 import { errMessage } from "../util/errors.ts";
 
@@ -31,7 +31,7 @@ export function runResultDelivery(run: Run, taskList: Task[] = []): RunResultDel
     run.result.refusalKind === "security_quarantine" &&
     run.request.addressed
   ) {
-    return { destination, text: SECURITY_QUARANTINE_REFUSAL_TEXT, idempotencyKey };
+    return { destination, text: quarantineRefusalText(run.result.sessionId), idempotencyKey };
   }
   if (run.request.surfaceTools && run.result?.status !== "failed" && !run.result?.attachments?.length) return null;
   if (run.status === "failed") {

--- a/src/slack/refusals.ts
+++ b/src/slack/refusals.ts
@@ -1,4 +1,4 @@
-import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../../plugins/chassis/src/security-quarantine.ts";
+import { quarantineRefusalText } from "../../plugins/chassis/src/security-quarantine.ts";
 
 export function isBoundaryRefusal(reason: string | undefined): boolean {
   return (reason ?? "").startsWith("internal-only");
@@ -27,11 +27,16 @@ export async function postThenAckRunDelivery(opts: {
 }
 
 export function refusalNote(
-  result: { reason?: string; adminUrl?: string; refusalKind?: "security_quarantine" },
+  result: {
+    reason?: string;
+    adminUrl?: string;
+    refusalKind?: "security_quarantine";
+    sessionId?: string;
+  },
   kind: "dm" | "channel",
 ): string {
   if (result.refusalKind === "security_quarantine") {
-    return SECURITY_QUARANTINE_REFUSAL_TEXT;
+    return quarantineRefusalText(result.sessionId);
   }
   const reason = result.reason ?? "refused";
   if (isBoundaryRefusal(reason)) {

--- a/test/run-result-delivery.test.ts
+++ b/test/run-result-delivery.test.ts
@@ -108,6 +108,22 @@ test("runResultDelivery recovers a security quarantine without exposing its inte
   assert.doesNotMatch(d?.text ?? "", /internal screening details/);
 });
 
+test("runResultDelivery surfaces the session id holding the quarantine record (#574)", () => {
+  const d = runResultDelivery(
+    run({
+      request: { ...turn("hi", "C9:171.001"), addressed: true },
+      result: {
+        status: "refused",
+        refusalKind: "security_quarantine",
+        reason: "internal screening details",
+        sessionId: "sess-5678",
+      },
+    }),
+  );
+  assert.match(d?.text ?? "", /quarantine record: session sess-5678/);
+  assert.doesNotMatch(d?.text ?? "", /internal screening details/);
+});
+
 test("runResultDelivery keeps an unprompted quarantine silent — a replay has no live handler to suppress it", () => {
   const spine = run({ result: { status: "refused", refusalKind: "security_quarantine" } });
   spine.request = { ...spine.request, surfaceTools: true, origin: { kind: "ambient" } };

--- a/test/slack-refusals.test.ts
+++ b/test/slack-refusals.test.ts
@@ -90,3 +90,25 @@ test("isBoundaryRefusal: only internal-only reasons are boundary refusals", () =
   assert.equal(isBoundaryRefusal("An unknown error occurred"), false);
   assert.equal(isBoundaryRefusal(undefined), false);
 });
+
+test("refusalNote: a quarantine refusal surfaces the session that holds the quarantine record (#574)", () => {
+  const note = refusalNote(
+    {
+      refusalKind: "security_quarantine",
+      reason: "Auto quarantined suspicious or unscreenable external input before the agent ran.",
+      sessionId: "sess-1234",
+    },
+    "channel",
+  );
+  assert.match(note, /quarantine record: session sess-1234/);
+  assert.match(note, /ask an admin to review the quarantine/);
+  assert.doesNotMatch(note, /Auto quarantined|unscreenable/);
+});
+
+test("refusalNote: a quarantine refusal without a session keeps the plain text", () => {
+  const note = refusalNote({ refusalKind: "security_quarantine" }, "channel");
+  assert.equal(
+    note,
+    "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review the quarantine.",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes part 1 of #574: the quarantine refusal text promises an admin review, but nothing in the refusal pointed at where the review material actually lives.

## The gap

Both rendering sites — `slack/refusals.ts#refusalNote` and `delivery/run-result-delivery.ts` — substituted the fixed `SECURITY_QUARANTINE_REFUSAL_TEXT` with no reference, even though:

- the orchestrator's refused result already carries `sessionId`, and
- the refused input (appended to the session transcript with `securityTainted: true`) and the screen's full request snapshot both live on that session, readable via `GET /v1/admin/sessions/:id/llm` and visible on the admin history page.

So the review the sentence promises was reachable with existing storage — only the wire-up was missing.

## Fix

A `quarantineRefusalText(sessionId?)` helper in `plugins/chassis/src/security-quarantine.ts`, used by both rendering sites:

- with a session id, the refusal ends with `(quarantine record: session <id>)` — locates the record on the admin history page / admin API;
- without one (stored results replaying through delivery), the text is byte-for-byte unchanged;
- the internal screening reason stays hidden in both cases.

Deliberately not touching part 2 (the `strict` posture semantics) — that's a design discussion about whether `strict` should retain inbound screening, and changing posture behavior unilaterally would be the wrong way to settle it.

## Tests

- `slack-refusals.test.ts`: quarantine note surfaces the session id; no-session fallback keeps the exact prior text; internal reason stays hidden.
- `run-result-delivery.test.ts`: delivery text carries the record reference for a refused result with a session.
- All 30 pre-existing refusal/delivery tests and the `refusal-admin-link-integration` test pass unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644110&installation_model_id=19911&pr_number=581&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F581&signature=8507f79891293a6875dbf3c9b681321ab58f890927ae187538a6c4bb98762444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->