### PR TITLE
fix(cli): probe the configured provider endpoint in doctor

### DIFF
--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -214,26 +214,70 @@ async function baseModelCheck(config: QmConfig, secrets: Map<string, string>): P
     warn(`${name} is not available locally — skipping the live ${provider} check`);
     return;
   }
-  await modelProviderCheck(provider, key);
+  await modelProviderCheck(provider, key, secrets);
   step(`base model provider ${provider}: ${name} accepted`);
 }
 
 const MODEL_PROVIDER_PROBES: Readonly<
-  Record<ModelProvider, { url: string; headers: (key: string) => Record<string, string> }>
+  Record<ModelProvider, { baseUrl: string; path: string; headers: (key: string) => Record<string, string> }>
 > = {
   anthropic: {
-    url: "https://api.anthropic.com/v1/models?limit=1",
+    baseUrl: "https://api.anthropic.com",
+    path: "/v1/models?limit=1",
     headers: (key) => ({ "x-api-key": key, "anthropic-version": "2023-06-01" }),
   },
-  openai: { url: "https://api.openai.com/v1/models", headers: (key) => ({ authorization: `Bearer ${key}` }) },
-  openrouter: { url: "https://openrouter.ai/api/v1/key", headers: (key) => ({ authorization: `Bearer ${key}` }) },
+  openai: {
+    baseUrl: "https://api.openai.com/v1",
+    path: "/models",
+    headers: (key) => ({ authorization: `Bearer ${key}` }),
+  },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    path: "/key",
+    headers: (key) => ({ authorization: `Bearer ${key}` }),
+  },
 };
 
-async function modelProviderCheck(provider: ModelProvider, apiKey: string): Promise<void> {
+const MODEL_PROVIDER_BASE_URL_ENV: Readonly<Record<ModelProvider, string>> = {
+  anthropic: "ANTHROPIC_BASE_URL",
+  openai: "OPENAI_BASE_URL",
+  openrouter: "OPENROUTER_BASE_URL",
+};
+
+/**
+ * Resolves the probe URL for a provider, honouring its `*_BASE_URL` override
+ * the way the runtime does (src/api/routes/admin/model-providers.ts resolves
+ * through the shared provider-endpoints module; the CLI package cannot import
+ * it, so the validation rules are mirrored here and must stay aligned):
+ * http(s) only, no embedded credentials, no query string, no fragment,
+ * trailing slashes trimmed. Loopback and private hosts stay allowed.
+ */
+export function modelProviderProbeUrl(provider: ModelProvider, baseUrlEnvValue: string | undefined): string {
   const probe = MODEL_PROVIDER_PROBES[provider];
+  const envName = MODEL_PROVIDER_BASE_URL_ENV[provider];
+  const raw = baseUrlEnvValue?.trim();
+  if (!raw) return `${probe.baseUrl}${probe.path}`;
+  const trimmed = raw.replace(/\/+$/, "");
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new CliError(`${envName} is not a valid URL: ${raw}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:")
+    throw new CliError(`${envName} must be an http(s) URL, got ${url.protocol}//`);
+  if (url.username || url.password) throw new CliError(`${envName} must not contain credentials`);
+  if (url.search) throw new CliError(`${envName} must not contain a query string`);
+  if (url.hash) throw new CliError(`${envName} must not contain a fragment`);
+  return `${trimmed}${probe.path}`;
+}
+
+async function modelProviderCheck(provider: ModelProvider, apiKey: string, secrets: Map<string, string>): Promise<void> {
+  const probe = MODEL_PROVIDER_PROBES[provider];
+  const url = modelProviderProbeUrl(provider, secrets.get(MODEL_PROVIDER_BASE_URL_ENV[provider]));
   let res: Response;
   try {
-    res = await fetch(probe.url, { headers: probe.headers(apiKey), signal: AbortSignal.timeout(10_000) });
+    res = await fetch(url, { headers: probe.headers(apiKey), signal: AbortSignal.timeout(10_000) });
   } catch (e) {
     throw new CliError(
       `could not reach the ${provider} API: ${errMessage(e)} — check network access (and any proxy) and retry`,

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   doctorCommon,
   localDoctorSecrets,
+  modelProviderProbeUrl,
   requiredSlackScopes,
   slackManifestBotScopes,
 } from "../src/backends/doctor.ts";
@@ -615,4 +616,24 @@ test("doctor without required local values warns-and-skips the live Slack check 
     if (priorApp !== undefined) process.env.SLACK_APP_TOKEN = priorApp;
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("modelProviderProbeUrl probes the official endpoints when no override is configured", () => {
+  assert.equal(modelProviderProbeUrl("openai", undefined), "https://api.openai.com/v1/models");
+  assert.equal(modelProviderProbeUrl("anthropic", "  "), "https://api.anthropic.com/v1/models?limit=1");
+  assert.equal(modelProviderProbeUrl("openrouter", undefined), "https://openrouter.ai/api/v1/key");
+});
+
+test("modelProviderProbeUrl honours the configured OpenAI-compatible endpoint (#525)", () => {
+  assert.equal(modelProviderProbeUrl("openai", "https://gw.internal:8443/openai/v1/"), "https://gw.internal:8443/openai/v1/models");
+  // Loopback and private hosts stay allowed, matching the shared endpoint parser.
+  assert.equal(modelProviderProbeUrl("openai", "http://127.0.0.1:8010/v1"), "http://127.0.0.1:8010/v1/models");
+});
+
+test("modelProviderProbeUrl rejects override values the shared parser rejects", () => {
+  assert.throws(() => modelProviderProbeUrl("openai", "ftp://example.com/v1"), /must be an http\(s\) URL/);
+  assert.throws(() => modelProviderProbeUrl("openai", "https://user:pass@example.com/v1"), /must not contain credentials/);
+  assert.throws(() => modelProviderProbeUrl("openai", "https://example.com/v1?x=1"), /must not contain a query string/);
+  assert.throws(() => modelProviderProbeUrl("openai", "https://example.com/v1#frag"), /must not contain a fragment/);
+  assert.throws(() => modelProviderProbeUrl("openai", "not a url"), /is not a valid URL/);
 });


### PR DESCRIPTION
## Summary

Fixes #525.

## The bug

`cli/src/backends/doctor.ts` hardcoded the official endpoints in `MODEL_PROVIDER_PROBES`, so with `OPENAI_BASE_URL` pointing at an OpenAI-compatible gateway the doctor probed `api.openai.com/v1/models` and reported a **false credential failure** for a key that is only valid at the configured endpoint — while runtime/Admin endpoint resolution (`src/api/routes/admin/model-providers.ts` → the shared `provider-endpoints` module) used the override.

## Fix

The doctor now resolves the probe URL the way the Admin route does — `override ?? default` — reading `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` / `OPENROUTER_BASE_URL` from the **same secrets map** the API keys are read from, so a staged/local `.env` override is honored consistently.

The CLI package doesn't import core modules, so the shared parser's validation rules are mirrored in a new exported `modelProviderProbeUrl(provider, envValue)`:

- http(s) only,
- no embedded credentials, no query string, no fragment,
- trailing slashes trimmed,
- **loopback and private HTTP hosts stay allowed** (gateway deployments on internal networks are the point of the override).

Probe shapes: `openai` → `<base>/models` (base default `https://api.openai.com/v1`), `anthropic` → `<base>/v1/models?limit=1`, `openrouter` → `<base>/key`.

## Tests

Three new unit tests over `modelProviderProbeUrl`:

- no-override defaults resolve to the official endpoints (whitespace-only values treated as unset);
- the override resolves the exact false-failure case from the issue, including trailing-slash trimming and a loopback host;
- each parser rejection (non-HTTP scheme, credentials, query, fragment, unparseable) throws the same class of `CliError` as the shared parser's messages.

Local run: 21 passing (18 pre-existing + 3 new); the 5 pre-existing Fly-doctor failures on this Windows checkout are unchanged by this PR and pass on CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644453&installation_model_id=19911&pr_number=583&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F583&signature=e3a89627539891084496f788061597e6f8736c5fa92c236c0b7345e75f6f95aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->