### PR TITLE
fix(webhooks): reject stale Stripe signatures (replay window)

### DIFF
--- a/src/webhooks/verifiers.ts
+++ b/src/webhooks/verifiers.ts
@@ -39,6 +39,8 @@ function signedBodyId(rawBody: string, field: string): string {
   return bodyHash(rawBody);
 }
 
+const STRIPE_TS_TOLERANCE_SECONDS = 60 * 5;
+
 const github: Verifier = {
   verify({ secret, headers, rawBody }) {
     if (!secret) return false;
@@ -87,6 +89,12 @@ const stripe: Verifier = {
     const t = parts.find(([k]) => k === "t")?.[1];
     const v1s = parts.filter(([k, v]) => k === "v1" && v).map(([, v]) => v);
     if (!t || v1s.length === 0) return false;
+    // The timestamp is part of the signed payload, so a captured
+    // (signature, body) pair stays valid forever unless the freshness of `t`
+    // is checked — Stripe's own SDKs default to the same five-minute window.
+    const tsSeconds = Number(t);
+    if (!Number.isFinite(tsSeconds)) return false;
+    if (Math.abs(Date.now() / 1000 - tsSeconds) > STRIPE_TS_TOLERANCE_SECONDS) return false;
     const expected = hmacHex(secret, `${t}.${rawBody}`);
     return v1s.some((v1) => constantTimeEqual(v1, expected));
   },

--- a/test/webhook-verifiers.test.ts
+++ b/test/webhook-verifiers.test.ts
@@ -92,7 +92,7 @@ test("slack dedup key is the signed body's event_id, not the unsigned x-slack-ev
 test("stripe verifier validates t=…,v1=… over `t.body` and uses the event id for dedup", () => {
   const v = getVerifier("stripe")!;
   const rawBody = JSON.stringify({ id: "evt_123", type: "charge.failed" });
-  const t = "1700000000";
+  const t = String(Math.floor(Date.now() / 1000));
   const v1 = hmac(`${t}.${rawBody}`);
   const input = { secret: SECRET, headers: { "stripe-signature": `t=${t},v1=${v1}` }, rawBody };
   assert.equal(v.verify(input), true);
@@ -103,7 +103,7 @@ test("stripe verifier validates t=…,v1=… over `t.body` and uses the event id
 test("stripe verifier accepts any valid v1 signature during key rotation", () => {
   const v = getVerifier("stripe")!;
   const rawBody = JSON.stringify({ id: "evt_rot" });
-  const t = "1700000000";
+  const t = String(Math.floor(Date.now() / 1000));
   const valid = hmac(`${t}.${rawBody}`);
   const rotated = { secret: SECRET, headers: { "stripe-signature": `t=${t},v1=oldkeysig,v1=${valid}` }, rawBody };
   assert.equal(v.verify(rotated), true);
@@ -130,4 +130,28 @@ test("hmac-sha256 dedup key is the signed body, ignoring the unsigned x-delivery
 test("an unknown scheme has no verifier", () => {
   assert.equal(getVerifier("paypal"), null);
   assert.equal(getVerifier("none"), null);
+});
+
+test("stripe verifier rejects a valid signature whose timestamp is stale (replay protection)", () => {
+  const v = getVerifier("stripe")!;
+  const rawBody = JSON.stringify({ id: "evt_replay", type: "charge.failed" });
+  // A captured delivery: correctly signed, but its `t` is far in the past.
+  const t = String(Math.floor(Date.now() / 1000) - 60 * 60);
+  const v1 = hmac(`${t}.${rawBody}`);
+  assert.equal(v.verify({ secret: SECRET, headers: { "stripe-signature": `t=${t},v1=${v1}` }, rawBody }), false);
+
+  const futureT = String(Math.floor(Date.now() / 1000) + 60 * 60);
+  const futureV1 = hmac(`${futureT}.${rawBody}`);
+  assert.equal(
+    v.verify({ secret: SECRET, headers: { "stripe-signature": `t=${futureT},v1=${futureV1}` }, rawBody }),
+    false,
+  );
+});
+
+test("stripe verifier accepts a signature inside the five-minute window", () => {
+  const v = getVerifier("stripe")!;
+  const rawBody = JSON.stringify({ id: "evt_fresh" });
+  const t = String(Math.floor(Date.now() / 1000) - 60);
+  const v1 = hmac(`${t}.${rawBody}`);
+  assert.equal(v.verify({ secret: SECRET, headers: { "stripe-signature": `t=${t},v1=${v1}` }, rawBody }), true);
 });


### PR DESCRIPTION
## Summary

Source audit finding in the webhook subsystem restored by #570: **the Stripe verifier accepted signatures of any age**, leaving webhook deliveries replayable forever.

## The gap

`src/webhooks/verifiers.ts` validated the `v1` HMAC over `t.body` but never checked the freshness of `t`. Because the timestamp is part of the signed payload, a captured `(signature, body)` pair remains cryptographically valid indefinitely — an attacker who observed one delivery could re-deliver it forever, re-triggering whatever standing order the webhook drives (each re-delivery counting as a fresh, verified event).

The Slack verifier in the same file already enforces a five-minute window (`SLACK_TS_TOLERANCE_SECONDS`), and Stripe's own SDKs default to the same tolerance — this was a one-verifier omission. The existing verifier tests actually demonstrated the hole: they used a frozen `t = "1700000000"` (November 2023) and passed.

## Fix

Reject signatures whose `t` is outside a five-minute window of the current time, or not a finite number — mirroring the Slack verifier's posture exactly.

## Tests

- Existing Stripe verifier tests updated to use the current time (their frozen 2023 timestamp now fails the freshness check — that flip is the regression signal).
- New tests: a correctly-signed stale-past timestamp is rejected, a correctly-signed future timestamp is rejected, and a signature inside the five-minute window is accepted.
- All 13 verifier tests pass locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789645657&installation_model_id=19911&pr_number=584&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F584&signature=c881cb249b092130c201b0c4f87e61f180059770e45fde775abc1930bb0a9e1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->