### PR TITLE
fix(slack): ack run recovery delivery only after the reply reaches Slack

### DIFF
--- a/src/slack/core-bridge.ts
+++ b/src/slack/core-bridge.ts
@@ -13,6 +13,10 @@ interface CoreCallHooks {
   onFirstBlock?: (text: string) => void;
   onSurfacePosted?: () => void;
   onTasks?: (tasks: RunTaskView[]) => void;
+  /** The caller posts the ok reply itself and settles the run's recovery delivery afterward:
+   *  ack on a successful post, release on failure so the delivery poller can redeliver.
+   *  Without this, an ok run is acked here — BEFORE the reply reaches Slack. */
+  deferOkAck?: boolean;
 }
 
 export interface CoreBridge {
@@ -152,7 +156,10 @@ export function createCoreBridge(core: SlackCoreClient): CoreBridge {
       return result;
     }
     if (result && (result.status === "ok" || result.status === "refused" || result.status === "failed")) {
-      ackRunDeliveryWithRetry(runId);
+      // Ack marks the run's recovery delivery as delivered. For ok results the reply text has
+      // NOT been posted to Slack yet — acking here erases the poller's ability to recover a
+      // failed post. Callers that post the reply themselves pass deferOkAck and settle after.
+      if (!(result.status === "ok" && hooks.deferOkAck)) ackRunDeliveryWithRetry(runId);
     } else {
       inFlightRuns.delete(runId);
     }

--- a/src/slack/delivery.ts
+++ b/src/slack/delivery.ts
@@ -294,6 +294,7 @@ export function deliveryCandidatesFor(
 
 const DELIVERY_MAX_ATTEMPTS = 5;
 const DELIVERY_MAX_TRACKED = 1000;
+const DELIVERY_GIVEUP_RETRY_MS = 5 * 60_000;
 
 export interface DeliveryTracker {
   givenUp(id: string): boolean;
@@ -311,15 +312,25 @@ function capMap<K, V>(map: Map<K, V>, max: number): void {
   }
 }
 
-export function createDeliveryTracker(opts: { maxAttempts?: number; maxTracked?: number } = {}): DeliveryTracker {
+export function createDeliveryTracker(
+  opts: { maxAttempts?: number; maxTracked?: number; giveUpRetryMs?: number } = {},
+): DeliveryTracker {
   const maxAttempts = opts.maxAttempts ?? DELIVERY_MAX_ATTEMPTS;
   const maxTracked = opts.maxTracked ?? DELIVERY_MAX_TRACKED;
+  const giveUpRetryMs = opts.giveUpRetryMs ?? DELIVERY_GIVEUP_RETRY_MS;
   const failures = new Map<string, number>();
   const posted = new Map<string, { ackBody?: unknown }>();
-  const dead = new Map<string, true>();
+  // A "dead" delivery is only benched, not abandoned: after giveUpRetryMs it becomes
+  // eligible again, so a transient Slack outage can't silently strand a pending row forever.
+  const dead = new Map<string, number>();
   return {
     givenUp(id) {
-      return dead.has(id);
+      const until = dead.get(id);
+      if (until === undefined) return false;
+      if (Date.now() < until) return true;
+      dead.delete(id);
+      console.error(`[slack-plugin] delivery ${id} give-up window expired — retrying delivery`);
+      return false;
     },
     posted(id) {
       return posted.get(id);
@@ -331,7 +342,7 @@ export function createDeliveryTracker(opts: { maxAttempts?: number; maxTracked?:
         if (oldest === undefined) break;
         posted.delete(oldest);
         failures.delete(oldest);
-        dead.set(oldest, true);
+        dead.set(oldest, Date.now() + giveUpRetryMs);
         capMap(dead, maxTracked);
       }
     },
@@ -340,7 +351,7 @@ export function createDeliveryTracker(opts: { maxAttempts?: number; maxTracked?:
       if (count >= maxAttempts) {
         failures.delete(id);
         posted.delete(id);
-        dead.set(id, true);
+        dead.set(id, Date.now() + giveUpRetryMs);
         capMap(dead, maxTracked);
         return true;
       }

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -455,6 +455,7 @@ export function createTurnHandler(deps: {
       result = await callCore(
         { ...turn, intakePreambleMs: Math.round(tSubmit - t0), clientSentAt: Date.now() },
         {
+          deferOkAck: true,
           onQueued: (runId) => {
             queuedRunId = runId;
             inFlightRunByThread.set(threadRef, runId);
@@ -533,6 +534,7 @@ export function createTurnHandler(deps: {
       const postText = reply;
       const tDeliverStart = performance.now();
       let finalizedTaskList = false;
+      try {
       if (result.attachments?.length) {
         let uploadError: unknown;
         try {
@@ -557,6 +559,20 @@ export function createTurnHandler(deps: {
         if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
         if (postText && !finalizedTaskList) await postReply(postText);
       }
+      } catch (err) {
+        // The run finished but the reply never reached Slack. Do NOT ack the run's recovery
+        // delivery — release the pin so the delivery poller redelivers it after the grace period.
+        if (queuedRunId) {
+          console.error(
+            `[slack-plugin] reply post failed after run ${queuedRunId} finished (ch=${inc.channel} ts=${inc.ts}): ${(err as Error).message} — leaving delivery run:${queuedRunId} for the recovery poller`,
+          );
+          inFlightRuns.delete(queuedRunId);
+          return;
+        }
+        throw err;
+      }
+      // The reply is on Slack (or there was nothing to post) — now settle the recovery delivery.
+      if (queuedRunId) ackRunDeliveryWithRetry(queuedRunId);
       if (queuedRunId) {
         reportTurnMetrics(queuedRunId, {
           deliverMs: Math.round(performance.now() - tDeliverStart),

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -535,30 +535,30 @@ export function createTurnHandler(deps: {
       const tDeliverStart = performance.now();
       let finalizedTaskList = false;
       try {
-      if (result.attachments?.length) {
-        let uploadError: unknown;
-        try {
-          await uploadAttachments(
-            client,
-            inc.channel,
-            replyThreadTs,
-            result.attachments,
-            fetchBlobFromCore,
-            fetchFileArtifactFromCore,
-          );
-        } catch (err) {
-          uploadError = err;
-          console.error("[slack-plugin] file upload failed:", (err as Error).message);
+        if (result.attachments?.length) {
+          let uploadError: unknown;
+          try {
+            await uploadAttachments(
+              client,
+              inc.channel,
+              replyThreadTs,
+              result.attachments,
+              fetchBlobFromCore,
+              fetchFileArtifactFromCore,
+            );
+          } catch (err) {
+            uploadError = err;
+            console.error("[slack-plugin] file upload failed:", (err as Error).message);
+          }
+          await settleAck();
+          if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
+          if (postText && !finalizedTaskList) await postReply(postText);
+          if (uploadError) await postReply(uploadFailureNote(uploadError));
+        } else {
+          await settleAck();
+          if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
+          if (postText && !finalizedTaskList) await postReply(postText);
         }
-        await settleAck();
-        if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
-        if (postText && !finalizedTaskList) await postReply(postText);
-        if (uploadError) await postReply(uploadFailureNote(uploadError));
-      } else {
-        await settleAck();
-        if (postText) finalizedTaskList = (await taskList?.finalize(postText)) ?? false;
-        if (postText && !finalizedTaskList) await postReply(postText);
-      }
       } catch (err) {
         // The run finished but the reply never reached Slack. Do NOT ack the run's recovery
         // delivery — release the pin so the delivery poller redelivers it after the grace period.

--- a/test/slack-reply-ack-ordering.test.ts
+++ b/test/slack-reply-ack-ordering.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { createCoreBridge } from "../src/slack/core-bridge.ts";
+import { createDeliveryTracker, deliverWithRetry } from "../src/slack/delivery.ts";
+
+function fakeCore(pending: Map<string, { text: string }>, events: string[]) {
+  return {
+    async submitTurn() {
+      pending.set("run:r1", { text: "the finished reply" });
+      return { status: "queued", runId: "r1" };
+    },
+    async waitRun() {
+      return { status: "ok", reply: "the finished reply", runId: "r1" };
+    },
+    async ackRunDelivery(runId: string) {
+      events.push("ack");
+      pending.delete(`run:${runId}`);
+    },
+    async signalRunAbort() {},
+    async activeRunForThread() { return undefined; },
+    async stageBlob() { return { blobId: "b", sizeBytes: 0 }; },
+    async readBlob() { return Buffer.alloc(0); },
+    async readFileArtifact() { return Buffer.alloc(0); },
+    async reportTurnMetrics() {},
+    async reportRunEditRef() {},
+  } as any;
+}
+
+/** Regression: an ok run must NOT ack its recovery delivery before the caller posts the
+ *  reply to Slack. With deferOkAck the bridge leaves the delivery pending; a post failure
+ *  releases the run pin and the poller can still redeliver — the reply is never lost. */
+test("deferOkAck: recovery delivery stays pending until the caller settles it", async () => {
+  const events: string[] = [];
+  const pending = new Map<string, { text: string }>();
+  const bridge = createCoreBridge(fakeCore(pending, events));
+
+  const result = await bridge.callCore({ text: "hi" } as any, { deferOkAck: true });
+  assert.equal(result.status, "ok");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.deepEqual(events, [], "no ack before the reply is posted");
+  assert.ok(pending.has("run:r1"), "recovery copy still pending — a failed post is recoverable");
+  assert.ok(bridge.inFlightRuns.has("r1"), "run stays pinned so the poller waits for the handler");
+
+  // handler posts to Slack, then settles:
+  bridge.ackRunDeliveryWithRetry("r1");
+  await new Promise((r) => setTimeout(r, 10));
+  assert.deepEqual(events, ["ack"]);
+  assert.equal(pending.size, 0);
+  assert.equal(bridge.inFlightRuns.has("r1"), false, "pin released after settle");
+});
+
+/** Callers that don't opt in (approvals) keep the old behavior: ok acks immediately. */
+test("without deferOkAck an ok run still acks its recovery delivery", async () => {
+  const events: string[] = [];
+  const pending = new Map<string, { text: string }>();
+  const bridge = createCoreBridge(fakeCore(pending, events));
+  await bridge.callCore({ text: "hi" } as any);
+  await new Promise((r) => setTimeout(r, 10));
+  assert.deepEqual(events, ["ack"]);
+  assert.equal(pending.size, 0);
+});
+
+/** Regression: the poller's give-up is a timed bench, not a permanent abandonment.
+ *  After maxAttempts failures the delivery is skipped only until giveUpRetryMs passes;
+ *  then delivery resumes, so a pending DB row can't be stranded silently forever. */
+test("delivery tracker retries a given-up delivery after the bench window", async () => {
+  const tracker = createDeliveryTracker({ giveUpRetryMs: 50 });
+  let posts = 0;
+  let acked = false;
+  const failing = {
+    tracker, id: "d1",
+    post: async () => { posts++; throw new Error("slack 429"); },
+    ack: async () => { acked = true; },
+    onError: () => {},
+  };
+  for (let i = 0; i < 6; i++) await deliverWithRetry(failing);
+  assert.equal(posts, 5, "benched after 5 attempts");
+
+  // Slack recovers; within the bench window nothing happens…
+  const healthy = { ...failing, post: async () => { posts++; } };
+  await deliverWithRetry(healthy);
+  assert.equal(posts, 5);
+  // …but after it expires, delivery resumes and completes.
+  await new Promise((r) => setTimeout(r, 60));
+  await deliverWithRetry(healthy);
+  assert.equal(posts, 6, "retried after the bench expired");
+  assert.equal(acked, true, "delivery finally acked");
+});

--- a/test/slack-reply-ack-ordering.test.ts
+++ b/test/slack-reply-ack-ordering.test.ts
@@ -17,10 +17,18 @@ function fakeCore(pending: Map<string, { text: string }>, events: string[]) {
       pending.delete(`run:${runId}`);
     },
     async signalRunAbort() {},
-    async activeRunForThread() { return undefined; },
-    async stageBlob() { return { blobId: "b", sizeBytes: 0 }; },
-    async readBlob() { return Buffer.alloc(0); },
-    async readFileArtifact() { return Buffer.alloc(0); },
+    async activeRunForThread() {
+      return undefined;
+    },
+    async stageBlob() {
+      return { blobId: "b", sizeBytes: 0 };
+    },
+    async readBlob() {
+      return Buffer.alloc(0);
+    },
+    async readFileArtifact() {
+      return Buffer.alloc(0);
+    },
     async reportTurnMetrics() {},
     async reportRunEditRef() {},
   } as any;
@@ -68,16 +76,27 @@ test("delivery tracker retries a given-up delivery after the bench window", asyn
   let posts = 0;
   let acked = false;
   const failing = {
-    tracker, id: "d1",
-    post: async () => { posts++; throw new Error("slack 429"); },
-    ack: async () => { acked = true; },
+    tracker,
+    id: "d1",
+    post: async () => {
+      posts++;
+      throw new Error("slack 429");
+    },
+    ack: async () => {
+      acked = true;
+    },
     onError: () => {},
   };
   for (let i = 0; i < 6; i++) await deliverWithRetry(failing);
   assert.equal(posts, 5, "benched after 5 attempts");
 
   // Slack recovers; within the bench window nothing happens…
-  const healthy = { ...failing, post: async () => { posts++; } };
+  const healthy = {
+    ...failing,
+    post: async () => {
+      posts++;
+    },
+  };
   await deliverWithRetry(healthy);
   assert.equal(posts, 5);
   // …but after it expires, delivery resumes and completes.


### PR DESCRIPTION
Public port of yc-software/qm-yc#2033 (merged internally, validated there).

**Bug:** replies could finish in the web UI but never appear in Slack. Two mechanisms:
1. The turn handler acked the run recovery delivery the moment the run resolved ok — before posting the reply. A failed post after that ack was unrecoverable and left no pending row behind.
2. The delivery tracker gave up permanently (in memory) after 5 failed attempts, silently.

**Fix:**
- `core-bridge`: new `deferOkAck` hook — an ok run no longer auto-acks when the caller owns the reply post; approvals paths unchanged.
- `turn-handler`: post first, ack after; on post failure logs `reply post failed after run <id> … leaving delivery for the recovery poller` and releases the run pin so the poller redelivers.
- `delivery`: give-up is a 5-minute bench instead of permanent abandonment, with a retry log line.

**Tests:** `test/slack-reply-ack-ordering.test.ts` (3 regressions); full slack+turn suites 416/416, tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789659150&installation_model_id=19911&pr_number=587&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F587&signature=35f5d271f60603e493cc27d0e95cd84607f28bc18a57ee1c2ff93b49da4a5caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->