### PR TITLE
fix(admin): state the security-posture lattice in the resource label

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -91,7 +91,14 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
     id: "security-posture",
     kind: "enum",
     target: "any",
-    label: "Harness security posture. The org value is a minimum; narrower scopes may tighten it but cannot weaken it.",
+    // The lattice is not per-control: strict does not retain auto's inbound
+    // screening -- it swaps content screening for approval-gated tools, and
+    // dangerous resolves back to auto as the floor. The old label's blanket
+    // "cannot weaken it" read as a per-control guarantee and led an operator
+    // tightening a scope to believe they had kept screening when they had
+    // swapped it away (#574).
+    label:
+      "Harness security posture. The org value is a floor: auto screens inbound content with no tool approvals; strict trades that screening for approval-gated tools (every harness tool pauses for a human); dangerous disables screening. Narrower scopes may move to a stricter mode but not below the org floor. Note: moving auto -> strict turns inbound content screening OFF in exchange for tool approvals.",
     readKey: "securityPosture",
     enumValues: SECURITY_POSTURES,
     get: (deps, scope) => deps.config!.getSecurityPostureDurable(scope),


### PR DESCRIPTION
## Summary

Addresses the "at minimum" ask of part 2 of #574 (the label fix; the posture-behavior design question is left to the maintainers).

## The problem (from the issue's own analysis)

The admin resource for `security-posture` labeled the org value as a blanket guarantee: *"narrower scopes may tighten it but cannot weaken it."* But the postures do not form a per-control lattice — `strict` does **not** retain `auto`'s inbound screening; it swaps content screening for approval-gated tools. An operator tightening a scope in response to a security concern could thereby silently **lose** a control, which the label explicitly promised could not happen.

## Fix

The label now states the actual lattice up front:

> auto screens inbound content with no tool approvals; strict trades that screening for approval-gated tools (every harness tool pauses for a human); dangerous disables screening. Narrower scopes may move to a stricter mode but not below the org floor. Note: moving auto → strict turns inbound content screening OFF in exchange for tool approvals.

The org value remains a floor on **mode ordering** — the only guarantee the postures actually form.

All 20 tests in `test/admin-resources.test.ts` + `test/security-posture.test.ts` pass unchanged (no test asserts label text).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789659362&installation_model_id=19911&pr_number=588&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F588&signature=7d36742e958d62a92f2ce8aa42c7e6e7bd642c0e7fd456939203767ae618731d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->