### PR TITLE
fix(admin): ack-emoji picker — proxy fix, auto-save, Slack-style picker

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -6573,6 +6573,11 @@
           renderChips();
           syncDefault();
         }
+        function autoSaveAckEmoji() {
+          updateSectionDirty("ack-emoji");
+          const btn = sectionButton("ack-emoji");
+          if (btn && !btn.disabled) btn.click();
+        }
         function initAckEmojiPicker() {
           const chips = $("ack-emoji-chips");
           const addInput = $("ack-emoji-add");
@@ -6601,6 +6606,7 @@
               x.onclick = () => {
                 ackEmojiNames = ackEmojiNames.filter((v) => v !== name);
                 renderAckChips();
+                autoSaveAckEmoji();
               };
               chip.appendChild(label);
               chip.appendChild(x);
@@ -6623,7 +6629,11 @@
               .replace(/^:+|:+$/g, "")
               .toLowerCase();
             if (!name || !/^[a-z0-9_+-]+$/.test(name)) return;
-            if (!ackEmojiNames.includes(name)) ackEmojiNames.push(name);
+            if (!ackEmojiNames.includes(name)) {
+              ackEmojiNames.push(name);
+              renderAckChips();
+              autoSaveAckEmoji();
+            }
             addInput.value = "";
             renderAckChips();
           };

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -6636,7 +6636,7 @@
           };
           if (!ackEmojiCatalogLoaded) {
             ackEmojiCatalogLoaded = true;
-            api("GET", "/v1/admin/slack-emoji")
+            api("GET", "/api/slack-emoji")
               .then((res) => {
                 if (res && res.ok && res.data && res.data.emoji) ackEmojiCatalog = res.data.emoji;
                 renderAckChips();

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -313,6 +313,7 @@ const READS = [
   "ambient-judgments",
   "ack-emoji-picks",
   "slack-installation",
+  "slack-emoji",
   "model-providers",
   "custom-providers",
 ];


### PR DESCRIPTION
Follow-up to #571 — three ack-emoji picker improvements, found/requested while testing live on a Fly deployment.

**1. Catalog fetch bypassed the admin proxy.** The UI fetched `/v1/admin/slack-emoji`, but the admin plugin only forwards `GET /api/<resource>` paths — the fetch returned the dashboard shell and the picker's catalog silently never loaded. UI now calls `GET /api/slack-emoji` and `slack-emoji` is in the proxied READS.

**2. Removing a chip didn't persist.** Chip add/remove only mutated local state; without pressing Save the change was silently lost. Chip changes now auto-save through the existing save machinery (dirty-mark, then trigger the section save — status text and error handling unchanged).

**3. Slack-style emoji picker.** The datalist type-ahead is replaced with a proper picker popover: search box, scrollable grid, the org's custom emoji first (with image previews), then the full standard set grouped by Slack's categories. Click to add; Escape closes; Enter picks the first match. The core endpoint now also returns the ordered standard emoji (name, char, category) from emoji-datasource so the picker isn't custom-only.