### PR TITLE
fix(budget): debit from metered usage instead of input-only estimates

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -44,7 +44,7 @@ import {
 } from "../credentials/connector-status.ts";
 import { renderComputerBlock, renderResidentLoginsBlock, renderConnectedAppsBlock } from "./environment-facts.ts";
 import { PROVIDERS } from "../connectors/oauth.ts";
-import { estimateCostUsd } from "../ratelimit/budget.ts";
+import { estimateCostUsd, modelCallCostUsd } from "../ratelimit/budget.ts";
 import {
   mintCapabilityToken,
   CAPABILITY_TTL_MS,
@@ -2484,6 +2484,15 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
                 await deps.sessions.recordLlmRequest(session.id, { ...rec, scopeLabel: scopeId });
               } catch (err) {
                 console.error("[orchestrator] failed to persist LLM request snapshot:", errMessage(err));
+              }
+              // Debit the budget from the provider-metered usage when it exists:
+              // the upfront recordModelCall estimate is input-only at a fixed
+              // rate, so models with cheaper input or dominant output costs
+              // were mispriced by up to 5x (#586).
+              const metered = modelCallCostUsd(rec, rec.usage ?? null);
+              const estimated = estimateCostUsd(rec.usage?.input ?? 0);
+              if (metered > estimated) {
+                void deps.budget?.record(actor.id, metered - estimated);
               }
             },
           });

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -16,6 +16,32 @@ export function estimateCostUsd(inputTokens: number, usdPerMTok = DEFAULT_AGENT_
   return (inputTokens / 1_000_000) * usdPerMTok;
 }
 
+/**
+ * Cost attribution for one model call, preferring the provider-metered usage
+ * the harnesses already report through recordLlmRequest (LlmCallUsage) and
+ * falling back to the input-only fixed-rate estimate when no metered numbers
+ * exist (#586).
+ */
+export function modelCallCostUsd(
+  rec: { model: string; inputTokens: number },
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    costUsd: number;
+  } | null,
+): number {
+  if (usage) {
+    if (Number.isFinite(usage.costUsd) && usage.costUsd > 0) return usage.costUsd;
+    // Metered tokens without a provider-computed cost: price input+output at
+    // the conservative fixed rate instead of dropping the output share.
+    return estimateCostUsd(usage.input + usage.output);
+  }
+  return estimateCostUsd(rec.inputTokens);
+}
+
 export function createBudgetTracker(
   opts: { limitUsd?: number; orgLimitUsd?: number; windowMs?: number } = {},
 ): BudgetTracker {

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBudgetTracker, estimateCostUsd } from "../src/ratelimit/budget.ts";
+import { createBudgetTracker, estimateCostUsd, modelCallCostUsd } from "../src/ratelimit/budget.ts";
 import { DEFAULT_AGENT_INPUT_USD_PER_MTOK } from "../src/model/pi-models.ts";
 import { buildApp } from "../src/wiring.ts";
 import type { TurnRequest } from "../src/types.ts";
@@ -58,4 +58,25 @@ test("a principal over budget is refused by the app", async () => {
   const second = await app.turn(dm("again"));
   assert.equal(second.status, "refused");
   assert.match(second.reason ?? "", /budget exceeded/);
+});
+
+test("modelCallCostUsd prefers provider-metered cost, then metered tokens, then the estimate (#586)", () => {
+  const rec = { model: "gpt-5.6-sol", inputTokens: 1000 };
+
+  // Provider computed the cost: used verbatim.
+  assert.equal(
+    modelCallCostUsd(rec, { input: 1000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 3000, costUsd: 0.07 }),
+    0.07,
+  );
+
+  // Metered tokens but no provider cost: input+output at the fixed rate
+  // (output no longer invisible).
+  assert.equal(
+    modelCallCostUsd(rec, { input: 1000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 3000, costUsd: 0 }),
+    estimateCostUsd(3000),
+  );
+
+  // No metered usage at all: the legacy input-only estimate.
+  assert.equal(modelCallCostUsd(rec, null), estimateCostUsd(1000));
+  assert.equal(modelCallCostUsd(rec, undefined), estimateCostUsd(1000));
 });


### PR DESCRIPTION
## Summary

Implements the "smallest useful change" from #586.

## Root cause (as diagnosed in the issue, verified)

The budget debited `estimateCostUsd(rec.inputTokens)` — a fixed **$5/MTok over an input-only estimate** — at every `recordModelCall` site, while the provider-metered numbers (`input`, `output`, `cacheRead/Write`, `costUsd`) were already arriving one callback over, on `recordLlmRequest`, and being persisted to `session_llm_requests` with full usage. Consequences per the issue's table: cheap-input models overcharged up to 5×, and output tokens — the larger share of a real bill — completely invisible.

## Fix

1. **`modelCallCostUsd(rec, usage)`** (in `ratelimit/budget.ts`) resolves one call's cost in priority order:
   - provider-computed `usage.costUsd` when positive → used verbatim;
   - metered `input + output` at the existing fixed rate when tokens exist but the provider didn't price them (output no longer invisible);
   - the legacy input-only estimate when no metered usage exists.
2. The turn path's **`recordLlmRequest` callback now also debits the budget** with the metered figure — charging only the **positive difference** over what the upfront input-only estimate already booked for that step's input. No double-counting (the upfront charge isn't refunded when metered cost is lower), no refunds.
3. The **upfront `recordModelCall` estimate is untouched** — budget ceilings still trip promptly for turns that never report usage (detection, compaction, security-screen paths).

## Scope note

The `turn_metrics` observability gap (no cost/output columns at the metrics sink) is the other half of the issue and is deliberately left for its own change.

## Tests

`modelCallCostUsd` resolution tests in `test/budget.test.ts` (provider cost verbatim; metered-tokens fallback prices input+output; null/undefined usage falls back to the estimate). Budget suite: 5/5 green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789665476&installation_model_id=19911&pr_number=592&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F592&signature=5127762d758ab5795e61868c2844ce369459fcd7244b31097abaa34e680aa2eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->