### PR TITLE
fix(admin): show the harness/model card at every accepted scope

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -6413,7 +6413,11 @@
           Array.isArray(r.data.approvedHarnesses) && r.data.approvedHarnesses.length
             ? r.data.approvedHarnesses
             : [harnessDefault];
-        const showBaseModel = scope.startsWith("org:") && opts.length > 0 && dflt && "runtime" in r.data;
+        // The runtime/base-model resources accept any scope (admin-resources.ts
+        // target: "any"); the org: prefix here hid them for channels and
+        // projects, forcing per-scope model choices through hand-rolled API
+        // calls (#589).
+        const showBaseModel = opts.length > 0 && dflt && "runtime" in r.data;
         $("card-base-model").classList.toggle("hidden", !showBaseModel);
         if (showBaseModel) {
           const current = r.data.runtime || { harnessId: harnessDefault, modelId: r.data.baseModel || dflt };


### PR DESCRIPTION
## Summary

Fixes #589.

## Root cause

Purely a UI gate: the `runtime` (and `base-model`) resources are declared `target: "any"` in `admin-resources.ts`, and `scope-config.ts` already returns `baseModelOptions` / `modelsByHarness` / `runtime` for **every** scope — which is exactly why the issue's API round-trip works on a channel while the card stays hidden. The one-line culprit:

```js
const showBaseModel = scope.startsWith("org:") && opts.length > 0 && dflt && "runtime" in r.data;
```

## Fix

Drop the `org:` prefix from `showBaseModel` — the harness/model card now renders at every scope the resource accepts, and per-channel/per-project model selection happens through the same form as org-level.

Deliberately untouched, because their backends are genuinely org-scoped:

- `approved-harnesses` (`target: "org"`, org-wide by design),
- the ambient/external-Slack/fast-mode/header-pin cards (all org-scoped resources in the same block).

No backend change needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789665651&installation_model_id=19911&pr_number=593&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F593&signature=fd4a873caa57350d77d34999659490c8fa39b1fd91dada6c164d204fd0485a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->