### PR TITLE
Propose: make the docker target deployable with SANDBOX_BACKEND=local

### DIFF
--- a/adrs/docker-target-local-sandbox.md
+++ b/adrs/docker-target-local-sandbox.md
@@ -1,0 +1,24 @@
+# Make the docker target deployable with SANDBOX_BACKEND=local
+
+`SANDBOX_BACKEND=local` runs agent computers as local Docker containers with no
+Fly agent-computer app, and the production config fixture already runs on it —
+but the docker target can't actually deploy with it end to end.
+
+`qm init --target docker` scaffolds a `sandbox.app` block, then `qm up` throws
+"sandbox.app is set but no sandbox layer image is pinned" because the local
+backend never publishes a pinned Fly image. Removing the block hits the gate
+in the other direction ("a Fly agent-computer app is required"). So docker+local
+is documented-valid but unbootable either way.
+
+A few more gaps in the same area once the gate clears: core runs in a container
+but the local backend reaches the sandbox exec daemon at `127.0.0.1`, which is
+core's own loopback (the daemon never becomes reachable); core has no Docker
+CLI or socket so it can't spawn sandboxes at all; and the auth broker is
+addressed as `http://auth:8080`, a bare Docker DNS name portal's private-network
+guard rejects.
+
+Could the docker target support `SANDBOX_BACKEND=local` as a first-class path —
+relaxing the `sandbox.app` gate for docker+local, giving core access to the host
+Docker socket + CLI, reaching the sandbox by name on a shared network (keeping
+per-scope isolation), and addressing the auth broker on `.internal`? We got it
+working on a single host with these changes and are happy to share the diff.


### PR DESCRIPTION
Hey — per CONTRIBUTING, dropping this as a short proposal rather than code. We've been running qm on a single host with `SANDBOX_BACKEND=local` and found the docker target is documented-valid (the production config fixture runs on `local`) but doesn't actually deploy end to end. Wrote up the gaps we hit in the ADR. We have it working on a box and are happy to share the diff if useful — but no pressure to take our code; happy to just flag the rough edges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789672178&installation_model_id=19911&pr_number=594&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F594&signature=be59cad1e31088654e36b0ae4a1682072cfe2ff983e0a41a85635b814aa87e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->