### PR TITLE
web-ui: drop duplicate admin shortcut from sidebar footer

### DIFF
--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -450,9 +450,6 @@ export function mountShell(): void {
               <span class="avatar">${initials(appState.me?.user ?? "?")}</span>
               <span class="user-name">${appState.me?.user ?? ""}</span>
             </div>
-            <a class="icon-btn subtle" href=${ADMIN_HOME_URL} title="Back to admin" aria-label="Back to admin"
-              >${icon(ShieldCheck, 17)}</a
-            >
             <theme-toggle .includeSystem=${true} title="Color scheme: light / dark / system"></theme-toggle>
             <button class="icon-btn subtle" title="Sign out" aria-label="Sign out" @click=${signOut}>
               ${icon(LogOut, 17)}

--- a/plugins/web-ui/test/admin-navigation-source.test.ts
+++ b/plugins/web-ui/test/admin-navigation-source.test.ts
@@ -5,8 +5,12 @@ import test from "node:test";
 const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
 
 test("admin navigation uses an admin-specific icon", () => {
-  const adminLink = shell.match(/<a class="icon-btn subtle" href=\$\{ADMIN_HOME_URL\}[\s\S]*?<\/a/);
+  const adminLink = shell.match(/<a class="navrow" href=\$\{ADMIN_HOME_URL\}[\s\S]*?<\/a>/);
   assert.ok(adminLink, "admin navigation link exists");
   assert.match(adminLink[0], /icon\(ShieldCheck, 17\)/);
   assert.doesNotMatch(adminLink[0], /icon\(ArrowLeft, 17\)/);
+});
+
+test("the sidebar footer carries no duplicate admin shortcut", () => {
+  assert.doesNotMatch(shell, /<a class="icon-btn subtle" href=\$\{ADMIN_HOME_URL\}/);
 });


### PR DESCRIPTION
The sidebar footer had a small admin shortcut icon that duplicates the Admin nav row (shown to admins in the sidebar list). Remove the footer shortcut to reduce clutter; the nav row remains the single entry point.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789688228&installation_model_id=19911&pr_number=595&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F595&signature=16e4fb0367e653b3fc8fd90977b113f50162040bb81ed0fa267c14b957024f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->