### PR TITLE
fix(ci): verify the provenance attestation landed after publishing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -92,6 +92,18 @@ jobs:
           else
             npm publish --provenance --access public
           fi
+          # The provenance flag only produces an attestation when the run's
+          # OIDC token satisfies npm's requirements; every other failure mode
+          # publishes cleanly WITHOUT one, silently downgrading trust for
+          # attestation-checking installers (aube/pnpm trust policies) — exactly
+          # the 0.1.5 incident (#591). Verify the attestation actually landed
+          # and fail loudly otherwise.
+          attestations=$(npm view "@yc-software/qm@$version" attestations --json 2>/dev/null || echo '[]')
+          if [ "$attestations" = 'null' ] || [ "$attestations" = '[]' ] || [ -z "$attestations" ]; then
+            echo "::error::@yc-software/qm@$version published without a provenance attestation; trust-checking installers will refuse or downgrade it. Check the run's id-token permission and republish a new version."
+            exit 1
+          fi
+          echo "@yc-software/qm@$version published with provenance attestation"
           if [ "$version" = 0.1.5 ]; then
             npm deprecate @yc-software/qm@1.0.5 "Published with an incorrect version number; use 0.1.5."
           fi


### PR DESCRIPTION
## Summary

Addresses #591 — prevents the silent trust-downgrade class of failure that produced 0.1.5.

## Root cause (per the analysis on the issue)

`npm publish --provenance` publishes **cleanly without an attestation** whenever the run's OIDC token doesn't satisfy npm's requirements (wrong event/ref for the token, permission hiccup, manual correction run). No error surfaces — the version simply lands with no trust evidence, and attestation-checking installers (aube `trust check`, pnpm trust policies) then see a **downgrade** versus any earlier version that had one. That's exactly the 0.1.5 shape: 0.1.0 had an attestation, 0.1.5 (published through the version-correction run) had none.

## Fix

The publish job now **verifies the attestation landed**, instead of trusting the flag:

```sh
attestations=$(npm view "@yc-software/qm@$version" attestations --json 2>/dev/null || echo '[]')
# fail the job when empty/null
```

- fails loudly with an actionable message (id-token permission, republish) — the next silent downgrade becomes a red build instead of a user-facing trust error;
- runs on **both** branches — the fresh-publish path and the already-published keep-path — so an early-exit path can never skip the evidence check either.

## Notes

- Republishing 0.1.5 itself isn't possible from a PR (immutable registry); for that release the issue's `trustPolicyExclude` workaround stands. This change protects every future release.
- `npm view <pkg> attestations` returns `null` for no evidence on supported npm versions; the check treats `null`, `[]`, and empty as failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789691168&installation_model_id=19911&pr_number=596&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F596&signature=89a2e76bd0c16f0a3a12dffecc22501e8fb043da3e742ebb6d3837088dcd6de8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->