### PR TITLE
Close owned file artifact PostgreSQL pools

### DIFF
--- a/src/files/file-artifact-store.ts
+++ b/src/files/file-artifact-store.ts
@@ -70,6 +70,8 @@ export interface FileArtifactStore {
   setEnabled(id: string, enabled: boolean): Promise<void>;
 
   delete(id: string): Promise<void>;
+
+  close?(): Promise<void>;
 }
 
 export function fileArtifactId(seed: string, direction: FileDirection, batchIndex: number): string {

--- a/src/files/postgres-file-artifact-store.ts
+++ b/src/files/postgres-file-artifact-store.ts
@@ -1,4 +1,4 @@
-import { createPgPool } from "../persistence/pg-pool.ts";
+import { createPgPool, usePgPool, type Pool } from "../persistence/pg-pool.ts";
 import type { ScopeId } from "../types.ts";
 import type { DurableByteStore } from "./durable-byte-store.ts";
 import {
@@ -61,10 +61,11 @@ function rowToArtifact(r: Record<string, unknown>): FileArtifact {
 }
 
 export function createPostgresFileArtifactStore(
-  connectionString: string,
+  connection: string | Pool,
   byteStore: DurableByteStore,
 ): FileArtifactStore {
-  const { q, query } = createPgPool(connectionString, SCHEMA);
+  const database = typeof connection === "string" ? createPgPool(connection, SCHEMA) : usePgPool(connection, SCHEMA);
+  const { q, query } = database;
 
   async function getRow(id: string): Promise<FileArtifact | null> {
     const rows = await q("SELECT * FROM file_artifacts WHERE id = $1", [id]);
@@ -170,5 +171,7 @@ export function createPostgresFileArtifactStore(
     async delete(id) {
       await query("DELETE FROM file_artifacts WHERE id = $1", [id]);
     },
+
+    close: database.close,
   };
 }

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -107,7 +107,10 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
   const schema = statements.map((s) => s.trim()).filter((s) => s.length > 0);
   for (const stmt of schema) assertOneStatement(stmt);
   let poolP: Promise<Pool> | null = null;
+  let closed = false;
+  let closeP: Promise<void> | null = null;
   function pool(): Promise<Pool> {
+    if (closed) return Promise.reject(new Error("pg-pool: closed"));
     if (!poolP) {
       poolP = (async () => {
         const pg = (await import("pg")).default;
@@ -134,13 +137,52 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
   async function q(text: string, params: unknown[] = []): Promise<Rows> {
     return (await query(text, params)).rows;
   }
-  async function close(): Promise<void> {
-    if (poolP) await (await poolP).end();
+  function close(): Promise<void> {
+    if (closeP) return closeP;
+    closed = true;
+    closeP = poolP ? poolP.then((activePool) => activePool.end()) : Promise.resolve();
+    return closeP;
   }
   async function applySchema(schemaSql: string): Promise<void> {
     const stmt = schemaSql.trim();
     assertOneStatement(stmt);
     await applyDdl(await pool(), [stmt]);
+  }
+  return { pool, q, query, schema: applySchema, close };
+}
+
+export function usePgPool(borrowedPool: Pool, statements: string[]): PgPool {
+  const schema = statements.map((s) => s.trim()).filter((s) => s.length > 0);
+  for (const stmt of schema) assertOneStatement(stmt);
+  let schemaP: Promise<void> | null = null;
+  let closed = false;
+  let closeP: Promise<void> | null = null;
+  async function pool(): Promise<Pool> {
+    if (closed) throw new Error("pg-pool: closed");
+    schemaP ??= applyDdl(borrowedPool, schema).catch((error) => {
+      schemaP = null;
+      throw error;
+    });
+    await schemaP;
+    return borrowedPool;
+  }
+  async function query(text: string, params: unknown[] = []): Promise<{ rows: Rows; rowCount: number }> {
+    const result = await (await pool()).query(text, params);
+    return { rows: result.rows as Rows, rowCount: result.rowCount ?? 0 };
+  }
+  async function q(text: string, params: unknown[] = []): Promise<Rows> {
+    return (await query(text, params)).rows;
+  }
+  async function applySchema(schemaSql: string): Promise<void> {
+    const statement = schemaSql.trim();
+    assertOneStatement(statement);
+    await applyDdl(await pool(), [statement]);
+  }
+  function close(): Promise<void> {
+    if (closeP) return closeP;
+    closed = true;
+    closeP = Promise.resolve();
+    return closeP;
   }
   return { pool, q, query, schema: applySchema, close };
 }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -1479,6 +1479,7 @@ export function buildApp(
       void runActivity.close?.();
       await harness.turns.close?.();
       await tasks.close?.();
+      await files.close?.();
     },
   };
 

--- a/test/postgres-file-artifact-store.test.ts
+++ b/test/postgres-file-artifact-store.test.ts
@@ -154,3 +154,28 @@ test("pg rows survive across store instances (no per-process cache to diverge)",
   const reader = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
   assert.ok(await reader.get("across"));
 });
+
+test("pg store closes an owned pool", { skip }, async () => {
+  const store = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
+  await store.get("missing");
+  const closing = store.close?.();
+  assert.equal(store.close?.(), closing);
+  await closing;
+  await assert.rejects(store.get("missing"), /pg-pool: closed/);
+});
+
+test("pg store does not close a borrowed pool", { skip }, async () => {
+  const pg = (await import("pg")).default;
+  const pool = new pg.Pool({ connectionString: URL });
+  const store = createPostgresFileArtifactStore(pool, createMemoryDurableByteStore());
+  try {
+    await store.get("missing");
+    const closing = store.close?.();
+    assert.equal(store.close?.(), closing);
+    await closing;
+    await assert.rejects(store.get("missing"), /pg-pool: closed/);
+    assert.deepEqual((await pool.query("SELECT 1 AS ok")).rows, [{ ok: 1 }]);
+  } finally {
+    await pool.end();
+  }
+});


### PR DESCRIPTION
Fixes PostgreSQL File Artifact store pool ownership and shutdown. Owned pools are closed during runtime stop, borrowed pools remain caller-owned, and concurrent close calls share completion.\n\nValidation: focused PostgreSQL tests (9/9), TypeScript, ESLint, and independent review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789705994&installation_model_id=19911&pr_number=598&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F598&signature=119aad4f58f8b61593665096e747932bb5371924a6b4105a5a4ce9bdaa78aa49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->