### PR TITLE
ADR: allow memory to be served by an external backend

### DIFF
--- a/adrs/external-memory-backend.md
+++ b/adrs/external-memory-backend.md
@@ -1,0 +1,28 @@
+# Allow memory to be served by an external backend
+
+Memory is one markdown notebook per scope (`memory/MEMORY.md`), recalled into the
+prompt each turn and captured after it. The backend is fixed in `wiring.ts` —
+Postgres when `DATABASE_URL` is set, a file workspace otherwise — and `chassis`
+exposes no turn-lifecycle hooks, so a deployment that wants to reuse an existing
+memory system (a layered/vector store with its own atom→scene→persona pyramid and
+BM25+semantic recall) has no integration point short of forking core.
+
+The built-in notebook should stay the zero-config default; it is small and
+human-curatable. The gap is only the missing seam: nothing generic lets an external
+memory service take over recall and capture without a core edit.
+
+Two shapes, and we would like the project's view before building either:
+
+- A pluggable `MemoryService` chosen by config (`MEMORY_BACKEND=http`,
+  `MEMORY_URL=…`) — one more `MemoryService` that delegates `recall`/`capture`/
+  `query` to an HTTP sidecar. Minimal, but `recall` returns a markdown body string,
+  so a layered backend has to flatten its atoms and persona into one block to fit,
+  losing the structure that made it worth plugging in.
+- A turn-lifecycle hook on the plugin surface — a `memory` provider returning
+  structured recall the orchestrator renders, plus `onTurnEnd` for capture, with the
+  notebook as the built-in provider. More surface, but a layered backend keeps its
+  tiers and the notebook stays the default.
+
+Would qm take either — an HTTP memory backend, a structured recall hook, or both
+behind one config? We have mapped the integration surface and can implement whichever
+the project prefers.


### PR DESCRIPTION
Adds an ADR proposing a seam for external memory backends: `adrs/external-memory-backend.md`.

Today memory is one markdown notebook per scope, with the backend fixed in `wiring.ts` (Postgres when `DATABASE_URL` is set, else a file workspace) and no turn-lifecycle hooks on the `chassis` plugin surface. A deployment that wants to reuse an existing layered/vector memory system has no integration point short of forking core.

The ADR keeps the built-in notebook as the zero-config default and asks for the project's direction between two shapes:

- a pluggable `MemoryService` via config (`MEMORY_BACKEND=http`) delegating to an HTTP sidecar — minimal, but `recall`'s markdown-body return forces a layered backend to flatten its atoms/persona into one block; and
- a turn-lifecycle hook (a `memory` provider returning structured recall the orchestrator renders, plus `onTurnEnd` for capture) with the notebook as the built-in provider — more surface, but preserves a layered backend's tiers.

Seeking a decision on whether to take either, both behind one config, or neither. No code yet; implementation follows whichever direction the project prefers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789715918&installation_model_id=19911&pr_number=600&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F600&signature=7991d11d42428480c6cad29ddfd8d415395141b8ad82b429dbdbaad56f696da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->