### PR TITLE
fix: support channel credential grants

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4732,14 +4732,14 @@
                           class="sc-broker-only"
                           style="display: flex; align-items: center; gap: 8px; cursor: pointer; margin-bottom: 6px"
                           ><input type="radio" name="sc-share" value="people" style="width: auto" /> Only selected
-                          people or teams</label
+                          people or channels</label
                         >
                         <input
                           type="text"
                           id="sc-people"
                           class="sc-broker-only"
                           list="sc-people-options"
-                          placeholder="Principal IDs, comma-separated"
+                          placeholder="Principal or channel IDs, comma-separated"
                           style="width: 100%"
                         />
                         <datalist id="sc-people-options"></datalist>
@@ -6906,7 +6906,9 @@
       function syncScPeople() {
         const orgWide = $("sc-share-org").checked;
         $("sc-people").disabled = orgWide;
-        $("sc-people").placeholder = orgWide ? "Organization-wide access selected" : "Principal IDs, comma-separated";
+        $("sc-people").placeholder = orgWide
+          ? "Organization-wide access selected"
+          : "Principal or channel IDs, comma-separated";
         renderServiceCredentialCapability();
       }
       function serviceCredentialGrantees() {
@@ -6918,7 +6920,7 @@
               .map((s) => s.trim())
               .filter(Boolean)
               .map((id) => {
-                if (/^(personal|team|org|channel|group):/.test(id)) return id;
+                if (/^(personal|org|channel):/.test(id)) return id;
                 const q = id.toLowerCase();
                 const identifiers = serviceCredDirectory.filter(
                   (member) => member.principalId.toLowerCase() === q || member.slackId?.toLowerCase() === q,
@@ -6989,7 +6991,7 @@
             chip.className = "identity-chip";
             const label = serviceCredentialPrincipalLabel(grantee);
             chip.textContent = label;
-            if (/^(channel|group):/.test(grantee)) {
+            if (/^(team|group):/.test(grantee)) {
               const unsupported = document.createElement("small");
               unsupported.textContent = "unsupported · remove before saving";
               chip.appendChild(unsupported);
@@ -7057,13 +7059,13 @@
           return "Add at least one person or choose org-wide access.";
         if (body.delivery !== "env" && serviceCredentialResolutionError) return serviceCredentialResolutionError;
         const unsupported = body.grantees.find(
-          (grantee) => /^(channel|group):/.test(grantee) || /^personal:[^,]*:/.test(grantee),
+          (grantee) => /^(team|group):/.test(grantee) || /^personal:[^,]*:/.test(grantee),
         );
         if (unsupported)
           return (
             "Remove unsupported legacy grant \u201c" +
             unsupported +
-            "\u201d before saving. Shared credentials support people, teams, or the organization."
+            "\u201d before saving. Shared credentials support people, channels, or the organization."
           );
         return "";
       }

--- a/plugins/admin/test/default-view.test.ts
+++ b/plugins/admin/test/default-view.test.ts
@@ -276,7 +276,9 @@ test("governance credential editor previews effective capability and uses an in-
   assert.match(html, /usageTruncated \? "at least "/);
   assert.match(html, /Recent users in the retained window/);
   assert.doesNotMatch(html, /serviceCredList\.find\(\(c\) => c\.slug === scEditing\)\?\.updatedAt/);
-  assert.match(html, /personal\|team\|org\|channel\|group/);
+  assert.match(html, /personal\|org\|channel/);
+  assert.doesNotMatch(html, /people or teams|Shared credentials support people, teams/);
+  assert.match(html, /Shared credentials support people, channels, or the organization/);
   assert.match(html, /unsupported legacy grant/);
   assert.match(html, /matches multiple people/);
   assert.match(html, /reviewGovernanceChange/);

--- a/skills-seed/publish/SKILL.md
+++ b/skills-seed/publish/SKILL.md
@@ -109,9 +109,8 @@ publish({
 ```
 
 - **read** = can reach the app. **write** = can also manage it (redeploy/rollback).
-- Share to `personal:<id>` (one teammate), or `org:<id>` (the whole org). Team/channel
-  scopes can be granted, but team-membership reach at the link is not enforced yet — for
-  now use `org:` or `personal:` grants for reach.
+- Share to `personal:<id>` (one teammate), `channel:<id>` (a channel), or `org:<id>`
+  (the whole org).
 
 ## What you can rely on
 

--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -914,14 +914,14 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       const badGrantee = desired?.find((g) => {
         const parsed = parseScopeId(g);
         return (
-          !["org", "personal", "team"].includes(parsed.kind ?? "") ||
+          !["org", "personal", "channel"].includes(parsed.kind ?? "") ||
           !parsed.ref ||
           parsed.ref.includes(":") ||
           (parsed.kind === "org" && g !== scope)
         );
       });
       if (badGrantee !== undefined)
-        return { error: `grantee must be this org or a valid personal:/team: scope (got ${badGrantee})` };
+        return { error: `grantee must be this org or a valid personal:/channel: scope (got ${badGrantee})` };
       const injection =
         b.injection && typeof b.injection === "object"
           ? ({

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -806,11 +806,11 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
       "Google-Docs style: the file keeps living in your workspace, the grant just lets others " +
       "reach it. To share a file that already exists (e.g. one you made with `execute`), call " +
       "write with just its `path` and `share` (no `data`). Each share is { scope, permission }: " +
-      '`scope` is "org" (everyone in your org), a person (personal:<userId>), a channel ' +
-      "(channel:<id>), or a team (team:<id>); `permission` is read (view, default) or write " +
+      '`scope` is "org" (everyone in your org), a person (personal:<userId>), or a channel ' +
+      "(channel:<id>); `permission` is read (view, default) or write " +
       "(view + manage). A grant to a PERSON follows them — it's visible wherever you two are " +
       "together (your DMs and any room whose members are all entitled to it); to make a file " +
-      "visible to a whole channel/team or everyone, share that scope. Recipients see shared " +
+      "visible to a whole channel or everyone, share that scope. Recipients see shared " +
       "files under ./shared/.",
     parameters: Type.Object({
       path: Type.String({ description: "Relative path within the workspace." }),
@@ -821,7 +821,7 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
         Type.Array(
           Type.Object({
             scope: Type.String({
-              description: 'Who to share with: "org", personal:<userId>, channel:<id>, or team:<id>.',
+              description: 'Who to share with: "org", personal:<userId>, or channel:<id>.',
             }),
             permission: Type.Optional(
               Type.Union([Type.Literal("read"), Type.Literal("write")], {
@@ -2132,7 +2132,7 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
       "Default (move omitted/false) SHARES it: adds a grant so the target can reach it, while it keeps " +
       "living in its current home with you as its creator (Google-Docs style). move:true MOVES it: " +
       "changes its home scope to the target (the creator is unchanged); supported for skills and deployments — moving a deployment to a teammate makes THEM the owner (ownership transfer; existing shares survive).\n" +
-      '`toScope` is where it goes: "org" (everyone), a scope id (channel:<id>, team:<id>, personal:<id>), ' +
+      '`toScope` is where it goes: "org" (everyone), a scope id (channel:<id>, personal:<id>), ' +
       "or a teammate's NAME (core resolves it — you can't author a raw address). Sharing/moving into a " +
       "context you're already in is frictionless. Ceding a skill to the whole org is the one gated " +
       "step: only an org admin, in a turn they started themselves, can do it.\n" +
@@ -2144,8 +2144,7 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
       }),
       id: Type.String({ description: "The artifact's id (a deployment may also be named by its handle)." }),
       toScope: Type.String({
-        description:
-          'Where to share/move it: "org", a scope id (channel:<id>, team:<id>, personal:<id>), or a teammate\'s name.',
+        description: 'Where to share/move it: "org", a scope id (channel:<id>, personal:<id>), or a teammate\'s name.',
       }),
       permission: Type.Optional(
         Type.Union([Type.Literal("read"), Type.Literal("write")], {

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -729,7 +729,7 @@ export function createToolContext(deps: ToolContextDeps): ToolContext {
               if (!granteeScopeId) throw new Error('cannot resolve "org" — no org scope is mounted in this session');
               if (parseScopeId(granteeScopeId).kind === null) {
                 throw new Error(
-                  `invalid share target "${s.scope}" — use a scope id like personal:<id>, channel:<id>, team:<id>, or org:<id> (or "org")`,
+                  `invalid share target "${s.scope}" — use a scope id like personal:<id>, channel:<id>, or org:<id> (or "org")`,
                 );
               }
               const permission: Permission = s.permission ?? "read";

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -334,6 +334,17 @@ const call = (tool: ReturnType<typeof createPiTools>[number] | undefined, params
   return (tool.execute as unknown as (id: string, p: unknown) => Promise<unknown>)("t", params);
 };
 
+test("artifact sharing advertises only reachable OSS grant scopes", () => {
+  const ref: ToolContextRef = { current: fakeToolContext() };
+  const tools = createPiTools(ref, { controlTools: true });
+  for (const name of ["write", "share"]) {
+    const tool = tools.find((candidate) => candidate.name === name);
+    assert.ok(tool);
+    assert.match(tool.description, /channel:<id>/);
+    assert.doesNotMatch(tool.description, /team:<id>/);
+  }
+});
+
 test("each pi tool emits a tool_call then a tool_result", async () => {
   const emitted: Emitted[] = [];
   const ref: ToolContextRef = {

--- a/test/service-credential-route.test.ts
+++ b/test/service-credential-route.test.ts
@@ -210,7 +210,7 @@ test("env-delivery credential: envKey validated, host refused, duplicates refuse
   }
 });
 
-test("env-delivery accepts person/team grantees — grants now gate env injection like broker calls", async () => {
+test("env-delivery accepts narrowed grantees — grants gate env injection like broker calls", async () => {
   const srv = start();
   try {
     const narrowed = await putCred(srv.base, {
@@ -720,30 +720,32 @@ test("re-sharing reconciles the ACL allow-list (org-wide → specific people →
   }
 });
 
-test("a non-org/personal/team grantee is rejected", async () => {
+test("credential grants accept every supported scope kind and reject unreachable or malformed scopes", async () => {
   const srv = start();
   try {
-    await putCred(srv.base, { slug: "k", name: "K", secret: "s", host: "h.example" });
-    const version = (await getCfg(srv.base)).serviceCredentials[0]!.updatedAt;
-    const r = await putCred(srv.base, {
-      slug: "k",
-      name: "K",
-      host: "h.example",
-      grantees: ["channel:C1"],
-      expectedUpdatedAt: version,
-    });
-    assert.equal(r.status, 400);
-    assert.match(await r.text(), /grantee must be/);
+    const supported = ["org:default-org", "personal:alice", "channel:C1"];
+    for (const [index, grantee] of supported.entries()) {
+      const r = await putCred(srv.base, {
+        slug: `supported-${index}`,
+        name: `Supported ${index}`,
+        secret: "s",
+        host: "h.example",
+        grantees: [grantee],
+      });
+      assert.equal(r.status, 200, `${grantee} should be accepted`);
+    }
 
-    const disguised = await putCred(srv.base, {
-      slug: "k",
-      name: "K",
-      host: "h.example",
-      grantees: ["personal:channel:C1"],
-      expectedUpdatedAt: version,
-    });
-    assert.equal(disguised.status, 400);
-    assert.match(await disguised.text(), /personal:channel:C1/);
+    for (const grantee of ["team:T1", "group:G1", "org:another-org", "personal:channel:C1", "unknown:X1"]) {
+      const r = await putCred(srv.base, {
+        slug: `rejected-${grantee.toLowerCase().replace(/[^a-z0-9]/g, "-")}`,
+        name: "Rejected",
+        secret: "s",
+        host: "h.example",
+        grantees: [grantee],
+      });
+      assert.equal(r.status, 400, `${grantee} should be rejected`);
+      assert.match(await r.text(), /grantee must be/);
+    }
   } finally {
     await srv.close();
   }
@@ -1030,6 +1032,45 @@ test("orchestrator stamps AGENT_CREDENTIAL_TOKEN with an org-wide credential's s
   assert.equal(botClaims?.botActor, true);
   assert.equal(botClaims?.liveActor, true);
   assert.deepEqual(botClaims?.members, [{ id: "B-LEGACY", type: "internal" }]);
+});
+
+test("orchestrator exposes a channel-granted credential only in that channel scope", async () => {
+  const { built, env } = buildWithCapture();
+  await built.serviceCreds.setServiceCredential("org:default-org", {
+    slug: "channel-api",
+    name: "Channel API",
+    secret: "s",
+    host: "api.example.com",
+  });
+  await built.acl.grant({
+    ownerScopeId: "org:default-org",
+    ref: "service-cred:channel-api",
+    granteeScopeId: "channel:C1",
+    permission: "read",
+    grantedBy: "admin",
+  });
+
+  const channelTurn: TurnRequest = {
+    surface: "slack",
+    actor: internalActor,
+    conversation: {
+      kind: "channel",
+      threadRef: "ch:C1:t1",
+      channelRef: "C1",
+      audience: [internalActor],
+      publishMembers: [internalActor],
+    },
+    text: "!run echo hi",
+  };
+  const channelResult = await built.app.turn(channelTurn);
+  assert.equal(channelResult.status, "ok", channelResult.reason);
+  const channelToken = env()?.AGENT_CREDENTIAL_TOKEN;
+  assert.ok(channelToken);
+  assert.deepEqual((await verifyCapabilityToken(channelToken!, TEST_CAPABILITY_SECRET))?.credentials, ["channel-api"]);
+
+  const dmResult = await built.app.turn(dm("!run echo hi"));
+  assert.equal(dmResult.status, "ok", dmResult.reason);
+  assert.equal(env()?.AGENT_CREDENTIAL_TOKEN, undefined);
 });
 
 test("orchestrator does NOT stamp a credential granted only to someone else", async () => {


### PR DESCRIPTION
Allow shared credentials to target channels and align OSS-facing scope guidance with supported grants.

- verification: affected tests (126 passed)
- verification: typecheck, formatting, and lint
- verification: live admin API channel-grant round trip

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755547&installation_model_id=19911&pr_number=610&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F610&signature=ef0a87c89e1eb155abadabda6b29606237a9689d18f29f64e68d6568eea3d23e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->