### PR TITLE
Fix admin CSP hashing across line endings

### DIFF
--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -33,9 +33,15 @@ const BASE_HTML = readFileSync(
   "utf8",
 ).replaceAll("__ADMIN_BASE__", () => ADMIN_BASE_PATH);
 const ADMIN_SCRIPT = BASE_HTML.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? "";
+
+/** Browsers normalize inline-script line endings before checking CSP hashes. */
+export function cspScriptHash(script: string): string {
+  return createHash("sha256").update(script.replace(/\r\n?/g, "\n")).digest("base64");
+}
+
 const ADMIN_CSP = [
   "default-src 'self'",
-  `script-src 'sha256-${createHash("sha256").update(ADMIN_SCRIPT).digest("base64")}'`,
+  `script-src 'sha256-${cspScriptHash(ADMIN_SCRIPT)}'`,
   "style-src 'unsafe-inline'",
   "img-src 'self' data:",
   "connect-src 'self'",

--- a/plugins/admin/test/csp.test.ts
+++ b/plugins/admin/test/csp.test.ts
@@ -66,8 +66,10 @@ test("served CSP carries the hash of the LF-normalized inline script", async () 
   const csp = r.headers["content-security-policy"];
   assert.ok(typeof csp === "string", "CSP header present");
 
-  const script = r.body.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? "";
-  assert.ok(script.length > 0, "inline script present in served HTML");
+  const scriptStart = r.body.indexOf("<script>");
+  const scriptEnd = r.body.indexOf("</script>", scriptStart);
+  assert.ok(scriptStart >= 0 && scriptEnd > scriptStart, "inline script present in served HTML");
+  const script = r.body.slice(scriptStart + "<script>".length, scriptEnd);
 
   // This is exactly what a browser does before checking the CSP source.
   const browserHash = createHash("sha256").update(script.replace(/\r\n?/g, "\n")).digest("base64");

--- a/plugins/admin/test/csp.test.ts
+++ b/plugins/admin/test/csp.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createServer, request as httpRequest, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const SCOPES_BODY = { scopes: [{ id: "org:acme", label: "Org", kind: "org" }] };
+
+const core = createServer((req: IncomingMessage, res) => {
+  if (req.method === "GET" && (req.url ?? "").startsWith("/v1/admin/scopes")) {
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(JSON.stringify(SCOPES_BODY));
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+});
+await new Promise<void>((r) => core.listen(0, r));
+const corePort = (core.address() as AddressInfo).port;
+
+process.env.CORE_API_URL = `http://localhost:${corePort}`;
+process.env.CORE_SIGNING_SECRET = "admin-csp-test-secret";
+
+const { server, cspScriptHash } = await import("../src/index.ts");
+await new Promise<void>((r) => server.listen(0, r));
+const port = (server.address() as AddressInfo).port;
+
+test.after(() => {
+  server.close();
+  if (core.listening) core.close();
+});
+
+function get(
+  path: string,
+): Promise<{ status: number; headers: Record<string, string | string[] | undefined>; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({ host: "localhost", port, path, method: "GET" }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c) => chunks.push(c as Buffer));
+      res.on("end", () =>
+        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString("utf8") }),
+      );
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("cspScriptHash matches what browsers compute for CRLF/CR-normalized script text", () => {
+  const lf = "let x = 1;\nlet y = 2;\n";
+  const crlf = "let x = 1;\r\nlet y = 2;\r\n";
+  const cr = "let x = 1;\rlet y = 2;\r";
+
+  const browserHash = createHash("sha256").update(lf).digest("base64");
+
+  assert.equal(cspScriptHash(lf), browserHash);
+  // A Windows (CRLF) or classic-Mac (CR) checkout must hash to the same value
+  // the browser computes over the LF-normalized script (#552).
+  assert.equal(cspScriptHash(crlf), browserHash);
+  assert.equal(cspScriptHash(cr), browserHash);
+});
+
+test("served CSP carries the hash of the LF-normalized inline script", async () => {
+  const r = await get("/");
+  assert.equal(r.status, 200);
+
+  const csp = r.headers["content-security-policy"];
+  assert.ok(typeof csp === "string", "CSP header present");
+
+  const script = r.body.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? "";
+  assert.ok(script.length > 0, "inline script present in served HTML");
+
+  // This is exactly what a browser does before checking the CSP source.
+  const browserHash = createHash("sha256").update(script.replace(/\r\n?/g, "\n")).digest("base64");
+  assert.ok(
+    csp.includes(`sha256-${browserHash}`),
+    `served CSP must allow the inline script; CSP=${csp} expected sha256-${browserHash}`,
+  );
+});


### PR DESCRIPTION
Normalizes inline admin script line endings before CSP hashing so browser checks agree across build platforms.

- verification: admin suite (81/81)
- verification: admin typecheck, focused lint, and format checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755672&installation_model_id=19911&pr_number=612&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F612&signature=2d12c5d39f30cfc081c36ec5cf915593b9cd18b4e8a3d2e1c95e7aa528b0f5bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->