### PR TITLE
Carry conversation roster into ambient replies

### DIFF
--- a/src/api/app-ambient.ts
+++ b/src/api/app-ambient.ts
@@ -218,22 +218,10 @@ export function createAmbientHelpers(deps: AppDeps, app: App) {
   }
 
   async function conversationAudience(batch: AmbientBatch): Promise<ActorAssertion[] | undefined> {
-    if (batch.kind !== "group") {
-      const channels = await deps.directory.listChannels().catch(() => []);
-      const channel = channels.find((candidate) => candidate.channelId === batch.container);
-      if (!channel || channel.isExternal) return undefined;
-    }
-    const ids = await (
-      batch.kind === "group"
-        ? deps.directory.groupMemberIds(batch.container)
-        : deps.directory.channelMemberIds(batch.container)
-    ).catch(() => undefined);
-    if (!ids?.length) return undefined;
-    const directory = await deps.directory.list().catch(() => [] as DirectoryMember[]);
-    const members = ids
-      .map((id) => directory.find((member) => samePerson(member.principalId, id)))
-      .filter((member): member is DirectoryMember => member !== undefined);
-    if (members.length !== ids.length) return undefined;
+    const members = await deps.directory
+      .conversationMembers(batch.kind === "group" ? "group" : "channel", batch.container)
+      .catch(() => undefined);
+    if (!members?.length) return undefined;
     return members.map((member) => ({
       externalId: member.principalId,
       ...(member.displayName ? { displayName: member.displayName } : {}),

--- a/src/api/app-ambient.ts
+++ b/src/api/app-ambient.ts
@@ -1,4 +1,4 @@
-import type { TurnRequest } from "../types.ts";
+import type { ActorAssertion, TurnRequest } from "../types.ts";
 import { orgId as orgIdOf } from "../config.ts";
 import type { OrchestratorInput } from "../core/orchestrator.ts";
 import { samePerson } from "../directory/person.ts";
@@ -207,17 +207,55 @@ export function createAmbientHelpers(deps: AppDeps, app: App) {
   function workerConversation(
     batch: AmbientBatch,
     threadRef: string,
-  ): { kind: "channel" | "group"; threadRef: string; channelRef: string; isMpim?: boolean } {
+    audience: ActorAssertion[],
+  ): TurnRequest["conversation"] {
+    const roster: Pick<TurnRequest["conversation"], "audience" | "publishMembers"> = audience.length
+      ? { audience, publishMembers: audience }
+      : { audience };
     return batch.kind === "group"
-      ? { kind: "group", threadRef, channelRef: batch.container, isMpim: true }
-      : { kind: "channel", threadRef, channelRef: batch.container };
+      ? { kind: "group" as const, threadRef, channelRef: batch.container, isMpim: true, ...roster }
+      : { kind: "channel" as const, threadRef, channelRef: batch.container, ...roster };
+  }
+
+  async function conversationAudience(batch: AmbientBatch): Promise<ActorAssertion[] | undefined> {
+    if (batch.kind !== "group") {
+      const channels = await deps.directory.listChannels().catch(() => []);
+      const channel = channels.find((candidate) => candidate.channelId === batch.container);
+      if (!channel || channel.isExternal) return undefined;
+    }
+    const ids = await (
+      batch.kind === "group"
+        ? deps.directory.groupMemberIds(batch.container)
+        : deps.directory.channelMemberIds(batch.container)
+    ).catch(() => undefined);
+    if (!ids?.length) return undefined;
+    const directory = await deps.directory.list().catch(() => [] as DirectoryMember[]);
+    const members = ids
+      .map((id) => directory.find((member) => samePerson(member.principalId, id)))
+      .filter((member): member is DirectoryMember => member !== undefined);
+    if (members.length !== ids.length) return undefined;
+    return members.map((member) => ({
+      externalId: member.principalId,
+      ...(member.displayName ? { displayName: member.displayName } : {}),
+    }));
   }
 
   async function spawnAmbientWorker(batch: AmbientBatch, decision: AmbientDecision): Promise<void> {
     const latestTs = batch.messages.reduce((max, m) => (m.ts > max ? m.ts : max), "");
     const threadRef = `${batch.surface}:${batch.container}:ambient:${latestTs}`;
-    const conversation = workerConversation(batch, threadRef);
-    const solicited = await solicitedAsker(batch, decision);
+    let solicited = await solicitedAsker(batch, decision);
+    let audience: ActorAssertion[] = [];
+    if (solicited) {
+      const askerId = solicited.member.principalId;
+      const resolved = await conversationAudience(batch);
+      if (!resolved?.some((member) => samePerson(member.externalId, askerId))) {
+        console.error(`[ambient] solicited wake has no complete roster (container=${batch.container})`);
+        solicited = undefined;
+      } else {
+        audience = resolved;
+      }
+    }
+    const conversation = workerConversation(batch, threadRef, audience);
     if (decision.askedBy && !solicited)
       console.error(
         `[ambient] solicited wake degraded to proactive (asked_by=${decision.askedBy}, container=${batch.container})`,
@@ -284,7 +322,10 @@ export function createAmbientHelpers(deps: AppDeps, app: App) {
       .screenSecuritySteer({
         payload: req.text,
         actor: { id: `system:ambient:${orgIdOf()}`, type: "internal" },
-        conversation: { ...workerConversation(batch, liveRef), audience: [] },
+        conversation:
+          batch.kind === "group"
+            ? { kind: "group", threadRef: liveRef, channelRef: batch.container, isMpim: true, audience: [] }
+            : { kind: "channel", threadRef: liveRef, channelRef: batch.container, audience: [] },
         ...(session ? { sessionId: session.id } : {}),
       })
       .catch(() => "block" as const);

--- a/src/directory/directory-store.ts
+++ b/src/directory/directory-store.ts
@@ -68,9 +68,9 @@ export interface DirectoryStore {
   upsertGroup(groupId: string, principalIds: readonly string[]): Promise<void>;
   resolveGroupByParticipants(participants: readonly string[]): Promise<GroupResolution>;
   groupMember(groupId: string, principalId: string): Promise<boolean>;
-  groupMemberIds(groupId: string): Promise<string[] | undefined>;
   groupMembership(groupId: string, principalId: string): Promise<boolean | undefined>;
   listGroupsFor(principalId: string): Promise<string[]>;
+  conversationMembers(kind: "channel" | "group", id: string): Promise<DirectoryMember[] | undefined>;
   listChannelsFor(principalId: string): Promise<DirectoryChannel[]>;
   setWorkspaceUrl(url: string): Promise<void>;
   meta(): Promise<DirectoryMeta>;
@@ -229,10 +229,6 @@ export function createDirectoryStore(): DirectoryStore {
     async groupMember(groupId, principalId) {
       return groupMembers?.get(groupId)?.has(principalId) ?? false;
     },
-    async groupMemberIds(groupId) {
-      if (!knownGroupRosters?.has(groupId)) return undefined;
-      return [...(groupMembers?.get(groupId) ?? [])];
-    },
     async groupMembership(groupId, principalId) {
       if (!groupsSynced) return undefined;
       if (!listedGroupIds?.has(groupId)) return false;
@@ -243,6 +239,22 @@ export function createDirectoryStore(): DirectoryStore {
       const memberships = groupMembers;
       if (!memberships) return [];
       return [...memberships].filter(([, members]) => members.has(principalId)).map(([groupId]) => groupId);
+    },
+    async conversationMembers(kind, id) {
+      let ids: string[];
+      if (kind === "channel") {
+        const channel = channels.find((candidate) => candidate.channelId === id);
+        if (!channel || channel.isExternal || !knownChannelRosters?.has(id)) return undefined;
+        ids = [...(channelMembers?.get(id) ?? [])];
+      } else {
+        if (!knownGroupRosters?.has(id)) return undefined;
+        ids = [...(groupMembers?.get(id) ?? [])];
+      }
+      if (!ids.length) return undefined;
+      const roster = ids
+        .map((principalId) => members.find((member) => samePerson(member.principalId, principalId)))
+        .filter((member): member is DirectoryMember => member !== undefined);
+      return roster.length === ids.length ? roster : undefined;
     },
     async listChannelsFor(principalId) {
       return channels.filter(

--- a/src/directory/directory-store.ts
+++ b/src/directory/directory-store.ts
@@ -68,6 +68,7 @@ export interface DirectoryStore {
   upsertGroup(groupId: string, principalIds: readonly string[]): Promise<void>;
   resolveGroupByParticipants(participants: readonly string[]): Promise<GroupResolution>;
   groupMember(groupId: string, principalId: string): Promise<boolean>;
+  groupMemberIds(groupId: string): Promise<string[] | undefined>;
   groupMembership(groupId: string, principalId: string): Promise<boolean | undefined>;
   listGroupsFor(principalId: string): Promise<string[]>;
   listChannelsFor(principalId: string): Promise<DirectoryChannel[]>;
@@ -227,6 +228,10 @@ export function createDirectoryStore(): DirectoryStore {
     },
     async groupMember(groupId, principalId) {
       return groupMembers?.get(groupId)?.has(principalId) ?? false;
+    },
+    async groupMemberIds(groupId) {
+      if (!knownGroupRosters?.has(groupId)) return undefined;
+      return [...(groupMembers?.get(groupId) ?? [])];
     },
     async groupMembership(groupId, principalId) {
       if (!groupsSynced) return undefined;

--- a/src/directory/postgres-directory-store.ts
+++ b/src/directory/postgres-directory-store.ts
@@ -523,6 +523,19 @@ export function createPostgresDirectoryStore(connectionString: string): Director
       return rows.length > 0;
     },
 
+    async groupMemberIds(groupId) {
+      const known = await q("SELECT roster_known FROM directory_groups WHERE org_id = $1 AND group_id = $2", [
+        orgId,
+        groupId,
+      ]);
+      if (known[0]?.roster_known !== true) return undefined;
+      const rows = await q(
+        "SELECT principal_id FROM directory_group_members WHERE org_id = $1 AND group_id = $2 ORDER BY principal_id",
+        [orgId, groupId],
+      );
+      return rows.map((row) => row.principal_id as string);
+    },
+
     async groupMembership(groupId, principalId) {
       const rows = await q(
         `SELECT EXISTS (

--- a/src/directory/postgres-directory-store.ts
+++ b/src/directory/postgres-directory-store.ts
@@ -523,19 +523,6 @@ export function createPostgresDirectoryStore(connectionString: string): Director
       return rows.length > 0;
     },
 
-    async groupMemberIds(groupId) {
-      const known = await q("SELECT roster_known FROM directory_groups WHERE org_id = $1 AND group_id = $2", [
-        orgId,
-        groupId,
-      ]);
-      if (known[0]?.roster_known !== true) return undefined;
-      const rows = await q(
-        "SELECT principal_id FROM directory_group_members WHERE org_id = $1 AND group_id = $2 ORDER BY principal_id",
-        [orgId, groupId],
-      );
-      return rows.map((row) => row.principal_id as string);
-    },
-
     async groupMembership(groupId, principalId) {
       const rows = await q(
         `SELECT EXISTS (
@@ -564,6 +551,38 @@ export function createPostgresDirectoryStore(connectionString: string): Director
         [orgId, principalId],
       );
       return rows.map((row) => row.group_id as string);
+    },
+
+    async conversationMembers(kind, id) {
+      const rows =
+        kind === "channel"
+          ? await q(
+              `SELECT channel.roster_known, channel.is_external, roster.principal_id AS roster_principal_id,
+                      member.principal_id, member.display_name, member.type, member.slack_id
+               FROM directory_channels channel
+               LEFT JOIN directory_channel_members roster
+                 ON roster.org_id = channel.org_id AND roster.channel_id = channel.channel_id
+               LEFT JOIN directory_members member
+                 ON member.org_id = roster.org_id AND member.principal_id = roster.principal_id
+               WHERE channel.org_id = $1 AND channel.channel_id = $2
+               ORDER BY roster.principal_id`,
+              [orgId, id],
+            )
+          : await q(
+              `SELECT group_row.roster_known, FALSE AS is_external, roster.principal_id AS roster_principal_id,
+                      member.principal_id, member.display_name, member.type, member.slack_id
+               FROM directory_groups group_row
+               LEFT JOIN directory_group_members roster
+                 ON roster.org_id = group_row.org_id AND roster.group_id = group_row.group_id
+               LEFT JOIN directory_members member
+                 ON member.org_id = roster.org_id AND member.principal_id = roster.principal_id
+               WHERE group_row.org_id = $1 AND group_row.group_id = $2
+               ORDER BY roster.principal_id`,
+              [orgId, id],
+            );
+      if (!rows.length || rows[0]?.roster_known !== true || rows[0]?.is_external === true) return undefined;
+      if (rows.some((row) => !row.roster_principal_id || !row.principal_id)) return undefined;
+      return rows.map(memberRow);
     },
 
     async listChannelsFor(principalId) {

--- a/test/directory-store.test.ts
+++ b/test/directory-store.test.ts
@@ -123,6 +123,11 @@ describe("member slackId (the real <@…> mention id for an email principal)", (
 describe("group-DM (mpim) membership (addressed by participant set, §10)", () => {
   const dir = async (): Promise<DirectoryStore> => {
     const d = createDirectoryStore();
+    await d.replace([
+      { principalId: "U-alice", displayName: "Alice", type: "internal" },
+      { principalId: "U-carol", displayName: "Carol", type: "internal" },
+      { principalId: "U-sam", displayName: "Sam", type: "internal" },
+    ]);
     await d.replaceGroups([
       { groupId: "G-1", principalId: "U-alice" },
       { groupId: "G-1", principalId: "U-carol" },
@@ -154,14 +159,18 @@ describe("group-DM (mpim) membership (addressed by participant set, §10)", () =
     assert.equal(await d.groupMember("G-2", "U-sam"), false);
     assert.equal(await d.groupMember("G-unknown", "U-alice"), false);
     assert.deepEqual(await d.listGroupsFor("U-sam"), ["G-1"]);
-    assert.deepEqual((await d.groupMemberIds("G-1"))?.sort(), ["U-alice", "U-carol", "U-sam"]);
+    assert.deepEqual((await d.conversationMembers("group", "G-1"))?.map((member) => member.principalId).sort(), [
+      "U-alice",
+      "U-carol",
+      "U-sam",
+    ]);
     assert.equal(await d.groupMembership("G-2", "U-sam"), false);
   });
 
   it("distinguishes an unavailable group roster from a definitive nonmember", async () => {
     const d = createDirectoryStore();
     assert.equal(await d.groupMembership("G-1", "U-alice"), undefined);
-    assert.equal(await d.groupMemberIds("G-1"), undefined);
+    assert.equal(await d.conversationMembers("group", "G-1"), undefined);
     await d.replaceGroups([]);
     assert.equal(await d.groupMembership("G-1", "U-alice"), false);
   });
@@ -227,6 +236,10 @@ describe("group-DM (mpim) membership (addressed by participant set, §10)", () =
 describe("private-channel membership (authorizes private-channel sends, §10)", () => {
   it("channelMember reflects pushed membership; omitting it leaves it intact; providing it is a full swap", async () => {
     const d = createDirectoryStore();
+    await d.replace([
+      { principalId: "U-alice", displayName: "Alice", type: "internal" },
+      { principalId: "U-carol", displayName: "Carol", type: "internal" },
+    ]);
     await d.replaceChannels(
       [{ channelId: "C-sec", name: "secret", isPrivate: true }],
       [{ channelId: "C-sec", principalId: "U-carol" }],
@@ -236,6 +249,10 @@ describe("private-channel membership (authorizes private-channel sends, §10)", 
     assert.equal(await d.channelMembership("C-sec", "U-alice"), false);
     assert.equal(await d.channelMember("C-sec", "U-alice"), false);
     assert.equal(await d.channelMember("C-other", "U-carol"), false);
+    assert.deepEqual(
+      (await d.conversationMembers("channel", "C-sec"))?.map((member) => member.principalId),
+      ["U-carol"],
+    );
 
     await d.replaceChannels([{ channelId: "C-sec", name: "secret", isPrivate: true }]);
     assert.equal(await d.channelMember("C-sec", "U-carol"), true);
@@ -260,6 +277,12 @@ describe("private-channel membership (authorizes private-channel sends, §10)", 
     );
     assert.equal(await d.channelMembership("C-public", "U-alice"), undefined);
     assert.equal(await d.channelMembership("C-sec", "U-alice"), false);
+    assert.equal(await d.conversationMembers("channel", "C-sec"), undefined);
+    await d.replaceChannels(
+      [{ channelId: "C-external", name: "external", isExternal: true }],
+      [{ channelId: "C-external", principalId: "U-alice" }],
+    );
+    assert.equal(await d.conversationMembers("channel", "C-external"), undefined);
   });
 
   it("partially replaces only the channel rosters known by the source", async () => {

--- a/test/directory-store.test.ts
+++ b/test/directory-store.test.ts
@@ -154,12 +154,14 @@ describe("group-DM (mpim) membership (addressed by participant set, §10)", () =
     assert.equal(await d.groupMember("G-2", "U-sam"), false);
     assert.equal(await d.groupMember("G-unknown", "U-alice"), false);
     assert.deepEqual(await d.listGroupsFor("U-sam"), ["G-1"]);
+    assert.deepEqual((await d.groupMemberIds("G-1"))?.sort(), ["U-alice", "U-carol", "U-sam"]);
     assert.equal(await d.groupMembership("G-2", "U-sam"), false);
   });
 
   it("distinguishes an unavailable group roster from a definitive nonmember", async () => {
     const d = createDirectoryStore();
     assert.equal(await d.groupMembership("G-1", "U-alice"), undefined);
+    assert.equal(await d.groupMemberIds("G-1"), undefined);
     await d.replaceGroups([]);
     assert.equal(await d.groupMembership("G-1", "U-alice"), false);
   });

--- a/test/postgres-directory-store.test.ts
+++ b/test/postgres-directory-store.test.ts
@@ -229,6 +229,7 @@ test(
     assert.equal(await store.groupMember("G-1", "U-sam"), true);
     assert.equal(await store.groupMember("G-2", "U-sam"), false);
     assert.equal(await store.groupMembership("G-2", "U-sam"), false);
+    assert.deepEqual(await store.groupMemberIds("G-1"), ["U-alice", "U-carol", "U-sam"]);
     assert.deepEqual(await store.listGroupsFor("U-sam"), ["G-1"]);
 
     const direct = (await freshPg(URL!)).query;

--- a/test/postgres-directory-store.test.ts
+++ b/test/postgres-directory-store.test.ts
@@ -168,6 +168,10 @@ test(
   { skip },
   async () => {
     const store = createPostgresDirectoryStore(URL!);
+    await store.replace([
+      { principalId: "U-alice", displayName: "Alice", type: "internal" },
+      { principalId: "U-carol", displayName: "Carol", type: "internal" },
+    ]);
     await store.replaceChannels(
       [{ channelId: "C-sec", name: "secret", isPrivate: true }],
       [{ channelId: "C-sec", principalId: "U-carol" }],
@@ -177,6 +181,10 @@ test(
     assert.equal(await store.channelMembership("C-sec", "U-alice"), false);
     assert.equal(await store.channelMember("C-sec", "U-alice"), false);
     assert.equal(await store.channelMember("C-other", "U-carol"), false);
+    assert.deepEqual(
+      (await store.conversationMembers("channel", "C-sec"))?.map((member) => member.principalId),
+      ["U-carol"],
+    );
 
     await store.replaceChannels([{ channelId: "C-sec", name: "secret", isPrivate: true }]);
     assert.equal(await store.channelMember("C-sec", "U-carol"), true);
@@ -211,6 +219,11 @@ test(
   { skip },
   async () => {
     const store = createPostgresDirectoryStore(URL!);
+    await store.replace([
+      { principalId: "U-alice", displayName: "Alice", type: "internal" },
+      { principalId: "U-carol", displayName: "Carol", type: "internal" },
+      { principalId: "U-sam", displayName: "Sam", type: "internal" },
+    ]);
     await store.replaceGroups([
       { groupId: "G-1", principalId: "U-alice" },
       { groupId: "G-1", principalId: "U-carol" },
@@ -229,7 +242,10 @@ test(
     assert.equal(await store.groupMember("G-1", "U-sam"), true);
     assert.equal(await store.groupMember("G-2", "U-sam"), false);
     assert.equal(await store.groupMembership("G-2", "U-sam"), false);
-    assert.deepEqual(await store.groupMemberIds("G-1"), ["U-alice", "U-carol", "U-sam"]);
+    assert.deepEqual(
+      (await store.conversationMembers("group", "G-1"))?.map((member) => member.principalId),
+      ["U-alice", "U-carol", "U-sam"],
+    );
     assert.deepEqual(await store.listGroupsFor("U-sam"), ["G-1"]);
 
     const direct = (await freshPg(URL!)).query;
@@ -406,12 +422,14 @@ test("pg directory: removals apply without clearing a failed channel refresh", {
 
 test("pg directory: a private Slack Connect roster is not an ordinary send target", { skip }, async () => {
   const store = createPostgresDirectoryStore(URL!);
+  await store.replace([{ principalId: "U-member", displayName: "Member", type: "internal" }]);
   await store.replaceChannels(
     [{ channelId: "C-connect", name: "connect", isPrivate: true, isExternal: true }],
     [{ channelId: "C-connect", principalId: "U-member" }],
   );
   assert.equal(await store.channelMembership("C-connect", "U-member"), true);
   assert.equal(await store.channelMember("C-connect", "U-member"), false);
+  assert.equal(await store.conversationMembers("channel", "C-connect"), undefined);
   assert.deepEqual(await store.listChannelsFor("U-member"), []);
 });
 

--- a/test/surface-cache-ambient.test.ts
+++ b/test/surface-cache-ambient.test.ts
@@ -772,7 +772,10 @@ test("a solicited ambient wake runs as the asking person, not the system actor",
     await built.directory.replace([
       { principalId: "alice@acme.com", displayName: "Alice", type: "internal", slackId: "U1" },
     ]);
-    await built.directory.replaceChannels([{ channelId: container, name: "solicited-chan", isPrivate: false }]);
+    await built.directory.replaceChannels(
+      [{ channelId: container, name: "solicited-chan", isPrivate: false }],
+      [{ channelId: container, principalId: "alice@acme.com" }],
+    );
     await built.app.setChannelPolicy(container, "!engage-asked", "U-admin");
     await built.app.ingestSurfaceEvents([
       { container, ts: "300.1", authorId: "U1", authorName: "Alice", text: "!post solicited reply", createdAt: 1 },
@@ -788,6 +791,36 @@ test("a solicited ambient wake runs as the asking person, not the system actor",
     assert.equal(rows.length, 1);
     assert.equal(rows[0]!.askedBy, "300.1", "asked_by is a first-class judgment field");
     assert.ok(!(rows[0]!.reason ?? "").includes("[asked_by"), "the reason carries no asked_by splice");
+  } finally {
+    await built.runtime.stop();
+  }
+});
+
+test("a solicited ambient wake carries the complete channel roster", async () => {
+  const built = freshApp();
+  built.runtime.start();
+  try {
+    const container = "C-solicited-roster";
+    await built.directory.replace([
+      { principalId: "alice@acme.com", displayName: "Alice", type: "internal", slackId: "U1" },
+      { principalId: "bob@acme.com", displayName: "Bob", type: "internal", slackId: "U2" },
+    ]);
+    await built.directory.replaceChannels(
+      [{ channelId: container, name: "solicited-roster", isPrivate: false }],
+      [
+        { channelId: container, principalId: "alice@acme.com" },
+        { channelId: container, principalId: "bob@acme.com" },
+      ],
+    );
+    await built.app.setChannelPolicy(container, "!engage-asked", "U-admin");
+    await built.app.ingestSurfaceEvents([
+      { container, ts: "350.1", authorId: "U1", authorName: "Alice", text: "!sysprompt", createdAt: 1 },
+    ]);
+
+    const pending = await pollDeliveries(built.deliveries);
+    assert.equal(pending.length, 1);
+    assert.match(pending[0].text, /Alice \(alice@acme\.com\)/);
+    assert.match(pending[0].text, /Bob \(bob@acme\.com\)/);
   } finally {
     await built.runtime.stop();
   }


### PR DESCRIPTION
## Summary

- carry the complete directory roster into solicited ambient replies
- use an explicit empty audience for proactive ambient work
- fall back to proactive behavior when a complete roster is unavailable
- add group-DM roster lookup parity for in-memory and Postgres directory stores

This keeps ambient conversation context consistent with directly addressed channel turns.

## Test plan

- `node --experimental-test-module-mocks --test test/surface-cache-ambient.test.ts test/directory-store.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/api/app-ambient.ts src/directory/directory-store.ts src/directory/postgres-directory-store.ts test/surface-cache-ambient.test.ts test/directory-store.test.ts test/postgres-directory-store.test.ts`
- `npx prettier --check src/api/app-ambient.ts src/directory/directory-store.ts src/directory/postgres-directory-store.ts test/surface-cache-ambient.test.ts test/directory-store.test.ts test/postgres-directory-store.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789768501&installation_model_id=19911&pr_number=613&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F613&signature=655047252076b829ec2cb439ae199c88f6886065a06930cfae2236f72b956c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


