### PR TITLE
fix(harness): strict-posture approval records carry the gated call's arguments

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2898,7 +2898,10 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             const blocks = approvalBlocksInput(pa.kind, outcome);
             const command = pa.command;
             const requestId = commandApprovalId(session.id, command);
-            const summary = await approvalSummary(scopeId, command, pa.reason, pa.purpose);
+            // A producer-provided summary (the strict tool gate renders the
+            // call's arguments deterministically) needs no LLM pass and is
+            // more specific than one generated from the bare tool name.
+            const summary = pa.summary ?? (await approvalSummary(scopeId, command, pa.reason, pa.purpose));
             prepared.push({
               requestId,
               record: {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -105,6 +105,7 @@ export interface HarnessTurnResult {
     matched?: string;
     purpose?: string;
     approvalKey?: string;
+    summary?: string;
   }>;
   pausedOnApproval?: boolean;
   modelCalls?: number;

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -38,6 +38,7 @@ export interface ToolContextRef {
     matched?: string;
     purpose?: string;
     approvalKey?: string;
+    summary?: string;
   }>;
   pausedOnApproval?: boolean;
   emit?: (entry: { type: EntryType; payload: unknown; scopeLabel: ScopeId }) => void | Promise<unknown>;
@@ -2986,6 +2987,31 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
 
 const TOOL_APPROVAL_EXEMPT = new Set(["finish_silently", "stay_silent"]);
 const STRICT_TOOL_APPROVAL_REASON = "strict posture: this tool call requires human approval";
+// Cap for a strict-gate approval's rendered arguments. Matches the
+// LLM-generated approval summary cap in the orchestrator, so a huge tool
+// payload can't flood the approval surface an integrator renders (#560).
+const APPROVAL_ARGS_SUMMARY_MAX = 300;
+
+function approvalArgsSummary(params: unknown): string | undefined {
+  /** Render a gated tool call's arguments for the approval record.
+
+   * A strict-posture approver must see the action, not just the tool name:
+   * "execute `rm -rf /var/data`" is a decidable ask, "execute" alone is not.
+   * Deterministic (no LLM round-trip), bounded, and omitted for calls with
+   * no arguments or unrenderable ones (#560).
+   */
+  if (params === undefined || params === null) return undefined;
+  let rendered: string;
+  try {
+    rendered = typeof params === "string" ? params : JSON.stringify(params);
+  } catch {
+    return undefined;
+  }
+  if (!rendered) return undefined;
+  return rendered.length > APPROVAL_ARGS_SUMMARY_MAX
+    ? `${rendered.slice(0, APPROVAL_ARGS_SUMMARY_MAX)}\u2026`
+    : rendered;
+}
 
 function withToolApprovalGate(
   tool: ToolDefinition,
@@ -3007,21 +3033,29 @@ function withToolApprovalGate(
     async execute(callId: string, params: unknown) {
       const gate = ref.toolApprovalGate;
       if (gate && !gate(tool.name)) {
+        const argsSummary = approvalArgsSummary(params);
         ref.pendingApprovals?.push({
           command: tool.name,
           reason: STRICT_TOOL_APPROVAL_REASON,
           kind: "approval",
           approvalKey: `tool:${tool.name}`,
+          ...(argsSummary ? { summary: argsSummary } : {}),
         });
         ref.pausedOnApproval = true;
         await rec.recordCall(callId, {
           tool: tool.name,
           blocked: "needs_approval",
           reason: STRICT_TOOL_APPROVAL_REASON,
+          ...(argsSummary ? { args: argsSummary } : {}),
         });
         return rec.recordResult(
           callId,
-          { tool: tool.name, blocked: "needs_approval", reason: STRICT_TOOL_APPROVAL_REASON },
+          {
+            tool: tool.name,
+            blocked: "needs_approval",
+            reason: STRICT_TOOL_APPROVAL_REASON,
+            ...(argsSummary ? { args: argsSummary } : {}),
+          },
           {
             content: [
               { type: "text" as const, text: `[blocked: needs human approval] ${STRICT_TOOL_APPROVAL_REASON}` },

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -598,6 +598,59 @@ test("the screen never rewrites a strict-posture per-tool gate", async () => {
   assert.equal(pending.length, 1);
 });
 
+test("a strict-posture gate record carries the tool call's arguments", async () => {
+  // An approver deciding on a gated call must see the action, not just the
+  // tool name — "execute {command: 'rm -rf /var/data'}" is decidable, a bare
+  // "execute" is not (#560).
+  const emitted: Emitted[] = [];
+  const pending: Array<{ command: string; reason: string; summary?: string }> = [];
+  const ref: ToolContextRef = {
+    current: fakeToolContext(),
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+    pendingApprovals: pending,
+    toolApprovalGate: () => false,
+  };
+  const [execute] = createPiTools(ref);
+  await call(execute, { command: "rm -rf /var/data" });
+
+  assert.equal(pending.length, 1);
+  assert.match(pending[0]!.summary ?? "", /rm -rf \/var\/data/);
+  // The persisted tool_call and tool_result records carry the same bounded
+  // rendering, so the transcript audit shows what was blocked, not just that
+  // something was.
+  const callEntry = emitted.find((entry) => entry.type === "tool_call")!.payload;
+  assert.match(String(callEntry.args ?? ""), /rm -rf \/var\/data/);
+  const resultEntry = emitted.find((entry) => entry.type === "tool_result")!.payload;
+  assert.match(String(resultEntry.args ?? ""), /rm -rf \/var\/data/);
+});
+
+test("a strict-posture gate renders huge arguments bounded and argless calls without a summary", async () => {
+  const pending: Array<{ command: string; reason: string; summary?: string }> = [];
+  const ref: ToolContextRef = {
+    current: fakeToolContext(),
+    scopeLabel: "personal:U1",
+    pendingApprovals: pending,
+    toolApprovalGate: () => false,
+  };
+  const tools = createPiTools(ref);
+  const execute = tools.find((t) => t.name === "execute")!;
+  const memory = tools.find((t) => t.name === "memory")!;
+
+  await call(execute, { command: "x".repeat(5_000) });
+  await call(memory, undefined as unknown as Record<string, unknown>);
+
+  assert.equal(pending.length, 2);
+  // Bounded to the approval-summary cap so a huge payload can't flood the
+  // approval surface an integrator renders.
+  assert.ok((pending[0]!.summary ?? "").length <= 301, "bounded with an ellipsis");
+  assert.ok((pending[0]!.summary ?? "").endsWith("…"));
+  // No arguments → no summary field at all, not an empty one.
+  assert.equal(pending[1]!.summary, undefined);
+});
+
 const surfaceTool = (ref: ToolContextRef, name = "slack") => {
   const t = createPiTools(ref, { surfaceTools: true, ...(name !== "slack" ? { surfaceName: name } : {}) }).find(
     (x) => x.name === name,


### PR DESCRIPTION
Fixes the narrower half of #560 — the reporter's explicitly preferred first step ("If the arguments were simply added to the pending-approval record, that would solve this half outright and would be a smaller change than a new route"). The HMAC-reachable session-content route is deliberately **not** included: widening source-auth read access to transcripts is a trust-model decision only the maintainers can make, and this half stands on its own.

## What changes

Under Strict posture, `withToolApprovalGate` fired on the tool *name* and recorded only that name — `pendingApprovals` got `{command: "execute"}`, and the transcript's `tool_call`/`tool_result` records got `{tool, blocked, reason}`. An approver (human or integration) could see the category but never the action: *"the agent wants to use `execute`"*, never *"…to run `rm -rf /var/data`"*. The arguments lived only in the model's tool-use block in the transcript — precisely what a `auth: "source"` integration cannot read.

The gate now renders the call's arguments:

1. **`pendingApprovals` gains `summary`** — the field that already exists on `PendingApproval`/`PendingApprovalRecord` for exactly this purpose (the LLM-generated exec approval summaries). Here it's deterministic: JSON for object params, verbatim for strings, capped at 300 chars (the same cap the orchestrator's LLM summaries use, so a huge payload can't flood the approval surface), and **omitted entirely** for argless or unrenderable calls.
2. **The persisted `tool_call`/`tool_result` records gain the same bounded `args` rendering**, so the transcript audit shows *what* was blocked, not just that something was.
3. **The orchestrator prefers a producer-provided summary over generating an LLM one** (`pa.summary ?? await approvalSummary(...)`): for tool-gate entries the LLM pass would only ever see the bare tool name, so the deterministic rendering is strictly more informative — and skipping the round-trip saves the model call. No existing producer sets `summary`, so exec-path approvals behave exactly as before.

`HarnessTurnResult`/`ToolContextRef` pending-approval item types gain the optional `summary` field; the public API types already had it.

## Testing

Two new tests in `test/pi-tools.test.ts`:

- `a strict-posture gate record carries the tool call's arguments` — `pendingApprovals[0].summary` matches the gated command, and both persisted records carry the same `args`. **Fails on `main`** (no summary/args anywhere).
- `a strict-posture gate renders huge arguments bounded and argless calls without a summary` — a 5,000-char command is capped at the 300-char bound with an ellipsis; an argless gated call produces no `summary` field at all. The bounded half **fails on `main`** (no rendering exists).

Full file: 71/71 pass with the fix, 69 pass + the 2 new failing on unpatched `main`. `orchestrator`/approval test files: identical results with and without the change in this environment (84 pass / 60 pre-existing environment failures in both runs), zero regressions.

## What an integrator gets

With this, an approval-queue integration building on `POST /v1/turns` (source-auth) can render *"the agent wants to run `execute` with `{"command":"rm -rf /var/data"}`"* — a decidable ask — instead of the tool name alone. The approver already controls execution of that exact call; showing them the call's arguments leaks nothing they can't already cause.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789786491&installation_model_id=19911&pr_number=615&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F615&signature=5494ed688298a57f981a6d969a8773e76b8f99576e0c6ca2405564ca8545ff9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->