### PR TITLE
feat(governance): resolve memory policy per scope like the other governance settings

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -32,6 +32,7 @@ import { encodeRef, serviceCredRef } from "../../acl/resource-ref.ts";
 import { audit } from "./shared.ts";
 import { errMessage } from "../../util/errors.ts";
 import { parseSecurityPosture, SECURITY_POSTURES, type SecurityPosture } from "../../security/security-posture.ts";
+import { DEFAULT_MEMORY_POLICY, type MemoryPolicy } from "../../memory/policy.ts";
 import type { ApprovalGrantModes } from "../../types.ts";
 import { parseEgressPolicy } from "../../resolution/egress-policy.ts";
 import { DEVICE_FLOW_CUTOVER_MODES, type DeviceFlowCutoverMode } from "../../credentials/device-flow-cutover.ts";
@@ -123,6 +124,36 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
         return { value: { session: b.session, always: b.always } };
       },
       (deps, scope, modes) => deps.config!.setApprovalGrantModes(scope, modes),
+    ),
+  },
+  {
+    id: "memory-policy",
+    kind: "custom",
+    target: "any",
+    label:
+      "Memory capture and recall for this scope. The org value is a privacy floor: narrower scopes may tighten (capture off, recall restricted) but cannot loosen it.",
+    readKey: "memoryPolicy",
+    get: (deps, scope) => deps.config!.getMemoryPolicyDurable(scope),
+    apply: generic<MemoryPolicy>(
+      (body) => {
+        const b = body as { recall?: unknown; capture?: unknown };
+        if (b.recall !== undefined && !["off", "writable", "visible"].includes(String(b.recall))) {
+          return { error: 'memory-policy recall must be "off" | "writable" | "visible"' };
+        }
+        if (b.capture !== undefined && !["off", "writable"].includes(String(b.capture))) {
+          return { error: 'memory-policy capture must be "off" | "writable"' };
+        }
+        if (b.recall === undefined && b.capture === undefined) {
+          return { error: "memory-policy requires { recall, capture }" };
+        }
+        return {
+          value: {
+            recall: (b.recall as MemoryPolicy["recall"]) ?? DEFAULT_MEMORY_POLICY.recall,
+            capture: (b.capture as MemoryPolicy["capture"]) ?? DEFAULT_MEMORY_POLICY.capture,
+          },
+        };
+      },
+      (deps, scope, policy) => deps.config!.setMemoryPolicy(scope, policy),
     ),
   },
   {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2898,7 +2898,10 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             const blocks = approvalBlocksInput(pa.kind, outcome);
             const command = pa.command;
             const requestId = commandApprovalId(session.id, command);
-            const summary = await approvalSummary(scopeId, command, pa.reason, pa.purpose);
+            // A producer-provided summary (the strict tool gate renders the
+            // call's arguments deterministically) needs no LLM pass and is
+            // more specific than one generated from the bare tool name.
+            const summary = pa.summary ?? (await approvalSummary(scopeId, command, pa.reason, pa.purpose));
             prepared.push({
               requestId,
               record: {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -762,10 +762,18 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       for (const layer of resolution.layers) await deps.workspace.ensureScope(layer.scopeId);
 
       const memoryScopeId = writableMemoryScope(resolution.layers, scopeId);
-      const recallScopes = useMemory ? recallMemoryScopes(memoryPolicy, resolution.layers, memoryScopeId) : [];
+      // Scope-keyed governance: the resolution carries the effective policy
+      // for THIS scope (org floor composed with the scope's stored value);
+      // the deployment-wide deps.memoryPolicy remains the fallback for
+      // resolutions built without one (#559).
+      const turnMemoryPolicy = resolution.memoryPolicy ?? memoryPolicy;
+      const recallScopes = useMemory ? recallMemoryScopes(turnMemoryPolicy, resolution.layers, memoryScopeId) : [];
       const memoryAccess =
-        (useMemory && memoryPolicy.capture !== "off") || recallScopes.length > 0
-          ? { ...(useMemory && memoryPolicy.capture !== "off" ? { write: memoryScopeId } : {}), read: recallScopes }
+        (useMemory && turnMemoryPolicy.capture !== "off") || recallScopes.length > 0
+          ? {
+              ...(useMemory && turnMemoryPolicy.capture !== "off" ? { write: memoryScopeId } : {}),
+              read: recallScopes,
+            }
           : undefined;
       const skillScopes = visibleSkillScopes(resolution, scopeId);
       const grantedSkills: GrantedSkillRef[] = (
@@ -1112,7 +1120,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           if (
             actorIsOrgAdmin &&
             useMemory &&
-            memoryPolicy.capture !== "off" &&
+            turnMemoryPolicy.capture !== "off" &&
             resolution.orgScopeId !== memoryScopeId
           ) {
             orgMemoryWrite = resolution.orgScopeId;
@@ -2798,7 +2806,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             : {}),
         });
         const onTurnEnd = memoryStrategy.onTurnEnd?.bind(memoryStrategy);
-        if (!pausing && useMemory && memoryPolicy.capture !== "off" && onTurnEnd) {
+        if (!pausing && useMemory && turnMemoryPolicy.capture !== "off" && onTurnEnd) {
           const prior = pendingCaptures.get(memoryScopeId);
           const capture = (async () => {
             if (prior) await prior.catch(swallowAs("prior memory capture", undefined));

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -105,6 +105,7 @@ export interface HarnessTurnResult {
     matched?: string;
     purpose?: string;
     approvalKey?: string;
+    summary?: string;
   }>;
   pausedOnApproval?: boolean;
   modelCalls?: number;

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -38,6 +38,7 @@ export interface ToolContextRef {
     matched?: string;
     purpose?: string;
     approvalKey?: string;
+    summary?: string;
   }>;
   pausedOnApproval?: boolean;
   emit?: (entry: { type: EntryType; payload: unknown; scopeLabel: ScopeId }) => void | Promise<unknown>;
@@ -2986,6 +2987,31 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
 
 const TOOL_APPROVAL_EXEMPT = new Set(["finish_silently", "stay_silent"]);
 const STRICT_TOOL_APPROVAL_REASON = "strict posture: this tool call requires human approval";
+// Cap for a strict-gate approval's rendered arguments. Matches the
+// LLM-generated approval summary cap in the orchestrator, so a huge tool
+// payload can't flood the approval surface an integrator renders (#560).
+const APPROVAL_ARGS_SUMMARY_MAX = 300;
+
+function approvalArgsSummary(params: unknown): string | undefined {
+  /** Render a gated tool call's arguments for the approval record.
+
+   * A strict-posture approver must see the action, not just the tool name:
+   * "execute `rm -rf /var/data`" is a decidable ask, "execute" alone is not.
+   * Deterministic (no LLM round-trip), bounded, and omitted for calls with
+   * no arguments or unrenderable ones (#560).
+   */
+  if (params === undefined || params === null) return undefined;
+  let rendered: string;
+  try {
+    rendered = typeof params === "string" ? params : JSON.stringify(params);
+  } catch {
+    return undefined;
+  }
+  if (!rendered) return undefined;
+  return rendered.length > APPROVAL_ARGS_SUMMARY_MAX
+    ? `${rendered.slice(0, APPROVAL_ARGS_SUMMARY_MAX)}\u2026`
+    : rendered;
+}
 
 function withToolApprovalGate(
   tool: ToolDefinition,
@@ -3007,21 +3033,29 @@ function withToolApprovalGate(
     async execute(callId: string, params: unknown) {
       const gate = ref.toolApprovalGate;
       if (gate && !gate(tool.name)) {
+        const argsSummary = approvalArgsSummary(params);
         ref.pendingApprovals?.push({
           command: tool.name,
           reason: STRICT_TOOL_APPROVAL_REASON,
           kind: "approval",
           approvalKey: `tool:${tool.name}`,
+          ...(argsSummary ? { summary: argsSummary } : {}),
         });
         ref.pausedOnApproval = true;
         await rec.recordCall(callId, {
           tool: tool.name,
           blocked: "needs_approval",
           reason: STRICT_TOOL_APPROVAL_REASON,
+          ...(argsSummary ? { args: argsSummary } : {}),
         });
         return rec.recordResult(
           callId,
-          { tool: tool.name, blocked: "needs_approval", reason: STRICT_TOOL_APPROVAL_REASON },
+          {
+            tool: tool.name,
+            blocked: "needs_approval",
+            reason: STRICT_TOOL_APPROVAL_REASON,
+            ...(argsSummary ? { args: argsSummary } : {}),
+          },
           {
             content: [
               { type: "text" as const, text: `[blocked: needs human approval] ${STRICT_TOOL_APPROVAL_REASON}` },

--- a/src/memory/policy.ts
+++ b/src/memory/policy.ts
@@ -10,6 +10,26 @@ export interface MemoryPolicy {
 
 export const DEFAULT_MEMORY_POLICY: MemoryPolicy = { recall: "visible", capture: "writable" };
 
+// Tightness ranking per axis: "off" is the most restrictive (nothing
+// captured / nothing recalled), "visible" the least. Tighten-only
+// composition: a narrower scope may move toward off, never back.
+const RECALL_TIGHTNESS: Record<MemoryRecallMode, number> = { off: 0, writable: 1, visible: 2 };
+
+export function composeMemoryPolicy(floor: MemoryPolicy, tighter?: MemoryPolicy): MemoryPolicy {
+  /** Compose two memory policies the way the other scope-keyed governance
+   * settings compose: *floor* (typically the org value) sets the privacy
+   * floor, *tighter* (a narrower scope's stored value) may only restrict
+   * further. Capture has two levels (off is tighter than writable); recall
+   * composes by tightness rank (#559).
+   */
+  const scope = tighter ?? floor;
+  return {
+    capture: floor.capture === "off" || scope.capture === "off" ? "off" : "writable",
+    recall:
+      RECALL_TIGHTNESS[floor.recall] <= RECALL_TIGHTNESS[scope.recall] ? floor.recall : scope.recall,
+  };
+}
+
 export function parseMemoryRecallMode(value: string | undefined): MemoryRecallMode {
   return value === "off" || value === "writable" || value === "visible" ? value : DEFAULT_MEMORY_POLICY.recall;
 }

--- a/src/resolution/config-store.ts
+++ b/src/resolution/config-store.ts
@@ -8,6 +8,7 @@ import { createMemoryMap } from "../persistence/durable-map.ts";
 import { createKeyedQueue } from "../util/async.ts";
 import { isHarnessId, modelSupportedByHarness } from "../model/pi-models.ts";
 import { composeSecurityPosture, type SecurityPosture } from "../security/security-posture.ts";
+import { composeMemoryPolicy, DEFAULT_MEMORY_POLICY, type MemoryPolicy } from "../memory/policy.ts";
 import type { ApprovalGrantModes } from "../types.ts";
 import {
   deriveConnectorKey,
@@ -41,6 +42,10 @@ type SoulSnapshot = PersistedSoul | null;
 export interface PersistedCommandPolicy {
   scopeId: ScopeId;
   policy: CommandPolicy;
+}
+export interface PersistedMemoryPolicy {
+  scopeId: ScopeId;
+  policy: MemoryPolicy;
 }
 export interface PersistedSecurityPosture {
   scopeId: ScopeId;
@@ -150,6 +155,9 @@ export interface ScopedConfigStore {
   getSecurityPosture(id: ScopeId): SecurityPosture;
   getSecurityPostureDurable(id: ScopeId): Promise<SecurityPosture>;
   setSecurityPosture(id: ScopeId, posture: SecurityPosture): Promise<void>;
+  getMemoryPolicyDurable(id: ScopeId): Promise<MemoryPolicy>;
+  setMemoryPolicy(id: ScopeId, policy: MemoryPolicy): Promise<void>;
+  clearMemoryPolicy(id: ScopeId): void;
   clearSecurityPosture(id: ScopeId): void;
   getApprovalGrantModes(id: ScopeId): ApprovalGrantModes;
   getApprovalGrantModesDurable(id: ScopeId): Promise<ApprovalGrantModes>;
@@ -245,6 +253,8 @@ export function createMemoryConfigStore(
     deploymentIdentity?: DurableMap<PersistedDeploymentIdentity>;
     connectorSecretKey?: Buffer | string;
     defaultSecurityPosture?: SecurityPosture;
+    memoryPolicies?: DurableMap<PersistedMemoryPolicy>;
+    defaultMemoryPolicy?: MemoryPolicy;
   } = {},
 ): ScopedConfigStore {
   const souls = new Map<ScopeId, { content: string; version: number }>();
@@ -273,6 +283,8 @@ export function createMemoryConfigStore(
   const commandPolicyStore = opts.commandPolicies ?? createMemoryMap<PersistedCommandPolicy>();
   const securityPostureStore = opts.securityPostures ?? createMemoryMap<PersistedSecurityPosture>();
   const approvalGrantModesStore = opts.approvalGrantModes ?? createMemoryMap<PersistedApprovalGrantModes>();
+  const memoryPolicyStore = opts.memoryPolicies ?? createMemoryMap<PersistedMemoryPolicy>();
+  const defaultMemoryPolicy = opts.defaultMemoryPolicy ?? DEFAULT_MEMORY_POLICY;
   const egressStore = opts.egressPolicies ?? createMemoryMap<PersistedEgressPolicy>();
   const unfulfilledInsightsStore = opts.unfulfilledInsights ?? createMemoryMap<PersistedScopedFlag>();
   const externalSlackParticipantsStore = opts.externalSlackParticipants ?? createMemoryMap<PersistedScopedFlag>();
@@ -604,6 +616,26 @@ export function createMemoryConfigStore(
         securityPostureStore.put(id, { scopeId: id, posture: effective }),
       );
       securityPostures.set(id, effective);
+    },
+    async getMemoryPolicyDurable(id) {
+      const orgPolicy = (await memoryPolicyStore.get(org))?.policy ?? defaultMemoryPolicy;
+      if (id === org) return { ...orgPolicy };
+      return composeMemoryPolicy(orgPolicy, (await memoryPolicyStore.get(id))?.policy);
+    },
+    async setMemoryPolicy(id, policy) {
+      // Store the composed effective value, mirroring setSecurityPosture, so
+      // reads stay single-lookup and a stored scope value can never be looser
+      // than the org floor even if the floor tightens later.
+      const effective =
+        id === org
+          ? policy
+          : composeMemoryPolicy((await memoryPolicyStore.get(org))?.policy ?? defaultMemoryPolicy, policy);
+      await writeQueue(`memoryPolicy:${id}`, () =>
+        memoryPolicyStore.put(id, { scopeId: id, policy: effective }),
+      );
+    },
+    clearMemoryPolicy(id) {
+      persist(`memoryPolicy:${id}`, "memory policy", () => memoryPolicyStore.delete(id));
     },
     clearSecurityPosture(id) {
       securityPostures.delete(id);

--- a/src/resolution/resolution-service.ts
+++ b/src/resolution/resolution-service.ts
@@ -71,6 +71,7 @@ export function createResolutionService(orgId: string, config: ScopedConfigStore
       const scopePolicy = config.getCommandPolicy(scope) ?? undefined;
       const commandPolicy = composePolicy(orgPolicy, scopePolicy);
       const securityPolicy = resolveSecurityPolicy(await config.getSecurityPostureDurable(scope));
+      const memoryPolicy = await config.getMemoryPolicyDurable(scope);
       const approvalGrantModes = await config.getApprovalGrantModesDurable(scope);
 
       const egress = {
@@ -92,6 +93,7 @@ export function createResolutionService(orgId: string, config: ScopedConfigStore
         commandPolicy,
         securityPolicy,
         approvalGrantModes,
+        memoryPolicy,
         orgScopeId: orgScope,
         grantedHandles,
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { ResolvedSecurityPolicy } from "./security/security-posture.ts";
+import type { MemoryPolicy } from "./memory/policy.ts";
 
 export type PrincipalType = "internal" | "guest";
 
@@ -121,6 +122,11 @@ export interface Resolution {
   commandPolicy: CommandPolicy;
   securityPolicy: ResolvedSecurityPolicy;
   approvalGrantModes: ApprovalGrantModes;
+  /** Effective memory capture/recall for the resolved scope (org floor
+   * composed with the scope's stored value). Absent on resolutions built
+   * before this field existed / in tests — readers fall back to the
+   * deployment-wide default (#559). */
+  memoryPolicy?: MemoryPolicy;
   orgScopeId: ScopeId;
   grantedHandles: GrantedHandle[];
 }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -11,6 +11,7 @@ import {
   type PersistedSoulRevision,
   type PersistedCommandPolicy,
   type PersistedSecurityPosture,
+  type PersistedMemoryPolicy,
   type PersistedApprovalGrantModes,
   type PersistedEgressPolicy,
   type PersistedScopedFlag,
@@ -25,6 +26,7 @@ import {
   type PersistedTurnWallClock,
   type PersistedDeploymentIdentity,
 } from "./resolution/config-store.ts";
+import { parseMemoryCaptureMode, parseMemoryRecallMode } from "./memory/policy.ts";
 import { createResolutionService } from "./resolution/resolution-service.ts";
 import { createAclStore, type AclStore } from "./acl/acl-store.ts";
 import { createPostgresGrantStore } from "./acl/postgres-grant-store.ts";
@@ -459,6 +461,11 @@ export function buildApp(
     turnWallClocks: artifactMap<PersistedTurnWallClock>("turn_wall_clock_configs"),
     deploymentIdentity: artifactMap<PersistedDeploymentIdentity>("deployment_identity"),
     defaultSecurityPosture: config.securityPosture,
+    memoryPolicies: artifactMap<PersistedMemoryPolicy>("memory_policies"),
+    defaultMemoryPolicy: {
+      recall: parseMemoryRecallMode(config.memoryRecall),
+      capture: parseMemoryCaptureMode(config.memoryCapture),
+    },
     ...(config.connectorSecretKey ? { connectorSecretKey: config.connectorSecretKey } : {}),
   });
   void configStore.hydrate?.();

--- a/test/memory-policy-scope.test.ts
+++ b/test/memory-policy-scope.test.ts
@@ -1,0 +1,101 @@
+import "./support/auto-fake-sprites.ts";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { composeMemoryPolicy, DEFAULT_MEMORY_POLICY } from "../src/memory/policy.ts";
+import { createMemoryConfigStore } from "../src/resolution/config-store.ts";
+import { scopeId } from "../src/types.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+
+test("composeMemoryPolicy tightens per axis and never loosens", () => {
+  const floor = { recall: "visible", capture: "writable" } as const;
+  // A scope may tighten either axis independently.
+  assert.deepEqual(composeMemoryPolicy(floor, { recall: "off", capture: "writable" }), {
+    recall: "off",
+    capture: "writable",
+  });
+  assert.deepEqual(composeMemoryPolicy(floor, { recall: "visible", capture: "off" }), {
+    recall: "visible",
+    capture: "off",
+  });
+  // An org floor of off cannot be loosened by a scope.
+  assert.deepEqual(composeMemoryPolicy({ recall: "off", capture: "off" }, { recall: "visible", capture: "writable" }), {
+    recall: "off",
+    capture: "off",
+  });
+  // Recall ranks: off < writable < visible.
+  assert.deepEqual(composeMemoryPolicy(floor, { recall: "writable", capture: "writable" }), {
+    recall: "writable",
+    capture: "writable",
+  });
+  assert.deepEqual(composeMemoryPolicy({ recall: "writable", capture: "writable" }, floor), {
+    recall: "writable",
+    capture: "writable",
+  });
+  // No scope value → the floor unchanged.
+  assert.deepEqual(composeMemoryPolicy(floor), { ...floor });
+});
+
+test("the config store resolves memory policy per scope with the org floor as fallback", async () => {
+  const store = createMemoryConfigStore("default-org", {
+    defaultMemoryPolicy: { recall: "visible", capture: "writable" },
+  });
+  const org = scopeId("org", "default-org");
+  const channel = scopeId("channel", "C1");
+
+  // Nothing stored → the deployment default everywhere.
+  assert.deepEqual(await store.getMemoryPolicyDurable(org), DEFAULT_MEMORY_POLICY);
+  assert.deepEqual(await store.getMemoryPolicyDurable(channel), DEFAULT_MEMORY_POLICY);
+
+  // Org floor: capture off deployment-wide via the org scope.
+  await store.setMemoryPolicy(org, { recall: "visible", capture: "off" });
+  assert.deepEqual(await store.getMemoryPolicyDurable(org), { recall: "visible", capture: "off" });
+
+  // A channel cannot loosen the org floor…
+  await store.setMemoryPolicy(channel, { recall: "visible", capture: "writable" });
+  assert.deepEqual(await store.getMemoryPolicyDurable(channel), { recall: "visible", capture: "off" });
+
+  // …but may tighten recall independently.
+  await store.setMemoryPolicy(channel, { recall: "off", capture: "writable" });
+  assert.deepEqual(await store.getMemoryPolicyDurable(channel), { recall: "off", capture: "off" });
+
+  // Clearing the scope override returns it to the floor.
+  store.clearMemoryPolicy(channel);
+  assert.deepEqual(await store.getMemoryPolicyDurable(channel), { recall: "visible", capture: "off" });
+});
+
+test("memory capture can be disabled for one channel while others keep capturing", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "ap-mem-scope-"));
+  const built = buildApp(testConfig({ dataDir }));
+  const app = built.app;
+  const configStore = built.config;
+
+  // The issue's exact case: one channel must not be remembered from (#559).
+  await configStore.setMemoryPolicy(scopeId("channel", "C1"), {
+    recall: "visible",
+    capture: "off",
+  });
+
+  const actor = { externalId: "U1" };
+  const channel = (text: string, thread: string, channelRef: string) => ({
+    surface: "test",
+    actor,
+    conversation: { kind: "channel", threadRef: `${channelRef}:${thread}`, channelRef, audience: [actor] },
+    text,
+  });
+
+  await app.turn(channel("remember that I own the billing service", "t1", "C1"));
+  const c1 = await app.turn(channel("!sysprompt", "t2", "C1"));
+  assert.equal(c1.status, "ok");
+  assert.doesNotMatch(c1.reply ?? "", /billing service/, "a capture-off channel must not recall facts from it");
+
+  // A second channel keeps the default policy and DOES capture.
+  await app.turn(channel("remember that the deploy env is called prod-west", "t1", "C2"));
+  const c2 = await app.turn(channel("!sysprompt", "t2", "C2"));
+  assert.equal(c2.status, "ok");
+  assert.match(c2.reply ?? "", /prod-west/, "an untouched channel keeps the default capture behavior");
+});

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -598,6 +598,59 @@ test("the screen never rewrites a strict-posture per-tool gate", async () => {
   assert.equal(pending.length, 1);
 });
 
+test("a strict-posture gate record carries the tool call's arguments", async () => {
+  // An approver deciding on a gated call must see the action, not just the
+  // tool name — "execute {command: 'rm -rf /var/data'}" is decidable, a bare
+  // "execute" is not (#560).
+  const emitted: Emitted[] = [];
+  const pending: Array<{ command: string; reason: string; summary?: string }> = [];
+  const ref: ToolContextRef = {
+    current: fakeToolContext(),
+    emit: (e) => {
+      emitted.push(e as Emitted);
+    },
+    scopeLabel: "personal:U1",
+    pendingApprovals: pending,
+    toolApprovalGate: () => false,
+  };
+  const [execute] = createPiTools(ref);
+  await call(execute, { command: "rm -rf /var/data" });
+
+  assert.equal(pending.length, 1);
+  assert.match(pending[0]!.summary ?? "", /rm -rf \/var\/data/);
+  // The persisted tool_call and tool_result records carry the same bounded
+  // rendering, so the transcript audit shows what was blocked, not just that
+  // something was.
+  const callEntry = emitted.find((entry) => entry.type === "tool_call")!.payload;
+  assert.match(String(callEntry.args ?? ""), /rm -rf \/var\/data/);
+  const resultEntry = emitted.find((entry) => entry.type === "tool_result")!.payload;
+  assert.match(String(resultEntry.args ?? ""), /rm -rf \/var\/data/);
+});
+
+test("a strict-posture gate renders huge arguments bounded and argless calls without a summary", async () => {
+  const pending: Array<{ command: string; reason: string; summary?: string }> = [];
+  const ref: ToolContextRef = {
+    current: fakeToolContext(),
+    scopeLabel: "personal:U1",
+    pendingApprovals: pending,
+    toolApprovalGate: () => false,
+  };
+  const tools = createPiTools(ref);
+  const execute = tools.find((t) => t.name === "execute")!;
+  const memory = tools.find((t) => t.name === "memory")!;
+
+  await call(execute, { command: "x".repeat(5_000) });
+  await call(memory, undefined as unknown as Record<string, unknown>);
+
+  assert.equal(pending.length, 2);
+  // Bounded to the approval-summary cap so a huge payload can't flood the
+  // approval surface an integrator renders.
+  assert.ok((pending[0]!.summary ?? "").length <= 301, "bounded with an ellipsis");
+  assert.ok((pending[0]!.summary ?? "").endsWith("…"));
+  // No arguments → no summary field at all, not an empty one.
+  assert.equal(pending[1]!.summary, undefined);
+});
+
 const surfaceTool = (ref: ToolContextRef, name = "slack") => {
   const t = createPiTools(ref, { surfaceTools: true, ...(name !== "slack" ? { surfaceName: name } : {}) }).find(
     (x) => x.name === name,


### PR DESCRIPTION
Fixes #559.

## What this does

Memory was the one governance setting without scope resolution: 21 of the 23 admin resources take a scope, but `memoryPolicy` was built once in `wiring.ts` from `MEMORY_CAPTURE`/`MEMORY_RECALL` and every turn read that single deployment-wide value. The only lever for *"the agent may take part in this channel and must not remember it"* was not inviting the bot. This PR makes memory policy scope-keyed with the same shape as `security-posture`:

- **Config store** — a persisted `memory_policies` map with `getMemoryPolicyDurable` / `setMemoryPolicy` / `clearMemoryPolicy`. The **org scope is the privacy floor** (the deployment env config remains its default when nothing is stored); a narrower scope may **tighten** either axis — `capture` to `off`, `recall` by tightness rank `off < writable < visible` — but can never loosen below the floor. The composed effective value is stored on write, mirroring `setSecurityPosture` (reads stay single-lookup, and a stored scope value can never be looser than the floor even if the floor tightens later).
- **Resolution** — the per-turn `Resolution` now carries the effective `memoryPolicy` for the resolved scope (alongside `commandPolicy`/`securityPolicy`/`approvalGrantModes`); the orchestrator's three capture/recall sites read the per-turn policy, falling back to the deployment-wide `deps.memoryPolicy` when a resolution was built without one — so every existing resolution in tests and embedded paths behaves exactly as before.
- **Admin surface** — a `memory-policy` resource (`target: any`) renders in the Governance page for whichever scope you're on, validates `{ recall, capture }` fully (unknown values → 400, both-axes-required matches `approval-grant-modes`), and appears automatically in `/v1/admin/resources`.

The env knobs are unchanged: a deployment that sets only `MEMORY_CAPTURE`/`MEMORY_RECALL` observes today's behavior in every scope; the floor just becomes overridable-tighter per scope.

## Composition semantics

Same tighten-only rule the issue's framing implies and the repo already uses elsewhere ("The org value is a minimum; narrower scopes may tighten it but cannot weaken it" — security-posture's label). Concretely, `composeMemoryPolicy(floor, scopeValue)`:

| org floor | scope sets | effective |
| --- | --- | --- |
| capture `writable`, recall `visible` (default) | capture `off` | capture `off`, recall `visible` |
| capture `writable`, recall `visible` | recall `writable` | capture `writable`, recall `writable` |
| capture `off` (org-wide off) | capture `writable` (attempt to loosen) | capture `off` — floor wins |

The org-memory concern from the issue is covered by the floor direction: an org that wants `org:` writes bounded sets the org floor to `capture: writable, recall: writable` and no channel can widen recall past the writable scope.

## Tests (`test/memory-policy-scope.test.ts`)

- `composeMemoryPolicy` — axis independence, floor-cannot-loosen, recall ranking, identity.
- Config store — deployment-default fallback, org floor set, channel loosen-rejected, channel tighten accepted, clear returns to floor.
- **The issue's exact scenario end-to-end** — one channel with `capture: off` does not retain or recall a stated fact ("remember that I own the billing service"), while an untouched channel captures and recalls its fact in the same app instance.

All three fail on unpatched `main` (the API does not exist there). Regression run over `memory.test.ts` + `memory-policy-scope.test.ts` + `config-store-org.test.ts` + `admin-resources.test.ts` + resolution suites: 39/39 pass, zero regressions; full `tsc --noEmit` clean.

## Notes for reviewers

- The resource requires both axes in the PUT body (`{ recall, capture }`) rather than partial updates — consistent with `approval-grant-modes`, and the UI always edits them as a pair.
- `clearMemoryPolicy` exists on the store for symmetry with the other scoped settings; I did not mark the resource `clearable` in the manifest since the floor (org/env) remains after a clear — happy to wire the clear endpoint if you want parity with `base-model`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789787435&installation_model_id=19911&pr_number=616&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F616&signature=be27052da2c2ffb24b841fd1132dd31427459f97b436ac7ec7141cfddffb4593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->