### PR TITLE
feat(files): collapse viewer-facing file lists to one row per document

### DIFF
--- a/src/api/app-helpers.ts
+++ b/src/api/app-helpers.ts
@@ -318,8 +318,12 @@ export function createAppHelpers(deps: AppDeps, app: App) {
     inScope?: ScopeId,
   ): Promise<FileListPage> {
     const myScopes = await currentResourceScopesForViewer(principalId);
+    // Viewer-facing views show one row per document, not the per-turn
+    // ledger: an agent re-attaching the same file each turn must not grow
+    // the list without bound (#601). Admin/ledger listings keep raw rows.
     const owned = await deps.files.listOwnedByScopes(myScopes, {
       ...opts,
+      distinctByContent: true,
       ...(inScope ? { createdInScope: inScope } : {}),
     });
     const handles = await deps.acl.handlesFor(myScopes);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -574,6 +574,9 @@ export interface ContextSummary {
 interface FileListItem {
   id: string;
   ownerScopeId: ScopeId;
+  /** Who first registered this document. With content-grouped listings this
+   * is the author of the earliest row per document (#601). */
+  createdBy?: string;
   name: string;
   mimetype: string;
   sizeBytes: number;
@@ -624,6 +627,7 @@ export function toFileItem(a: FileArtifact): FileListItem {
   return {
     id: a.id,
     ownerScopeId: a.ownerScopeId,
+    ...(a.createdBy ? { createdBy: a.createdBy } : {}),
     name: a.name,
     mimetype: a.mimetype,
     sizeBytes: a.sizeBytes,

--- a/src/files/file-artifact-store.ts
+++ b/src/files/file-artifact-store.ts
@@ -54,6 +54,14 @@ export interface ListOwnedOptions {
   cursor?: string;
   includeDisabled?: boolean;
   createdInScope?: ScopeId;
+  /**
+   * Collapse per-turn duplicate rows: one row per document (the earliest
+   * registration of each sha256; null-sha rows stay distinct). The artifact
+   * table is a per-turn ledger — a document re-attached each turn is a new row
+   * by construction — so USER-FACING file views pass this to stop the file
+   * list growing with use. Ledger/admin listings leave it off (#601).
+   */
+  distinctByContent?: boolean;
 }
 
 export interface FileArtifactStore {
@@ -168,9 +176,25 @@ export function createMemoryFileArtifactStore(byteStore: DurableByteStore): File
       const set = new Set(scopes);
       const limit = clampLimit(opts?.limit);
       const cursor = opts?.cursor ? decodeCursor(opts.cursor) : null;
-      const all = [...rows.values()]
+      let all = [...rows.values()]
         .filter((r) => set.has(r.ownerScopeId) && (opts?.includeDisabled || r.enabled))
-        .filter((r) => opts?.createdInScope == null || r.createdInScope === opts.createdInScope)
+        .filter((r) => opts?.createdInScope == null || r.createdInScope === opts.createdInScope);
+      if (opts?.distinctByContent) {
+        // Group FIRST (over every matching row, cursor ignored), then apply
+        // the cursor to the representatives: a group whose earliest row was
+        // already emitted on a prior page must not reappear via a later
+        // duplicate that happens to follow the cursor (#601).
+        const earliest = new Map<string, FileArtifact>();
+        for (const r of all) {
+          const key = r.sha256 ?? `id:${r.id}`;
+          const cur = earliest.get(key);
+          if (!cur || r.createdAt < cur.createdAt || (r.createdAt === cur.createdAt && r.id < cur.id)) {
+            earliest.set(key, r);
+          }
+        }
+        all = [...earliest.values()];
+      }
+      all = all
         .filter((r) => (cursor ? afterCursor(r, cursor) : true))
         .sort((a, b) => b.createdAt - a.createdAt || idOrderDesc(a.id, b.id));
       const page = all.slice(0, limit);

--- a/src/files/postgres-file-artifact-store.ts
+++ b/src/files/postgres-file-artifact-store.ts
@@ -132,18 +132,39 @@ export function createPostgresFileArtifactStore(
         params.push(opts.createdInScope);
         filters.push(`created_in_scope = $${params.length}::text`);
       }
-      if (cursor) {
-        params.push(cursor.createdAt, cursor.id);
-        filters.push(`(created_at, id) < ($${params.length - 1}::bigint, $${params.length}::text)`);
-      }
+      // distinctByContent collapses the per-turn ledger to one row per
+      // document (earliest registration per sha256; null-sha rows stay
+      // distinct via their id key). The grouping runs BEFORE the cursor
+      // filter so a group already emitted on a prior page cannot reappear
+      // through a later duplicate that follows the cursor (#601).
+      const groupKey = opts?.distinctByContent ? `COALESCE(sha256, 'id:' || id)` : null;
+      const cursorClause = cursor
+        ? (() => {
+            params.push(cursor.createdAt, cursor.id);
+            return `(created_at, id) < ($${params.length - 1}::bigint, $${params.length}::text)`;
+          })()
+        : null;
       params.push(limit + 1);
-      const rows = await q(
-        `SELECT * FROM file_artifacts
-           WHERE ${filters.join(" AND ")}
-           ORDER BY created_at DESC, id DESC
-           LIMIT $${params.length}`,
-        params,
-      );
+      const rows = groupKey
+        ? await q(
+            `SELECT * FROM (
+               SELECT DISTINCT ON (${groupKey}) *
+               FROM file_artifacts
+               WHERE ${filters.join(" AND ")}
+               ORDER BY ${groupKey}, created_at ASC, id ASC
+             ) grouped
+             WHERE ${cursorClause ?? "TRUE"}
+             ORDER BY created_at DESC, id DESC
+             LIMIT $${params.length}`,
+            params,
+          )
+        : await q(
+            `SELECT * FROM file_artifacts
+               WHERE ${filters.join(" AND ")} ${cursorClause ? `AND ${cursorClause}` : ""}
+               ORDER BY created_at DESC, id DESC
+               LIMIT $${params.length}`,
+            params,
+          );
       const all = rows.map(rowToArtifact);
       const page = all.slice(0, limit);
       const nextCursor = all.length > limit && page.length > 0 ? encodeCursor(page[page.length - 1]!) : undefined;

--- a/test/file-artifact-store.test.ts
+++ b/test/file-artifact-store.test.ts
@@ -196,3 +196,44 @@ test("delete removes the ROW only — bytes shared with another row stay openabl
   const back = await drain(store, "in");
   assert.deepEqual(back, PNG, "the surviving row's bytes are intact (no inline byte delete)");
 });
+
+
+test("distinctByContent collapses per-turn duplicates to the earliest row per document", async () => {
+  // The issue's shape: the same bytes registered by different turns (and
+  // different owners) — one row per document in the grouped view, earliest
+  // registration as the representative (#601).
+  const store = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  await store.put(put({ id: fileArtifactId("run-1", "in", 0), direction: "in", createdBy: "sales", createdAt: 1000 }));
+  await store.put(put({ id: fileArtifactId("run-2", "in", 0), direction: "in", createdBy: "finance", createdAt: 2000 }));
+  await store.put(put({ id: fileArtifactId("run-3", "out", 0), direction: "out", createdBy: "agent", createdAt: 3000 }));
+  await store.put(
+    put({ id: fileArtifactId("run-4", "out", 0), name: "notes.txt", data: Buffer.from([0x01]), createdAt: 1500 }),
+  );
+
+  // Raw ledger: one row per registration.
+  const ledger = await store.listOwnedByScopes([owner]);
+  assert.equal(ledger.files.length, 4);
+
+  // Grouped view: one row per document (per sha256), earliest wins.
+  const grouped = await store.listOwnedByScopes([owner], { distinctByContent: true });
+  assert.equal(grouped.files.length, 2);
+  const doc = grouped.files.find((r) => r.name === "pirate_flag.png");
+  assert.ok(doc, "document row present");
+  assert.equal(doc.createdBy, "sales", "earliest registration is the representative");
+  assert.equal(doc.direction, "in");
+  assert.equal(doc.createdAt, 1000);
+
+  // Cursor pagination over grouped rows: a group already emitted must not
+  // reappear through a later duplicate following the cursor.
+  const page1 = await store.listOwnedByScopes([owner], { distinctByContent: true, limit: 1 });
+  assert.equal(page1.files.length, 1);
+  assert.ok(page1.nextCursor, "more pages");
+  const page2 = await store.listOwnedByScopes([owner], {
+    distinctByContent: true,
+    limit: 10,
+    cursor: page1.nextCursor,
+  });
+  const ids = [...page1.files, ...page2.files].map((r) => r.sha256);
+  assert.equal(new Set(ids).size, ids.length, "no document appears on two pages");
+});
+

--- a/test/postgres-file-artifact-store.test.ts
+++ b/test/postgres-file-artifact-store.test.ts
@@ -154,3 +154,31 @@ test("pg rows survive across store instances (no per-process cache to diverge)",
   const reader = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
   assert.ok(await reader.get("across"));
 });
+
+test("pg distinctByContent collapses per-turn duplicates to one row per document", { skip }, async () => {
+  const store = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
+  await store.put(put({ id: "t1", direction: "in", path: "p/t1", createdBy: "sales", createdAt: 1000 }));
+  await store.put(put({ id: "t2", direction: "in", path: "p/t2", createdBy: "finance", createdAt: 2000 }));
+  await store.put(put({ id: "t3", direction: "out", path: "p/t3", createdBy: "agent", createdAt: 3000 }));
+  await store.put(put({ id: "t4", path: "p/t4", data: Buffer.from("other"), createdAt: 1500 }));
+
+  const ledger = await store.listOwnedByScopes([owner]);
+  assert.equal(ledger.files.length, 4);
+
+  const grouped = await store.listOwnedByScopes([owner], { distinctByContent: true });
+  assert.equal(grouped.files.length, 2);
+  const doc = grouped.files.find((r) => r.name === "flag.png")!;
+  assert.equal(doc.createdBy, "sales", "earliest registration is the representative");
+  assert.equal(doc.createdAt, 1000);
+
+  // Cursor pagination over grouped rows never repeats a document across pages.
+  const page1 = await store.listOwnedByScopes([owner], { distinctByContent: true, limit: 1 });
+  assert.ok(page1.nextCursor);
+  const page2 = await store.listOwnedByScopes([owner], {
+    distinctByContent: true,
+    limit: 10,
+    cursor: page1.nextCursor,
+  });
+  const keys = [...page1.files, ...page2.files].map((r) => r.sha256);
+  assert.equal(new Set(keys).size, keys.length, "no document appears on two pages");
+});


### PR DESCRIPTION
Fixes #601.

## What this does

The artifact table is a **per-turn ledger** — `fileArtifactId` seeds from the run, so the same document re-attached by a later turn (or handed back by the agent) is a new row by construction, and `ON CONFLICT (id) DO NOTHING` only makes *within-run* retries idempotent. Nothing collapsed rows across turns, so a project's Files view filled with byte-identical, same-named, indistinguishable entries — one per turn that touched the document, degrading fastest exactly where the agent is most active (the issue's finance scope: three identically-named reimbursement schedules with no marker of which arrived from whom).

Per the issue's framing, the fix **keeps the ledger and stops treating it as the file list**:

- **`ListOwnedOptions.distinctByContent`** (opt-in): one row per document — the earliest registration of each `sha256` (the issue's "earliest `createdAt`" representative). Null-hash rows stay distinct via their id as the group key (`COALESCE(sha256, 'id:' || id)`), so the guard can never collapse unrelated rows.
  - Postgres: `DISTINCT ON (COALESCE(sha256, 'id:' || id)) … ORDER BY key, created_at ASC, id ASC` in a subquery, re-sorted `created_at DESC` outside — same ordering contract as today.
  - Memory store: the same grouping as a group-then-sort pass.
  - **Cursor correctness**: grouping happens *before* the cursor filter, so a document already emitted on a prior page cannot reappear through a later duplicate that happens to follow the cursor — the naive "filter then group" would straddle groups across pages.
- **`filesForViewer` passes it** — owned/shared and in-scope viewer views show one row per document. **Admin/ledger listings keep raw rows**: the admin files export and the per-user admin view are the audit surfaces where every registration should still be visible.
- **`FileListItem` gains `createdBy`** — who first registered the document, surfaced from the representative row. In the issue's words: three identical copies with no visible marker of which arrived from whom "is not a cosmetic problem — picking the wrong one is a wrong filing."

Not included (deliberately): the contributor-*set* aggregation and per-document occurrence count from the issue's fuller sketch — both need a second grouped query and UI to expand into; the row collapse plus `createdBy` removes the wrong-filing risk and the unbounded growth, and the rest builds cleanly on `distinctByContent` if wanted.

## Tests

`test/file-artifact-store.test.ts` (memory store, always runs): three same-bytes registrations across turns, owners, and directions (`in`/`in`/`out`, the issue's exact shape) collapse to the earliest row (`createdBy: sales`, `direction: in`, earliest `createdAt`); the raw ledger still returns all 4 rows; a second document stays distinct; cursor pagination over grouped pages never repeats a document across pages. **Fails on `main`** (no grouping exists).

`test/postgres-file-artifact-store.test.ts`: the same assertions against the `DISTINCT ON` path (skipped without `DATABASE_URL`, runs in CI).

Regression: the four file-surface suites (`files-http`, `reach-files`, `file-share`, `file-sharing`) pass 56/62 both with and without the change in this environment — the 6 failures are identical pre-existing Windows-only issues (fs `rename` EPERM); zero regressions. `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789788997&installation_model_id=19911&pr_number=617&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F617&signature=32804b5e32e4f97b303201be2f917eb0a974a7b4f28aec7a86c9dd64c2b0373b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->