### PR TITLE
fix(slack): include forwarded messages in agent context

### DIFF
--- a/src/slack/attachments.ts
+++ b/src/slack/attachments.ts
@@ -32,6 +32,23 @@ export interface SlackFile {
   user?: string;
 }
 
+export async function hydrateSlackFiles(
+  files: readonly SlackFile[],
+  lookup: (fileId: string) => Promise<SlackFile | undefined>,
+): Promise<SlackFile[]> {
+  return Promise.all(
+    files.map(async (file) => {
+      if (!file.id || file.url_private || file.url_private_download) return file;
+      try {
+        const hydrated = await lookup(file.id);
+        return hydrated ? { ...file, ...hydrated, ...(file.user ? { user: file.user } : {}) } : file;
+      } catch {
+        return file;
+      }
+    }),
+  );
+}
+
 export const MAX_ATTACHMENT_BYTES = 1_000_000_000;
 
 export function isOversize(file: Pick<SlackFile, "size">): boolean {

--- a/src/slack/attachments.ts
+++ b/src/slack/attachments.ts
@@ -1,4 +1,5 @@
 import { sleep } from "./util.ts";
+import { messageWithForwardedContent, type SlackMessageAttachment } from "./forwards.ts";
 
 export interface IncomingAttachment {
   name: string;
@@ -44,6 +45,7 @@ export interface ThreadMessage {
   bot_id?: string;
   subtype?: string;
   files?: SlackFile[];
+  attachments?: SlackMessageAttachment[];
 }
 
 export function collectEarlierThreadFiles(
@@ -59,7 +61,7 @@ export function collectEarlierThreadFiles(
     if (m.ts === opts.triggerTs) continue;
     const isBot = (m.user && m.user === opts.botUserId) || (opts.ownBotId !== "" && m.bot_id === opts.ownBotId);
     if (isBot) continue;
-    for (const f of m.files ?? []) {
+    for (const f of messageWithForwardedContent(m).files) {
       if (f.id && seen.has(f.id)) continue;
       if (f.id) seen.add(f.id);
       out.push(f.user || !m.user ? f : { ...f, user: m.user });

--- a/src/slack/conversation-view.ts
+++ b/src/slack/conversation-view.ts
@@ -14,6 +14,7 @@ import {
 } from "./lib.ts";
 import type { BotIdentity, Directory } from "./directory.ts";
 import type { SlackConversationKind } from "./messaging.ts";
+import { messageWithForwardedContent } from "./forwards.ts";
 
 export const RECENT_HISTORY_LIMIT = 200;
 export const RECENT_THREAD_LIMIT = 200;
@@ -153,20 +154,21 @@ export function createConversationSerializer(deps: {
     });
     const botNameById = new Map<string, string>();
     await resolveMissingAuthorNames(client, kept, nameById, botNameById);
-    return kept.map((m) => ({
-      ts: m.ts as string,
-      name: messageAuthorName(m, nameById, botNameById),
-      ...(m.user || m.bot_id ? { authorId: String(m.user || m.bot_id) } : {}),
-      text: decodeSlackEntities(String(m.text ?? "").trim()),
-      ...(m.ts === triggerTs ? { isTrigger: true } : {}),
-      ...(m.bot_id ? { isBot: true } : {}),
-      ...(isSelfMessage(m) ? { isSelf: true } : {}),
-      ...(m.thread_ts && String(m.thread_ts) !== m.ts ? { parentTs: String(m.thread_ts) } : {}),
-      ...(reactionTallies(m.reactions).length ? { reactions: reactionTallies(m.reactions) } : {}),
-      ...(Array.isArray(m.files) && m.files.length
-        ? { files: (m.files as any[]).map((f) => String(f?.name ?? f?.title ?? f?.id ?? "file")) }
-        : {}),
-    }));
+    return kept.map((m) => {
+      const content = messageWithForwardedContent(m);
+      return {
+        ts: m.ts as string,
+        name: messageAuthorName(m, nameById, botNameById),
+        ...(m.user || m.bot_id ? { authorId: String(m.user || m.bot_id) } : {}),
+        text: decodeSlackEntities(content.text.trim()),
+        ...(m.ts === triggerTs ? { isTrigger: true } : {}),
+        ...(m.bot_id ? { isBot: true } : {}),
+        ...(isSelfMessage(m) ? { isSelf: true } : {}),
+        ...(m.thread_ts && String(m.thread_ts) !== m.ts ? { parentTs: String(m.thread_ts) } : {}),
+        ...(reactionTallies(m.reactions).length ? { reactions: reactionTallies(m.reactions) } : {}),
+        ...(content.files.length ? { files: content.files.map((f) => slackFileName(f)) } : {}),
+      };
+    });
   }
 
   async function serializeSlackConversation(

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -1,5 +1,4 @@
 import {
-  type SlackFile,
   channelPrivacyChange,
   createDeduper,
   dedupeKey,
@@ -11,6 +10,7 @@ import {
   shouldProcessMessage,
 } from "./lib.ts";
 import type { AckGate } from "./deferred-ack.ts";
+import { messageWithForwardedContent } from "./forwards.ts";
 import type { BotIdentity, Directory } from "./directory.ts";
 import type { Mirror } from "./mirror.ts";
 import type { SlackReactionEvent, TurnHandler } from "./turn-handler.ts";
@@ -74,6 +74,7 @@ export function registerSlackEvents(
       channel: e.channel,
       ts: e.ts,
     });
+    const content = messageWithForwardedContent(e);
     await dispatch(
       key,
       {
@@ -81,8 +82,8 @@ export function registerSlackEvents(
         channel: e.channel,
         userId: identity.userId,
         ...(identity.actor ? { actor: identity.actor } : {}),
-        rawText: e.text ?? "",
-        files: (e.files as SlackFile[]) ?? [],
+        rawText: content.text,
+        files: content.files,
         threadTs: e.thread_ts,
         ts: e.ts,
         ...(e.bot_id || e.subtype === "bot_message" ? { botAuthored: true } : {}),
@@ -138,6 +139,7 @@ export function registerSlackEvents(
         channel: m.channel,
         ts: m.ts,
       });
+      const content = messageWithForwardedContent(m);
       await dispatch(
         key,
         {
@@ -146,8 +148,8 @@ export function registerSlackEvents(
           userId: identity.userId,
           ...(identity.actor ? { actor: identity.actor } : {}),
           ...(m.bot_profile?.name || m.username ? { authorName: String(m.bot_profile?.name || m.username) } : {}),
-          rawText: m.text ?? "",
-          files: (m.files as SlackFile[]) ?? [],
+          rawText: content.text,
+          files: content.files,
           threadTs: m.thread_ts,
           ts: m.ts,
           ...(m.bot_id || m.subtype === "bot_message" ? { botAuthored: true } : {}),
@@ -179,6 +181,7 @@ export function registerSlackEvents(
         ts: m.ts,
       });
       const identity = await eventIdentity(client, m);
+      const content = messageWithForwardedContent(m);
       await dispatch(
         key,
         {
@@ -187,8 +190,8 @@ export function registerSlackEvents(
           userId: identity.userId,
           ...(identity.actor ? { actor: identity.actor } : {}),
           ...(m.bot_profile?.name || m.username ? { authorName: String(m.bot_profile?.name || m.username) } : {}),
-          rawText: m.text ?? "",
-          files: (m.files as SlackFile[]) ?? [],
+          rawText: content.text,
+          files: content.files,
           threadTs: m.thread_ts,
           ts: m.ts,
           unprompted: true,

--- a/src/slack/forwards.ts
+++ b/src/slack/forwards.ts
@@ -1,0 +1,80 @@
+import type { SlackFile } from "./attachments.ts";
+
+export const MAX_RENDERED_FORWARDS = 5;
+const MAX_FORWARD_DEPTH = 4;
+
+interface ForwardedMessage {
+  text?: string;
+  files?: SlackFile[];
+  attachments?: SlackMessageAttachment[];
+}
+
+interface SlackMessageBlock {
+  message?: ForwardedMessage;
+}
+
+export interface SlackMessageAttachment extends ForwardedMessage {
+  fallback?: string;
+  author_name?: string;
+  author_subname?: string;
+  author_id?: string;
+  channel_name?: string;
+  channel_id?: string;
+  is_msg_unfurl?: boolean;
+  is_share?: boolean;
+  ts?: string | number;
+  message_blocks?: SlackMessageBlock[];
+}
+
+function isForwardedAttachment(attachment: SlackMessageAttachment): boolean {
+  return attachment.is_msg_unfurl === true || attachment.is_share === true;
+}
+
+function nestedMessages(attachment: SlackMessageAttachment): ForwardedMessage[] {
+  const messages = (attachment.message_blocks ?? []).flatMap((block) =>
+    block?.message && typeof block.message === "object" ? [block.message] : [],
+  );
+  return attachment.attachments?.length ? [...messages, { attachments: attachment.attachments }] : messages;
+}
+
+export function messageWithForwardedContent(message: ForwardedMessage): { text: string; files: SlackFile[] } {
+  const rendered: string[] = [];
+  const files: SlackFile[] = [];
+  const seenFiles = new Set<string>();
+  let renderedForwards = 0;
+
+  const addFile = (file: SlackFile, authorId?: string): void => {
+    if (!file || typeof file !== "object") return;
+    if (file.id && seenFiles.has(file.id)) return;
+    if (file.id) seenFiles.add(file.id);
+    files.push(file.user || !authorId ? file : { ...file, user: authorId });
+  };
+
+  const visit = (current: ForwardedMessage, depth: number): void => {
+    if (depth > MAX_FORWARD_DEPTH) return;
+    for (const attachment of Array.isArray(current.attachments) ? current.attachments : []) {
+      if (!attachment || typeof attachment !== "object" || !isForwardedAttachment(attachment)) continue;
+      if (renderedForwards >= MAX_RENDERED_FORWARDS) return;
+      renderedForwards += 1;
+
+      const author = attachment.author_subname || attachment.author_name || attachment.author_id;
+      let channel: string | undefined;
+      if (attachment.channel_name) channel = `#${attachment.channel_name}`;
+      else if (attachment.channel_id) channel = `channel ${attachment.channel_id}`;
+      const label = `forwarded message${author ? ` from ${author}` : ""}${channel ? ` in ${channel}` : ""}`;
+      const body = String(attachment.text || attachment.fallback || "").trim();
+      rendered.push(body ? `[${label}] ${body}` : `[${label}]`);
+
+      for (const file of Array.isArray(attachment.files) ? attachment.files : []) addFile(file, attachment.author_id);
+      for (const nested of nestedMessages(attachment)) visit(nested, depth + 1);
+    }
+  };
+
+  for (const file of Array.isArray(message.files) ? message.files : []) addFile(file);
+  visit(message, 0);
+
+  const base = String(message.text ?? "");
+  let text = base;
+  if (rendered.length) text = base ? `${base}\n${rendered.join("\n")}` : rendered.join("\n");
+  return { text, files };
+}

--- a/src/slack/forwards.ts
+++ b/src/slack/forwards.ts
@@ -1,6 +1,6 @@
 import type { SlackFile } from "./attachments.ts";
 
-export const MAX_RENDERED_FORWARDS = 5;
+const MAX_RENDERED_FORWARDS = 5;
 const MAX_FORWARD_DEPTH = 4;
 
 interface ForwardedMessage {

--- a/src/slack/lib.ts
+++ b/src/slack/lib.ts
@@ -50,6 +50,7 @@ export {
 } from "./message-gating.ts";
 export {
   type SlackFile,
+  hydrateSlackFiles,
   MAX_ATTACHMENT_BYTES,
   isOversize,
   type ThreadMessage,

--- a/src/slack/mirror.ts
+++ b/src/slack/mirror.ts
@@ -1,5 +1,6 @@
 import { swallow } from "../util/errors.ts";
 import { decodeSlackEntities, mentionsBot, resolveMentionsInText } from "./lib.ts";
+import { messageWithForwardedContent } from "./forwards.ts";
 import type { SlackCoreClient } from "../api/slack-core-client.ts";
 import type { IngestEvent } from "../surface-cache/surface-cache.ts";
 import type { BotIdentity, Directory } from "./directory.ts";
@@ -104,7 +105,7 @@ export function createMirror(deps: {
       }
       if (!gate.allowed) return;
     }
-    const raw = String(m.text ?? "");
+    const raw = messageWithForwardedContent(m).text;
     const { text, mentions } = await resolveTextMentions(client, decodeSlackEntities(raw));
     await pushSurfaceEvents([
       {

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -27,6 +27,7 @@ import {
   encodeDeliveryTarget,
   groupDmDisplayName,
   hasContent,
+  hydrateSlackFiles,
   isExternallyShared,
   isMpim,
   type SurfaceHeaderClient,
@@ -400,7 +401,13 @@ export function createTurnHandler(deps: {
     }
 
     const ownFiles = inc.files.map((f) => (f.user || !inc.userId ? f : { ...f, user: inc.userId }));
-    const inboundFiles = earlierFiles.length ? [...ownFiles, ...earlierFiles] : ownFiles;
+    const inboundFiles = await hydrateSlackFiles(
+      earlierFiles.length ? [...ownFiles, ...earlierFiles] : ownFiles,
+      async (id) => {
+        const response = await client.files.info({ file: id });
+        return response?.file as SlackFile | undefined;
+      },
+    );
     const resolveFileAuthor = async (userId: string | undefined): Promise<string | undefined> =>
       userId ? (await classifyUserCached(client, userId)).actor.displayName : undefined;
     const { attachments, issues } = await processInboundFiles(

--- a/test/slack-forwards.test.ts
+++ b/test/slack-forwards.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { messageWithForwardedContent } from "../src/slack/forwards.ts";
+
+const file = (id: string, name: string) => ({
+  id,
+  name,
+  mimetype: "text/plain",
+  size: 4,
+  url_private_download: `https://files.slack.com/files-pri/${id}/${name}`,
+});
+
+test("messageWithForwardedContent labels forwarded text with its original author and channel", () => {
+  const result = messageWithForwardedContent({
+    text: "please review",
+    attachments: [
+      {
+        is_msg_unfurl: true,
+        author_name: "Ada Lovelace",
+        channel_name: "project-notes",
+        text: "the original message",
+      },
+    ],
+  });
+
+  assert.equal(
+    result.text,
+    "please review\n[forwarded message from Ada Lovelace in #project-notes] the original message",
+  );
+  assert.deepEqual(result.files, []);
+});
+
+test("messageWithForwardedContent carries files attached to a forwarded message", () => {
+  const result = messageWithForwardedContent({
+    attachments: [
+      {
+        is_msg_unfurl: true,
+        author_id: "UORIGINAL",
+        author_name: "Grace Hopper",
+        channel_name: "research",
+        text: "supporting material",
+        files: [file("F1", "notes.txt")],
+      },
+    ],
+  });
+
+  assert.equal(result.text, "[forwarded message from Grace Hopper in #research] supporting material");
+  assert.deepEqual(result.files, [{ ...file("F1", "notes.txt"), user: "UORIGINAL" }]);
+});
+
+test("messageWithForwardedContent recursively includes a nested forward", () => {
+  const result = messageWithForwardedContent({
+    attachments: [
+      {
+        is_msg_unfurl: true,
+        author_name: "outer author",
+        channel_name: "outer-room",
+        text: "outer message",
+        message_blocks: [
+          {
+            message: {
+              attachments: [
+                {
+                  is_msg_unfurl: true,
+                  author_name: "inner author",
+                  channel_name: "inner-room",
+                  text: "inner message",
+                  files: [file("F2", "nested.txt")],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(
+    result.text,
+    "[forwarded message from outer author in #outer-room] outer message\n" +
+      "[forwarded message from inner author in #inner-room] inner message",
+  );
+  assert.deepEqual(result.files, [file("F2", "nested.txt")]);
+});
+
+test("messageWithForwardedContent ignores timestamped legacy attachments", () => {
+  const result = messageWithForwardedContent({
+    text: "top-level message",
+    attachments: [{ ts: "1787162400", author_name: "build bot", text: "legacy attachment" }],
+  });
+
+  assert.deepEqual(result, { text: "top-level message", files: [] });
+});

--- a/test/slack-index.integration.test.ts
+++ b/test/slack-index.integration.test.ts
@@ -118,9 +118,14 @@ class FakeSlackClient {
     },
     get: async () => ({}),
   };
+  readonly filesById = new Map<string, any>();
+  readonly fileInfoCalls: string[] = [];
   readonly files = {
     uploadV2: async () => ({ ok: true }),
-    info: async () => ({ file: {} }),
+    info: async ({ file }: { file: string }) => {
+      this.fileInfoCalls.push(file);
+      return { file: this.filesById.get(file) ?? {} };
+    },
   };
   readonly bots = { info: async ({ bot }: { bot: string }) => ({ bot: this.botsById.get(bot) }) };
 
@@ -475,6 +480,13 @@ test("a forwarded Slack message reaches the turn with labeled nested content and
   );
   const f = await fixture();
   try {
+    f.client.filesById.set("F1", {
+      id: "F1",
+      name: "notes.txt",
+      mimetype: "text/plain",
+      size: 4,
+      url_private_download: "https://files.slack.com/files-pri/F1/notes.txt",
+    });
     await f.app.emitMessage({
       channel: "D1",
       channel_type: "im",
@@ -492,9 +504,7 @@ test("a forwarded Slack message reaches the turn with labeled nested content and
             {
               id: "F1",
               name: "notes.txt",
-              mimetype: "text/plain",
-              size: 4,
-              url_private_download: "https://files.slack.com/files-pri/F1/notes.txt",
+              is_hidden_by_limit: 1,
             },
           ],
           message_blocks: [
@@ -515,6 +525,7 @@ test("a forwarded Slack message reaches the turn with labeled nested content and
       ],
     });
 
+    assert.deepEqual(f.client.fileInfoCalls, ["F1"]);
     assert.equal(fetchMock.mock.callCount(), 1);
     assert.equal(f.core.turns.length, 1);
     assert.equal(

--- a/test/slack-index.integration.test.ts
+++ b/test/slack-index.integration.test.ts
@@ -463,6 +463,80 @@ test("a DM becomes one scoped live turn and one Slack reply", async () => {
   }
 });
 
+test("a forwarded Slack message reaches the turn with labeled nested content and files", async (t) => {
+  const fetchMock = t.mock.method(
+    globalThis,
+    "fetch",
+    async () =>
+      new Response("data", {
+        status: 200,
+        headers: { "content-type": "text/plain", "content-length": "4" },
+      }),
+  );
+  const f = await fixture();
+  try {
+    await f.app.emitMessage({
+      channel: "D1",
+      channel_type: "im",
+      user: "U1",
+      text: "please review",
+      ts: "100.15",
+      attachments: [
+        {
+          is_msg_unfurl: true,
+          author_id: "U2",
+          author_name: "Bob",
+          channel_name: "project-notes",
+          text: "outer message",
+          files: [
+            {
+              id: "F1",
+              name: "notes.txt",
+              mimetype: "text/plain",
+              size: 4,
+              url_private_download: "https://files.slack.com/files-pri/F1/notes.txt",
+            },
+          ],
+          message_blocks: [
+            {
+              message: {
+                attachments: [
+                  {
+                    is_msg_unfurl: true,
+                    author_name: "Carol",
+                    channel_name: "research",
+                    text: "nested message",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+    assert.equal(f.core.turns.length, 1);
+    assert.equal(
+      f.core.turns[0].text,
+      "please review\n[forwarded message from Bob in #project-notes] outer message\n" +
+        "[forwarded message from Carol in #research] nested message",
+    );
+    assert.deepEqual(f.core.turns[0].attachments, [
+      {
+        name: "notes.txt",
+        mimetype: "text/plain",
+        sizeBytes: 4,
+        blobId: "blob-1",
+        sourceId: "F1",
+        author: "Bob",
+      },
+    ]);
+  } finally {
+    await f.stop();
+  }
+});
+
 test("public channel rosters stay current in the core directory", async () => {
   const f = await fixture();
   try {


### PR DESCRIPTION
Includes forwarded Slack text, nested forwards, and attached files in agent context with original author/channel labels when available.

- verification: `npm run typecheck`
- verification: `npm run lint && npm run lint:ox && npm run format:check`
- verification: event-to-core E2E plus 72 focused Slack tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789792465&installation_model_id=19911&pr_number=618&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F618&signature=929f0fcf1d63dfcb2751288021cc8140defefdf9ab678c311586da331af76e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->