### PR TITLE
Preserve approval pauses on addressed turns

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2555,7 +2555,8 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           surfaceToolDeps &&
           spine.surfaceOutboundCount === 0 &&
           spine.staySilentReason === undefined &&
-          !result.silent
+          !result.silent &&
+          result.pausedOnApproval !== true
         ) {
           const firstTapeWriteFailed = !!result.tapeWriteFailed;
           const primaryStopped = !!result.stopped;

--- a/test/surface-spine-routing.test.ts
+++ b/test/surface-spine-routing.test.ts
@@ -283,6 +283,25 @@ test("spine ON: an unprompted thread-follow ALSO routes to a sub-conversation wi
   }
 });
 
+test("an addressed approval pause is returned without a reply-or-decline nudge", async () => {
+  const built = freshApp();
+  built.runtime.start();
+  try {
+    const res = await built.app.turn({
+      ...mention("!finish-silent-paused", "C-approval-pause", "700.0"),
+      async: false,
+    });
+
+    assert.equal(res.status, "pending_approval");
+    assert.equal(res.pendingApprovals?.length, 1);
+    assert.equal(res.pendingApprovals?.[0]?.command, "gated-check");
+    const all = (await built.deliveries.pending("slack")) as any[];
+    assert.equal(all.length, 0, "an approval pause must not be nudged into a surface reply");
+  } finally {
+    await built.runtime.stop();
+  }
+});
+
 test("addressed + no post → exactly one nudge → the agent posts on the continuation turn", async () => {
   const built = freshApp();
   built.runtime.start();


### PR DESCRIPTION
Preserve approval-paused addressed turns instead of starting the reply-or-decline continuation.

- verification: focused surface routing suite (24/24)
- verification: adjacent approval/orchestrator suites (141/141)
- verification: typecheck, formatting, and lint
- verification: live six-tool replay returns `pending_approval` without a continuation turn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789793565&installation_model_id=19911&pr_number=619&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F619&signature=c1cfd0ef67aa215e6375e85f57309ca582b85ace58a6cc26fcb57becf472da59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->