### PR TITLE
feat(dev): foreground mode for `up` so a service manager owns the lifecycle

### DIFF
--- a/scripts/dev/cli.ts
+++ b/scripts/dev/cli.ts
@@ -29,7 +29,7 @@ import {
   takenSummary,
 } from "./lib/lease.ts";
 import { callerEnvSnapshot, currentBranch, repoRoot } from "./lib/envctx.ts";
-import { killTree, pidAlive, portHolders, spawnDetached } from "./lib/proc.ts";
+import { killTree, pidAlive, portHolders, spawnDetached, spawnForeground } from "./lib/proc.ts";
 import {
   resolveSocketPath,
   streamBootEvents,
@@ -60,6 +60,7 @@ function parseCli() {
         sandbox: { type: "string", default: "auto" },
         "no-slack": { type: "boolean", default: false },
         "no-watch": { type: "boolean", default: false },
+        foreground: { type: "boolean", default: false },
         org: { type: "string" },
       },
     });
@@ -75,7 +76,7 @@ const command = positionals[0] ?? "up";
 const store = poolStore();
 
 const commandOptions: Record<string, readonly string[]> = {
-  up: ["json", "force", "strict", "rotate", "sandbox", "no-slack", "no-watch", "org"],
+  up: ["json", "force", "strict", "rotate", "sandbox", "no-slack", "no-watch", "org", "foreground"],
   down: ["json"],
   status: ["json"],
   restart: ["json"],
@@ -203,6 +204,10 @@ function renderPhase(e: BootPhaseEvent): void {
   console.log(`  ${mark} ${e.name}${e.detail ? ` -- ${e.detail}` : ""}`);
 }
 
+// The foreground `up`'s attached supervisor, so cmdUp can wait on it after a
+// successful boot (#603). Null in the normal detached mode.
+let foregroundSupervisor: ReturnType<typeof spawnForeground> | null = null;
+
 async function bootOnSlot(slot: string, worktree: string, branch: string): Promise<BootResult> {
   const ports = slotPorts(slot);
   const lock = lockDir(slot, store);
@@ -257,12 +262,30 @@ async function bootOnSlot(slot: string, worktree: string, branch: string): Promi
   );
 
   const supervisorScript = join(worktree, "scripts/dev/supervisor/main.ts");
-  spawnDetached({
-    cwd: worktree,
-    logFile: join(lock, "supervisor.log"),
-    argv: ["node", supervisorScript, "--slot", slot, "--worktree", worktree, "--store", store],
-    env: callerEnv,
-  });
+  const supervisorArgv = [
+    "node",
+    supervisorScript,
+    "--slot",
+    slot,
+    "--worktree",
+    worktree,
+    "--store",
+    store,
+  ];
+  if (opts.foreground) {
+    // Foreground/service mode: the supervisor stays attached to THIS process
+    // (output inherited → the caller's console or journald), and cmdUp waits
+    // on it after the boot so a service manager owning the lifecycle sees the
+    // real exit and can restart (#603).
+    foregroundSupervisor = spawnForeground({ cwd: worktree, argv: supervisorArgv, env: callerEnv });
+  } else {
+    spawnDetached({
+      cwd: worktree,
+      logFile: join(lock, "supervisor.log"),
+      argv: supervisorArgv,
+      env: callerEnv,
+    });
+  }
 
   const sock = resolveSocketPath(lock);
   if (!(await waitForSupervisor(sock, 60_000))) {
@@ -392,6 +415,7 @@ async function cmdUp(): Promise<number> {
     if (result.ok) {
       emitJson(result);
       printSuccess(result, branch);
+      if (opts.foreground) return await waitForegroundSupervisor();
       return EXIT.ok;
     }
 
@@ -622,6 +646,37 @@ async function cmdLogs(): Promise<number> {
   return EXIT.ok;
 }
 
+/**
+ * Stay attached to the foreground supervisor until it exits (#603).
+ *
+ * SIGTERM/SIGINT (a service manager's stop, Ctrl-C) tear the supervisor tree
+ * down via its own graceful path and exit 0; a supervisor that dies on its
+ * own exits non-zero so `Restart=always` reacts — the detached mode's silent
+ * "active (exited)" failure this flag exists to fix.
+ */
+async function waitForegroundSupervisor(): Promise<number> {
+  const supervisor = foregroundSupervisor;
+  if (supervisor === null) return EXIT.ok;
+  let stopping = false;
+  const forward = (signal: NodeJS.Signals) => {
+    if (stopping) return;
+    stopping = true;
+    // The supervisor owns its children's teardown; give it the signal and let
+    // its exit resolve the waiter below.
+    bestEffort(() => supervisor.kill(signal));
+  };
+  process.on("SIGTERM", forward);
+  process.on("SIGINT", forward);
+  const code = await new Promise<number | null>((resolve) => {
+    supervisor.on("exit", (c) => resolve(typeof c === "number" ? c : null));
+  });
+  foregroundSupervisor = null;
+  if (stopping) return EXIT.ok;
+  out(`dev: foreground supervisor exited (code ${code ?? "signal"})`);
+  // Non-zero on an unassisted death so a supervising unit restarts the tree.
+  return EXIT.internal;
+}
+
 async function main(): Promise<number> {
   if (!validOrgId(orgId)) {
     console.error("dev: --org must be a lowercase DNS label (a-z, 0-9, and hyphens between)");
@@ -644,7 +699,7 @@ async function main(): Promise<number> {
       return await runDoctor({ json: opts.json, fix: opts.fix, store, slack: withSlack });
     default:
       console.error(
-        "usage: dev [up|down|status|restart|canary|logs|doctor] [--json] [--force] [--rotate] [--strict] [--sandbox local|sprites|smolmachines|auto] [--no-slack] [--no-watch] [--org id] [--fix]",
+        "usage: dev [up|down|status|restart|canary|logs|doctor] [--json] [--force] [--rotate] [--strict] [--sandbox local|sprites|smolmachines|auto] [--no-slack] [--no-watch] [--org id] [--foreground] [--fix]",
       );
       return EXIT.usage;
   }

--- a/scripts/dev/lib/proc.ts
+++ b/scripts/dev/lib/proc.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { openSync } from "node:fs";
 import { connect } from "node:net";
 import { bestEffort, sleep } from "./util.ts";
@@ -67,6 +67,31 @@ export function spawnDetached(opts: {
   child.unref();
   if (!child.pid) throw new Error(`failed to spawn ${opts.argv.join(" ")}`);
   return child.pid;
+}
+
+/**
+ * Spawn a supervisor (or any dev-tree root) ATTACHED to the caller's lifetime.
+ *
+ * The mirror of {@link spawnDetached} for foreground/service use: stdio is
+ * inherited so output lands on the caller's console (or journald under
+ * systemd), the child is NOT unref'd, and the returned handle lets the caller
+ * wait for the tree to die and exit non-zero so a supervising unit
+ * (`Restart=always`) can react (#603).
+ */
+export function spawnForeground(opts: {
+  cwd: string;
+  argv: string[];
+  env: Record<string, string>;
+}): ChildProcess {
+  const [cmd, ...rest] = opts.argv;
+  if (!cmd) throw new Error("spawnForeground: empty argv");
+  const child = spawn(cmd, rest, {
+    cwd: opts.cwd,
+    stdio: "inherit",
+    env: opts.env,
+  });
+  if (!child.pid) throw new Error(`failed to spawn ${opts.argv.join(" ")}`);
+  return child;
 }
 
 export async function killTree(pid: number | null | undefined, graceMs = 5000): Promise<void> {

--- a/test/dev-cli-lib.test.ts
+++ b/test/dev-cli-lib.test.ts
@@ -1,4 +1,6 @@
 import { test } from "node:test";
+
+import { spawnForeground } from "../scripts/dev/lib/proc.ts";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -398,4 +400,24 @@ test("formatAge renders the bash-compatible shapes", () => {
   assert.equal(formatAge(150), "2m");
   assert.equal(formatAge(3 * 3600 + 5 * 60), "3h05m");
   assert.equal(formatAge(2 * 86400 + 3 * 3600), "2d03h");
+});
+
+
+test("spawnForeground stays attached and surfaces the child's exit code", async () => {
+  // Foreground/service mode is only useful if the caller can WAIT on the tree
+  // and see how it died: an unassisted death must be observable as a non-zero
+  // exit so a service manager's Restart=always reacts (#603).
+  const child = spawnForeground({
+    cwd: process.cwd(),
+    argv: [process.execPath, "-e", "process.exit(3)"],
+    env: { ...process.env },
+  });
+  const code = await new Promise<number | null>((resolve) => {
+    child.on("exit", (c) => resolve(typeof c === "number" ? c : null));
+  });
+  assert.equal(code, 3);
+});
+
+test("spawnForeground rejects an empty argv like spawnDetached", () => {
+  assert.throws(() => spawnForeground({ cwd: process.cwd(), argv: [], env: {} }));
 });


### PR DESCRIPTION
Implements the foreground half of #603 (option 1 in the issue).

## What this does

`up` always detached the supervisor (`spawnDetached`), so the best a systemd unit could do was `Type=oneshot` + `RemainAfterExit=yes` — when the tree died on its own, the unit sat there "active (exited)" and `Restart=` had nothing to react to. `dev up --foreground` fixes that:

- the supervisor is spawned **attached** (new `spawnForeground` in `scripts/dev/lib/proc.ts` — the mirror of `spawnDetached`: stdio inherited so output lands on the caller's console or journald, child not unref'd, handle returned);
- after a successful boot the CLI **waits on the supervisor's exit** instead of returning;
- `SIGTERM`/`SIGINT` (a stop command, Ctrl-C) are forwarded to the supervisor so its own graceful tree teardown runs, and the CLI exits **0**;
- a supervisor that dies **on its own** exits non-zero (`EXIT.internal`), which `Restart=always` reacts to — the "active (exited)" silent-death failure mode this flag exists to remove.

```ini
[Service]
Type=simple
ExecStart=/path/to/qm dev up --foreground --org myorg
Restart=always
```

The detached mode is byte-for-byte unchanged (same `spawnDetached` call, same log file); the flag only swaps the spawn and adds the post-boot wait. Boot failure paths (supervisor never came up → killed, slot stolen, etc.) are untouched.

## Tests

`spawnForeground` unit tests in `test/dev-cli-lib.test.ts`: an attached child's exit code is observable through the returned handle (a `process.exit(3)` child resolves to 3 — the contract `Restart=always` depends on), and empty argv fails loud like `spawnDetached`. File: 19/19.

## Scope note

The crash-restart half of the issue — the supervisor itself respawning dead children and writing a durable crash event the admin UI shows — is a separate, larger change to the supervisor's lifecycle (it intersects with the ambient detection work and the admin error log's intake, #604) and is deliberately not bundled here; the foreground mode makes the OS-level supervisor the owner of exactly that failure instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789797155&installation_model_id=19911&pr_number=620&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F620&signature=f031ce7c973e7be23a31427477cc7af09b09ca9c25fbfe5cf7cf888b4562abe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->