### PR TITLE
fix(mcp): inline internal $refs in tool schemas at ingest

### DIFF
--- a/src/mcp/mcp-tool-service.ts
+++ b/src/mcp/mcp-tool-service.ts
@@ -14,6 +14,8 @@ import type { McpServer, McpServerStore } from "./mcp-server-store.ts";
 const REFRESH_INTERVAL_MS = 5 * 60_000;
 const MAX_TOOLS_PER_SERVER = 64;
 const MAX_RESULT_CHARS = 60_000;
+const MAX_SCHEMA_NODES = 20_000;
+const MAX_SCHEMA_DEPTH = 100;
 
 export interface McpToolDescriptor {
   /** Namespaced tool name exposed to the model, e.g. "salesforce_query". */
@@ -35,6 +37,73 @@ export interface McpToolService {
   /** Probe a server config without persisting it. Returns its tool names. */
   probe(server: McpServer): Promise<string[]>;
   close(): void;
+}
+
+function resolvePointer(root: unknown, ref: string): unknown {
+  if (!ref.startsWith("#/")) return undefined;
+  let node: unknown = root;
+  for (const raw of ref.slice(2).split("/")) {
+    let key: string;
+    try {
+      key = decodeURIComponent(raw).replace(/~1/g, "/").replace(/~0/g, "~");
+    } catch {
+      return undefined;
+    }
+    if (Array.isArray(node)) node = node[Number(key)];
+    else if (node && typeof node === "object") node = (node as Record<string, unknown>)[key];
+    else return undefined;
+  }
+  return node;
+}
+
+function expandRef(
+  ref: string,
+  root: unknown,
+  stack: string[],
+  budget: { left: number },
+  depth: number,
+): Record<string, unknown> {
+  if (stack.includes(ref)) return {};
+  const target = resolvePointer(root, ref);
+  if (typeof target === "boolean") return target ? {} : { not: {} };
+  if (!target || typeof target !== "object" || Array.isArray(target)) return {};
+  return inlineRefs(target, root, [...stack, ref], budget, depth) as Record<string, unknown>;
+}
+
+function inlineRefs(
+  node: unknown,
+  root: unknown,
+  stack: string[],
+  budget: { left: number },
+  depth = 0,
+): unknown {
+  if (budget.left <= 0 || depth > MAX_SCHEMA_DEPTH) return Array.isArray(node) ? [] : {};
+  budget.left -= 1;
+  if (Array.isArray(node)) return node.map((item) => inlineRefs(item, root, stack, budget, depth + 1));
+  if (!node || typeof node !== "object") return node;
+  const obj = node as Record<string, unknown>;
+  const siblings: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === "$ref" || k === "$defs" || k === "definitions" || k === "__proto__") continue;
+    siblings[k] = inlineRefs(v, root, stack, budget, depth + 1);
+  }
+  if (typeof obj.$ref !== "string") return siblings;
+  return { ...expandRef(obj.$ref, root, stack, budget, depth + 1), ...siblings };
+}
+
+export function sanitizeToolSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const inlined = inlineRefs(schema, schema, [], { left: MAX_SCHEMA_NODES });
+  if (!inlined || typeof inlined !== "object" || Array.isArray(inlined)) return objectSchemaFallback();
+  const out = inlined as Record<string, unknown>;
+  if (out.type === "object") return out;
+  if (out.type === undefined && out.properties && typeof out.properties === "object") {
+    return { ...out, type: "object" };
+  }
+  return objectSchemaFallback();
+}
+
+function objectSchemaFallback(): Record<string, unknown> {
+  return { type: "object", properties: {}, additionalProperties: true };
 }
 
 function authOf(server: McpServer): McpAuth {
@@ -92,7 +161,7 @@ export function createMcpToolService(opts: {
             serverId: server.id,
             remoteName: tool.name,
             description: tool.description || `${tool.name} on ${server.name}`,
-            inputSchema: tool.inputSchema,
+            inputSchema: sanitizeToolSchema(tool.inputSchema),
             readOnly: server.readOnly,
           });
         }

--- a/test/mcp-connectors.test.ts
+++ b/test/mcp-connectors.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createMcpClient, mcpResultText, type McpFetch } from "../src/mcp/mcp-client.ts";
 import { createMcpServerStore, isValidMcpServerId, type McpServer } from "../src/mcp/mcp-server-store.ts";
-import { createMcpToolService } from "../src/mcp/mcp-tool-service.ts";
+import { createMcpToolService, sanitizeToolSchema } from "../src/mcp/mcp-tool-service.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 
 function jsonResponse(body: unknown, status = 200, contentType = "application/json") {
@@ -123,4 +123,151 @@ test("unknown tool call rejects", async () => {
   const service = createMcpToolService({ servers: store, refreshIntervalMs: 3600_000 });
   await assert.rejects(() => service.call("nope_tool", {}), /unknown MCP tool/);
   service.close();
+});
+
+test("tool schemas ingest with internal refs inlined", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  const schema = {
+    type: "object",
+    $defs: { id: { type: "string", minLength: 1 } },
+    properties: {
+      board: { $ref: "#/$defs/id" },
+      parent: { $ref: "#/properties/board" },
+      missing: { $ref: "#/$defs/nope" },
+      external: { $ref: "https://example.com/schema.json#/x" },
+    },
+  };
+  const fetch: McpFetch = async (_url, init) => {
+    const req = JSON.parse(init.body) as { id: number; method: string };
+    if (req.method === "tools/list") {
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id: req.id,
+        result: { tools: [{ name: "create", description: "Create", inputSchema: schema }] },
+      });
+    }
+    return jsonResponse({ jsonrpc: "2.0", id: req.id, result: {} });
+  };
+  const service = createMcpToolService({ servers: store, fetchImpl: fetch, refreshIntervalMs: 3600_000 });
+  await store.put(server());
+  await service.refresh();
+  const def = service.toolDefs().find((d) => d.name === "crm_create");
+  assert.ok(def);
+  const props = (def.inputSchema as { properties: Record<string, unknown> }).properties;
+  assert.equal(JSON.stringify(def.inputSchema).includes("$ref"), false);
+  assert.deepEqual(props.board, { type: "string", minLength: 1 });
+  assert.deepEqual(props.parent, { type: "string", minLength: 1 });
+  assert.deepEqual(props.missing, {});
+  assert.deepEqual(props.external, {});
+  assert.equal((def.inputSchema as Record<string, unknown>).$defs, undefined);
+  service.close();
+});
+
+test("sanitizeToolSchema keeps keywords that sit beside a $ref", () => {
+  const out = sanitizeToolSchema({
+    type: "object",
+    $defs: { int: { type: "integer" } },
+    properties: {
+      count: { $ref: "#/$defs/int", minimum: 1, maximum: 10, description: "1..10 only" },
+    },
+  }) as { properties: Record<string, Record<string, unknown>> };
+  assert.deepEqual(out.properties.count, {
+    type: "integer",
+    minimum: 1,
+    maximum: 10,
+    description: "1..10 only",
+  });
+});
+
+test("sanitizeToolSchema always yields an object schema", () => {
+  const fallback = { type: "object", properties: {}, additionalProperties: true };
+  assert.deepEqual(sanitizeToolSchema({ $ref: "#/$defs/Input" }), fallback);
+  assert.deepEqual(sanitizeToolSchema({ $ref: "#" }), fallback);
+  assert.deepEqual(sanitizeToolSchema({ type: "string" }), fallback);
+  assert.deepEqual(sanitizeToolSchema({ properties: { a: { type: "string" } } }), {
+    type: "object",
+    properties: { a: { type: "string" } },
+  });
+});
+
+test("sanitizeToolSchema bounds expansion instead of exploding", () => {
+  const width = 8;
+  const depth = 8;
+  const defs: Record<string, unknown> = { leaf: { type: "string" } };
+  for (let level = 1; level <= depth; level += 1) {
+    const properties: Record<string, unknown> = {};
+    const child = level === 1 ? "#/$defs/leaf" : `#/$defs/level${level - 1}`;
+    for (let field = 0; field < width; field += 1) properties[`f${field}`] = { $ref: child };
+    defs[`level${level}`] = { type: "object", properties };
+  }
+  const schema = { type: "object", $defs: defs, properties: { root: { $ref: `#/$defs/level${depth}` } } };
+  const started = Date.now();
+  const out = sanitizeToolSchema(schema);
+  assert.ok(Date.now() - started < 2000);
+  assert.ok(JSON.stringify(out).length < 2_000_000);
+});
+
+test("sanitizeToolSchema survives deep nesting without refs", () => {
+  let node: Record<string, unknown> = { type: "string" };
+  for (let i = 0; i < 5000; i += 1) node = { type: "object", properties: { next: node } };
+  assert.equal(typeof sanitizeToolSchema(node), "object");
+});
+
+test("sanitizeToolSchema resolves escaped and indexed pointers", () => {
+  const out = sanitizeToolSchema({
+    type: "object",
+    $defs: { "a/b": { type: "number" }, "c~d": { type: "boolean" }, "e f": { type: "null" } },
+    prefixItems: [{ type: "integer" }],
+    properties: {
+      slash: { $ref: "#/$defs/a~1b" },
+      tilde: { $ref: "#/$defs/c~0d" },
+      spaced: { $ref: "#/$defs/e%20f" },
+      indexed: { $ref: "#/prefixItems/0" },
+    },
+  }) as { properties: Record<string, unknown> };
+  assert.deepEqual(out.properties.slash, { type: "number" });
+  assert.deepEqual(out.properties.tilde, { type: "boolean" });
+  assert.deepEqual(out.properties.spaced, { type: "null" });
+  assert.deepEqual(out.properties.indexed, { type: "integer" });
+});
+
+test("sanitizeToolSchema stops cyclic refs, direct and mutual", () => {
+  const direct = sanitizeToolSchema({
+    type: "object",
+    properties: { self: { $ref: "#/properties/self" } },
+  }) as { properties: Record<string, unknown> };
+  assert.deepEqual(direct.properties.self, {});
+  const mutual = sanitizeToolSchema({
+    type: "object",
+    $defs: { a: { $ref: "#/$defs/b" }, b: { $ref: "#/$defs/a" } },
+    properties: { start: { $ref: "#/$defs/a" } },
+  }) as { properties: Record<string, unknown> };
+  assert.deepEqual(mutual.properties.start, {});
+});
+
+test("sanitizeToolSchema drops nested $defs and a __proto__ key", () => {
+  const out = sanitizeToolSchema({
+    type: "object",
+    properties: {
+      nested: { type: "object", $defs: { x: { type: "string" } }, definitions: { y: { type: "string" } } },
+    },
+  }) as { properties: Record<string, Record<string, unknown> | undefined> };
+  assert.equal(out.properties.nested?.$defs, undefined);
+  assert.equal(out.properties.nested?.definitions, undefined);
+  assert.deepEqual(out.properties.nested, { type: "object" });
+
+  const hostile = sanitizeToolSchema(
+    JSON.parse('{"type":"object","properties":{"__proto__":{"type":"string"},"ok":{"type":"string"}}}'),
+  ) as { properties: Record<string, unknown> };
+  assert.deepEqual(Object.keys(hostile.properties), ["ok"]);
+  assert.equal(Object.getPrototypeOf(hostile.properties), Object.prototype);
+});
+
+test("sanitizeToolSchema keeps a false subschema restrictive", () => {
+  const out = sanitizeToolSchema({
+    type: "object",
+    $defs: { never: false },
+    properties: { blocked: { $ref: "#/$defs/never" } },
+  }) as { properties: Record<string, unknown> };
+  assert.deepEqual(out.properties.blocked, { not: {} });
 });


### PR DESCRIPTION
## Summary

A tool whose input schema refers to its own `$defs` or `properties` by JSON pointer breaks every turn once its schema is re-rooted into a model provider's tool list: the pointer still reads `#/properties/...`, but that path no longer exists at the new root. The provider rejects the entire tool list — Anthropic answers `Reference not found` — so turns fail even when they never touch the offending tool. Registration does not catch it: `tools/list` and the admin probe both succeed, because the re-rooting happens later.

This change inlines internal refs when a server's tools are ingested:

- Keywords beside a `$ref` still apply, so `{"$ref": "#/$defs/int", "minimum": 1, "maximum": 10}` keeps its bounds and description instead of widening to the bare target.
- External, unresolvable, and cyclic refs become a permissive `{}`; a `false` subschema stays restrictive as `{"not": {}}`.
- `$defs`/`definitions` are dropped at every level once inlined, not only at the root.
- Pointers are percent-decoded before `~1`/`~0` unescaping, per RFC 6901.

Expansion is bounded. Inlining duplicates a target at every use site, so an ordinary schema with a reused type — what `zod`'s `toJSONSchema({reused: "ref"})` and pydantic emit by default — can expand by orders of magnitude; a 2 KB schema of depth 8 with 8 fields per level expanded to hundreds of MB and stalled the event loop for tens of seconds, and deep plain nesting could exhaust the stack. A node budget and a depth cap now degrade those to a permissive subschema instead. Since `refresh()` runs on the main loop at construction, on registry change, and on a timer, that bound matters for availability.

Finally, the result is always an object schema: a root-level `$ref` that cannot be resolved falls back to a permissive object rather than an untyped `{}`, which would otherwise reach the provider as a tool with no object schema and reproduce the original failure by another route.

## Test plan

`node --experimental-test-module-mocks --test test/mcp-connectors.test.ts` — 16/16 pass, `tsc --noEmit` and `eslint` clean. New cases:

- ingest through the tool service: multi-hop chain, unresolvable ref, external ref, root `$defs` removal, no `$ref` anywhere in the result;
- keywords beside a `$ref` survive;
- always an object schema: root `$ref`, `#`, and a non-object schema all fall back; a typeless schema with `properties` gains `type: "object"`;
- bounded expansion: depth 8 × width 8 stays under 2 MB and 2 s;
- 5000-deep plain nesting does not exhaust the stack;
- escaped (`~0`, `~1`, `%20`) and array-index pointers resolve;
- direct and mutual cycles terminate;
- nested `$defs`/`definitions` dropped, and a `__proto__` key neither reparents the output nor survives;
- a `false` subschema stays restrictive.

Observed in practice with a public MCP server whose schemas carry `#/properties/...` refs: with it enabled every turn failed; with this change the same server's tools ingest and run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789799729&installation_model_id=19911&pr_number=622&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F622&signature=221b6c88e3ddfc801b0b055e4fdc695d0b0a00835d41565c5da6b7ab34633fcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->