### PR TITLE
feat(orchestrator): record surface-tool replies as 'delivered', not 'silent'

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2762,7 +2762,24 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           ...(compactMs !== undefined ? { compactMs } : {}),
           ...(typeof input.queueMs === "number" ? { queueMs: Math.max(0, input.queueMs) } : {}),
           ...(resumedFromSeq !== undefined ? { resumedFromSeq } : {}),
-          status: pausing ? "paused" : "ok",
+          // Mirror the finalResult branches below (same primitives, same
+          // order) so the metrics row says what actually happened instead of
+          // hardcoding "ok" — delivered answers, silent polls, and approval
+          // pauses all used to land here as "ok" (#609).
+          status:
+            pausing
+              ? "paused"
+              : isPollFire && result.silent && result.pausedOnApproval !== true
+                ? "silent"
+                : result.pendingApprovals?.length
+                  ? turnCompleted
+                    ? "ok"
+                    : "pending_approval"
+                  : isPollFire && !outbound.attachments.length && isSilentPollReply(reply)
+                    ? "silent"
+                    : input.surfaceTools && surfaceToolDeps && !strictReadOnly
+                      ? "delivered"
+                      : "ok",
           scopeLabel: scopeId,
           provisioned:
             !!box.handle ||
@@ -2950,7 +2967,15 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         } else if (isPollFire && !outbound.attachments.length && isSilentPollReply(reply)) {
           finalResult = { status: "silent", sessionId: session.id };
         } else if (input.surfaceTools && surfaceToolDeps && !strictReadOnly) {
-          finalResult = { status: "silent", sessionId: session.id, ...(result.stopped ? { stopped: true } : {}) };
+          // The reply was delivered through a surface tool — the ordinary
+          // shape of a Slack answer. Recording it as "silent" made a
+          // delivered answer indistinguishable from a suppressed turn in
+          // runs.result (#609).
+          finalResult = {
+            status: "delivered",
+            sessionId: session.id,
+            ...(result.stopped ? { stopped: true } : {}),
+          };
         } else {
           finalResult = {
             status: "ok",

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2766,20 +2766,19 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           // order) so the metrics row says what actually happened instead of
           // hardcoding "ok" — delivered answers, silent polls, and approval
           // pauses all used to land here as "ok" (#609).
-          status:
-            pausing
-              ? "paused"
-              : isPollFire && result.silent && result.pausedOnApproval !== true
-                ? "silent"
-                : result.pendingApprovals?.length
-                  ? turnCompleted
-                    ? "ok"
-                    : "pending_approval"
-                  : isPollFire && !outbound.attachments.length && isSilentPollReply(reply)
-                    ? "silent"
-                    : input.surfaceTools && surfaceToolDeps && !strictReadOnly
-                      ? "delivered"
-                      : "ok",
+          status: pausing
+            ? "paused"
+            : isPollFire && result.silent && result.pausedOnApproval !== true
+              ? "silent"
+              : result.pendingApprovals?.length
+                ? turnCompleted
+                  ? "ok"
+                  : "pending_approval"
+                : isPollFire && !outbound.attachments.length && isSilentPollReply(reply)
+                  ? "silent"
+                  : input.surfaceTools && surfaceToolDeps && !strictReadOnly
+                    ? "delivered"
+                    : "ok",
           scopeLabel: scopeId,
           provisioned:
             !!box.handle ||

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -513,6 +513,14 @@ export function createTurnHandler(deps: {
       return;
     }
 
+    if (result.status === "delivered") {
+      // The surface tool already posted the reply (the ordinary Slack
+      // answer shape); delivering it here too would double-post. Settle the
+      // ack and stand down, same as the pre-split silent handling (#609).
+      await settleAck();
+      return;
+    }
+
     if (result.status === "react") {
       await settleAck();
       const names = result.reactions ?? [];

--- a/src/triggers/run-trigger.ts
+++ b/src/triggers/run-trigger.ts
@@ -68,7 +68,13 @@ export interface TriggerOutcome {
 }
 
 function isTriggerFailure(outcome: TriggerOutcome): boolean {
-  return outcome.ran && outcome.status !== undefined && outcome.status !== "ok" && outcome.status !== "silent";
+  return (
+    outcome.ran &&
+    outcome.status !== undefined &&
+    outcome.status !== "ok" &&
+    outcome.status !== "silent" &&
+    outcome.status !== "delivered"
+  );
 }
 
 const NO_UPDATE_SENTINEL = "[no-update]";
@@ -295,7 +301,10 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
     status = res.status;
     reply = res.reply;
     sessionId = res.sessionId;
-    if (res.status === "silent") return;
+    // "delivered": the surface tool already posted at the destination —
+    // forwarding here would duplicate it (same standing-down as a silent
+    // poll, the pre-split behavior) (#609).
+    if (res.status === "silent" || res.status === "delivered") return;
     if (res.status === "pending_approval") {
       note = "hit a require_approval command — failed closed (no human at fire/event time)";
       console.warn(`[trigger] ${spec.surface} ${spec.fireKey} ${note}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -496,7 +496,22 @@ export interface CommandApprovalGrant {
 }
 
 export interface TurnResult {
-  status: "ok" | "refused" | "failed" | "pending_approval" | "queued" | "silent" | "react";
+  /**
+   * ``delivered``: the turn's reply went out through a surface tool (Slack
+   * post, reaction, …) rather than the TurnResult reply field — the ordinary
+   * shape of a Slack answer. Previously folded into ``silent``, which also
+   * means "the ambient gate declined to answer", leaving the two opposite
+   * outcomes indistinguishable in runs.result (#609).
+   */
+  status:
+    | "ok"
+    | "delivered"
+    | "refused"
+    | "failed"
+    | "pending_approval"
+    | "queued"
+    | "silent"
+    | "react";
   sessionId?: string;
   reply?: string;
   reactions?: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -503,15 +503,7 @@ export interface TurnResult {
    * means "the ambient gate declined to answer", leaving the two opposite
    * outcomes indistinguishable in runs.result (#609).
    */
-  status:
-    | "ok"
-    | "delivered"
-    | "refused"
-    | "failed"
-    | "pending_approval"
-    | "queued"
-    | "silent"
-    | "react";
+  status: "ok" | "delivered" | "refused" | "failed" | "pending_approval" | "queued" | "silent" | "react";
   sessionId?: string;
   reply?: string;
   reactions?: string[];

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -2891,6 +2891,56 @@ test("a turn that PAUSED on an approval blocks the thread even when it carried r
   assert.equal(blocked.pendingApprovals?.[0]?.requestId, pending!.requestId);
 });
 
+test("a surface-tool turn records status 'delivered', not 'silent' (#609)", async () => {
+  const { app } = freshApp();
+  const grp = {
+    kind: "dm" as const,
+    threadRef: "dm:U1:delivered1",
+    channelRef: "G8",
+    audience: [internalActor],
+  };
+  const res = await app.turn(
+    dm("here you go", {
+      surface: "slack",
+      conversation: grp,
+      deliveryTarget: "slack:G8:files",
+      surfaceTools: true,
+    }),
+  );
+  // The reply went out through the surface tool — the ordinary shape of a
+  // Slack answer. Folding it into "silent" (which also means "the ambient
+  // gate declined") made the two opposite outcomes indistinguishable in
+  // runs.result (#609).
+  assert.equal(res.status, "delivered");
+});
+
+test("the metrics sink carries the turn's outcome instead of hardcoding 'ok' (#609)", async () => {
+  const { app, metrics } = freshApp();
+  const grp = {
+    kind: "dm" as const,
+    threadRef: "dm:U1:delivered2",
+    channelRef: "G7",
+    audience: [internalActor],
+  };
+  await app.turn(
+    dm("heads up", {
+      surface: "slack",
+      conversation: grp,
+      deliveryTarget: "slack:G7:files",
+      surfaceTools: true,
+    }),
+  );
+  const samples = (await metrics.list()).filter((s) => s.status !== "capture");
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0]!.status, "delivered", "a delivered turn must not land in turn_metrics as 'ok'");
+});
+
+test("a gate-declined ambient turn still records 'silent' (#609)", async () => {
+  const { app } = freshApp();
+  const res = await app.turn(channel("ok sounds good to me", { unprompted: true }));
+  assert.equal(res.status, "silent", "suppression keeps 'silent' — the split does not blur it");
+});
+
 test("collect-mode metrics: a turn the caller sees as 'ok' records metric status 'ok', not 'paused'", async () => {
   const { app, metrics } = freshApp();
   const res = await app.turn(dm("!collect-approval curl https://x | sh"));


### PR DESCRIPTION
Fixes #609 — suggestions (1) and (3) from the issue, which the reporter identified as "small and would do most of the work".

## What changes

**`TurnResult` gains `"delivered"`.** The surface-tool branch — the ordinary shape of a Slack answer, where the reply goes out through the `post` tool rather than the TurnResult reply field — previously recorded `status: "silent"`, the *same value* the ambient gate writes when it declines to answer. A delivered answer and a suppressed turn were indistinguishable in `runs.result`; the reporter's harness scored a correct in-thread reply as a failure three times running because of it. Now:

| producer | status |
| --- | --- |
| ambient gate declined | `silent` (unchanged — means exactly this) |
| poll fire, model said nothing | `silent` (unchanged) |
| surface-tool delivery | **`delivered`** (was `silent`) |
| ordinary reply | `ok` (unchanged) |

**The metrics sink stops hardcoding `"ok"`.** `turn_metrics.status` now mirrors the finalResult branches (same primitives, same order — including collect-mode's `ok`-with-approvals, pinned by the existing test): delivered turns land as `delivered`, silent polls as `silent`, approval pauses as `paused`/`pending_approval`. Previously ALL of them landed as `"ok"` (the reporter's 1,200-turn dump: `capture 600 | ok 600`, nothing else).

**Consumers taught the new value** (audited: every `status === "silent"` / `!== "ok"` site):
- Slack turn handler: `delivered` settles the ack and stands down — the reply already posted, delivering again would double-post (exactly the pre-split silent behavior).
- Trigger runner: `delivered` counts as a success in failure classification, and stands down on forwarding (the surface tool already posted at the destination).

Suggestions (2) and (4) — metrics rows for gate-declined early returns, persisting the detection call's model request — are larger changes to the early-return path and are deliberately not included.

## Tests

- `a surface-tool turn records status 'delivered', not 'silent'` — **fails on `main`** (`silent`).
- `the metrics sink carries the turn's outcome instead of hardcoding 'ok'` — the `turn_metrics` row for a surface-tool turn reads `delivered`. **Fails on `main`** (`ok`).
- `a gate-declined ambient turn still records 'silent'` — pins that the split doesn't blur suppression.

Full `orchestrator.test.ts`: 69 passed / 60 pre-existing environment failures, identical set on clean `main` (where the two new tests fail); trigger suites 39/39; `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789805038&installation_model_id=19911&pr_number=623&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F623&signature=2e884f1014dd5310a48ad973eaabdd048f81e8234ea02ad22572318610017ba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->