### PR TITLE
Support multiple Google OAuth accounts

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1422,10 +1422,20 @@ const apiRoutes: readonly WebRoute[] = [
     method: "POST",
     path: "/api/connectors/:provider/start",
     handle: async (c) => {
-      const { res, user } = c;
+      const { req, res, user } = c;
+      const p = await readJson<{ accountType?: unknown }>(req, res);
+      if (!p) return;
+      const accountType = typeof p.accountType === "string" ? p.accountType : undefined;
+      if (accountType && accountType !== "default" && accountType !== "personal" && accountType !== "company") {
+        return json(res, 400, { error: "bad_request", message: "invalid accountType" });
+      }
       const provider = c.params.provider!;
+      if (accountType && accountType !== "default" && provider !== "google") {
+        return json(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+      }
       const callback = `${PUBLIC_URL}/v1/connectors/oauth/${encodeURIComponent(provider)}/callback`;
       const params = new URLSearchParams({ principalId: user, redirectUri: callback, returnTo: "/keychain" });
+      if (accountType) params.set("accountType", accountType);
       const corePath = `/v1/connectors/oauth/${encodeURIComponent(provider)}/start?${params.toString()}`;
       return relayCore(res, "GET", corePath);
     },
@@ -1435,12 +1445,23 @@ const apiRoutes: readonly WebRoute[] = [
     path: "/api/connectors/revoke",
     handle: async (c) => {
       const { req, res, user } = c;
-      const p = await readJson<{ provider?: unknown; host?: unknown }>(req, res, false);
+      const p = await readJson<{ provider?: unknown; host?: unknown; accountType?: unknown }>(req, res, false);
       if (!p) return;
       const provider = typeof p.provider === "string" ? p.provider : "";
       const host = typeof p.host === "string" ? p.host : "";
+      const accountType = typeof p.accountType === "string" ? p.accountType : undefined;
+      if (accountType && accountType !== "default" && accountType !== "personal" && accountType !== "company") {
+        return json(res, 400, { error: "bad_request", message: "invalid accountType" });
+      }
       if (!provider && !host) return json(res, 400, { error: "bad_request", message: "provider or host required" });
-      const rawBody = JSON.stringify({ principalId: user, ...(provider ? { provider } : { host }) });
+      if (accountType && accountType !== "default" && provider !== "google") {
+        return json(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+      }
+      const rawBody = JSON.stringify({
+        principalId: user,
+        ...(provider ? { provider } : { host }),
+        ...(accountType ? { accountType } : {}),
+      });
       return relayCore(res, "POST", "/v1/connectors/oauth/revoke", rawBody);
     },
   },

--- a/plugins/web-ui/src/connectors.ts
+++ b/plugins/web-ui/src/connectors.ts
@@ -100,6 +100,42 @@ interface KeychainConnectorCredential {
   needsReconnect?: boolean;
 }
 
+type GoogleAccountType = "default" | "personal" | "company";
+
+interface GoogleAccountState {
+  accountType: GoogleAccountType;
+  connected: boolean;
+  needsReconnect: boolean;
+}
+
+function googleAccountLabel(accountType: GoogleAccountType): string {
+  if (accountType === "company") return "Work Google";
+  if (accountType === "personal") return "Personal Google";
+  return "Google account";
+}
+
+function googleAccountStates(credentials: KeychainConnectorCredential[]): GoogleAccountState[] {
+  const order: GoogleAccountType[] = ["company", "personal", "default"];
+  return order.flatMap((accountType) => {
+    const matches = credentials.filter((credential) => (credential.accountType ?? "default") === accountType);
+    if (!matches.length) return [];
+    return [
+      {
+        accountType,
+        connected: matches.some((credential) => credential.connected),
+        needsReconnect: matches.some((credential) => Boolean(credential.needsReconnect)),
+      },
+    ];
+  });
+}
+
+function nextGoogleAccountType(accounts: GoogleAccountState[]): GoogleAccountType | undefined {
+  if (!accounts.length || accounts.some((account) => account.accountType === "default")) return undefined;
+  if (!accounts.some((account) => account.accountType === "company")) return "company";
+  if (!accounts.some((account) => account.accountType === "personal")) return "personal";
+  return undefined;
+}
+
 interface KeychainGrant {
   id: string;
   credentialId: string;
@@ -446,6 +482,8 @@ function drawConnectors(loading = false): void {
         .filter((host): host is string => Boolean(host)),
     );
     const credentials = keychainConnectorCredentials.filter((credential) => hosts.has(credential.host));
+    const googleAccounts = id === "google" ? googleAccountStates(credentials) : [];
+    const nextGoogleAccount = nextGoogleAccountType(googleAccounts);
     const credentialsById = new Map(
       credentials.map((credential) => [credential.credentialId, { id: credential.credentialId, kind: "connector" }]),
     );
@@ -453,6 +491,26 @@ function drawConnectors(loading = false): void {
     let connectionState: TemplateResult | string = html`<span class="kc-state neutral">Not connected</span>`;
     if (needsReconnect) connectionState = html`<span class="kc-state warning">Reconnect needed</span>`;
     else if (connected) connectionState = "";
+    let connectorAction: TemplateResult | string = "";
+    if (
+      available &&
+      id === "google" &&
+      googleAccounts.length < 2 &&
+      ((!connected && !needsReconnect) || googleAccounts.length > 0)
+    ) {
+      const label = nextGoogleAccount ? "Add another account" : "Reconnect Google";
+      connectorAction = html`<button
+        class="btn"
+        type="button"
+        @click=${() => void startConnector(id, nextGoogleAccount)}
+      >
+        ${googleAccounts.length ? html`${icon(Plus, 15)}<span>${label}</span>` : "Connect Google"}
+      </button>`;
+    } else if (available && id !== "google") {
+      connectorAction = html`<button class="btn" type="button" @click=${() => void startConnector(id)}>
+        ${connected || needsReconnect ? "Reconnect" : "Connect account"}
+      </button>`;
+    }
     return html`
       <article class="kc-resource kc-account">
         <div class="kc-resource-main">
@@ -467,6 +525,46 @@ function drawConnectors(loading = false): void {
         </div>
         ${meta.desc ? html`<p class="kc-resource-description">${meta.desc}</p>` : ""}
         ${needsReconnect && p.refreshError ? html`<div class="kc-inline-warning" role="status">Refresh failed: ${p.refreshError}</div>` : ""}
+        ${
+          id === "google" && googleAccounts.length
+            ? html`<div class="kc-access-block kc-connected-accounts">
+                <div class="kc-access-label">Connected accounts</div>
+                ${googleAccounts.map(
+                  (account) =>
+                    html`<div class="kc-access-row">
+                      <div>
+                        <strong>${googleAccountLabel(account.accountType)}</strong>
+                        <div>
+                          ${account.needsReconnect ? "Reconnect required" : "Gmail, Calendar, Drive, and files"}
+                        </div>
+                      </div>
+                      <div class="kc-account-actions">
+                        ${
+                          account.needsReconnect
+                            ? html`<button
+                                class="kc-text-action"
+                                type="button"
+                                @click=${() => void startConnector(id, account.accountType)}
+                              >
+                                Reconnect
+                              </button>`
+                            : ""
+                        }
+                        <button
+                          class="kc-text-action danger"
+                          type="button"
+                          data-confirm-key=${`disconnect:${id}:${account.accountType}`}
+                          ?disabled=${keychainOperations.mutationInFlight}
+                          @click=${() => void revokeConnector(id, account.accountType)}
+                        >
+                          Disconnect
+                        </button>
+                      </div>
+                    </div>`,
+                )}
+              </div>`
+            : ""
+        }
         ${
           grants.length
             ? html`<div class="kc-access-block">
@@ -493,8 +591,20 @@ function drawConnectors(loading = false): void {
             : ""
         }
         <div class="kc-resource-actions">
-          ${available ? html`<button class="btn" type="button" @click=${() => void startConnector(id)}>${connected || needsReconnect ? "Reconnect" : "Connect account"}</button>` : ""}
-          ${connected || needsReconnect ? html`<button class="kc-text-action danger" type="button" data-confirm-key=${`disconnect:${id}`} ?disabled=${keychainOperations.mutationInFlight} @click=${() => void revokeConnector(id)}>Disconnect</button>` : ""}
+          ${connectorAction}
+          ${
+            id !== "google" && (connected || needsReconnect)
+              ? html`<button
+                  class="kc-text-action danger"
+                  type="button"
+                  data-confirm-key=${`disconnect:${id}`}
+                  ?disabled=${keychainOperations.mutationInFlight}
+                  @click=${() => void revokeConnector(id)}
+                >
+                  Disconnect
+                </button>`
+              : ""
+          }
         </div>
       </article>
     `;
@@ -770,12 +880,13 @@ async function createDrop(): Promise<void> {
   }
 }
 
-async function startConnector(provider: string): Promise<void> {
+async function startConnector(provider: string, accountType?: GoogleAccountType): Promise<void> {
   const stateEpoch = keychainOperations.captureEpoch();
   connectorNotice = "";
   try {
     const r = await api<{ authorizeUrl?: string }>(`/api/connectors/${encodeURIComponent(provider)}/start`, {
       method: "POST",
+      body: JSON.stringify(accountType ? { accountType } : {}),
     });
     if (!keychainOperations.isCurrentEpoch(stateEpoch)) return;
     if (r.authorizeUrl) {
@@ -790,13 +901,17 @@ async function startConnector(provider: string): Promise<void> {
   drawConnectors(false);
 }
 
-async function revokeConnector(provider: string): Promise<void> {
+async function revokeConnector(provider: string, accountType?: GoogleAccountType): Promise<void> {
   const hosts = new Set(
     (connectorProviders[provider]?.hosts ?? [])
       .map((entry) => (typeof entry === "string" ? entry : entry.host))
       .filter((host): host is string => Boolean(host)),
   );
-  const providerCredentials = keychainConnectorCredentials.filter((credential) => hosts.has(credential.host));
+  const providerCredentials = keychainConnectorCredentials.filter(
+    (credential) =>
+      hosts.has(credential.host) &&
+      (accountType === undefined || (credential.accountType ?? "default") === accountType),
+  );
   const credentialIds = new Set(providerCredentials.map((credential) => credential.credentialId));
   const credentialsById = new Map(
     providerCredentials.map((credential) => [
@@ -812,7 +927,7 @@ async function revokeConnector(provider: string): Promise<void> {
     : "";
   confirmationOpener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   confirmation = {
-    title: `Disconnect ${CONNECTOR_LABELS[provider]?.name ?? provider}?`,
+    title: `Disconnect ${accountType ? googleAccountLabel(accountType) : (CONNECTOR_LABELS[provider]?.name ?? provider)}?`,
     body: `${impact} Automations using this account may stop working.`.trim(),
     action: "Disconnect account",
     run: async () => {
@@ -822,7 +937,7 @@ async function revokeConnector(provider: string): Promise<void> {
       confirmationOpener = null;
       drawConnectors();
       try {
-        await performRevokeConnector(provider, operation.epoch);
+        await performRevokeConnector(provider, operation.epoch, accountType);
       } finally {
         if (keychainOperations.finishMutation(operation)) drawConnectors();
       }
@@ -831,10 +946,17 @@ async function revokeConnector(provider: string): Promise<void> {
   drawConnectors();
 }
 
-async function performRevokeConnector(provider: string, stateEpoch: number): Promise<void> {
+async function performRevokeConnector(
+  provider: string,
+  stateEpoch: number,
+  accountType?: GoogleAccountType,
+): Promise<void> {
   connectorNotice = "";
   try {
-    await api("/api/connectors/revoke", { method: "POST", body: JSON.stringify({ provider }) });
+    await api("/api/connectors/revoke", {
+      method: "POST",
+      body: JSON.stringify({ provider, ...(accountType ? { accountType } : {}) }),
+    });
   } catch (e) {
     if (keychainOperations.isCurrentEpoch(stateEpoch)) connectorNotice = errMessage(e, "Could not disconnect.");
   }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -3772,6 +3772,12 @@ a.chat-row-open {
 .kc-access-row + .kc-access-row {
   border-top: 1px solid var(--kc-line);
 }
+.kc-account-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 auto;
+}
 .kc-credential-facts {
   display: flex;
   align-items: center;
@@ -3905,6 +3911,19 @@ a.chat-row-open {
   .kc-hero-actions {
     width: 100%;
     justify-content: flex-end;
+  }
+  .kc-access-row {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .kc-account-actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+  .kc-account-actions .kc-text-action {
+    min-height: 32px;
+    padding: 5px 0;
   }
   .kc-summary {
     display: grid;

--- a/plugins/web-ui/test/api-body-parsing.test.ts
+++ b/plugins/web-ui/test/api-body-parsing.test.ts
@@ -81,3 +81,30 @@ test("routes that historically tolerated an empty body still do", async () => {
   const forked = calls.at(-1);
   assert.deepEqual(forked?.body, { principalId: "alice" });
 });
+
+test("connector start forwards an optional Google account type", async () => {
+  const r = await fetch(`${base}/api/connectors/google/start`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ accountType: "company" }),
+  });
+  assert.equal(r.status, 200);
+  const started = calls.at(-1);
+  const url = new URL(started?.url ?? "", "http://core.test");
+  assert.equal(url.pathname, "/v1/connectors/oauth/google/start");
+  assert.equal(url.searchParams.get("accountType"), "company");
+});
+
+test("connector revoke forwards the selected Google account only", async () => {
+  const r = await fetch(`${base}/api/connectors/revoke`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ provider: "google", accountType: "personal" }),
+  });
+  assert.equal(r.status, 200);
+  assert.deepEqual(calls.at(-1)?.body, {
+    principalId: "alice",
+    provider: "google",
+    accountType: "personal",
+  });
+});

--- a/plugins/web-ui/test/keychain-flow.test.ts
+++ b/plugins/web-ui/test/keychain-flow.test.ts
@@ -156,7 +156,9 @@ test("keychain rows reserve success badges for actionable states", () => {
 });
 
 test("keychain actions keep secondary weight and compact mobile sizing", () => {
-  assert.match(connectorsSource, /\$\{available \? html`<button class="btn" type="button"/);
+  assert.match(connectorsSource, /available\s*&&\s*id === "google"\s*&&\s*googleAccounts\.length < 2/);
+  assert.match(connectorsSource, /!connected\s*&&\s*!needsReconnect/);
+  assert.match(connectorsSource, /Add another account/);
   assert.doesNotMatch(shellCssSource, /\.kc-hero-actions \.btn\s*\{\s*flex:\s*1;/);
   assert.doesNotMatch(shellCssSource, /sidebar-closed \.kc-hero-copy/);
 });

--- a/src/api/routes/connectors.ts
+++ b/src/api/routes/connectors.ts
@@ -149,9 +149,23 @@ async function oauthCallback(ctx: BaseCtx): Promise<void> {
       ...(state.codeVerifier ? { codeVerifier: state.codeVerifier } : {}),
     });
     if (!token.accessToken) throw new Error("oauth exchange returned an empty access token");
-    const stamped = { ...token, clientRef: client.clientRef, accountType, orgId: configOrgId() };
+    const storedAccountType =
+      accountType === "default" && (token.accountType === "personal" || token.accountType === "company")
+        ? token.accountType
+        : accountType;
+    const stamped = { ...token, clientRef: client.clientRef, accountType: storedAccountType, orgId: configOrgId() };
     for (const host of hosts)
-      await deps.connectorTokens.setConnectorToken(host, state.principalId, stamped, accountType);
+      await deps.connectorTokens.setConnectorToken(host, state.principalId, stamped, storedAccountType);
+    if (accountType === "default" && storedAccountType !== "default") {
+      for (const host of hosts) await deps.connectorTokens.setConnectorToken(host, state.principalId, stamped, "default");
+    } else if (storedAccountType !== "default") {
+      for (const host of hosts) {
+        const primary = await deps.connectorTokens.connectorTokenStatus(host, state.principalId, "default");
+        if (primary.accountType === storedAccountType) {
+          await deps.connectorTokens.setConnectorToken(host, state.principalId, stamped, "default");
+        }
+      }
+    }
     audit(deps, {
       principalId: state.principalId,
       action: "connector.oauth.connected",
@@ -167,7 +181,13 @@ async function oauthCallback(ctx: BaseCtx): Promise<void> {
       dest.searchParams.set("status", "connected");
       return sendRedirect(res, `${dest.pathname}${dest.search}${dest.hash}`);
     }
-    return sendJson(res, 200, { ok: true, provider: oauthRoute.provider, principalId: state.principalId, hosts });
+    return sendJson(res, 200, {
+      ok: true,
+      provider: oauthRoute.provider,
+      principalId: state.principalId,
+      accountType: storedAccountType,
+      hosts,
+    });
   } catch (e) {
     return sendJson(res, 400, { error: "oauth_callback_failed", message: errMessage(e) });
   }
@@ -274,6 +294,9 @@ async function consentMint(ctx: ApiCtx): Promise<void> {
   if (!PROVIDERS[provider])
     return sendJson(res, 404, { error: "not_found", message: `unknown OAuth provider: ${provider}` });
   const accountType = parseAccountType(typeof b.accountType === "string" ? b.accountType : null);
+  if (accountType !== "default" && provider !== "google") {
+    return sendJson(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+  }
   const base = deps.publicUrl ? deps.publicUrl.replace(/\/$/, "") : "";
   const intendedPrincipalId = personKey(typeof b.intendedPrincipalId === "string" ? b.intendedPrincipalId : "");
   if (intendedPrincipalId && !samePerson(intendedPrincipalId, capability.actorId)) {
@@ -350,6 +373,9 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
   if (!principalId || !redirectUri)
     return sendJson(res, 400, { error: "bad_request", message: "principalId and redirectUri required" });
   const accountType = parseAccountType(url.searchParams.get("accountType"));
+  if (accountType !== "default" && oauthRoute.provider !== "google") {
+    return sendJson(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+  }
   try {
     const client = await resolverFor(deps)(oauthRoute.provider, { accountType });
     if (client.redirectAllowlist && !client.redirectAllowlist.includes(redirectUri)) {
@@ -429,6 +455,15 @@ export async function oauthRevoke(ctx: ApiCtx): Promise<void> {
   }
   const providerName = typeof b.provider === "string" ? b.provider : "";
   const host = typeof b.host === "string" ? b.host : "";
+  const requestedAccountType = typeof b.accountType === "string" ? b.accountType : undefined;
+  if (
+    requestedAccountType !== undefined &&
+    requestedAccountType !== "default" &&
+    requestedAccountType !== "personal" &&
+    requestedAccountType !== "company"
+  ) {
+    return sendJson(res, 400, { error: "bad_request", message: "invalid accountType" });
+  }
   if (!principalId || (!providerName && !host)) {
     return sendJson(res, 400, { error: "bad_request", message: "principalId and provider or host required" });
   }
@@ -436,14 +471,33 @@ export async function oauthRevoke(ctx: ApiCtx): Promise<void> {
     const provider = PROVIDERS[providerName];
     if (!provider)
       return sendJson(res, 404, { error: "not_found", message: `unknown OAuth provider: ${providerName}` });
-    for (const h of provider.hosts)
-      for (const at of CONNECTOR_STATUS_ACCOUNT_TYPES)
-        await deps.connectorTokens.deleteConnectorToken(h, principalId, at);
+    if (requestedAccountType !== undefined && providerName !== "google") {
+      return sendJson(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+    }
+    const accountTypes = requestedAccountType ? [requestedAccountType] : CONNECTOR_STATUS_ACCOUNT_TYPES;
+    for (const h of provider.hosts) {
+      for (const at of accountTypes) await deps.connectorTokens.deleteConnectorToken(h, principalId, at);
+      if (providerName === "google" && requestedAccountType && requestedAccountType !== "default") {
+        const legacy = await deps.connectorTokens.connectorTokenStatus(h, principalId, "default");
+        if (legacy.accountType === requestedAccountType) {
+          await deps.connectorTokens.deleteConnectorToken(h, principalId, "default");
+        }
+      }
+    }
     audit(deps, { principalId, action: "connector.oauth.revoked", resource: providerName, scopeLabel: principalId });
     return sendJson(res, 200, { ok: true, principalId, provider: providerName, hosts: provider.hosts });
   }
-  for (const at of CONNECTOR_STATUS_ACCOUNT_TYPES)
-    await deps.connectorTokens.deleteConnectorToken(host, principalId, at);
+  if (requestedAccountType !== undefined && !PROVIDERS.google!.hosts.includes(host)) {
+    return sendJson(res, 400, { error: "bad_request", message: "accountType is only supported for Google" });
+  }
+  const accountTypes = requestedAccountType ? [requestedAccountType] : CONNECTOR_STATUS_ACCOUNT_TYPES;
+  for (const at of accountTypes) await deps.connectorTokens.deleteConnectorToken(host, principalId, at);
+  if (requestedAccountType && requestedAccountType !== "default") {
+    const primary = await deps.connectorTokens.connectorTokenStatus(host, principalId, "default");
+    if (primary.accountType === requestedAccountType) {
+      await deps.connectorTokens.deleteConnectorToken(host, principalId, "default");
+    }
+  }
   audit(deps, { principalId, action: "connector.oauth.revoked", resource: host, scopeLabel: principalId });
   return sendJson(res, 200, { ok: true, principalId, host });
 }

--- a/src/connectors/oauth.ts
+++ b/src/connectors/oauth.ts
@@ -154,23 +154,42 @@ const { exchange: defaultExchange, refresh: defaultRefresh } = makeTokenAdapters
 
 const googleExchange: OAuthExchangeAdapter = async (args) => {
   const { client, accountType } = args;
+  const requestedAccountType = accountType ?? "default";
   const { hosts, token, raw } = await defaultExchange(args);
-  if (accountType === "company" && client.hostedDomain) {
-    const idToken = typeof raw?.id_token === "string" ? raw.id_token : "";
-    let claims: Record<string, unknown> | undefined;
-    try {
-      if (idToken) claims = decodeJwt(idToken);
-    } catch (e) {
-      swallow("google id_token decode", e);
-    }
-    const hd = typeof claims?.hd === "string" ? claims.hd : "";
+  const idToken = typeof raw?.id_token === "string" ? raw.id_token : "";
+  let claims: Record<string, unknown> | undefined;
+  try {
+    if (idToken) claims = decodeJwt(idToken);
+  } catch (e) {
+    swallow("google id_token decode", e);
+  }
+  const hd = typeof claims?.hd === "string" ? claims.hd : "";
+  const email = typeof claims?.email === "string" ? claims.email : "";
+  let classifiedAccountType: AccountType | undefined;
+  if (hd) classifiedAccountType = "company";
+  else if (email) classifiedAccountType = "personal";
+  if (!classifiedAccountType && requestedAccountType !== "default") {
+    throw new Error("Google did not identify the selected account — reconnect and choose an account");
+  }
+  if (!classifiedAccountType) return { hosts, token };
+  if (requestedAccountType !== "default" && requestedAccountType !== classifiedAccountType) {
+    throw new Error(
+      requestedAccountType === "company"
+        ? "selected account is not a Google Workspace account — pick your company Google account"
+        : "selected account is a Google Workspace account — pick your personal Google account",
+    );
+  }
+  if (classifiedAccountType === "company" && client.hostedDomain) {
     if (hd.toLowerCase() !== client.hostedDomain.toLowerCase()) {
       throw new Error(
         `connected account is not in the ${client.hostedDomain} workspace — pick your company Google account`,
       );
     }
   }
-  return { hosts, token };
+  return {
+    hosts,
+    token: { ...token, accountType: classifiedAccountType },
+  };
 };
 
 const github = makeTokenAdapters({ acceptJson: true, rejectErrorBody: true, label: "github" });
@@ -245,7 +264,7 @@ export const PROVIDERS: Record<string, OAuthProviderConfig> = {
       "oauth2.googleapis.com",
       "accounts.google.com",
     ],
-    authParams: { access_type: "offline", prompt: "consent" },
+    authParams: { access_type: "offline", prompt: "consent select_account" },
     exchange: googleExchange,
     setupGuide: {
       console: "Google Cloud Console → APIs & Services → Credentials",

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -28,7 +28,7 @@ import { supportsProcessSessions, supportsScopeProfile } from "../sandbox/sandbo
 import { createBackgroundBroker } from "../connectors/background-exec-broker.ts";
 import { createMonitorBroker, readBackgroundOutputTail } from "../monitors/monitor-broker.ts";
 import { isPollSurface, isSilentPollReply } from "../triggers/run-trigger.ts";
-import { envKey } from "../credentials/connector-token.ts";
+import { accountEnvKey, envKey } from "../credentials/connector-token.ts";
 import {
   renderKeychainManifest,
   type MaterializedEnvCred,
@@ -1069,10 +1069,24 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       }
       if (!strictReadOnly && deps.connectorTokens && conversation.kind === "dm") {
         for (const host of CONNECTOR_HOSTS) {
+          const typedTokens: Partial<Record<"personal" | "company", string>> = {};
+          for (const accountType of ["personal", "company"] as const) {
+            const status = await deps.connectorTokens.connectorTokenStatus(host, actor.id, accountType);
+            if (!status.connected) continue;
+            const accountToken = await deps.connectorTokens.connectorAccessToken(host, actor.id, accountType);
+            if (!accountToken) continue;
+            typedTokens[accountType] = accountToken;
+            connectorEnv[accountEnvKey(host, accountType)] = accountToken;
+          }
+          const defaultStatus = await deps.connectorTokens.connectorTokenStatus(host, actor.id, "default");
+          const defaultToken = defaultStatus.connected
+            ? await deps.connectorTokens.connectorAccessToken(host, actor.id, "default")
+            : null;
           const token =
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id, "personal")) ??
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id)) ??
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id, "company"));
+            defaultToken ??
+            typedTokens.company ??
+            typedTokens.personal ??
+            (await deps.connectorTokens.connectorAccessToken(host, actor.id));
           if (token) connectorEnv[envKey(host)] = token;
         }
       }

--- a/src/credentials/connector-token.ts
+++ b/src/credentials/connector-token.ts
@@ -10,6 +10,10 @@ export function envKey(host: string, principalId?: string): string {
   return `VAULT_TOKEN_${normalizedHost}__${normalizedPrincipal}_${tag}`;
 }
 
+export function accountEnvKey(host: string, accountType: "personal" | "company"): string {
+  return `${envKey(host)}__${accountType.toUpperCase()}`;
+}
+
 export function withOperatorTokenFallback(
   store: ConnectorTokenStore,
   serviceHosts: string[],

--- a/test/connector-invariants.test.ts
+++ b/test/connector-invariants.test.ts
@@ -9,7 +9,7 @@ import type { AddressInfo } from "node:net";
 import { buildApp, type BuiltApp } from "../src/wiring.ts";
 import { createInsecureTestServer, createServer } from "../src/api/server.ts";
 import { PROVIDERS, sealOAuthState } from "../src/connectors/oauth.ts";
-import { envKey } from "../src/credentials/connector-token.ts";
+import { accountEnvKey, envKey } from "../src/credentials/connector-token.ts";
 import type { TurnRequest } from "../src/types.ts";
 import { fakeSprites } from "./support/auto-fake-sprites.ts";
 import { testConfig } from "./support/test-config.ts";
@@ -188,6 +188,38 @@ test("F1/F3 — a DM injects the requester's connector token; a channel injects 
   assert.equal(ch.status, "ok");
   assert.ok(!execScriptsMention(gmailExport), "a channel must inject NO per-user connector token");
   assert.ok(!execScriptsMention("u1-gmail"), "the channel's exec env must not carry the token value");
+});
+
+test("a DM exposes both Google accounts under stable account-specific environment keys", async () => {
+  const built: BuiltApp = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "multi-google-")) }));
+  await built.connectorTokens.setConnectorToken(
+    "gmail.googleapis.com",
+    "U1",
+    { accessToken: "company-google", accountType: "company" },
+    "company",
+  );
+  await built.connectorTokens.setConnectorToken(
+    "gmail.googleapis.com",
+    "U1",
+    { accessToken: "personal-google", accountType: "personal" },
+    "personal",
+  );
+
+  fakeSprites.reset();
+  const dm = await built.app.turn(turn("dm", "!run true"));
+
+  assert.equal(dm.status, "ok");
+  assert.ok(execScriptsMention(`export ${accountEnvKey("gmail.googleapis.com", "company")}=`));
+  assert.ok(execScriptsMention(`export ${accountEnvKey("gmail.googleapis.com", "personal")}=`));
+  assert.ok(execScriptsMention("company-google"));
+  assert.ok(execScriptsMention("personal-google"));
+  const authScript = fakeSprites.execScripts().find((script) => script.includes(envKey("gmail.googleapis.com")));
+  assert.ok(authScript);
+  const genericOffset = authScript.indexOf(`${envKey("gmail.googleapis.com")}=`, 0);
+  assert.ok(genericOffset >= 0);
+  const genericAssignment = authScript.slice(genericOffset, genericOffset + 100);
+  assert.match(genericAssignment, /company-google/);
+  assert.doesNotMatch(genericAssignment, /personal-google/);
 });
 
 function wake(text: string, readOnly: boolean): TurnRequest {

--- a/test/connectors.test.ts
+++ b/test/connectors.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { envKey, withOperatorTokenFallback } from "../src/credentials/connector-token.ts";
+import { accountEnvKey, envKey, withOperatorTokenFallback } from "../src/credentials/connector-token.ts";
 import { createEnvSecretSource } from "../src/credentials/secret-source.ts";
 import {
   createKeychain,
@@ -53,6 +53,8 @@ test("operator token fallback can model per-user credentials and host-wide servi
 
 test("envKey: the host-wide form keeps its documented shape; per-user keys never collide across principals", () => {
   assert.equal(envKey("gmail.googleapis.com"), "VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM");
+  assert.equal(accountEnvKey("gmail.googleapis.com", "company"), "VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM__COMPANY");
+  assert.equal(accountEnvKey("gmail.googleapis.com", "personal"), "VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM__PERSONAL");
   assert.notEqual(envKey("gmail.googleapis.com", "a.b@c.com"), envKey("gmail.googleapis.com", "a-b@c.com"));
   assert.notEqual(envKey("gmail.googleapis.com", "a.b@c.com"), envKey("gmail.googleapis.com", "a_b@c.com"));
   assert.equal(envKey("gmail.googleapis.com", "a.b@c.com"), envKey("gmail.googleapis.com", "a.b@c.com"));

--- a/test/oauth-consent-bridge.test.ts
+++ b/test/oauth-consent-bridge.test.ts
@@ -339,6 +339,19 @@ test("mint refuses an unconfigured provider even when PUBLIC_WEB_URL is set", as
   }
 });
 
+test("consent mint rejects account slots for non-Google providers", async () => {
+  const srv = start(async () => {
+    throw new Error("must not exchange");
+  });
+  try {
+    const res = await mint(srv.base, await consentTok("U1"), { provider: "github", accountType: "personal" });
+    assert.equal(res.status, 400);
+    assert.match(await res.text(), /accountType is only supported for Google/);
+  } finally {
+    await srv.close();
+  }
+});
+
 test("an expired consent link reports an expiry status", async () => {
   const srv = start(async () => {
     throw new Error("must not exchange");

--- a/test/oauth-routes.test.ts
+++ b/test/oauth-routes.test.ts
@@ -10,6 +10,7 @@ import { createServer } from "../src/api/server.ts";
 import { buildApp, type BuiltApp } from "../src/wiring.ts";
 import { signRequest } from "../src/auth/source-auth.ts";
 import { PROVIDERS, type FetchLike } from "../src/connectors/oauth.ts";
+import { scopeId } from "../src/types.ts";
 import { testConfig } from "./support/test-config.ts";
 
 const SECRET = "oauth-route-test-secret".repeat(3);
@@ -104,6 +105,97 @@ test("OAuth start, unsigned callback, status, and revoke are principal-bound", a
   }
 });
 
+test("a first Google connection is classified and stored without another setup choice", async () => {
+  const payload = Buffer.from(JSON.stringify({ email: "alex@example.com", hd: "example.com" })).toString(
+    "base64url",
+  );
+  const srv = start(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ access_token: "at-company", refresh_token: "rt-company", id_token: `e30.${payload}.sig` }),
+  }));
+  try {
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", {
+      accessToken: "old-default",
+    });
+    const legacy = (await srv.built.keychain!.listConnectorsByOwners(["U1"])).get("U1")![0]!;
+    const grant = await srv.built.keychain!.createGrant({
+      credentialId: legacy.credentialId,
+      ownerId: "U1",
+      audienceScopeId: scopeId("channel", "C1"),
+      mode: "standing",
+      purpose: "preserve existing Google automation",
+    });
+    const redirectUri = `${srv.base}/v1/connectors/oauth/google/callback`;
+    const startPath = `/v1/connectors/oauth/google/start?principalId=U1&redirectUri=${encodeURIComponent(redirectUri)}`;
+    const startBody = (await (await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) })).json()) as {
+      authorizeUrl: string;
+    };
+    const state = new URL(startBody.authorizeUrl).searchParams.get("state");
+    assert.ok(state);
+
+    const callback = await fetch(
+      `${srv.base}/v1/connectors/oauth/google/callback?code=code-company&state=${encodeURIComponent(state)}`,
+    );
+
+    assert.equal(callback.status, 200);
+    assert.equal(
+      await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1", "company"),
+      "at-company",
+    );
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "at-company");
+    assert.equal((await srv.built.keychain!.getGrant(grant.id))?.status, "active");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("reconnecting the primary Google account refreshes its retained alias and grants", async () => {
+  const payload = Buffer.from(JSON.stringify({ email: "alex@example.com", hd: "example.com" })).toString(
+    "base64url",
+  );
+  const srv = start(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      access_token: "fresh-company",
+      refresh_token: "fresh-refresh",
+      id_token: `e30.${payload}.sig`,
+    }),
+  }));
+  try {
+    const stale = { accessToken: "stale-company", expiresAt: 1, accountType: "company" as const };
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", stale, "default");
+    const primaryId = (await srv.built.keychain!.listConnectorsByOwners(["U1"])).get("U1")![0]!.credentialId;
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", stale, "company");
+    const grant = await srv.built.keychain!.createGrant({
+      credentialId: primaryId,
+      ownerId: "U1",
+      audienceScopeId: scopeId("channel", "C1"),
+      mode: "standing",
+      purpose: "keep primary Google automation current",
+    });
+    const redirectUri = `${srv.base}/v1/connectors/oauth/google/callback`;
+    const startPath = `/v1/connectors/oauth/google/start?principalId=U1&redirectUri=${encodeURIComponent(redirectUri)}&accountType=company`;
+    const startBody = (await (await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) })).json()) as {
+      authorizeUrl: string;
+    };
+    const state = new URL(startBody.authorizeUrl).searchParams.get("state");
+    assert.ok(state);
+    const callback = await fetch(
+      `${srv.base}/v1/connectors/oauth/google/callback?code=reconnect&state=${encodeURIComponent(state)}`,
+    );
+
+    assert.equal(callback.status, 200);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "fresh-company");
+    assert.equal((await srv.built.keychain!.getGrant(grant.id))?.status, "active");
+    const materialized = await srv.built.keychain!.materializeStanding(scopeId("channel", "C1"));
+    assert.equal(materialized.length, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
 test("revoke clears a connector linked under a non-default account type", async () => {
   const srv = start(async () => {
     throw new Error("no token exchange expected");
@@ -135,6 +227,90 @@ test("revoke clears a connector linked under a non-default account type", async 
       providers: Record<string, { connected?: boolean }>;
     };
     assert.equal(after.providers.google?.connected, false);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("revoke can disconnect one Google account without removing the other", async () => {
+  const srv = start(async () => {
+    throw new Error("no token exchange expected");
+  });
+  try {
+    await srv.built.connectorTokens.setConnectorToken(
+      "gmail.googleapis.com",
+      "U1",
+      { accessToken: "at-company", accountType: "company" },
+      "company",
+    );
+    await srv.built.connectorTokens.setConnectorToken(
+      "gmail.googleapis.com",
+      "U1",
+      { accessToken: "at-personal", accountType: "personal" },
+      "personal",
+    );
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", {
+      accessToken: "at-personal",
+      accountType: "personal",
+    });
+
+    const revokeBody = JSON.stringify({ principalId: "U1", provider: "google", accountType: "personal" });
+    const revokeRes = await fetch(`${srv.base}/v1/connectors/oauth/revoke`, {
+      method: "POST",
+      headers: sign("POST", "/v1/connectors/oauth/revoke", revokeBody),
+      body: revokeBody,
+    });
+
+    assert.equal(revokeRes.status, 200);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1", "personal"), null);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), null);
+    assert.equal(
+      await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1", "company"),
+      "at-company",
+    );
+  } finally {
+    await srv.close();
+  }
+});
+
+test("account-specific revoke is rejected for non-Google providers", async () => {
+  const srv = start(async () => {
+    throw new Error("no token exchange expected");
+  });
+  try {
+    await srv.built.connectorTokens.setConnectorToken("api.github.com", "U1", { accessToken: "github-token" });
+    const body = JSON.stringify({ principalId: "U1", provider: "github", accountType: "personal" });
+    const response = await fetch(`${srv.base}/v1/connectors/oauth/revoke`, {
+      method: "POST",
+      headers: sign("POST", "/v1/connectors/oauth/revoke", body),
+      body,
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("api.github.com", "U1"), "github-token");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("host-scoped Google revoke removes a matching retained primary alias", async () => {
+  const srv = start(async () => {
+    throw new Error("no token exchange expected");
+  });
+  try {
+    const token = { accessToken: "company-token", accountType: "company" as const };
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", token, "company");
+    await srv.built.connectorTokens.setConnectorToken("gmail.googleapis.com", "U1", token, "default");
+    const body = JSON.stringify({ principalId: "U1", host: "gmail.googleapis.com", accountType: "company" });
+    const response = await fetch(`${srv.base}/v1/connectors/oauth/revoke`, {
+      method: "POST",
+      headers: sign("POST", "/v1/connectors/oauth/revoke", body),
+      body,
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1", "company"), null);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), null);
   } finally {
     await srv.close();
   }

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -40,6 +40,7 @@ test("authorizeUrl builds a consent URL with client id, scopes, redirect, state"
   assert.equal(u.searchParams.get("redirect_uri"), "https://app/cb");
   assert.equal(u.searchParams.get("state"), "st-1");
   assert.equal(u.searchParams.get("access_type"), "offline");
+  assert.equal(u.searchParams.get("prompt"), "consent select_account");
   assert.match(u.searchParams.get("scope") ?? "", /gmail\.modify/);
   assert.match(u.searchParams.get("scope") ?? "", /auth\/drive(\s|$)/);
   assert.match(u.searchParams.get("scope") ?? "", /spreadsheets/);
@@ -94,6 +95,24 @@ test("exchangeCode returns a token for the provider's hosts (default authorizati
   assert.deepEqual(token.grantedScopes, ["a", "b"]);
 });
 
+test("Google classifies a default connection from the selected account", async () => {
+  const payload = Buffer.from(JSON.stringify({ email: "alex@example.com", hd: "example.com" })).toString(
+    "base64url",
+  );
+  const fetchImpl: FetchLike = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ access_token: "at", id_token: `e30.${payload}.sig` }),
+  });
+
+  const { token } = await exchangeCode("google", "code-123", "https://app/cb", {
+    client: await googleClient(),
+    fetchImpl,
+  });
+
+  assert.equal(token.accountType, "company");
+});
+
 test("makeRefresh exchanges a refresh token, keeping it if the provider omits a new one", async () => {
   const fetchImpl: FetchLike = async (_url, init) => {
     assert.match(init.body, /grant_type=refresh_token/);
@@ -117,11 +136,11 @@ test("refresh dispatches by host (calendar host → google provider)", async () 
   assert.equal(hit, PROVIDERS.google!.tokenUrl);
 });
 
-test("google company-slot exchange verifies the id_token hosted domain server-side", async () => {
+test("google account-slot exchange verifies the selected identity server-side", async () => {
   const r = createSecretClientResolver(createEnvSecretSource({ ...env, GOOGLE_WORKSPACE_DOMAIN: "example.com" }));
   const client = await r("google", { accountType: "company" });
   const idToken = (hd?: string) =>
-    ["h", Buffer.from(JSON.stringify({ sub: "1", ...(hd ? { hd } : {}) }), "utf8").toString("base64url"), "s"].join(
+    ["h", Buffer.from(JSON.stringify({ sub: "1", email: "alex@example.com", ...(hd ? { hd } : {}) }), "utf8").toString("base64url"), "s"].join(
       ".",
     );
   const respondWith =
@@ -151,7 +170,7 @@ test("google company-slot exchange verifies the id_token hosted domain server-si
         accountType: "company",
         fetchImpl: respondWith({ access_token: "at", id_token: idToken() }),
       }),
-    /not in the example\.com workspace/,
+    /not a Google Workspace account/,
   );
   await assert.rejects(
     () =>
@@ -160,15 +179,26 @@ test("google company-slot exchange verifies the id_token hosted domain server-si
         accountType: "company",
         fetchImpl: respondWith({ access_token: "at" }),
       }),
-    /not in the example\.com workspace/,
+    /did not identify the selected account/,
   );
 
   const personal = await exchangeCode("google", "c", "https://app/cb", {
     client: await r("google", { accountType: "personal" }),
     accountType: "personal",
-    fetchImpl: respondWith({ access_token: "at" }),
+    fetchImpl: respondWith({ access_token: "at", id_token: idToken() }),
   });
   assert.equal(personal.token.accessToken, "at");
+  const personalClient = await r("google", { accountType: "personal" });
+
+  await assert.rejects(
+    () =>
+      exchangeCode("google", "c", "https://app/cb", {
+        client: personalClient,
+        accountType: "personal",
+        fetchImpl: respondWith({ access_token: "at", id_token: idToken("example.com") }),
+      }),
+    /pick your personal Google account/,
+  );
 });
 
 test("github refresh asks for JSON and surfaces GitHub's 200-with-error bodies", async () => {


### PR DESCRIPTION
## Summary

- classify the first Google connection automatically as personal or Workspace
- let users add, reconnect, and revoke a second Google account independently
- expose stable account-specific connector variables while retaining the primary alias for existing skills and grants
- force account selection and reject identity/slot mismatches

## Verification

- `npm run lint`
- `npm run typecheck`
- 84 focused OAuth, connector, orchestrator, and web UI tests
- independent security and runtime reviews
- deployed against a production Fly instance with both account slots connected
- read-only Gmail, Calendar, and Drive checks passed for both work and personal accounts

## Demo

Live deployment: https://audienti-portal.fly.dev/keychain

The production Keychain renders both accounts under one Google Workspace card:

| Account | Gmail | Calendar | Drive |
| --- | --- | --- | --- |
| Work Google | Pass | Pass | Pass |
| Personal Google | Pass | Pass | Pass |

The first connection auto-classified the Workspace identity. `Add another account` then forced the Google account picker and populated the personal slot. The smoke test used only per-user connector tokens; no deployment-wide Google refresh token was available.
