### PR TITLE
feat(slack): refuse unresolved own-team members as their own state

### DIFF
--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -5,6 +5,14 @@ export interface ActorAssertion {
   isExternalGuest?: boolean;
   isBot?: boolean;
   displayName?: string;
+  /**
+   * Own-team member whose principal could not be resolved in email identity
+   * mode (email not currently visible in the directory). Refused like a
+   * guest — fail closed, never a fallback Slack-ID principal — but as its
+   * OWN state, so logs and the user-facing refusal say "unresolved member"
+   * instead of masquerading as "external guest" (#626).
+   */
+  principalUnresolved?: true;
 }
 
 export interface SlackUser {
@@ -53,14 +61,22 @@ export function classifyUser(
   );
   const displayName = user.profile?.display_name || user.real_name || user.name || user.id || "";
   let externalId = String(user.id ?? "");
+  // Email mode keys members on their email — including guests, whose
+  // principal still resolves for refusal copy and audit. An email-LESS
+  // member with no Slack-side external evidence is own-team but
+  // principal-unresolved: kept distinct from an external guest (which the
+  // native flags above decide) so refusal copy and logs name what actually
+  // happened instead of masquerading as external (#626).
+  let principalUnresolved = false;
   if (identity === "email" && !user.is_bot) {
     const email = (user.profile?.email ?? "").trim().toLowerCase();
     if (email.includes("@")) externalId = email;
-    else isGuest = true;
+    else if (!isGuest) principalUnresolved = true;
   }
   return {
     externalId,
     isExternalGuest: isGuest,
+    ...(principalUnresolved ? { principalUnresolved: true as const } : {}),
     ...(user.is_bot ? { isBot: true } : {}),
     ...(displayName ? { displayName } : {}),
   };

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -296,7 +296,33 @@ export function createTurnHandler(deps: {
             ...(ids.botHandle ? { botHandle: ids.botHandle } : {}),
           };
 
+    // A principal-unresolved own-team member (email mode, email not yet
+    // visible) is refused as its OWN state — fail closed like a guest, but
+    // named for what it is, both to the sender and in the log, so the
+    // incident signature is decidable (#626: the refusal used to be
+    // indistinguishable from external-guest in logs, and its success path
+    // logged nothing at all).
+    const unresolvedMember = audience.find((a) => a.principalUnresolved);
+    if (unresolvedMember) {
+      console.warn(
+        `[slack-plugin] refusing turn: own-team member principal unresolved ` +
+          `(email identity mode; email not visible in the directory) ` +
+          `user=${unresolvedMember.externalId || "?"} ch=${inc.channel} ts=${inc.ts}`,
+      );
+      if (!inc.unprompted) {
+        await ephemeralOrSay(
+          "I can't respond here yet — I couldn't verify your team membership " +
+            "(your email isn't visible to me). This usually resolves within a " +
+            "few minutes of the directory refreshing; try again shortly.",
+        );
+      }
+      return;
+    }
+
     if (audience.some((a) => a.isExternalGuest) && !(await externalParticipantsEnabled())) {
+      console.warn(
+        `[slack-plugin] refusing turn: external guest ch=${inc.channel} ts=${inc.ts}`,
+      );
       if (!inc.unprompted) {
         await ephemeralOrSay(
           "I can't respond here — this conversation isn't fully internal. Try a DM or a fully-internal channel.",

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -63,7 +63,26 @@ test("classifyUser email mode keys members on their normalized work email", () =
 test("classifyUser email mode fails closed to guest when a member has no visible email", () => {
   const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "email");
   assert.equal(a.externalId, "U1");
-  assert.equal(a.isExternalGuest, true);
+  // Own-team member, principal unresolved: its OWN state, not external
+  // guest (#626). The refusal is equally closed, but logs and copy say
+  // what actually happened.
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, true);
+});
+
+test("classifyUser email mode: native external evidence still wins over unresolved", () => {
+  // A restricted member with no visible email is an EXTERNAL GUEST, not an
+  // unresolved own-team member — the third state never masks the flags
+  // (#626).
+  const g = classifyUser({ id: "U2", team_id: TEAM, is_restricted: true }, TEAM, "email");
+  assert.equal(g.isExternalGuest, true);
+  assert.equal(g.principalUnresolved, undefined);
+});
+
+test("classifyUser slack-id mode never marks principalUnresolved", () => {
+  const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "slack-id");
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, undefined);
 });
 
 test("classifyUser email mode keeps bots on their Slack id and non-guest", () => {


### PR DESCRIPTION
Fixes defects 1 and 2 of #626 (the classification collapse and the invisible refusal); the `ok:false` propagation (1b) and event-driven refresh (3) are separate follow-ups per the issue's fix ladder.

## Defect 1 — the third state

`classifyUser` folded three states into two: confirmed-external → guest; confirmed-internal-resolved → allowed; and **own-team-but-email-invisible → also "guest"**. An org owner with a just-set email masqueraded as an external guest for the directory-propagation window, with every log line and the user-facing copy asserting "external".

Now `ActorAssertion` carries `principalUnresolved: true` for that third case:

- **Native flags still decide `isExternalGuest`** — a restricted/other-workspace/stranger member with a *visible* email remains an email-keyed external guest exactly as before (pinned by the pre-existing tests, now joined by a "native evidence wins" case). The third state never masks the flags.
- **Email keying is unchanged for everyone with a visible email.**
- **slack-id mode never sets it** (no email resolution exists there).

## Defect 2 — the refusal is its own state, and observable

The turn-handler gate refuses `principalUnresolved` **ahead of** the external-guest gate — equally fail-closed (never a fallback Slack-ID principal, which would mint a second internal identity with wrong scope/grants, exactly what email mode exists to prevent), but:

- the sender sees *"I couldn't verify your team membership (your email isn't visible to me). This usually resolves within a few minutes of the directory refreshing; try again shortly"* — naming the actual condition and its actual remedy, instead of "this conversation isn't fully internal", which sent the owner looking for a channel-setting problem;
- **every refusal logs on the success path** — the new `principalUnresolved` refusal warns with user/channel/timestamp, and the external-guest refusal (which previously left no trace unless `postEphemeral` *threw*) now warns too. In the incident, H1 (path never ran) / H2 (ephemeral posted but not displayed) / H3 (hung await before the ephemeral) were indistinguishable precisely because a successful refusal was invisible; the success-side log line makes the next one decidable.

## Tests

- Updated: "email mode fails closed to guest when a member has no visible email" → asserts `isExternalGuest: false` + `principalUnresolved: true`. **Fails on `main`** (guest).
- New: "native external evidence still wins over unresolved" — restricted + email-less reads as external guest, `principalUnresolved` unset. Pins that the third state cannot mask the flags.
- New: "slack-id mode never marks principalUnresolved".

`slack-identity` 27/27; neighbors `external-slack-participants` / `slack-index.integration` / `identity-offboarding` 53/53 (all three suites identical on clean `main`); `tsc --noEmit` clean. The refusal-gate copy and logging are exercised through the integration suite's mention fixtures.

## Follow-ups (not included, per the issue's ladder)

- `ok:false` from `users.info` preserved at `classifyActor` and the direct-intake path, distinguishing "lookup failed" from "resolved but email-less" — the transient-failure half of defect 1.
- `user_change`/`team_join` manifest subscriptions + cache eviction — defect 3; needs the app-reinstall note the issue mentions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825790&installation_model_id=19911&pr_number=628&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F628&signature=344180b915a21f76faef1a3b7350979376adc561819adac5a2f46723916c1f2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->