### PR TITLE
fix(slack): preserve users.info failures instead of laundering them

### DIFF
--- a/src/slack/directory.ts
+++ b/src/slack/directory.ts
@@ -65,7 +65,11 @@ export interface Directory {
   getUserSnapshot(client: any): Promise<{ byId: Map<string, CachedUser>; fetchedAt: number } | undefined>;
   forceDirectorySync(client: any, invalidateChannelId?: string, invalidatePrincipalId?: string): Promise<void>;
   classifyUserCached(client: any, userId: string): Promise<CachedUser & { ok: boolean }>;
-  classifyActor(client: any, userId: string): Promise<ActorAssertion>;
+  lastKnownClassification(userId: string): ActorAssertion | undefined;
+  classifyActor(
+    client: any,
+    userId: string,
+  ): Promise<ActorAssertion & { ok: boolean }>;
   getChannelInfo(client: any, channel: string): Promise<ChannelMeta | undefined>;
   channelMembership(
     client: any,
@@ -588,12 +592,28 @@ export function createDirectory(deps: {
       if (ids.ownTeamId) userCache.set(userId, classified);
       return { ...classified, ok: true };
     } catch {
-      return { actor: { externalId: userId, isExternalGuest: true }, ok: false };
+      // Lookup failed — say so instead of asserting the user is an external
+      // guest (#626): the id-based actor carries lookupFailed so consumers
+      // can distinguish "couldn't check" from every checked state.
+      return { actor: { externalId: userId, lookupFailed: true }, ok: false };
     }
   }
 
-  async function classifyActor(client: any, userId: string): Promise<ActorAssertion> {
-    return (await classifyUserCached(client, userId)).actor;
+  function lastKnownClassification(userId: string): ActorAssertion | undefined {
+    // The LRU entry is the last SUCCESSFUL classification (failures are
+    // never cached), i.e. exactly the fallback a transient users.info
+    // failure should fall back to (#626). Time-bounded by the cache TTL.
+    return userCache.get(userId)?.actor;
+  }
+
+  async function classifyActor(client: any, userId: string): Promise<ActorAssertion & { ok: boolean }> {
+    // ok preserved, not discarded: a failed users.info currently reads as a
+    // confident "external guest" to every caller — transiently refusing a
+    // member whose record is merely unreachable. Callers decide what a failed
+    // lookup means (skip, retry, fall back to last-known); the classification
+    // itself must not launder the failure into an identity claim (#626).
+    const { actor, ok } = await classifyUserCached(client, userId);
+    return { ...actor, ok };
   }
 
   async function getChannelInfo(client: any, channel: string): Promise<ChannelMeta | undefined> {
@@ -658,6 +678,7 @@ export function createDirectory(deps: {
     forceDirectorySync,
     classifyUserCached,
     classifyActor,
+    lastKnownClassification,
     getChannelInfo,
     channelMembership,
     allInternalRosters,

--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -13,6 +13,13 @@ export interface ActorAssertion {
    * instead of masquerading as "external guest" (#626).
    */
   principalUnresolved?: true;
+  /**
+   * The users.info lookup itself failed — the classification below is a
+   * placeholder, not an identity claim. Distinct from every checked state
+   * (guest, internal, principal-unresolved) so callers can retry or fall
+   * back to last-known rather than acting on "external" (#626).
+   */
+  lookupFailed?: true;
 }
 
 export interface SlackUser {

--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -5,6 +5,14 @@ export interface ActorAssertion {
   isExternalGuest?: boolean;
   isBot?: boolean;
   displayName?: string;
+  /**
+   * Own-team member whose principal could not be resolved in email identity
+   * mode (email not currently visible in the directory). Refused like a
+   * guest — fail closed, never a fallback Slack-ID principal — but as its
+   * OWN state, so logs and the user-facing refusal say "unresolved member"
+   * instead of masquerading as "external guest" (#626).
+   */
+  principalUnresolved?: true;
 }
 
 export interface SlackUser {
@@ -53,14 +61,22 @@ export function classifyUser(
   );
   const displayName = user.profile?.display_name || user.real_name || user.name || user.id || "";
   let externalId = String(user.id ?? "");
+  // Email mode keys members on their email — including guests, whose
+  // principal still resolves for refusal copy and audit. An email-LESS
+  // member with no Slack-side external evidence is own-team but
+  // principal-unresolved: kept distinct from an external guest (which the
+  // native flags above decide) so refusal copy and logs name what actually
+  // happened instead of masquerading as external (#626).
+  let principalUnresolved = false;
   if (identity === "email" && !user.is_bot) {
     const email = (user.profile?.email ?? "").trim().toLowerCase();
     if (email.includes("@")) externalId = email;
-    else isGuest = true;
+    else if (!isGuest) principalUnresolved = true;
   }
   return {
     externalId,
     isExternalGuest: isGuest,
+    ...(principalUnresolved ? { principalUnresolved: true as const } : {}),
     ...(user.is_bot ? { isBot: true } : {}),
     ...(displayName ? { displayName } : {}),
   };

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -199,6 +199,27 @@ export function createTurnHandler(deps: {
         ...(inc.prefetched.timezone ? { timezone: inc.prefetched.timezone } : {}),
       };
     else classified = await classifyUserCached(client, inc.userId);
+    // A failed users.info must not read as a confident external-guest
+    // refusal: log it so the transient failure is visible, and fall back to
+    // the LAST-KNOWN classification when one exists (the incident in #626
+    // showed a single failed lookup refusing an owner outright). With no
+    // prior state, fail closed but as "unverifiable", the third-state
+    // refusal path — never a laundered "external".
+    if ("ok" in classified && !classified.ok) {
+      const cachedAgain = await directory.lastKnownClassification?.(inc.userId);
+      if (cachedAgain) {
+        console.warn(
+          `[slack-plugin] users.info failed for ${inc.userId}; using last-known classification`,
+        );
+        classified = { actor: cachedAgain };
+      } else {
+        console.warn(
+          `[slack-plugin] users.info failed for ${inc.userId} with no prior classification; ` +
+            `refusing as unverifiable ch=${inc.channel} ts=${inc.ts}`,
+        );
+        classified = { actor: { ...classified.actor, principalUnresolved: true as const } };
+      }
+    }
     const actor = classified.actor;
     const timezone = classified.timezone;
     const text = stripMention(inc.rawText, ids.botUserId);

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -296,7 +296,33 @@ export function createTurnHandler(deps: {
             ...(ids.botHandle ? { botHandle: ids.botHandle } : {}),
           };
 
+    // A principal-unresolved own-team member (email mode, email not yet
+    // visible) is refused as its OWN state — fail closed like a guest, but
+    // named for what it is, both to the sender and in the log, so the
+    // incident signature is decidable (#626: the refusal used to be
+    // indistinguishable from external-guest in logs, and its success path
+    // logged nothing at all).
+    const unresolvedMember = audience.find((a) => a.principalUnresolved);
+    if (unresolvedMember) {
+      console.warn(
+        `[slack-plugin] refusing turn: own-team member principal unresolved ` +
+          `(email identity mode; email not visible in the directory) ` +
+          `user=${unresolvedMember.externalId || "?"} ch=${inc.channel} ts=${inc.ts}`,
+      );
+      if (!inc.unprompted) {
+        await ephemeralOrSay(
+          "I can't respond here yet — I couldn't verify your team membership " +
+            "(your email isn't visible to me). This usually resolves within a " +
+            "few minutes of the directory refreshing; try again shortly.",
+        );
+      }
+      return;
+    }
+
     if (audience.some((a) => a.isExternalGuest) && !(await externalParticipantsEnabled())) {
+      console.warn(
+        `[slack-plugin] refusing turn: external guest ch=${inc.channel} ts=${inc.ts}`,
+      );
       if (!inc.unprompted) {
         await ephemeralOrSay(
           "I can't respond here — this conversation isn't fully internal. Try a DM or a fully-internal channel.",

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -102,6 +102,51 @@ test("classifyUser email mode still flags restricted/other-workspace members as 
   assert.equal(g.isExternalGuest, true);
 });
 
+test("a failed users.info asserts lookupFailed, not external guest (#626)", async () => {
+  // The directory's classifyUserCached currently launders a transient
+  // users.info failure into a confident "external guest" — the incident
+  // refused an owner outright on one failed lookup. The failure state must
+  // be distinguishable from every checked state.
+  const { createDirectory } = await import("../src/slack/directory.ts");
+  const failingClient = {
+    users: {
+      info: async () => { throw new Error("transient"); },
+      list: async () => ({ members: [] }),
+    },
+    conversations: { list: async () => ({ channels: [] }) },
+    auth: { test: async () => ({ ok: true, user_id: "UBOT", team_id: "T1" }) },
+  };
+  const dir = createDirectory({
+    core: failingClient as never,
+    ids: { botUserId: "UBOT", ownTeamId: "T1", identityMode: "slack-id" } as never,
+  });
+  const result = await dir.classifyUserCached(failingClient, "U1");
+  assert.equal(result.ok, false);
+  assert.equal(result.actor.lookupFailed, true, "the failure is named, not guest-folded");
+  assert.equal(result.actor.isExternalGuest, undefined);
+});
+
+test("classifyActor preserves ok instead of discarding it (#626)", async () => {
+  // Shape check without a live client: the interface change is the contract
+  // (ok rides on the assertion); the directory unit above covers behavior.
+  const { createDirectory } = await import("../src/slack/directory.ts");
+  const okClient = {
+    users: {
+      info: async () => ({ user: { id: "U1", team_id: "T1" } }),
+      list: async () => ({ members: [] }),
+    },
+    conversations: { list: async () => ({ channels: [] }) },
+    auth: { test: async () => ({ ok: true, user_id: "UBOT", team_id: "T1" }) },
+  };
+  const dir = createDirectory({
+    core: okClient as never,
+    ids: { botUserId: "UBOT", ownTeamId: "T1", identityMode: "slack-id" } as never,
+  });
+  const actor = await dir.classifyActor(okClient, "U1");
+  assert.equal(actor.ok, true, "ok rides on the returned assertion");
+  assert.equal(actor.isExternalGuest, false);
+});
+
 test("slackUserTimezone extracts only valid Slack user timezones", () => {
   assert.equal(slackUserTimezone({ id: "U1", tz: "America/Los_Angeles" }), "America/Los_Angeles");
   assert.equal(slackUserTimezone({ id: "U1", profile: { tz: "Europe/London" } }), "Europe/London");

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -63,7 +63,26 @@ test("classifyUser email mode keys members on their normalized work email", () =
 test("classifyUser email mode fails closed to guest when a member has no visible email", () => {
   const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "email");
   assert.equal(a.externalId, "U1");
-  assert.equal(a.isExternalGuest, true);
+  // Own-team member, principal unresolved: its OWN state, not external
+  // guest (#626). The refusal is equally closed, but logs and copy say
+  // what actually happened.
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, true);
+});
+
+test("classifyUser email mode: native external evidence still wins over unresolved", () => {
+  // A restricted member with no visible email is an EXTERNAL GUEST, not an
+  // unresolved own-team member — the third state never masks the flags
+  // (#626).
+  const g = classifyUser({ id: "U2", team_id: TEAM, is_restricted: true }, TEAM, "email");
+  assert.equal(g.isExternalGuest, true);
+  assert.equal(g.principalUnresolved, undefined);
+});
+
+test("classifyUser slack-id mode never marks principalUnresolved", () => {
+  const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "slack-id");
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, undefined);
 });
 
 test("classifyUser email mode keeps bots on their Slack id and non-guest", () => {


### PR DESCRIPTION
Fixes the `ok:false`-propagation half of #626 (defect 1b). **Stacked on #628** (the third-state commit — `principalUnresolved` and the refusal gates come from there); merge that first.

## The laundering

A transient `users.info` failure returned `{ actor: { isExternalGuest: true }, ok: false }` — the flag existed, but both consumers discarded it:

- `classifyActor` returned only `.actor`, so the assertion arrived as a confident "external guest" with no trace of the failure;
- the direct-intake path (`turn-handler`) read `classifyUserCached(...)` and ignored `.ok` identically.

A single failed lookup therefore refused a member outright — in the incident, an org owner, with no signal that the classification was a placeholder rather than a verdict.

## The fix

- **The failure arm stops asserting guest**: `classifyUserCached`'s catch returns a `lookupFailed` actor (id-based placeholder, named for what it is). Distinguishable from every checked state — guest, internal, and (from #628) principal-unresolved.
- **`classifyActor` returns `ActorAssertion & { ok }`** — the flag rides along; consumers decide what a failed lookup means. The roster path already consumed `ok` (`resolveChannelMembership` sets `complete=false`); the two discard sites no longer can.
- **The direct-intake path acts on it**: fall back to `lastKnownClassification(userId)` — the LRU entry, which failures never populate, so the fallback is always a *prior success*, time-bounded by the cache TTL — logging the fallback; with no prior state, refuse as `principalUnresolved` (the third-state gate: fail closed, visibly, never a laundered "external").

## Tests

- `a failed users.info asserts lookupFailed, not external guest` — drives a failing client through `createDirectory`: `ok:false`, `lookupFailed:true`, `isExternalGuest` unset. **Fails on the base** (guest).
- `classifyActor preserves ok instead of discarding it` — the interface contract with a working client: `ok:true` rides on the returned assertion. **Fails on the base** (no `ok` on the return).

`slack-identity` 29/29 on this stack; the four identity suites 80/80 both with and without the patch's base state. `tsc --noEmit` clean.

## Remaining from #626

Defect 3 (event-driven refresh: `user_change`/`team_join` subscriptions + cache eviction) — needs the manifest change and the app-reinstall note the issue describes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789826625&installation_model_id=19911&pr_number=629&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F629&signature=4fc5aa1d6c1cf232f6672fdd882748131efcf37c4ab3b7750902037cd2f46e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->