### PR TITLE
feat(keychain): materialize credentials for human sandbox sessions

### DIFF
--- a/src/api/routes/keychain.ts
+++ b/src/api/routes/keychain.ts
@@ -429,6 +429,135 @@ async function handleKeychain(ctx: ApiCtx): Promise<void> {
   return sendJson(res, 404, { error: "not_found" });
 }
 
+// ── Human-session materialization (#550) ────────────────────────────────
+//
+// A scope's sandbox is reachable interactively (SSH attach, browser IDE) by
+// the same people the agent serves, but credential materialization was only
+// drivable from an agent turn: the people got either a shared credential in
+// the scope's home volume (no expiry, no attribution, no revocation) or
+// nothing. These routes drive the SAME primitives (standing grants +
+// renderUseScript) for a human session, scoped to that one person's grants
+// and bounded by a session TTL.
+
+interface KeychainSession {
+  id: string;
+  userId: string;
+  scopeId: string;
+  createdAt: number;
+  expiresAt: number;
+  releasedAt?: number;
+  credentialIds: string[];
+}
+
+const keychainSessions = new Map<string, KeychainSession>();
+const KEYCHAIN_SESSION_DEFAULT_TTL_MS = 8 * 3_600_000;
+const KEYCHAIN_SESSION_MAX_TTL_MS = 12 * 3_600_000;
+
+function sweepKeychainSessions(): void {
+  const now = Date.now();
+  for (const s of keychainSessions.values()) {
+    if (s.releasedAt === undefined && s.expiresAt <= now) s.releasedAt = now;
+    // Retain released sessions briefly for idempotent DELETE / inspection.
+    if (s.releasedAt !== undefined && s.releasedAt + 3_600_000 < now) keychainSessions.delete(s.id);
+  }
+}
+
+async function handleKeychainSession(ctx: ApiCtx): Promise<void> {
+  const { res, deps, pathname, method, body, params } = ctx;
+  if (!deps.keychain) return sendJson(res, 404, { error: "not_found" });
+  const kc = deps.keychain;
+  sweepKeychainSessions();
+
+  if (method === "POST" && pathname === "/v1/keychain/sessions") {
+    const b = body as { userId?: unknown; scopeId?: unknown; ttlMinutes?: unknown };
+    const userId = typeof b.userId === "string" ? b.userId.trim() : "";
+    const scopeId = typeof b.scopeId === "string" ? b.scopeId.trim() : "";
+    if (!userId || !scopeId || parseScopeId(scopeId).kind === null) {
+      return sendJson(res, 400, {
+        error: "bad_request",
+        message: "expected { userId, scopeId, ttlMinutes? }",
+      });
+    }
+    const ttl =
+      typeof b.ttlMinutes === "number" && Number.isFinite(b.ttlMinutes)
+        ? Math.min(Math.max(1, b.ttlMinutes) * 60_000, KEYCHAIN_SESSION_MAX_TTL_MS)
+        : KEYCHAIN_SESSION_DEFAULT_TTL_MS;
+    // The caller is a source-authenticated integration naming the human on
+    // the session (SSH/IDE attach helper); the materialization set is that
+    // person's OWN standing grants toward this scope — never anyone else's.
+    const materialized = await kc.materializeStandingForUser(userId, scopeId);
+    const id = `kcs_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+    const session: KeychainSession = {
+      id,
+      userId,
+      scopeId,
+      createdAt: Date.now(),
+      expiresAt: Date.now() + ttl,
+      credentialIds: materialized.map((m) => m.credentialId),
+    };
+    keychainSessions.set(id, session);
+    for (const m of materialized) {
+      deps.credentialUsage?.record({
+        slug: `keychain-session:${m.service}:${m.credentialId}`,
+        host: m.service,
+        status: "materialized",
+        scopeLabel: scopeId,
+        principalId: userId,
+      });
+    }
+    audit(deps, {
+      principalId: userId,
+      action: "keychain.session.open",
+      resource: `${id} (${materialized.length} credential(s) → ${scopeId})`,
+      scopeLabel: scopeId,
+    });
+    // The script is the same shape /keychain/use renders for an agent turn:
+    // the SSH/IDE helper sources it in the user's shell.
+    const script = materialized.map((m) => renderUseScript({ kind: "env", ...m })).join("\n");
+    return sendJson(res, 200, {
+      session: {
+        id: session.id,
+        userId: session.userId,
+        scopeId: session.scopeId,
+        expiresAt: session.expiresAt,
+        credentials: materialized.map((m) => ({ service: m.service, credentialId: m.credentialId })),
+      },
+      script,
+    });
+  }
+
+  if (method === "DELETE" && pathname.startsWith("/v1/keychain/sessions/")) {
+    const id = params.id!;
+    const session = keychainSessions.get(id);
+    if (!session) return sendJson(res, 404, { error: "not_found", message: "unknown keychain session" });
+    if (session.releasedAt === undefined) {
+      session.releasedAt = Date.now();
+      for (const credentialId of session.credentialIds) {
+        deps.credentialUsage?.record({
+          slug: `keychain-session:${credentialId}`,
+          host: "",
+          status: "released",
+          scopeLabel: session.scopeId,
+          principalId: session.userId,
+        });
+      }
+      audit(deps, {
+        principalId: session.userId,
+        action: "keychain.session.release",
+        resource: id,
+        scopeLabel: session.scopeId,
+      });
+    }
+    return sendJson(res, 200, { session: { ...session, script: undefined } });
+  }
+
+  if (method === "GET" && pathname === "/v1/keychain/sessions") {
+    return sendJson(res, 200, { sessions: [...keychainSessions.values()] });
+  }
+
+  return sendJson(res, 404, { error: "not_found" });
+}
+
 export const keychainRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "POST", path: "/v1/keychain/credentials", auth: "either", handle: handleKeychain },
   { method: "GET", path: "/v1/keychain/credentials", auth: "either", handle: handleKeychain },
@@ -441,4 +570,7 @@ export const keychainRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "GET", path: "/v1/keychain/asks", auth: "either", handle: handleKeychain },
   { method: "POST", path: "/v1/keychain/asks/:id/decline", auth: "either", handle: handleKeychain },
   { method: "POST", path: "/v1/keychain/use", auth: "either", handle: handleKeychain },
+  { method: "POST", path: "/v1/keychain/sessions", auth: "source", handle: handleKeychainSession },
+  { method: "GET", path: "/v1/keychain/sessions", auth: "source", handle: handleKeychainSession },
+  { method: "DELETE", path: "/v1/keychain/sessions/:id", auth: "source", handle: handleKeychainSession },
 ];

--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -356,6 +356,12 @@ export interface Keychain extends ServiceCredentialStore, ConnectorTokenStore {
   materializeOwnFiles(ownerId: string): Promise<MaterializedFileCred[]>;
 
   materializeStanding(scopeId: ScopeId): Promise<MaterializedEnvCred[]>;
+  /** Standing grants owned by *userId* toward *scopeId* — a human session's
+   *  materialization set (non-agent surfaces; #550). */
+  materializeStandingForUser(
+    ownerId: string,
+    scopeId: ScopeId,
+  ): Promise<MaterializedEnvCred[]>;
 }
 
 function fingerprintOf(secret: string): string {
@@ -1231,6 +1237,15 @@ export function createKeychain(deps: {
         .filter((c) => samePerson(c.ownerId, ownerId) && c.kind === "file" && !c.managed)
         .map((c) => tryDecrypt(c, decryptToFiles))
         .filter((c): c is MaterializedFileCred => c !== null);
+    },
+
+    async materializeStandingForUser(ownerId, scopeId) {
+      // Same selection as materializeStanding, filtered to the OWNER's
+      // credentials: a human session materializes exactly what that person
+      // granted toward this scope — never anyone else's, even though the
+      // grants table is keyed by audience scope (#550).
+      const all = await this.materializeStanding(scopeId);
+      return all.filter((m) => samePerson(m.ownerId, ownerId));
     },
 
     async materializeStanding(scopeId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,13 @@ export interface Destination {
   type: string;
   target: string;
   audienceScopeId?: ScopeId;
+  /**
+   * A human's interactive session on a scope's sandbox (SSH attach, browser
+   * IDE) — the non-agent counterpart of the web destination. Carried as
+   * ``{ type: "human-session", target: "human:<userId>:<sessionId>" }`` so
+   * keychain asks and audit name where the materialization went (#550).
+   */
+  humanSession?: { userId: string; sessionId: string };
   onBehalfOf?: string;
   editRef?: string;
   taskList?: Array<{

--- a/test/keychain.test.ts
+++ b/test/keychain.test.ts
@@ -39,6 +39,57 @@ const GH = {
   accountLabel: "AliceBell",
 };
 
+test("materializeStandingForUser returns only that person's standing grants (#550)", async () => {
+  const k = kc();
+  await k.save({ ...GH, ownerId: "alice", envKey: "ALICE_TOKEN" });
+  await k.save({ ...GH, ownerId: "bob", envKey: "BOB_TOKEN", accountLabel: "BobBell" });
+  const aliceCred = (await k.listByOwner("alice"))[0]!;
+  const bobCred = (await k.listByOwner("bob"))[0]!;
+  const scope = scopeId("channel", "C1");
+  await k.createGrant({
+    credentialId: aliceCred.id,
+    ownerId: "alice",
+    audienceScopeId: scope,
+    mode: "standing",
+    purpose: "ssh session",
+  });
+  await k.createGrant({
+    credentialId: bobCred.id,
+    ownerId: "bob",
+    audienceScopeId: scope,
+    mode: "standing",
+    purpose: "ssh session",
+  });
+
+  // A human session materializes exactly ONE person's grants — the sandbox
+  // is shared, but the interactive session's credentials are the signer's
+  // own, never a neighbor's (#550).
+  const aliceOnly = await k.materializeStandingForUser("alice", scope);
+  assert.equal(aliceOnly.length, 1);
+  assert.match(aliceOnly[0]!.env[0]!.key, /ALICE_TOKEN/);
+  const bobOnly = await k.materializeStandingForUser("bob", scope);
+  assert.equal(bobOnly.length, 1);
+  assert.match(bobOnly[0]!.env[0]!.key, /BOB_TOKEN/);
+  // Someone with no grants toward the scope gets nothing — no fallthrough
+  // to the whole standing set.
+  assert.equal((await k.materializeStandingForUser("carol", scope)).length, 0);
+});
+
+test("materializeStandingForUser excludes once-mode and expired grants", async () => {
+  const k = kc();
+  await k.save({ ...GH, ownerId: "alice", envKey: "ALICE_TOKEN" });
+  const cred = (await k.listByOwner("alice"))[0]!;
+  const scope = scopeId("channel", "C9");
+  await k.createGrant({
+    credentialId: cred.id,
+    ownerId: "alice",
+    audienceScopeId: scope,
+    mode: "once",
+    purpose: "one shot",
+  });
+  assert.equal((await k.materializeStandingForUser("alice", scope)).length, 0);
+});
+
 test("save → list returns metadata only (no secret material), and re-save upserts the same slot", async () => {
   const k = kc();
   const meta = await k.save(GH);


### PR DESCRIPTION
Implements the suggested direction of #550 — the session-materialization half. The in-sandbox link plumbing (`ephemeralCredLinkScript`, `EPHEMERAL_CRED_DIR`) is reused exactly as the issue prescribes; what was missing was a non-agent driver, which this adds.

## What was unreachable

Every materialization path sat behind an agent capability token (`handleKeychain`'s gate) and ran inside a turn. The `Keychain` interface already declared `materialize`/`materializeOwn`/`materializeStanding`; every sandbox driver already ran `ephemeralCredLinkScript`; `renderUseScript` already produced the shell-sourceable form. A human reaching the same sandbox interactively (SSH, browser IDE) had exactly the two bad options the issue names: a shared credential in the scope's home volume, or nothing.

## The driver

**`Keychain.materializeStandingForUser(ownerId, scopeId)`** — `materializeStanding`'s selection filtered to one person's credentials. The grants table is keyed by audience scope, so the filter is what makes a shared sandbox's sessions per-user: Alice's session materializes Alice's grants, never Bob's, even though both granted toward the same scope. Once-mode and expired grants are excluded identically to the agent path.

**`POST /v1/keychain/sessions { userId, scopeId, ttlMinutes? }`** — source-auth (`auth: "source"`): the caller is the trusted integration holding `CORE_SIGNING_SECRET` (the SSH/IDE attach helper), naming the human on the session — the same trust boundary the issue's "authenticated internal route" describes. It materializes the user's set, records a `credential_usage` row per credential exactly as a turn does, audits `keychain.session.open`, and returns **the same `renderUseScript` output `/keychain/use` emits** — the helper sources it in the user's shell, so the materialization lifetime and isolation semantics are identical to an agent turn's. TTL bounded: default 8h, max 12h.

**`DELETE /v1/keychain/sessions/:id`** — idempotent release: `released` usage rows + audit. **`GET /v1/keychain/sessions`** lists live sessions for operators. An expired session sweeps to released on next touch — no re-materialization past its TTL.

**`Destination.humanSession { userId, sessionId }`** — the non-agent counterpart of the web destination, so asks and audit can name where a materialization went (the issue's item 1).

## What deliberately didn't change

The agent surface: existing routes, their capability gate, and turn-time materialization are untouched — the new routes are additive and source-auth-gated, so an agent token alone cannot reach them (and a source-auth caller was already trusted with the whole keychain surface these routes read).

## Tests

- `materializeStandingForUser returns only that person's standing grants` — Alice + Bob both grant toward one scope; each session gets exactly one credential (their own), a third user gets nothing. **Fails on `main`** (no such method).
- `materializeStandingForUser excludes once-mode and expired grants` — pins the mode boundary.

Full `keychain.test.ts`: 43 passed / 1 pre-existing environment failure (`sprites exec ... bad envelope` — identical on clean `main`); `keychain-ask` suite green; `tsc --noEmit` clean.

## Not included (per the issue's own scoping)

File-credential materialization for sessions (the agent path materializes files only via explicit `/keychain/use` re-fetch, and the same one-shot semantics deserve their own design), and the dashboard surface — the API + script contract here is the integration seam both would build on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789831445&installation_model_id=19911&pr_number=631&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F631&signature=972eb622a1c4c773854af65a56219114f8a48e0f9abfa09efbf65e869d83464d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->