### PR TITLE
fix(slack): recognize bot-id-form mentions (<@B…>) everywhere

### DIFF
--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -161,7 +161,7 @@ export function registerSlackEvents(
     if (m.channel_type === "channel" || m.channel_type === "group" || m.channel_type === "mpim") {
       if (m.channel_type === "mpim" && m.channel) syncForUnseenGroup(client, String(m.channel));
       const threadReply = isThreadReply(m);
-      const isMention = mentionsBot(m.text ?? "", ids.botUserId);
+      const isMention = mentionsBot(m.text ?? "", ids.botUserId, ids.ownBotId);
       const willDispatch = threadReply && !isMention && (await botHasStakeInThread(client, m.channel, m.thread_ts));
       await mirrorMessageEvent(m, client, willDispatch ? { handled: true } : {});
       if (!threadReply) return;

--- a/src/slack/message-gating.ts
+++ b/src/slack/message-gating.ts
@@ -1,7 +1,15 @@
 import { LRUCache } from "lru-cache";
 
-export function mentionsBot(text: string, botUserId: string): boolean {
-  return botUserId ? text.includes(`<@${botUserId}>`) : false;
+export function mentionsBot(text: string, botUserId: string, ownBotId = ""): boolean {
+  // Both id forms mention the bot: the bot USER id (`<@U…>`, the form
+  // Slack's autocomplete inserts) and the BOT id (`<@B…>`, which
+  // hand-typed mentions and some clients encode). A B-form mention is a
+  // legitimate mention of this bot — `bots.info` maps it to the same
+  // single-bot app — but Slack fires no `app_mention` for it, so without
+  // recognizing it here the message is dropped at top level and
+  // misdispatched as ambient in threads (#630).
+  if (botUserId && text.includes(`<@${botUserId}>`)) return true;
+  return Boolean(ownBotId) && text.includes(`<@${ownBotId}>`);
 }
 
 export function threadHasBotStake(
@@ -17,7 +25,7 @@ export function threadHasBotStake(
     return Boolean(
       (botUserId && user === botUserId) ||
       (ownBotId && bot === ownBotId) ||
-      (botUserId && mentionsBot(text, botUserId)),
+      mentionsBot(text, botUserId, ownBotId),
     );
   });
 }

--- a/src/slack/mirror.ts
+++ b/src/slack/mirror.ts
@@ -116,7 +116,7 @@ export function createMirror(deps: {
         text,
         ...(Object.keys(mentions).length ? { mentions } : {}),
         ...(m.bot_id || m.bot_profile ? { bot: true } : {}),
-        ...(mentionsBot(raw, ids.botUserId) ? { mentionsSelf: true } : {}),
+        ...(mentionsBot(raw, ids.botUserId, ids.ownBotId) ? { mentionsSelf: true } : {}),
         ...(opts.editedAt ? { editedAt: opts.editedAt } : {}),
         ...(opts.handled ? { handled: true } : {}),
         ...(opts.containerName ? { containerName: opts.containerName } : {}),

--- a/src/slack/mrkdwn.ts
+++ b/src/slack/mrkdwn.ts
@@ -10,8 +10,15 @@ export function resolveMentionsInText(text: string, lookup: (id: string) => stri
   });
 }
 
-export function stripMention(text: string, botUserId: string): string {
-  const withoutMention = botUserId ? text.replace(new RegExp(`<@${botUserId}>`, "g"), "") : text;
+export function stripMention(text: string, botUserId: string, ownBotId = ""): string {
+  // Strip BOTH mention forms (bot user id and bot id — see
+  // mentionsBot) including the legacy `<@ID|label>` shape, so the core
+  // never receives a raw `<@B…>` token for an addressed turn (#630).
+  let withoutMention = text;
+  for (const id of [botUserId, ownBotId]) {
+    if (!id) continue;
+    withoutMention = withoutMention.replace(new RegExp(`<@${id}(?:\|[^>]*)?>`, "g"), "");
+  }
   return decodeSlackEntities(withoutMention).trim();
 }
 

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -201,7 +201,7 @@ export function createTurnHandler(deps: {
     else classified = await classifyUserCached(client, inc.userId);
     const actor = classified.actor;
     const timezone = classified.timezone;
-    const text = stripMention(inc.rawText, ids.botUserId);
+    const text = stripMention(inc.rawText, ids.botUserId, ids.ownBotId);
     if (!hasContent(text, inc.files)) return;
 
     let audience: ActorAssertion[] = [actor];

--- a/test/slack-message-gating.test.ts
+++ b/test/slack-message-gating.test.ts
@@ -90,6 +90,19 @@ test("dmThreadRef gives the DM main pane one continuous lane and each thread its
   assert.notEqual(dmThreadRef("D1", "1699999999.000100"), dmThreadRef("D1"));
 });
 
+test("mentionsBot recognizes the bot-id form (<@B…>) alongside the user-id form (#630)", () => {
+  // A hand-typed mention can arrive encoded against the bot id; Slack fires
+  // no app_mention for it, so message-gating recognition is the only thing
+  // that can dispatch it.
+  assert.equal(mentionsBot("hey <@BOTID> do this", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("<@UBOT> classic form", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("both <@UBOT> <@BOTID>", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("<@OTHERBOT> not me", "UBOT", "BOTID"), false);
+  assert.equal(mentionsBot("no ids configured", "", ""), false);
+  // Back-compat: the two-arg form still works.
+  assert.equal(mentionsBot("hey <@BOT> do this", "BOT"), true);
+});
+
 test("mentionsBot detects the bot @mention so thread-follow leaves those to app_mention", () => {
   assert.equal(mentionsBot("hey <@BOT> do this", "BOT"), true);
   assert.equal(mentionsBot("just a follow-up", "BOT"), false);

--- a/test/slack-mrkdwn.test.ts
+++ b/test/slack-mrkdwn.test.ts
@@ -24,6 +24,15 @@ test("decodeSlackEntities / stripMention", () => {
   assert.equal(stripMention("<@BOT>", "BOT"), "");
 });
 
+test("stripMention strips the bot-id form and the legacy label shape (#630)", () => {
+  // The core must not receive a raw <@B…> token for an addressed turn.
+  assert.equal(stripMention("<@BOTID> run the tests", "UBOT", "BOTID"), "run the tests");
+  assert.equal(stripMention("<@BOTID|qm> run the tests", "UBOT", "BOTID"), "run the tests");
+  assert.equal(stripMention("<@UBOT> classic", "UBOT", "BOTID"), "classic");
+  assert.equal(stripMention("<@UBOT|qm> legacy label", "UBOT", "BOTID"), "legacy label");
+  assert.equal(stripMention("unrelated <@OTHER> stays", "UBOT", "BOTID"), "unrelated <@OTHER> stays");
+});
+
 test("toSlackMrkdwn: bold uses single * (the screenshot bug: **x** rendered literally)", () => {
   assert.equal(toSlackMrkdwn("**Git commands**"), "*Git commands*");
   assert.equal(toSlackMrkdwn("__also bold__"), "*also bold*");


### PR DESCRIPTION
Fixes the recognition half of #630 — both silent drop and thread misdispatch. The message-handler dispatch of the B-form top-level mention (the exact class `app_mention` won't fire for) is the issue's step 2 and is left as a follow-up; this fix is its prerequisite and already stops the ambient misdispatch.

## What was missed

A hand-typed `@qm` can arrive encoded against the **bot id** (`<@BOTID>`) rather than the bot **user id** (`<@UBOT>`) — your controlled verification shows exactly this client behavior. Both forms are legitimate mentions of the same single-bot app (`bots.info` maps one to the other), but:

- Slack fires **no `app_mention`** for the B-form (your debug-log table), and
- `mentionsBot` recognized only the U-form,

so a top-level B-form mention fell through every gate (mirrored `handled=f`, no dispatch), and a B-form **thread reply** skipped the addressed-turn early return at `events.ts` — dispatching as an *unprompted ambient* turn with the raw `<@B…>` token still in the text.

## The fix — recognition at every site the U-form was read

- **`mentionsBot(text, botUserId, ownBotId)`** — both forms; the two-arg call shape is unchanged for every existing caller (your `threadHasBotStake` free-ride note holds: it forwards both ids now).
- **`stripMention(text, botUserId, ownBotId)`** — strips both forms *including the legacy `<@ID|label>` shape* (your regex note), so the core never receives the raw token on an addressed turn. Wired through `turn-handler`'s call site.
- **`events.ts`'s thread-reply gate and `mirror.ts`'s `mentionsSelf`** — both pass the bot id through; it was already in scope at both sites (`ids.ownBotId`).

Per your resolution warning, the bot id is **not** fed to `users.info` — no B→U translation exists there and the lookup would fail; display naming continues through the existing identity paths.

## Tests

- `mentionsBot recognizes the bot-id form (<@B…>) alongside the user-id form` — B-form, U-form, both, another bot, no ids configured, plus the two-arg back-compat shape. **Fails on `main`** (B-form reads false).
- `stripMention strips the bot-id form and the legacy label shape` — `<@BOTID>`, `<@BOTID|qm>`, `<@UBOT>`, `<@UBOT|qm>`, and an unrelated id left untouched. **Fails on `main`** (raw token survives).

Full `slack-message-gating` + `slack-mrkdwn`: 50/50 with the fix, 48/2 on `main` (exactly the two new tests); `slack-index.integration` + `slack-identity`: 67/67 unchanged; `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789834313&installation_model_id=19911&pr_number=632&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F632&signature=441fed8d96f0ac4e4dff59e688117719be9238736e35e12670a9caf6debc7413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->