### PR TITLE
Improve model picker for large catalogs

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -57,11 +57,29 @@ import { clearDraft, newChatDraftKey, saveDraft } from "./drafts";
 
 export type ComposerMenu = "effort" | "harness" | "model" | "settings";
 
+interface ComposerMenuOption {
+  value: string;
+  label: string;
+  groupLabel?: string;
+}
+
+function groupMenuOptions(options: ComposerMenuOption[]): Array<{ label: string; options: ComposerMenuOption[] }> {
+  const groups = new Map<string, ComposerMenuOption[]>();
+  for (const option of options) {
+    const label = option.groupLabel ?? "";
+    const group = groups.get(label) ?? [];
+    group.push(option);
+    groups.set(label, group);
+  }
+  return [...groups].map(([label, groupOptions]) => ({ label, options: groupOptions }));
+}
+
 const LEGACY_MODEL_STORAGE_KEY = "web-ui:model";
 const THREAD_PICKS_STORAGE_KEY = "web-ui:model-picks";
 const THREAD_PICKS_CAP = 50;
 const FAST_MODE_STORAGE_KEY = "web-ui:fast-mode";
 const EFFORT_STORAGE_KEY = "web-ui:effort";
+const MENU_SEARCH_THRESHOLD = 8;
 
 function loadThreadPicks(): Map<string, ModelOptionValue> {
   try {
@@ -224,6 +242,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     processingFiles: false,
     dragging: false,
     openMenu: null as ComposerMenu | null,
+    menuQuery: "",
     slashDismissed: false,
     effortLevel: loadStoredEffort(defaultEffortForModel(modelOptionFor(defaultModelValue()).model)),
     fastMode: loadStoredFastMode(),
@@ -563,12 +582,15 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                     ${menuControl({
                       kind: "model",
                       label: selectedModel.buttonLabel,
+                      suffix: `· ${effortLabel(composerState.effortLevel)}`,
                       title: "Model",
                       selected: selectedModel.value,
                       align: "right",
+                      searchable: true,
                       options: getModelOptionsForHarness(selectedModel.harnessId, scopeKey()).map((option) => ({
                         value: option.value,
                         label: option.label,
+                        groupLabel: option.groupLabel,
                       })),
                       disabled: inputBlocked,
                       onSelect: (value: string) => selectModel(value, agent),
@@ -903,9 +925,11 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     kind: ComposerMenu;
     glyph?: IconNode;
     label: string;
+    suffix?: string;
     title: string;
     selected: string;
-    options: Array<{ value: string; label: string }>;
+    options: ComposerMenuOption[];
+    searchable?: boolean;
     disabled?: boolean;
     align?: "left" | "right";
     onSelect: (value: string) => void;
@@ -915,6 +939,14 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     let controlClass = "";
     if (args.kind === "model") controlClass = "model-control";
     else if (args.kind === "harness") controlClass = "harness-control";
+    const searchable = args.searchable === true && args.options.length >= MENU_SEARCH_THRESHOLD;
+    const query = searchable ? composerState.menuQuery.trim().toLocaleLowerCase() : "";
+    const matches = query
+      ? args.options.filter((option) =>
+          `${option.label} ${option.groupLabel ?? ""}`.toLocaleLowerCase().includes(query),
+        )
+      : args.options;
+    const grouped = groupMenuOptions(matches);
     return html`
       <div class="menu-control ${controlClass}" data-align=${args.align ?? "left"}>
         <button
@@ -929,29 +961,54 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
         >
           ${args.glyph ? icon(args.glyph, 16) : nothing}
           <span class="menu-label">${args.label}</span>
-          ${icon(ChevronDown, 14)}
+          ${args.suffix ? html`<span class="menu-suffix">${args.suffix}</span>` : nothing} ${icon(ChevronDown, 14)}
         </button>
         ${
           open && !args.disabled
             ? html`
                 <div class="menu-popover" id=${menuId} role="menu" @click=${(e: Event) => e.stopPropagation()}>
                   <div class="menu-title">${args.title}</div>
-                  ${args.options.map(
-                    (option) => html`
-                      <button
-                        class="menu-option ${option.value === args.selected ? "active" : ""}"
-                        type="button"
-                        role="menuitemradio"
-                        aria-checked=${option.value === args.selected ? "true" : "false"}
-                        @click=${() => args.onSelect(option.value)}
-                      >
-                        <span class="menu-option-copy">
-                          <span class="menu-option-label">${option.label}</span>
-                        </span>
-                        ${option.value === args.selected ? icon(Check, 15) : nothing}
-                      </button>
-                    `,
-                  )}
+                  ${
+                    searchable
+                      ? html`<label class="menu-search">
+                          <span class="sr-only">Search models</span>
+                          <input
+                            type="search"
+                            placeholder="Search models…"
+                            .value=${live(composerState.menuQuery)}
+                            @input=${(e: InputEvent) => {
+                              composerState.menuQuery = (e.currentTarget as HTMLInputElement).value;
+                              ctx.chat.drawActiveChat();
+                            }}
+                          />
+                        </label>`
+                      : nothing
+                  }
+                  ${
+                    matches.length
+                      ? grouped.map(
+                          (group) => html`
+                            ${group.label ? html`<div class="menu-group-label">${group.label}</div>` : nothing}
+                            ${group.options.map(
+                              (option) => html`
+                                <button
+                                  class="menu-option ${option.value === args.selected ? "active" : ""}"
+                                  type="button"
+                                  role="menuitemradio"
+                                  aria-checked=${option.value === args.selected ? "true" : "false"}
+                                  @click=${() => args.onSelect(option.value)}
+                                >
+                                  <span class="menu-option-copy">
+                                    <span class="menu-option-label">${option.label}</span>
+                                  </span>
+                                  ${option.value === args.selected ? icon(Check, 15) : nothing}
+                                </button>
+                              `,
+                            )}
+                          `,
+                        )
+                      : html`<div class="menu-empty">No models found</div>`
+                  }
                 </div>
               `
             : nothing
@@ -962,8 +1019,15 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
 
   function toggleComposerMenu(e: Event, kind: ComposerMenu): void {
     e.stopPropagation();
-    composerState.openMenu = composerState.openMenu === kind ? null : kind;
+    const opening = composerState.openMenu !== kind;
+    composerState.openMenu = opening ? kind : null;
+    composerState.menuQuery = "";
     ctx.chat.drawActiveChat();
+    if (opening && kind === "model") {
+      requestAnimationFrame(() =>
+        ctx.chat.state.host?.querySelector<HTMLInputElement>(".model-control .menu-search input")?.focus(),
+      );
+    }
   }
 
   function matchSkills(query: string, skills: SkillItem[]): SkillMatch[] {

--- a/plugins/web-ui/src/model-options.ts
+++ b/plugins/web-ui/src/model-options.ts
@@ -9,6 +9,7 @@ export interface ModelOption {
   model: Model<Api>;
   label: string;
   buttonLabel: string;
+  groupLabel: string;
 }
 
 interface ModelMeta {
@@ -74,6 +75,32 @@ const HARNESS_LABELS: Record<string, string> = {
   mock: "Mock",
 };
 
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+  google: "Google",
+  "arcee-ai": "Arcee AI",
+  "meta-llama": "Meta",
+  mistralai: "Mistral AI",
+};
+
+function providerLabel(id: string, name: string, provider: string): string {
+  if (provider === "openrouter") {
+    const namedProvider = /^([^:]{2,40}):\s/.exec(name)?.[1]?.trim();
+    if (namedProvider) return namedProvider;
+  }
+  const key = provider === "openrouter" ? (id.split("/", 1)[0] ?? provider) : provider;
+  return (
+    PROVIDER_LABELS[key] ??
+    key
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((part) => part[0]!.toUpperCase() + part.slice(1))
+      .join(" ")
+  );
+}
+
 function buildOption(
   id: string,
   harnessId = "pi",
@@ -91,6 +118,7 @@ function buildOption(
       harnessLabel: HARNESS_LABELS[harnessId] ?? harnessId,
       model,
       ...meta,
+      groupLabel: providerLabel(id, meta.label, dynamic?.provider ?? String(model.provider ?? model.api ?? "other")),
     };
   } catch {
     return null;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2484,6 +2484,11 @@ a.chat-row-open {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.menu-suffix {
+  flex: none;
+  white-space: nowrap;
+  color: var(--muted-foreground);
+}
 .model-control .menu-button {
   max-width: min(280px, 46vw);
   color: var(--foreground);
@@ -2591,6 +2596,45 @@ a.chat-row-open {
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--muted-foreground);
+}
+.menu-search {
+  position: sticky;
+  top: -6px;
+  z-index: 1;
+  display: block;
+  padding: 4px 2px 6px;
+  background: var(--background);
+}
+.menu-search input {
+  width: 100%;
+  height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 13px;
+  outline: none;
+}
+.menu-search input:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 18%, transparent);
+}
+.menu-group-label {
+  padding: 9px 8px 3px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 650;
+}
+.menu-empty {
+  padding: 18px 8px;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  text-align: center;
+}
+.menu-control.model-control[data-align="right"] .menu-popover {
+  width: 320px;
 }
 .menu-option {
   width: 100%;

--- a/plugins/web-ui/test/composer-source.test.ts
+++ b/plugins/web-ui/test/composer-source.test.ts
@@ -79,3 +79,11 @@ test("scope runtime defaults include effort and fast mode", () => {
   assert.match(composer, /config\.effective\.effortLevel/);
   assert.match(composer, /config\.effective\.fastMode === true/);
 });
+
+test("long model menus stay searchable and show the selected effort", () => {
+  assert.match(composer, /const MENU_SEARCH_THRESHOLD = 8;/);
+  assert.match(composer, /searchable: true/);
+  assert.match(composer, /placeholder="Search models…"/);
+  assert.match(composer, /option\.groupLabel/);
+  assert.match(composer, /suffix: `· \$\{effortLabel\(composerState\.effortLevel\)}`/);
+});

--- a/plugins/web-ui/test/model-options.test.ts
+++ b/plugins/web-ui/test/model-options.test.ts
@@ -209,3 +209,22 @@ test("runtime options include custom-provider models from the catalog", () => {
   assert.equal(acme.label, "Acme Large");
   assert.equal(acme.model.provider, "acme-gateway");
 });
+
+test("runtime model options expose useful provider groups for long OpenRouter catalogs", () => {
+  const options = runtimeModelOptions(
+    ["pi"],
+    {
+      pi: ["openai/o3-pro", "anthropic/claude-opus-4.7", "google/gemini-2.5-pro-preview", "arcee-ai/virtuoso-large"],
+    },
+    {
+      "openai/o3-pro": { name: "OpenAI: o3 Pro", provider: "openrouter" },
+      "anthropic/claude-opus-4.7": { name: "Anthropic: Claude Opus 4.7", provider: "openrouter" },
+      "google/gemini-2.5-pro-preview": { name: "Google: Gemini 2.5 Pro Preview", provider: "openrouter" },
+      "arcee-ai/virtuoso-large": { name: "Arcee AI: Virtuoso Large", provider: "openrouter" },
+    },
+  );
+  assert.deepEqual(
+    options.map((option) => option.groupLabel),
+    ["OpenAI", "Anthropic", "Google", "Arcee AI"],
+  );
+});


### PR DESCRIPTION
$Makes large model catalogs searchable, groups options by provider, and keeps effort visible when names truncate.\n\n- verification: web UI tests (562 passed)\n- verification: typecheck, lint, formatting, production build\n- verification: responsive browser flow at 442×478

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789839485&installation_model_id=19911&pr_number=633&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F633&signature=fb7e670f3a89e271cfc2d495c316c49efd1be0024906802523c1b83d6f45903a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->