### PR TITLE
fix(slack): dispatch bot-id-only mentions from the message handler

### DIFF
--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -162,10 +162,23 @@ export function registerSlackEvents(
       if (m.channel_type === "mpim" && m.channel) syncForUnseenGroup(client, String(m.channel));
       const threadReply = isThreadReply(m);
       const isMention = mentionsBot(m.text ?? "", ids.botUserId, ids.ownBotId);
-      const willDispatch = threadReply && !isMention && (await botHasStakeInThread(client, m.channel, m.thread_ts));
+      // A bot-id-form mention (<@B…>) never triggers Slack's app_mention
+      // event — only the bot-user-id form does. Scoped to exactly that
+      // class (bot-id form present, user-id form absent), the message
+      // handler dispatches the ADDRESSED turn itself instead of dropping
+      // it at top level or mis-dispatching it as ambient in a thread
+      // (#630).
+      const text = m.text ?? "";
+      const botIdMentionOnly =
+        Boolean(ids.ownBotId) &&
+        text.includes(`<@${ids.ownBotId}>`) &&
+        !(ids.botUserId && text.includes(`<@${ids.botUserId}>`));
+      const willDispatch =
+        botIdMentionOnly ||
+        (threadReply && !isMention && (await botHasStakeInThread(client, m.channel, m.thread_ts)));
       await mirrorMessageEvent(m, client, willDispatch ? { handled: true } : {});
-      if (!threadReply) return;
-      if (isMention) return;
+      if (!threadReply && !botIdMentionOnly) return;
+      if (isMention && !botIdMentionOnly) return;
       if (!willDispatch) {
         console.error(
           `[slack-plugin] thread-follow skipped: no bot stake detected in thread ch=${m.channel} thread_ts=${m.thread_ts} ts=${m.ts}`,
@@ -191,7 +204,10 @@ export function registerSlackEvents(
           files: (m.files as SlackFile[]) ?? [],
           threadTs: m.thread_ts,
           ts: m.ts,
-          unprompted: true,
+          // A bot-id-only mention is ADDRESSED even in a thread — the
+          // sender typed @qm; the ambient flag belongs to the
+          // stake-followed path alone (#630).
+          ...(botIdMentionOnly ? {} : { unprompted: true }),
           ...(m.bot_id || m.subtype === "bot_message" ? { botAuthored: true } : {}),
           ackGate,
         },

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -161,7 +161,7 @@ export function registerSlackEvents(
     if (m.channel_type === "channel" || m.channel_type === "group" || m.channel_type === "mpim") {
       if (m.channel_type === "mpim" && m.channel) syncForUnseenGroup(client, String(m.channel));
       const threadReply = isThreadReply(m);
-      const isMention = mentionsBot(m.text ?? "", ids.botUserId);
+      const isMention = mentionsBot(m.text ?? "", ids.botUserId, ids.ownBotId);
       const willDispatch = threadReply && !isMention && (await botHasStakeInThread(client, m.channel, m.thread_ts));
       await mirrorMessageEvent(m, client, willDispatch ? { handled: true } : {});
       if (!threadReply) return;

--- a/src/slack/message-gating.ts
+++ b/src/slack/message-gating.ts
@@ -1,7 +1,15 @@
 import { LRUCache } from "lru-cache";
 
-export function mentionsBot(text: string, botUserId: string): boolean {
-  return botUserId ? text.includes(`<@${botUserId}>`) : false;
+export function mentionsBot(text: string, botUserId: string, ownBotId = ""): boolean {
+  // Both id forms mention the bot: the bot USER id (`<@U…>`, the form
+  // Slack's autocomplete inserts) and the BOT id (`<@B…>`, which
+  // hand-typed mentions and some clients encode). A B-form mention is a
+  // legitimate mention of this bot — `bots.info` maps it to the same
+  // single-bot app — but Slack fires no `app_mention` for it, so without
+  // recognizing it here the message is dropped at top level and
+  // misdispatched as ambient in threads (#630).
+  if (botUserId && text.includes(`<@${botUserId}>`)) return true;
+  return Boolean(ownBotId) && text.includes(`<@${ownBotId}>`);
 }
 
 export function threadHasBotStake(
@@ -17,7 +25,7 @@ export function threadHasBotStake(
     return Boolean(
       (botUserId && user === botUserId) ||
       (ownBotId && bot === ownBotId) ||
-      (botUserId && mentionsBot(text, botUserId)),
+      mentionsBot(text, botUserId, ownBotId),
     );
   });
 }

--- a/src/slack/mirror.ts
+++ b/src/slack/mirror.ts
@@ -116,7 +116,7 @@ export function createMirror(deps: {
         text,
         ...(Object.keys(mentions).length ? { mentions } : {}),
         ...(m.bot_id || m.bot_profile ? { bot: true } : {}),
-        ...(mentionsBot(raw, ids.botUserId) ? { mentionsSelf: true } : {}),
+        ...(mentionsBot(raw, ids.botUserId, ids.ownBotId) ? { mentionsSelf: true } : {}),
         ...(opts.editedAt ? { editedAt: opts.editedAt } : {}),
         ...(opts.handled ? { handled: true } : {}),
         ...(opts.containerName ? { containerName: opts.containerName } : {}),

--- a/src/slack/mrkdwn.ts
+++ b/src/slack/mrkdwn.ts
@@ -10,8 +10,15 @@ export function resolveMentionsInText(text: string, lookup: (id: string) => stri
   });
 }
 
-export function stripMention(text: string, botUserId: string): string {
-  const withoutMention = botUserId ? text.replace(new RegExp(`<@${botUserId}>`, "g"), "") : text;
+export function stripMention(text: string, botUserId: string, ownBotId = ""): string {
+  // Strip BOTH mention forms (bot user id and bot id — see
+  // mentionsBot) including the legacy `<@ID|label>` shape, so the core
+  // never receives a raw `<@B…>` token for an addressed turn (#630).
+  let withoutMention = text;
+  for (const id of [botUserId, ownBotId]) {
+    if (!id) continue;
+    withoutMention = withoutMention.replace(new RegExp(`<@${id}(?:\|[^>]*)?>`, "g"), "");
+  }
   return decodeSlackEntities(withoutMention).trim();
 }
 

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -201,7 +201,7 @@ export function createTurnHandler(deps: {
     else classified = await classifyUserCached(client, inc.userId);
     const actor = classified.actor;
     const timezone = classified.timezone;
-    const text = stripMention(inc.rawText, ids.botUserId);
+    const text = stripMention(inc.rawText, ids.botUserId, ids.ownBotId);
     if (!hasContent(text, inc.files)) return;
 
     let audience: ActorAssertion[] = [actor];

--- a/test/slack-index.integration.test.ts
+++ b/test/slack-index.integration.test.ts
@@ -989,6 +989,76 @@ test("an internal channel mention carries the complete audience and thread conte
   }
 });
 
+test("a bot-id-form top-level mention dispatches an addressed turn (#630)", async () => {
+  // Slack fires app_mention only for the bot-USER-id form; a hand-typed
+  // mention encoded as <@BBOT> previously fell through every gate (mirrored
+  // handled=f, no turn). The message handler now dispatches it itself.
+  const f = await fixture();
+  try {
+    await f.app.emitMessage({
+      channel: "C1",
+      channel_type: "channel",
+      user: "U1",
+      text: "<@BBOT> deploy status?",
+      ts: "106.1",
+    });
+    assert.equal(f.core.turns.length, 1, "the bot-id mention must become a turn");
+    assert.equal(f.core.turns[0].text, "deploy status?");
+    // ADDRESSED, not ambient — no unprompted flag.
+    assert.equal(f.core.turns[0].unprompted, undefined);
+    assert.equal(
+      f.core.ingests.flat().some((e: any) => e.ts === "106.1" && e.handled),
+      true,
+      "the mirrored row must read handled",
+    );
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a bot-id-form thread reply dispatches ADDRESSED, not ambient (#630)", async () => {
+  const f = await fixture();
+  try {
+    f.client.messagesByChannel.set("C1", [
+      { channel: "C1", user: "U1", text: "kick off", ts: "107.1" },
+      { channel: "C1", user: "UBOT", text: "on it", ts: "107.2", thread_ts: "107.1" },
+    ]);
+    await f.app.emitMessage({
+      channel: "C1",
+      channel_type: "channel",
+      user: "U2",
+      text: "<@BBOT> and the logs?",
+      ts: "107.3",
+      thread_ts: "107.1",
+    });
+    assert.equal(f.core.turns.length, 1);
+    assert.equal(f.core.turns[0].text, "and the logs?");
+    // The sender typed @qm: addressed, never the ambient unprompted flag
+    // the stake-followed path carries.
+    assert.equal(f.core.turns[0].unprompted, undefined);
+  } finally {
+    await f.stop();
+  }
+});
+
+test("a user-id mention still routes through app_mention, not the message handler (#630)", async () => {
+  // The message-handler dispatch is scoped to EXACTLY the class app_mention
+  // won't fire for: a message carrying BOTH forms must not double-dispatch
+  // (app_mention + message handler), and the user-id path is unchanged.
+  const f = await fixture();
+  try {
+    const event = { channel: "C1", channel_type: "channel", user: "U1", text: "<@UBOT> <@BBOT> status?", ts: "108.1" };
+    f.client.messagesByChannel.set("C1", [event]);
+    await f.app.emitEvent("app_mention", event);
+    assert.equal(f.core.turns.length, 1);
+    // The message handler must not add a second turn for the same ts.
+    await f.app.emitMessage(event);
+    assert.equal(f.core.turns.length, 1, "no duplicate turn from the message handler");
+  } finally {
+    await f.stop();
+  }
+});
+
 test("an unaddressed top-level channel message is mirrored but never becomes a turn", async () => {
   const f = await fixture();
   try {

--- a/test/slack-message-gating.test.ts
+++ b/test/slack-message-gating.test.ts
@@ -90,6 +90,19 @@ test("dmThreadRef gives the DM main pane one continuous lane and each thread its
   assert.notEqual(dmThreadRef("D1", "1699999999.000100"), dmThreadRef("D1"));
 });
 
+test("mentionsBot recognizes the bot-id form (<@B…>) alongside the user-id form (#630)", () => {
+  // A hand-typed mention can arrive encoded against the bot id; Slack fires
+  // no app_mention for it, so message-gating recognition is the only thing
+  // that can dispatch it.
+  assert.equal(mentionsBot("hey <@BOTID> do this", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("<@UBOT> classic form", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("both <@UBOT> <@BOTID>", "UBOT", "BOTID"), true);
+  assert.equal(mentionsBot("<@OTHERBOT> not me", "UBOT", "BOTID"), false);
+  assert.equal(mentionsBot("no ids configured", "", ""), false);
+  // Back-compat: the two-arg form still works.
+  assert.equal(mentionsBot("hey <@BOT> do this", "BOT"), true);
+});
+
 test("mentionsBot detects the bot @mention so thread-follow leaves those to app_mention", () => {
   assert.equal(mentionsBot("hey <@BOT> do this", "BOT"), true);
   assert.equal(mentionsBot("just a follow-up", "BOT"), false);

--- a/test/slack-mrkdwn.test.ts
+++ b/test/slack-mrkdwn.test.ts
@@ -24,6 +24,15 @@ test("decodeSlackEntities / stripMention", () => {
   assert.equal(stripMention("<@BOT>", "BOT"), "");
 });
 
+test("stripMention strips the bot-id form and the legacy label shape (#630)", () => {
+  // The core must not receive a raw <@B…> token for an addressed turn.
+  assert.equal(stripMention("<@BOTID> run the tests", "UBOT", "BOTID"), "run the tests");
+  assert.equal(stripMention("<@BOTID|qm> run the tests", "UBOT", "BOTID"), "run the tests");
+  assert.equal(stripMention("<@UBOT> classic", "UBOT", "BOTID"), "classic");
+  assert.equal(stripMention("<@UBOT|qm> legacy label", "UBOT", "BOTID"), "legacy label");
+  assert.equal(stripMention("unrelated <@OTHER> stays", "UBOT", "BOTID"), "unrelated <@OTHER> stays");
+});
+
 test("toSlackMrkdwn: bold uses single * (the screenshot bug: **x** rendered literally)", () => {
   assert.equal(toSlackMrkdwn("**Git commands**"), "*Git commands*");
   assert.equal(toSlackMrkdwn("__also bold__"), "*also bold*");


### PR DESCRIPTION
Fixes the dispatch half of #630 (step 2 of the issue's fix sketch). **Stacked on #632** (the recognition commit — `mentionsBot`/`stripMention` both-id forms come from there); merge that first. Together they close #630 end to end.

## What still dropped after recognition

Even with `mentionsBot` recognizing the bot-id form, the message handler's channel path assumed `app_mention` would carry every mention: it returned before dispatch for top-level messages (`if (!threadReply) return`) and routed thread replies into the ambient stake-followed path (`unprompted: true`) when the mention wasn't the user-id form. Slack fires `app_mention` **only** for the bot-user-id form — the bot-id form had no dispatcher at all.

## The dispatch

The message handler now dispatches the **addressed** turn itself, scoped to exactly the class `app_mention` won't fire for:

```ts
const botIdMentionOnly =
  Boolean(ids.ownBotId) &&
  text.includes(`<@${ids.ownBotId}>`) &&
  !(ids.botUserId && text.includes(`<@${ids.botUserId}>`));
```

- **top-level bot-id-only mention** → dispatched as an addressed turn (previously: mirrored `handled=f`, silently dropped);
- **thread-reply bot-id-only mention** → dispatched addressed — `unprompted` is deliberately omitted: the sender typed `@qm`; the ambient flag belongs to the stake-followed path alone (previously: misdispatched as ambient carrying the raw `<@B…>` token);
- **both forms present** → the user-id form routes through `app_mention` as before; the scoping makes the two paths disjoint, so no double dispatch (pinned by a test that emits both events for the same ts and asserts exactly one turn);
- **neither form** → unchanged ambient/stake-followed behavior.

The mirrored row reads `handled` for every dispatched mention — the incident's `handled=f` signature for a message the bot actually answered is gone.

## Tests

- `a bot-id-form top-level mention dispatches an addressed turn` — turn dispatched, text stripped, **no** `unprompted`, mirror `handled`. **Fails on the base** (0 turns).
- `a bot-id-form thread reply dispatches ADDRESSED, not ambient` — `unprompted` undefined. **Fails on the base** (ambient dispatch).
- `a user-id mention still routes through app_mention, not the message handler` — both forms in one message, both events emitted, exactly one turn (disjointness).

Full identity suites (`slack-message-gating` + `slack-mrkdwn` + `slack-identity` + `slack-index.integration`): 120/120 on this stack; the two new dispatch tests fail on the recognition-only base (43/2). `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789841095&installation_model_id=19911&pr_number=634&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F634&signature=d33f56ebd04a9ea60a67a4a3894fbb9915d5fcebb0046586cf28e078f721c6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->