### PR TITLE
fix(web-ui): set the browser tab title from the open conversation

### DIFF
--- a/plugins/web-ui/src/document-title.ts
+++ b/plugins/web-ui/src/document-title.ts
@@ -1,0 +1,5 @@
+export function formatWebDocumentTitle(brand: string, conversationTitle: string | null | undefined): string {
+  const label = brand.trim() || "QM";
+  const title = conversationTitle?.trim();
+  return title ? `${title} · ${label}` : `${label} · Web`;
+}

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -73,7 +73,14 @@ import {
 } from "./contexts";
 import { groupDmLabel, groupDmText } from "./group-dm-label";
 import { transcriptModel } from "./model-options";
-import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, syncUrlFromState } from "./shell";
+import {
+  appState,
+  closeSidebarOnNarrowView,
+  renderSidebarTop,
+  showMainEmpty,
+  syncDocumentTitle,
+  syncUrlFromState,
+} from "./shell";
 import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
@@ -309,6 +316,7 @@ export function renderList(): void {
     requestAnimationFrame(() => placeSessionMenu(appState.listEl?.querySelector(".session-menu-popover") ?? undefined));
   }
   notifySessionsChanged();
+  syncDocumentTitle();
 }
 
 function recentItem(item: RecentItem): TemplateResult {

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -42,6 +42,7 @@ import {
   canvasToast,
   drawCanvas,
   exitSplitIfActive,
+  focusedPaneConversationTitle,
   loadPersistedSplit,
   mountRestoredCanvas,
   restoredCanvasNeedsSessionList,
@@ -57,8 +58,10 @@ import {
   renderList,
   resetSessionsState,
   sessionsState,
+  sessionTitle,
   toggleWebOnly,
 } from "./sessions";
+import { formatWebDocumentTitle } from "./document-title";
 import { openCronById, renderCronsPage, resetActiveCron, routeCronsHistory } from "./crons";
 import { openWebhookById, renderWebhooksPage, resetActiveWebhook, routeWebhooksHistory } from "./webhooks";
 import { renderFiles } from "./files";
@@ -97,6 +100,26 @@ export function syncUrlFromState(sessionOverride?: string | null): void {
   const sessionId = splitState.active ? null : fromState;
   const next = deepLinkPath(UI_BASE, appState.currentView, sessionId, contextsState.selected);
   if (`${location.pathname}${location.search}` !== next) history.replaceState(null, "", next);
+  syncDocumentTitle();
+}
+
+export function syncDocumentTitle(): void {
+  const next = formatWebDocumentTitle(brandName(), activeConversationTitle());
+  if (document.title !== next) document.title = next;
+}
+
+function activeConversationTitle(): string | null {
+  if (appState.currentView !== "chats") return null;
+  if (splitState.active) return focusedPaneConversationTitle();
+  const chat = mainConversation().state;
+  const sessionId = chat.sessionId ?? chat.rememberedSessionId;
+  const threadRef = chat.threadRef ?? chat.rememberedThreadRef;
+  const session =
+    (sessionId ? sessionsState.list.find((s) => s.id === sessionId) : undefined) ??
+    (threadRef ? sessionsState.list.find((s) => s.threadRef === threadRef) : undefined);
+  if (session) return sessionTitle(session);
+  if (threadRef) return "New chat";
+  return null;
 }
 
 const appEl = document.getElementById("app");

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -48,7 +48,7 @@ import { icon } from "./ui";
 import { contextsState, scopeTitle } from "./contexts";
 import type { DensityTier } from "./density";
 import { appState } from "./shell-state";
-import { renderSidebarTop, switchView, syncUrlFromState } from "./shell";
+import { renderSidebarTop, switchView, syncDocumentTitle, syncUrlFromState } from "./shell";
 import { sleep } from "./chat";
 import {
   createConversation,
@@ -208,6 +208,7 @@ function buildDock(): DockviewApi {
   });
   api.onDidActivePanelChange((e) => {
     splitState.focusedId = e.panel?.id ?? null;
+    syncDocumentTitle();
   });
   api.onDidMaximizedGroupChange(() => {
     for (const a of groupActions) a.draw();
@@ -353,6 +354,7 @@ export function exitSplitIfActive(): void {
   canvasHost = null;
   headerSignature = "";
   renderSidebarTop();
+  syncDocumentTitle();
 }
 
 function adoptPersisted(raw: unknown): void {
@@ -772,6 +774,16 @@ function paneTitle(panel: IDockviewPanel): string {
   if (session) return sessionTitle(session);
   if (panelParams(panel).sessionId) return "Conversation";
   return "New session";
+}
+
+export function focusedPaneConversationTitle(): string | null {
+  if (!splitState.active || !dockApi) return null;
+  const panel =
+    (splitState.focusedId ? dockApi.getPanel(splitState.focusedId) : null) ??
+    dockApi.activePanel ??
+    dockApi.panels[0] ??
+    null;
+  return panel ? paneTitle(panel) : null;
 }
 
 function paneScopeId(panel: IDockviewPanel): string | null {

--- a/plugins/web-ui/test/document-title.test.ts
+++ b/plugins/web-ui/test/document-title.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { formatWebDocumentTitle } from "../src/document-title.ts";
+
+test("default tab title matches the static shell branding", () => {
+  assert.equal(formatWebDocumentTitle("QM", null), "QM · Web");
+  assert.equal(formatWebDocumentTitle("  ", undefined), "QM · Web");
+});
+
+test("an open conversation uses its title with the brand suffix", () => {
+  assert.equal(formatWebDocumentTitle("QM", "Choose assistant tone"), "Choose assistant tone · QM");
+  assert.equal(formatWebDocumentTitle("straylight", "Weekly digest"), "Weekly digest · straylight");
+});
+
+test("untitled and whitespace-only titles fall back to the brand default", () => {
+  assert.equal(formatWebDocumentTitle("QM", ""), "QM · Web");
+  assert.equal(formatWebDocumentTitle("QM", "   "), "QM · Web");
+});
+
+test("brand label is trimmed and empty brand falls back to QM", () => {
+  assert.equal(formatWebDocumentTitle("  Acme  ", "Hello"), "Hello · Acme");
+  assert.equal(formatWebDocumentTitle("", "Hello"), "Hello · QM");
+});
+
+test("document title syncs from url state, session list redraws, and split focus changes", () => {
+  const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+  const sessions = readFileSync(new URL("../src/sessions.ts", import.meta.url), "utf8");
+  const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
+  assert.match(shell, /syncDocumentTitle\(\);/);
+  assert.match(shell, /export function syncDocumentTitle/);
+  assert.match(sessions, /syncDocumentTitle\(\);/);
+  assert.match(split, /onDidActivePanelChange[\s\S]*syncDocumentTitle\(\)/);
+  assert.match(split, /export function focusedPaneConversationTitle/);
+});


### PR DESCRIPTION
## Summary
- Set the Web UI browser tab title from the open conversation (e.g. `Choose assistant tone · QM`) instead of a fixed `QM · Web` for every chat
- Keep it in sync when switching conversations, renaming, auto-title refresh, and changing focused split panes
- Fall back to existing untitled labels (`New chat`, `Web chat`, …) or `QM · Web` when nothing is open

Fixes #345

## Test plan
- [ ] Open two conversations in separate tabs — each tab title should show that conversation’s name
- [ ] Rename a conversation — tab title updates without a reload
- [ ] Start a new untitled chat — tab shows a sensible fallback, then the generated title once it arrives
- [ ] Switch to a non-chat view (e.g. Files) — title returns to `QM · Web` (or branded equivalent)
- [ ] In split view, focus different panes — tab title follows the focused pane
- [ ] `cd plugins/web-ui && npm test -- test/document-title.test.ts`
- [ ] `cd plugins/web-ui && npm run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789842291&installation_model_id=19911&pr_number=635&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F635&signature=b3866e8a3c10d5724d4807a95830e9e79de2f5734dfb81d210d82af198e76b61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->