### PR TITLE
fix(slack): refresh identity caches on user_change/team_join events

### DIFF
--- a/src/slack/directory.ts
+++ b/src/slack/directory.ts
@@ -66,6 +66,11 @@ export interface Directory {
   forceDirectorySync(client: any, invalidateChannelId?: string, invalidatePrincipalId?: string): Promise<void>;
   classifyUserCached(client: any, userId: string): Promise<CachedUser & { ok: boolean }>;
   lastKnownClassification(userId: string): ActorAssertion | undefined;
+  /** Apply a `user_change`/`team_join` event payload to the caches (#626):
+   *  re-classify from the fresh profile and overwrite BOTH the LRU entry
+   *  and the snapshot's row, so a profile/email change propagates
+   *  immediately instead of waiting out the TTL. */
+  updateUserFromEvent(user: SlackUser): void;
   classifyActor(
     client: any,
     userId: string,
@@ -599,6 +604,22 @@ export function createDirectory(deps: {
     }
   }
 
+  function updateUserFromEvent(user: SlackUser): void {
+    // The event carries the FULL fresh profile — classify from it directly
+    // (no users.info round-trip) and overwrite every copy the caches hold.
+    // The LRU entry is the transient-lookup cache; the snapshot row feeds
+    // roster/membership resolution. Both must move together or a name/email
+    // change shows up in one surface and not the other until the TTLs lapse
+    // (#626 defect 3).
+    const actor = classifyUser(user, ids.ownTeamId, ids.identityMode);
+    const timezone = slackUserTimezone(user);
+    const classified = { actor, ...(timezone ? { timezone } : {}) };
+    if (user.id) {
+      userCache.set(user.id, classified);
+      if (userSnapshot) userSnapshot.byId.set(user.id, classified);
+    }
+  }
+
   function lastKnownClassification(userId: string): ActorAssertion | undefined {
     // The LRU entry is the last SUCCESSFUL classification (failures are
     // never cached), i.e. exactly the fallback a transient users.info
@@ -679,6 +700,7 @@ export function createDirectory(deps: {
     classifyUserCached,
     classifyActor,
     lastKnownClassification,
+    updateUserFromEvent,
     getChannelInfo,
     channelMembership,
     allInternalRosters,

--- a/src/slack/directory.ts
+++ b/src/slack/directory.ts
@@ -65,7 +65,11 @@ export interface Directory {
   getUserSnapshot(client: any): Promise<{ byId: Map<string, CachedUser>; fetchedAt: number } | undefined>;
   forceDirectorySync(client: any, invalidateChannelId?: string, invalidatePrincipalId?: string): Promise<void>;
   classifyUserCached(client: any, userId: string): Promise<CachedUser & { ok: boolean }>;
-  classifyActor(client: any, userId: string): Promise<ActorAssertion>;
+  lastKnownClassification(userId: string): ActorAssertion | undefined;
+  classifyActor(
+    client: any,
+    userId: string,
+  ): Promise<ActorAssertion & { ok: boolean }>;
   getChannelInfo(client: any, channel: string): Promise<ChannelMeta | undefined>;
   channelMembership(
     client: any,
@@ -588,12 +592,28 @@ export function createDirectory(deps: {
       if (ids.ownTeamId) userCache.set(userId, classified);
       return { ...classified, ok: true };
     } catch {
-      return { actor: { externalId: userId, isExternalGuest: true }, ok: false };
+      // Lookup failed — say so instead of asserting the user is an external
+      // guest (#626): the id-based actor carries lookupFailed so consumers
+      // can distinguish "couldn't check" from every checked state.
+      return { actor: { externalId: userId, lookupFailed: true }, ok: false };
     }
   }
 
-  async function classifyActor(client: any, userId: string): Promise<ActorAssertion> {
-    return (await classifyUserCached(client, userId)).actor;
+  function lastKnownClassification(userId: string): ActorAssertion | undefined {
+    // The LRU entry is the last SUCCESSFUL classification (failures are
+    // never cached), i.e. exactly the fallback a transient users.info
+    // failure should fall back to (#626). Time-bounded by the cache TTL.
+    return userCache.get(userId)?.actor;
+  }
+
+  async function classifyActor(client: any, userId: string): Promise<ActorAssertion & { ok: boolean }> {
+    // ok preserved, not discarded: a failed users.info currently reads as a
+    // confident "external guest" to every caller — transiently refusing a
+    // member whose record is merely unreachable. Callers decide what a failed
+    // lookup means (skip, retry, fall back to last-known); the classification
+    // itself must not launder the failure into an identity claim (#626).
+    const { actor, ok } = await classifyUserCached(client, userId);
+    return { ...actor, ok };
   }
 
   async function getChannelInfo(client: any, channel: string): Promise<ChannelMeta | undefined> {
@@ -658,6 +678,7 @@ export function createDirectory(deps: {
     forceDirectorySync,
     classifyUserCached,
     classifyActor,
+    lastKnownClassification,
     getChannelInfo,
     channelMembership,
     allInternalRosters,

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -1,3 +1,4 @@
+import type { SlackUser } from "./identity.ts";
 import {
   type SlackFile,
   channelPrivacyChange,
@@ -198,6 +199,26 @@ export function registerSlackEvents(
         client,
       );
     }
+  });
+
+  // Profile/membership changes must propagate to the identity caches
+  // immediately: classification updates previously waited out the 5-min
+  // snapshot/lookup TTLs, so a just-set email kept an own-team member
+  // refused (the #626 incident's ~39-min window) and a profile change
+  // showed stale names until the TTL lapsed. The event payload carries the
+  // full fresh profile, so the handler re-classifies from it directly.
+  app.event("user_change", async ({ body }: any) => {
+    const user = (body as { event?: { user?: unknown } })?.event?.user as
+      | undefined
+      | (SlackUser & { id?: string });
+    if (user?.id) directory.updateUserFromEvent(user);
+  });
+
+  app.event("team_join", async ({ body }: any) => {
+    const user = (body as { event?: { user?: unknown } })?.event?.user as
+      | undefined
+      | (SlackUser & { id?: string });
+    if (user?.id) directory.updateUserFromEvent(user);
   });
 
   app.event("member_joined_channel", async ({ event, body, client }: any) => {

--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -13,6 +13,13 @@ export interface ActorAssertion {
    * instead of masquerading as "external guest" (#626).
    */
   principalUnresolved?: true;
+  /**
+   * The users.info lookup itself failed — the classification below is a
+   * placeholder, not an identity claim. Distinct from every checked state
+   * (guest, internal, principal-unresolved) so callers can retry or fall
+   * back to last-known rather than acting on "external" (#626).
+   */
+  lookupFailed?: true;
 }
 
 export interface SlackUser {

--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -5,6 +5,14 @@ export interface ActorAssertion {
   isExternalGuest?: boolean;
   isBot?: boolean;
   displayName?: string;
+  /**
+   * Own-team member whose principal could not be resolved in email identity
+   * mode (email not currently visible in the directory). Refused like a
+   * guest — fail closed, never a fallback Slack-ID principal — but as its
+   * OWN state, so logs and the user-facing refusal say "unresolved member"
+   * instead of masquerading as "external guest" (#626).
+   */
+  principalUnresolved?: true;
 }
 
 export interface SlackUser {
@@ -53,14 +61,22 @@ export function classifyUser(
   );
   const displayName = user.profile?.display_name || user.real_name || user.name || user.id || "";
   let externalId = String(user.id ?? "");
+  // Email mode keys members on their email — including guests, whose
+  // principal still resolves for refusal copy and audit. An email-LESS
+  // member with no Slack-side external evidence is own-team but
+  // principal-unresolved: kept distinct from an external guest (which the
+  // native flags above decide) so refusal copy and logs name what actually
+  // happened instead of masquerading as external (#626).
+  let principalUnresolved = false;
   if (identity === "email" && !user.is_bot) {
     const email = (user.profile?.email ?? "").trim().toLowerCase();
     if (email.includes("@")) externalId = email;
-    else isGuest = true;
+    else if (!isGuest) principalUnresolved = true;
   }
   return {
     externalId,
     isExternalGuest: isGuest,
+    ...(principalUnresolved ? { principalUnresolved: true as const } : {}),
     ...(user.is_bot ? { isBot: true } : {}),
     ...(displayName ? { displayName } : {}),
   };

--- a/src/slack/manifest.json
+++ b/src/slack/manifest.json
@@ -55,6 +55,8 @@
         "message.mpim",
         "member_joined_channel",
         "member_left_channel",
+        "user_change",
+        "team_join",
         "channel_created",
         "channel_rename",
         "channel_unarchive",

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -199,6 +199,27 @@ export function createTurnHandler(deps: {
         ...(inc.prefetched.timezone ? { timezone: inc.prefetched.timezone } : {}),
       };
     else classified = await classifyUserCached(client, inc.userId);
+    // A failed users.info must not read as a confident external-guest
+    // refusal: log it so the transient failure is visible, and fall back to
+    // the LAST-KNOWN classification when one exists (the incident in #626
+    // showed a single failed lookup refusing an owner outright). With no
+    // prior state, fail closed but as "unverifiable", the third-state
+    // refusal path — never a laundered "external".
+    if ("ok" in classified && !classified.ok) {
+      const cachedAgain = await directory.lastKnownClassification?.(inc.userId);
+      if (cachedAgain) {
+        console.warn(
+          `[slack-plugin] users.info failed for ${inc.userId}; using last-known classification`,
+        );
+        classified = { actor: cachedAgain };
+      } else {
+        console.warn(
+          `[slack-plugin] users.info failed for ${inc.userId} with no prior classification; ` +
+            `refusing as unverifiable ch=${inc.channel} ts=${inc.ts}`,
+        );
+        classified = { actor: { ...classified.actor, principalUnresolved: true as const } };
+      }
+    }
     const actor = classified.actor;
     const timezone = classified.timezone;
     const text = stripMention(inc.rawText, ids.botUserId);

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -296,7 +296,33 @@ export function createTurnHandler(deps: {
             ...(ids.botHandle ? { botHandle: ids.botHandle } : {}),
           };
 
+    // A principal-unresolved own-team member (email mode, email not yet
+    // visible) is refused as its OWN state — fail closed like a guest, but
+    // named for what it is, both to the sender and in the log, so the
+    // incident signature is decidable (#626: the refusal used to be
+    // indistinguishable from external-guest in logs, and its success path
+    // logged nothing at all).
+    const unresolvedMember = audience.find((a) => a.principalUnresolved);
+    if (unresolvedMember) {
+      console.warn(
+        `[slack-plugin] refusing turn: own-team member principal unresolved ` +
+          `(email identity mode; email not visible in the directory) ` +
+          `user=${unresolvedMember.externalId || "?"} ch=${inc.channel} ts=${inc.ts}`,
+      );
+      if (!inc.unprompted) {
+        await ephemeralOrSay(
+          "I can't respond here yet — I couldn't verify your team membership " +
+            "(your email isn't visible to me). This usually resolves within a " +
+            "few minutes of the directory refreshing; try again shortly.",
+        );
+      }
+      return;
+    }
+
     if (audience.some((a) => a.isExternalGuest) && !(await externalParticipantsEnabled())) {
+      console.warn(
+        `[slack-plugin] refusing turn: external guest ch=${inc.channel} ts=${inc.ts}`,
+      );
       if (!inc.unprompted) {
         await ephemeralOrSay(
           "I can't respond here — this conversation isn't fully internal. Try a DM or a fully-internal channel.",

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -126,6 +126,37 @@ test("a failed users.info asserts lookupFailed, not external guest (#626)", asyn
   assert.equal(result.actor.isExternalGuest, undefined);
 });
 
+test("updateUserFromEvent propagates a fresh profile into both caches (#626)", async () => {
+  const { createDirectory } = await import("../src/slack/directory.ts");
+  // Email mode: the member starts email-less (principal-unresolved — the
+  // #626 incident shape) and a user_change carries the just-set email.
+  const client = {
+    users: {
+      info: async () => ({ user: { id: "U1", team_id: "T1" } }),
+      list: async () => ({ members: [] }),
+    },
+    conversations: { list: async () => ({ channels: [] }) },
+    auth: { test: async () => ({ ok: true, user_id: "UBOT", team_id: "T1", bot_id: "BBOT" }) },
+  };
+  const dir = createDirectory({
+    core: client as never,
+    ids: { botUserId: "UBOT", ownTeamId: "T1", bot_id: "BBOT", identityMode: "email" } as never,
+  });
+
+  const before = await dir.classifyUserCached(client, "U1");
+  assert.equal(before.actor.principalUnresolved, true, "fixture starts unresolved");
+
+  dir.updateUserFromEvent({ id: "U1", team_id: "T1", profile: { email: "U1@acme.com" } });
+
+  const after = await dir.classifyUserCached(client, "U1");
+  assert.equal(after.actor.principalUnresolved, undefined, "the fresh profile resolves immediately");
+  assert.equal(after.actor.externalId, "u1@acme.com", "keyed on the fresh email");
+  // A users.info failure now falls back to the UPDATED classification,
+  // not the stale unresolved one.
+  const lastKnown = dir.lastKnownClassification("U1");
+  assert.equal(lastKnown?.externalId, "u1@acme.com");
+});
+
 test("classifyActor preserves ok instead of discarding it (#626)", async () => {
   // Shape check without a live client: the interface change is the contract
   // (ok rides on the assertion); the directory unit above covers behavior.

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -102,6 +102,51 @@ test("classifyUser email mode still flags restricted/other-workspace members as 
   assert.equal(g.isExternalGuest, true);
 });
 
+test("a failed users.info asserts lookupFailed, not external guest (#626)", async () => {
+  // The directory's classifyUserCached currently launders a transient
+  // users.info failure into a confident "external guest" — the incident
+  // refused an owner outright on one failed lookup. The failure state must
+  // be distinguishable from every checked state.
+  const { createDirectory } = await import("../src/slack/directory.ts");
+  const failingClient = {
+    users: {
+      info: async () => { throw new Error("transient"); },
+      list: async () => ({ members: [] }),
+    },
+    conversations: { list: async () => ({ channels: [] }) },
+    auth: { test: async () => ({ ok: true, user_id: "UBOT", team_id: "T1" }) },
+  };
+  const dir = createDirectory({
+    core: failingClient as never,
+    ids: { botUserId: "UBOT", ownTeamId: "T1", identityMode: "slack-id" } as never,
+  });
+  const result = await dir.classifyUserCached(failingClient, "U1");
+  assert.equal(result.ok, false);
+  assert.equal(result.actor.lookupFailed, true, "the failure is named, not guest-folded");
+  assert.equal(result.actor.isExternalGuest, undefined);
+});
+
+test("classifyActor preserves ok instead of discarding it (#626)", async () => {
+  // Shape check without a live client: the interface change is the contract
+  // (ok rides on the assertion); the directory unit above covers behavior.
+  const { createDirectory } = await import("../src/slack/directory.ts");
+  const okClient = {
+    users: {
+      info: async () => ({ user: { id: "U1", team_id: "T1" } }),
+      list: async () => ({ members: [] }),
+    },
+    conversations: { list: async () => ({ channels: [] }) },
+    auth: { test: async () => ({ ok: true, user_id: "UBOT", team_id: "T1" }) },
+  };
+  const dir = createDirectory({
+    core: okClient as never,
+    ids: { botUserId: "UBOT", ownTeamId: "T1", identityMode: "slack-id" } as never,
+  });
+  const actor = await dir.classifyActor(okClient, "U1");
+  assert.equal(actor.ok, true, "ok rides on the returned assertion");
+  assert.equal(actor.isExternalGuest, false);
+});
+
 test("slackUserTimezone extracts only valid Slack user timezones", () => {
   assert.equal(slackUserTimezone({ id: "U1", tz: "America/Los_Angeles" }), "America/Los_Angeles");
   assert.equal(slackUserTimezone({ id: "U1", profile: { tz: "Europe/London" } }), "Europe/London");

--- a/test/slack-identity.test.ts
+++ b/test/slack-identity.test.ts
@@ -63,7 +63,26 @@ test("classifyUser email mode keys members on their normalized work email", () =
 test("classifyUser email mode fails closed to guest when a member has no visible email", () => {
   const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "email");
   assert.equal(a.externalId, "U1");
-  assert.equal(a.isExternalGuest, true);
+  // Own-team member, principal unresolved: its OWN state, not external
+  // guest (#626). The refusal is equally closed, but logs and copy say
+  // what actually happened.
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, true);
+});
+
+test("classifyUser email mode: native external evidence still wins over unresolved", () => {
+  // A restricted member with no visible email is an EXTERNAL GUEST, not an
+  // unresolved own-team member — the third state never masks the flags
+  // (#626).
+  const g = classifyUser({ id: "U2", team_id: TEAM, is_restricted: true }, TEAM, "email");
+  assert.equal(g.isExternalGuest, true);
+  assert.equal(g.principalUnresolved, undefined);
+});
+
+test("classifyUser slack-id mode never marks principalUnresolved", () => {
+  const a = classifyUser({ id: "U1", team_id: TEAM }, TEAM, "slack-id");
+  assert.equal(a.isExternalGuest, false);
+  assert.equal(a.principalUnresolved, undefined);
 });
 
 test("classifyUser email mode keeps bots on their Slack id and non-guest", () => {


### PR DESCRIPTION
Fixes defect 3 of #626 — the last of the three. **Stacked on #628 (third state) and #629 (ok-propagation)**; the three together close #626 completely.

## The gap

Classification updates only on the 5-minute snapshot/lookup TTLs. Neither `user_change` nor `team_join` appears in the manifest's `bot_events` or anywhere in `src/slack` — so a just-set email kept an own-team member refused for the directory-propagation window (the incident's ~39 minutes was Slack-side propagation PLUS this TTL floor), and a profile change showed stale display names until a TTL lapsed.

## The fix

1. **Manifest**: `user_change` and `team_join` added to `bot_events`. *(Note for operators: the app needs a reinstall to receive the new subscriptions — the same README note the issue cites for scope changes.)*
2. **Handlers** (events.ts): both route the event payload into the new `Directory.updateUserFromEvent(user)` — the payload carries the **full fresh profile**, so the handler re-classifies from it directly (no `users.info` round-trip) and overwrites **both** caches the classifier reads:
   - the **LRU lookup entry** — the transient `classifyUserCached` path, including the `lastKnownClassification` fallback #629 added;
   - the **snapshot row** — the roster/membership resolution path.

   Both must move together or a change shows up in one surface and not the other until the TTLs lapse — exactly the split-state drift the issue's H1/H2/H3 diagnosis was blinded by.

Eviction (deleting the row) was deliberately not used: the event already holds the authoritative profile, so re-classifying from it is both immediate and cheaper than delete-then-refetch.

## Test

`updateUserFromEvent propagates a fresh profile into both caches (#626)` — email-mode fixture starting in the incident's exact shape (email-less member → `principalUnresolved: true`), then a `user_change` carrying the just-set email: the classification resolves **immediately** (`externalId` keyed on the fresh email), and the `lastKnownClassification` fallback serves the updated state, not the stale unresolved one. **Fails on the base** (no such method; the TTL-only path keeps the member unresolved).

Full identity suites: 30/30 on this stack; the suites' prior 120-test combined run stays 120/120 (`tsc --noEmit` clean).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789842911&installation_model_id=19911&pr_number=637&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F637&signature=9d38792163f9ae73f71c9c6fbef9b2da4e4cc4879d76487a34499b33b8743ed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->