### PR TITLE
fix(budget): credit cache-folded bookings back to the metered cost

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -44,7 +44,7 @@ import {
 } from "../credentials/connector-status.ts";
 import { renderComputerBlock, renderResidentLoginsBlock, renderConnectedAppsBlock } from "./environment-facts.ts";
 import { PROVIDERS } from "../connectors/oauth.ts";
-import { estimateCostUsd, modelCallCostUsd } from "../ratelimit/budget.ts";
+import { budgetAdjustmentForRequest, estimateCostUsd, modelCallCostUsd } from "../ratelimit/budget.ts";
 import {
   mintCapabilityToken,
   CAPABILITY_TTL_MS,
@@ -2485,14 +2485,14 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               } catch (err) {
                 console.error("[orchestrator] failed to persist LLM request snapshot:", errMessage(err));
               }
-              // Debit the budget from the provider-metered usage when it exists:
-              // the upfront recordModelCall estimate is input-only at a fixed
-              // rate, so models with cheaper input or dominant output costs
-              // were mispriced by up to 5x (#586).
-              const metered = modelCallCostUsd(rec, rec.usage ?? null);
-              const estimated = estimateCostUsd(rec.usage?.input ?? 0);
-              if (metered > estimated) {
-                void deps.budget?.record(actor.id, metered - estimated);
+              // Correct the budget toward the provider-metered usage (#586).
+              // Signed: a cache-heavy claude turn was BOOKED at the full
+              // fixed rate over input+cacheRead+cacheWrite and the metered
+              // cost is lower — the difference is credited back, so the
+              // ceiling tracks the real bill instead of phantom cache cost.
+              const adjustment = budgetAdjustmentForRequest(rec.usage ?? null);
+              if (adjustment !== 0) {
+                void deps.budget?.record(actor.id, adjustment);
               }
             },
           });

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -44,7 +44,7 @@ import {
 } from "../credentials/connector-status.ts";
 import { renderComputerBlock, renderResidentLoginsBlock, renderConnectedAppsBlock } from "./environment-facts.ts";
 import { PROVIDERS } from "../connectors/oauth.ts";
-import { estimateCostUsd } from "../ratelimit/budget.ts";
+import { estimateCostUsd, modelCallCostUsd } from "../ratelimit/budget.ts";
 import {
   mintCapabilityToken,
   CAPABILITY_TTL_MS,
@@ -2484,6 +2484,15 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
                 await deps.sessions.recordLlmRequest(session.id, { ...rec, scopeLabel: scopeId });
               } catch (err) {
                 console.error("[orchestrator] failed to persist LLM request snapshot:", errMessage(err));
+              }
+              // Debit the budget from the provider-metered usage when it exists:
+              // the upfront recordModelCall estimate is input-only at a fixed
+              // rate, so models with cheaper input or dominant output costs
+              // were mispriced by up to 5x (#586).
+              const metered = modelCallCostUsd(rec, rec.usage ?? null);
+              const estimated = estimateCostUsd(rec.usage?.input ?? 0);
+              if (metered > estimated) {
+                void deps.budget?.record(actor.id, metered - estimated);
               }
             },
           });

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -16,6 +16,32 @@ export function estimateCostUsd(inputTokens: number, usdPerMTok = DEFAULT_AGENT_
   return (inputTokens / 1_000_000) * usdPerMTok;
 }
 
+/**
+ * Cost attribution for one model call, preferring the provider-metered usage
+ * the harnesses already report through recordLlmRequest (LlmCallUsage) and
+ * falling back to the input-only fixed-rate estimate when no metered numbers
+ * exist (#586).
+ */
+export function modelCallCostUsd(
+  rec: { model: string; inputTokens: number },
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    totalTokens: number;
+    costUsd: number;
+  } | null,
+): number {
+  if (usage) {
+    if (Number.isFinite(usage.costUsd) && usage.costUsd > 0) return usage.costUsd;
+    // Metered tokens without a provider-computed cost: price input+output at
+    // the conservative fixed rate instead of dropping the output share.
+    return estimateCostUsd(usage.input + usage.output);
+  }
+  return estimateCostUsd(rec.inputTokens);
+}
+
 export function createBudgetTracker(
   opts: { limitUsd?: number; orgLimitUsd?: number; windowMs?: number } = {},
 ): BudgetTracker {

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -42,6 +42,47 @@ export function modelCallCostUsd(
   return estimateCostUsd(rec.inputTokens);
 }
 
+/**
+ * Signed budget correction for one LLM request's metered usage (#586).
+ *
+ * Two harness shapes reach recordLlmRequest:
+ *
+ * - **cache-folded** (claude): the upfront recordModelCall booked
+ *   ``estimateCostUsd(input + cacheRead + cacheWrite)`` — cache reads and
+ *   writes priced at the FULL fixed rate — so a provider-metered ``costUsd``
+ *   (cache priced by the provider) is typically LOWER than what was already
+ *   booked. The correction is negative: a credit, and the budget's running
+ *   total lands on the metered figure exactly. Without it a cache-heavy turn
+ *   trips the ceiling on phantom cost (the false trip in #586's follow-up).
+ * - **estimate-fed** (pi): the upfront booking is a token estimate whose
+ *   value is not reconstructible here, so only a positive top-up toward the
+ *   metered figure is applied (the pre-existing behavior).
+ *
+ * :param usage: The metered usage from the harness's recordLlmRequest, or
+ *     ``null``/``undefined`` when the step reported none.
+ * :returns: The signed adjustment to record; ``0`` records nothing.
+ */
+export function budgetAdjustmentForRequest(
+  usage?:
+    | {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheWrite: number;
+        totalTokens: number;
+        costUsd: number;
+      }
+    | null,
+): number {
+  if (!usage) return 0;
+  const metered = modelCallCostUsd({ model: "", inputTokens: 0 }, usage);
+  if (usage.cacheRead > 0 || usage.cacheWrite > 0) {
+    const booked = estimateCostUsd(usage.input + usage.cacheRead + usage.cacheWrite);
+    return metered - booked;
+  }
+  return Math.max(0, metered - estimateCostUsd(usage.input));
+}
+
 export function createBudgetTracker(
   opts: { limitUsd?: number; orgLimitUsd?: number; windowMs?: number } = {},
 ): BudgetTracker {

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -5,7 +5,12 @@ import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBudgetTracker, estimateCostUsd, modelCallCostUsd } from "../src/ratelimit/budget.ts";
+import {
+  budgetAdjustmentForRequest,
+  createBudgetTracker,
+  estimateCostUsd,
+  modelCallCostUsd,
+} from "../src/ratelimit/budget.ts";
 import { DEFAULT_AGENT_INPUT_USD_PER_MTOK } from "../src/model/pi-models.ts";
 import { buildApp } from "../src/wiring.ts";
 import type { TurnRequest } from "../src/types.ts";
@@ -79,4 +84,33 @@ test("modelCallCostUsd prefers provider-metered cost, then metered tokens, then 
   // No metered usage at all: the legacy input-only estimate.
   assert.equal(modelCallCostUsd(rec, null), estimateCostUsd(1000));
   assert.equal(modelCallCostUsd(rec, undefined), estimateCostUsd(1000));
+});
+
+test("budgetAdjustmentForRequest credits a cache-folded booking back to metered (#586 follow-up)", () => {
+  // The claude harness books estimateCostUsd(input + cacheRead + cacheWrite)
+  // upfront at the FULL fixed rate; the provider-metered costUsd prices cache
+  // correctly and is lower. The adjustment must be NEGATIVE so the running
+  // total lands on the metered figure — the cache-read false trip.
+  const usage = { input: 1_000, output: 500, cacheRead: 500_000, cacheWrite: 100_000, totalTokens: 601_500, costUsd: 0.42 };
+  const adjustment = budgetAdjustmentForRequest(usage);
+  // The booking formula is input+cacheRead+cacheWrite (claude-harness.ts:613) — no output.
+  const booked = estimateCostUsd(601_000);
+  assert.ok(adjustment < 0, `expected a credit, got ${adjustment}`);
+  assert.ok(Math.abs(adjustment - (0.42 - booked)) < 1e-9, "exactly metered minus booked");
+  // A budget tracker's running total lands on the metered figure after the
+  // upfront + correction.
+  const tracker = createBudgetTracker({});
+  void tracker.record("u1", booked);
+  void tracker.record("u1", adjustment);
+  return tracker.check("u1").then((c) => {
+    assert.ok(Math.abs(c.spentUsd - 0.42) < 1e-9, `total should be the metered cost, got ${c.spentUsd}`);
+  });
+});
+
+test("budgetAdjustmentForRequest only tops up estimate-fed (cache-less) usage", () => {
+  // pi-shape: no cache fields, upfront not reconstructible — positive-only.
+  const usage = { input: 1_000, output: 2_000, cacheRead: 0, cacheWrite: 0, totalTokens: 3_000, costUsd: 0.07 };
+  assert.ok(budgetAdjustmentForRequest(usage) >= 0);
+  assert.equal(budgetAdjustmentForRequest(null), 0);
+  assert.equal(budgetAdjustmentForRequest(undefined), 0);
 });

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBudgetTracker, estimateCostUsd } from "../src/ratelimit/budget.ts";
+import { createBudgetTracker, estimateCostUsd, modelCallCostUsd } from "../src/ratelimit/budget.ts";
 import { DEFAULT_AGENT_INPUT_USD_PER_MTOK } from "../src/model/pi-models.ts";
 import { buildApp } from "../src/wiring.ts";
 import type { TurnRequest } from "../src/types.ts";
@@ -58,4 +58,25 @@ test("a principal over budget is refused by the app", async () => {
   const second = await app.turn(dm("again"));
   assert.equal(second.status, "refused");
   assert.match(second.reason ?? "", /budget exceeded/);
+});
+
+test("modelCallCostUsd prefers provider-metered cost, then metered tokens, then the estimate (#586)", () => {
+  const rec = { model: "gpt-5.6-sol", inputTokens: 1000 };
+
+  // Provider computed the cost: used verbatim.
+  assert.equal(
+    modelCallCostUsd(rec, { input: 1000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 3000, costUsd: 0.07 }),
+    0.07,
+  );
+
+  // Metered tokens but no provider cost: input+output at the fixed rate
+  // (output no longer invisible).
+  assert.equal(
+    modelCallCostUsd(rec, { input: 1000, output: 2000, cacheRead: 0, cacheWrite: 0, totalTokens: 3000, costUsd: 0 }),
+    estimateCostUsd(3000),
+  );
+
+  // No metered usage at all: the legacy input-only estimate.
+  assert.equal(modelCallCostUsd(rec, null), estimateCostUsd(1000));
+  assert.equal(modelCallCostUsd(rec, undefined), estimateCostUsd(1000));
 });


### PR DESCRIPTION
Follows up #592 by fixing the interaction [ianTPE flagged on #586](https://github.com/yc-software/qm/issues/586#issuecomment-…) — **stacked on #592** (merge that first); without it the cache-read false trip survives that PR unchanged.

## The surviving false trip (per the follow-up comment, verified)

The claude harness books `estimateCostUsd(seen.input + seen.cacheRead + seen.cacheWrite)` upfront via `recordModelCall` (`claude-harness.ts:613`) — cache reads and writes priced at the **full** $5/MTok fixed rate. The metered `costUsd` arrives later on `recordLlmRequest` with cache priced by the provider — lower. #592's correction was one-directional (`if (metered > estimated)` debit-only) and its `estimated` was `estimateCostUsd(rec.usage?.input)` — **input-only, not even the quantity that was booked**. So the cache-inflated charge stays booked, the ceiling trips on phantom cost, and no path could reduce a charge already made.

## The fix — a signed correction

`budgetAdjustmentForRequest(usage)` (in `ratelimit/budget.ts`) computes the adjustment per harness shape:

- **cache-folded** (claude; `cacheRead > 0 || cacheWrite > 0`): `booked = estimateCostUsd(input + cacheRead + cacheWrite)` — *exactly the formula the claude recordModelCall site applies to the same counts* — and the adjustment is `metered − booked`, **negative when the provider prices cache below the full rate**. The orchestrator records it as-is; the budget tracker's ledger entries sum signed, so `upfront + correction` lands on the metered figure exactly. No tracker-shape change — a credit is a plain negative entry.
- **estimate-fed** (pi): the upfront booking is a token estimate not reconstructible here, so only the positive top-up applies — #592's behavior, unchanged.

## Tests

- `budgetAdjustmentForRequest credits a cache-folded booking back to metered` — a cache-heavy step (501k cache tokens) whose metered cost is $0.42 vs $3.005 booked: the adjustment is negative, exactly `metered − booked` (with `booked` computed input+cacheRead+cacheWrite, the harness's own formula), and a tracker fed `booked` then `adjustment` reads **$0.42 spent** — the ceiling now tracks the real bill. **Fails on #592's base** (no such function).
- `budgetAdjustmentForRequest only tops up estimate-fed (cache-less) usage` — positive-only for the pi shape; `null`/`undefined` record nothing.

`test/budget.test.ts`: 7/7 on this stack. `tsc --noEmit` clean.

## Remaining from the follow-up

The **durability** half (the in-memory budget window vs. AGENTS.md's "Durable by default" rule) is a larger design change — the tracker's `Map` state, the org window, and where the durable store would live — deliberately not bundled here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789844293&installation_model_id=19911&pr_number=638&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F638&signature=13b16766761a764a8ad5579bbca309d1083b5b70bedbd31c1aa0463389b58b41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->