### PR TITLE
fix(web-ui): let project owners rename from the Projects page

### DIFF
--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -1,4 +1,5 @@
 import { html, nothing, render, type TemplateResult } from "lit";
+import { live } from "lit/directives/live.js";
 import {
   ArrowLeft,
   Boxes,
@@ -9,6 +10,7 @@ import {
   Hash,
   ListFilter,
   Lock,
+  Pencil,
   Plus,
   RefreshCw,
   Search,
@@ -32,7 +34,7 @@ import { errMessage } from "../../chassis/src/errors";
 import { actionSnippet, closeFormMenus, fieldSelect, formatBytes, icon, initials, relTime, toggleFormMenu } from "./ui";
 import { appState, replacePanePreservingFocus, switchView, syncUrlFromState } from "./shell";
 import { mainConversation } from "./conversations";
-import { groupDmTitle, openSession, refreshSessions, sessionsState, slackLogo, surfaceOf } from "./sessions";
+import { groupDmTitle, openSession, refreshSessions, renderList, sessionsState, slackLogo, surfaceOf } from "./sessions";
 import { activityOf } from "./session-list";
 import type { WebhookView } from "./webhooks";
 import type { CronView } from "./crons";
@@ -102,6 +104,10 @@ export const contextsState = {
   slackValue: "",
   slackBusy: false,
   slackError: "",
+  renaming: false,
+  renameDraft: "",
+  renameSaving: false,
+  renameError: "",
 };
 
 let contextsLoading = false;
@@ -160,6 +166,7 @@ export function resetContextsState(): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  clearProjectRename();
   cancelMemberSearchTimer();
   contextsNotice = "";
   memberSearchSeq++;
@@ -449,6 +456,8 @@ function detailTpl(c: CoreContext): TemplateResult {
   const { title, sub, glyph } = contextMeta(c);
   const sessions = sessionsIn(c.scopeId);
   const completelyEmpty = sessions.length === 0 && scopeResourcesEmpty(c.scopeId);
+  const canRename = Boolean(c.project) && isProjectOwner(c);
+  const renaming = canRename && contextsState.renaming;
   return html`
     <div class="context-detail">
       <button class="context-back" type="button" @click=${() => selectContext(null)}>
@@ -457,10 +466,65 @@ function detailTpl(c: CoreContext): TemplateResult {
       <div class="context-detail-head">
         <span class="context-glyph large">${icon(glyph, 22)}</span>
         <div class="context-detail-titles">
-          <h1 class="pane-title">
-            ${title}
-            ${c.isPrivate ? html`<span class="context-lock" title="Private channel">${icon(Lock, 14)}</span>` : nothing}
-          </h1>
+          ${
+            renaming
+              ? html`
+                  <div class="context-rename">
+                    <input
+                      class="context-rename-input"
+                      data-focus-key="project-rename"
+                      aria-label="Rename project"
+                      maxlength="200"
+                      autocomplete="off"
+                      .value=${live(contextsState.renameDraft)}
+                      ?disabled=${contextsState.renameSaving}
+                      @input=${(event: InputEvent) => {
+                        contextsState.renameDraft = (event.currentTarget as HTMLInputElement).value;
+                        contextsState.renameError = "";
+                      }}
+                      @keydown=${(event: KeyboardEvent) => {
+                        if (event.isComposing || event.keyCode === 229) return;
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          void commitProjectDetailRename(c);
+                        } else if (event.key === "Escape") {
+                          event.preventDefault();
+                          cancelProjectRename();
+                        }
+                      }}
+                      @blur=${() => void commitProjectDetailRename(c)}
+                    />
+                    ${
+                      contextsState.renameError
+                        ? html`<div class="form-error" aria-live="polite">${contextsState.renameError}</div>`
+                        : nothing
+                    }
+                  </div>
+                `
+              : html`
+                  <h1 class="pane-title">
+                    ${title}
+                    ${
+                      c.isPrivate
+                        ? html`<span class="context-lock" title="Private channel">${icon(Lock, 14)}</span>`
+                        : nothing
+                    }
+                    ${
+                      canRename
+                        ? html`<button
+                            class="project-icon-button context-rename-edit"
+                            type="button"
+                            aria-label="Rename project"
+                            title="Rename project"
+                            @click=${() => beginProjectRename(c)}
+                          >
+                            ${icon(Pencil, 15)}
+                          </button>`
+                        : nothing
+                    }
+                  </h1>
+                `
+          }
           <div class="context-sub">
             ${c.project ? sub : `${sub} The agent's files and memory here are separate from your other contexts.`}
           </div>
@@ -536,6 +600,68 @@ function projectPeople(context: CoreContext): string[] {
 
 function isProjectOwner(context: CoreContext): boolean {
   return context.project?.ownerId === appState.me?.user;
+}
+
+function clearProjectRename(): void {
+  contextsState.renaming = false;
+  contextsState.renameDraft = "";
+  contextsState.renameSaving = false;
+  contextsState.renameError = "";
+}
+
+function beginProjectRename(context: CoreContext): void {
+  if (!context.project || !isProjectOwner(context)) return;
+  memberSearchSeq++;
+  cancelMemberSearchTimer();
+  contextsState.memberProjectId = null;
+  contextsState.memberQuery = "";
+  contextsState.memberMatches = [];
+  contextsState.memberSearching = false;
+  contextsState.memberError = "";
+  contextsState.memberSearchedQuery = "";
+  contextsState.renaming = true;
+  contextsState.renameDraft = context.project.name;
+  contextsState.renameSaving = false;
+  contextsState.renameError = "";
+  drawContexts();
+  queueMicrotask(() => document.querySelector<HTMLInputElement>(".context-rename-input")?.focus());
+}
+
+function cancelProjectRename(): void {
+  if (!contextsState.renaming || contextsState.renameSaving) return;
+  clearProjectRename();
+  drawContexts();
+}
+
+async function commitProjectDetailRename(context: CoreContext): Promise<void> {
+  if (!contextsState.renaming || !context.project || contextsState.renameSaving) return;
+  if (!isProjectOwner(context)) {
+    clearProjectRename();
+    drawContexts();
+    return;
+  }
+  const project = context.project;
+  const next = contextsState.renameDraft.trim();
+  if (!next || next === project.name) {
+    clearProjectRename();
+    drawContexts();
+    return;
+  }
+  const resetSeq = contextsResetSeq;
+  contextsState.renameSaving = true;
+  contextsState.renameError = "";
+  drawContexts();
+  const ok = await renameProject(project, next);
+  if (resetSeq !== contextsResetSeq) return;
+  if (!ok) {
+    contextsState.renameSaving = false;
+    contextsState.renameError = "Couldn't rename this project.";
+    drawContexts();
+    queueMicrotask(() => document.querySelector<HTMLInputElement>(".context-rename-input")?.focus());
+    return;
+  }
+  clearProjectRename();
+  drawContexts();
 }
 
 function memberLabel(context: CoreContext, principalId: string): string {
@@ -1145,6 +1271,7 @@ export async function renameProject(project: CoreProject, name: string): Promise
     if (!updated) return false;
     upsertProject(updated);
     if (appState.currentView === "contexts") drawContexts();
+    renderList();
     return true;
   } catch {
     return false;
@@ -1243,6 +1370,7 @@ function toggleMemberPicker(context: CoreContext): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  clearProjectRename();
   drawContexts();
   if (contextsState.memberProjectId)
     queueMicrotask(() => document.querySelector<HTMLInputElement>("#project-member-search")?.focus());
@@ -1261,6 +1389,7 @@ function closeMemberPicker(): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  clearProjectRename();
   drawContexts();
 }
 
@@ -1455,6 +1584,7 @@ function selectContext(scopeId: string | null): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  clearProjectRename();
   contextsState.selected = scopeId;
   contextsState.resources = null;
   contextsState.resourcesScope = null;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5015,6 +5015,40 @@ a.chat-row-open {
   max-width: 100%;
   overflow-wrap: anywhere;
 }
+.context-detail-head .pane-title .context-rename-edit {
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+.context-detail-head .pane-title:hover .context-rename-edit,
+.context-detail-head .pane-title .context-rename-edit:focus-visible {
+  opacity: 1;
+}
+.context-rename {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-width: 420px;
+}
+.context-rename-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+.context-rename-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--foreground) 30%, transparent);
+}
+.context-rename-input:disabled {
+  opacity: 0.7;
+}
 .context-detail-titles {
   flex: 1;
   min-width: 0;

--- a/plugins/web-ui/test/contexts-source.test.ts
+++ b/plugins/web-ui/test/contexts-source.test.ts
@@ -16,6 +16,7 @@ test("contexts pane text inputs carry focus keys", () => {
   assert.match(source, /data-focus-key="project-member-search"/);
   assert.match(source, /data-focus-key="contexts-search"/);
   assert.match(source, /data-focus-key="project-name"/);
+  assert.match(source, /data-focus-key="project-rename"/);
   assert.match(
     readFileSync(new URL("../src/ambient-policy.ts", import.meta.url), "utf8"),
     /data-focus-key="ambient-orders"/,
@@ -68,10 +69,26 @@ test("result cap applies after the member filter", () => {
   assert.match(source, /\.filter\(\(match\) => !members\.has\(match\.principalId\)\)\.slice\(0, 8\)/);
 });
 
-test("every project member can invite while only the owner can remove people", () => {
+test("every project member can invite while only the owner can remove people or rename", () => {
   const detail = source.match(/function detailTpl\([^]*?\n\}/)?.[0] ?? "";
   const members = source.match(/function projectMembersSection\([^]*?\n\}/)?.[0] ?? "";
   assert.match(detail, /\$\{\s*c\.project\s*\? html`<button class="btn context-add-member"/);
-  assert.doesNotMatch(detail, /c\.project && isProjectOwner\(c\)/);
+  assert.match(detail, /Boolean\(c\.project\) && isProjectOwner\(c\)/);
+  assert.match(detail, /class="project-icon-button context-rename-edit"/);
+  assert.doesNotMatch(detail, /context-rename-button/);
+  assert.doesNotMatch(detail, /c\.project && isProjectOwner\(c\)\s*\?\s*html`<button class="btn context-add-member"/);
   assert.match(members, /isProjectOwner\(context\) && principalId !== project\.ownerId/);
+});
+
+test("project rename is owner-only and unavailable for personal contexts", () => {
+  assert.match(source, /function beginProjectRename\(/);
+  assert.match(source, /function commitProjectDetailRename\(/);
+  assert.match(source, /if \(!context\.project \|\| !isProjectOwner\(context\)\) return;/);
+  assert.doesNotMatch(source.match(/function contextRow\([^]*?\n\}/)?.[0] ?? "", /Rename/);
+});
+
+test("renaming a project refreshes the sidebar list", () => {
+  const body = source.match(/export async function renameProject\([^]*?\n\}/)?.[0] ?? "";
+  assert.match(body, /upsertProject\(updated\)/);
+  assert.match(body, /renderList\(\)/);
 });

--- a/plugins/web-ui/test/project-rename.test.ts
+++ b/plugins/web-ui/test/project-rename.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+import { createServer } from "vite";
+import type { CoreContext } from "../src/core-bridge.ts";
+
+test("project detail rename is owner-only and skips personal", async () => {
+  const dom = new JSDOM('<!doctype html><div id="app"></div><main id="main"></main>', {
+    url: "http://localhost/web-ui/?view=contexts",
+  });
+  Object.defineProperty(dom.window, "matchMedia", {
+    value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+  });
+  const globals = {
+    window: dom.window,
+    document: dom.window.document,
+    location: dom.window.location,
+    history: dom.window.history,
+    localStorage: dom.window.localStorage,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLDialogElement: dom.window.HTMLDialogElement,
+    customElements: dom.window.customElements,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MouseEvent: dom.window.MouseEvent,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    InputEvent: dom.window.InputEvent,
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: clearTimeout,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+  };
+  for (const [key, value] of Object.entries(globals))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+
+  const personal = {
+    scopeId: "personal:owner",
+    kind: "personal",
+    name: "Personal",
+    sessionCount: 0,
+    lastActivityAt: null,
+  } as const;
+  const ownedProject = {
+    id: "project-1",
+    name: "Launch",
+    ownerId: "owner",
+    memberIds: ["owner", "pal"],
+    scopeId: "project:1",
+    members: [
+      { principalId: "owner", displayName: "Owner" },
+      { principalId: "pal", displayName: "Pal" },
+    ],
+  };
+  const memberProject = {
+    id: "project-2",
+    name: "Shared",
+    ownerId: "other",
+    memberIds: ["other", "owner"],
+    scopeId: "project:2",
+    members: [
+      { principalId: "other", displayName: "Other" },
+      { principalId: "owner", displayName: "Owner" },
+    ],
+  };
+  const ownedContext = {
+    scopeId: ownedProject.scopeId,
+    kind: "group",
+    name: ownedProject.name,
+    sessionCount: 0,
+    lastActivityAt: null,
+    project: ownedProject,
+  } as CoreContext;
+  const memberContext = {
+    scopeId: memberProject.scopeId,
+    kind: "group",
+    name: memberProject.name,
+    sessionCount: 0,
+    lastActivityAt: null,
+    project: memberProject,
+  } as CoreContext;
+  let patchedName: string | null = null;
+  globalThis.fetch = async (input, init) => {
+    const path = String(input);
+    const method = init?.method ?? "GET";
+    if (path === "/api/contexts") {
+      return Response.json({ contexts: [personal, ownedContext, memberContext] });
+    }
+    if (path === "/api/sessions") return Response.json({ sessions: [] });
+    if (path.startsWith("/api/scope-resources?")) {
+      return Response.json({ files: [], webhooks: [], crons: [], deployments: [], skills: [], manageable: true });
+    }
+    if (path.includes("/ambient-policy")) {
+      return Response.json({ policy: { orders: "", bots: {}, updatedAt: 0 } });
+    }
+    if (path.startsWith("/api/channel-header-pin")) {
+      return Response.json({ pin: null });
+    }
+    if (path.startsWith("/api/runtime-config")) {
+      return Response.json({}, { status: 503 });
+    }
+    if (path === `/api/projects/${ownedProject.id}` && method === "PATCH") {
+      const body = JSON.parse(String(init?.body)) as { name: string };
+      patchedName = body.name;
+      return Response.json({
+        project: { ...ownedProject, name: body.name },
+      });
+    }
+    if (method === "GET") return Response.json({});
+    throw new Error(`Unexpected request: ${method} ${path}`);
+  };
+
+  const vite = await createServer({ server: { middlewareMode: true, hmr: false }, appType: "custom" });
+  try {
+    const { appState } = await vite.ssrLoadModule("/src/shell-state.ts");
+    const { contextsState, renderContexts, openProjectDetail } = await vite.ssrLoadModule("/src/contexts.ts");
+    appState.me = { user: "owner", org: "acme" };
+    appState.currentView = "contexts";
+    appState.mainEl = document.querySelector("#main");
+    contextsState.list = [];
+    contextsState.loaded = false;
+    contextsState.loadedAt = 0;
+
+    await renderContexts();
+
+    openProjectDetail(personal.scopeId);
+    await Promise.resolve();
+    assert.equal(document.querySelector(".context-rename-edit"), null);
+
+    openProjectDetail(memberProject.scopeId);
+    await Promise.resolve();
+    assert.equal(document.querySelector(".context-rename-edit"), null);
+    assert.match(document.querySelector(".pane-title")?.textContent ?? "", /Shared/);
+
+    openProjectDetail(ownedProject.scopeId);
+    await Promise.resolve();
+    const renameButton = document.querySelector<HTMLButtonElement>(".context-rename-edit");
+    assert.ok(renameButton);
+    renameButton.click();
+    await Promise.resolve();
+    const input = document.querySelector<HTMLInputElement>(".context-rename-input");
+    assert.ok(input);
+    assert.equal(input.value, "Launch");
+    contextsState.renameDraft = "Launch Renamed";
+    input.value = "Launch Renamed";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    for (let i = 0; i < 40 && (patchedName === null || contextsState.renaming); i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    assert.equal(patchedName, "Launch Renamed");
+    assert.equal(
+      contextsState.list.find((context: CoreContext) => context.scopeId === ownedProject.scopeId)?.project?.name,
+      "Launch Renamed",
+    );
+    assert.equal(contextsState.renaming, false);
+    assert.match(document.querySelector(".pane-title")?.textContent ?? "", /Launch Renamed/);
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
## Summary
- Lets project owners rename a project from the Projects detail page via a pencil on the title (Enter to save, Escape to cancel).
- Keeps Personal and non-owned projects non-renameable; same owner-only rule as the Chats sidebar.
- Refreshes the sidebar after rename so the new name shows without a full page reload.

## Test plan
- [ ] Open Projects → open a project you own → pencil appears next to the title; rename and confirm the header and sidebar update immediately
- [ ] Open Personal → no pencil
- [ ] Open a project you’re a member of but don’t own → no pencil; Add people still available
- [ ] `cd plugins/web-ui && node --test test/contexts-source.test.ts test/project-rename.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789845637&installation_model_id=19911&pr_number=639&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F639&signature=ec2d6abcd4dc553b2dfd92809f6ec594124bc0b95ae25659722bf562a3947016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->