### PR TITLE
Allow co-author checks on upstream sync PRs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -138,8 +138,10 @@ jobs:
         run: |
           set -euo pipefail
           base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          git fetch --no-tags https://github.com/yc-software/qm.git main
+          upstream_main=$(git rev-parse FETCH_HEAD)
           offenders=""
-          for sha in $(git rev-list "$base..$HEAD_SHA"); do
+          for sha in $(git rev-list "$base..$HEAD_SHA" --not "$upstream_main"); do
             if git log -1 --format='%(trailers:key=Co-authored-by,valueonly)' "$sha" \
               | grep -qi '@users\.noreply\.github\.com'; then
               offenders="$offenders $sha"


### PR DESCRIPTION
## Summary

- Exclude commits already reachable from official qm `main` when validating co-author trailers.
- Continue rejecting GitHub privacy addresses introduced by the pull request itself.

## Why

Merge-based upstream syncs place historical upstream commits in the pull request range. A trailer policy added later should not retroactively reject commits that official qm already accepted.

## Verification

- Prettier check for the workflow.
- Replayed the check against a merge-based sync range containing historical privacy-address trailers.
- Scrubbed outgoing history for organization paths, identifiers, and binaries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789852270&installation_model_id=19911&pr_number=640&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F640&signature=c2a10e6f448716da10eac2ffb9103036bcf52b467b535c7f6c151271b073ce0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->