### PR TITLE
Fix conversation file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A multiplayer agent harness for work. In Slack and on the web.
 
 ## Setup
 
-Tell your coding agent of choice `Let's deploy https://github.com/yc-software/qm`. From here, it should follow the deployment guide in this repo. 
+Tell your coding agent of choice `Let's deploy https://github.com/yc-software/qm`. From here, it should follow the deployment guide in this repo.
 
 ## What is QM?
 

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1274,6 +1274,43 @@ const apiRoutes: readonly WebRoute[] = [
   },
   {
     method: "GET",
+    path: "/api/files/by-name/content",
+    handle: async (c) => {
+      const { res, url, user } = c;
+      const name = url.searchParams.get("name")?.trim();
+      if (!name) return json(res, 400, { error: "bad_request", message: "name required" });
+      let cursor: string | undefined;
+      let match: { id: string; createdAt: number } | undefined;
+      for (let page = 0; page < 50; page++) {
+        const qs = new URLSearchParams({ viewer: user, limit: "200" });
+        if (cursor) qs.set("cursor", cursor);
+        const listed = await coreFetch("GET", `/v1/files?${qs.toString()}`);
+        if (listed.status !== 200) return relay(res, listed);
+        let body: {
+          owned?: Array<{ id?: string; name?: string; createdAt?: number; openable?: boolean }>;
+          shared?: Array<{ id?: string; name?: string; createdAt?: number; openable?: boolean }>;
+          nextCursor?: string;
+        };
+        try {
+          body = JSON.parse(listed.text) as typeof body;
+        } catch {
+          return json(res, 502, { error: "upstream_error" });
+        }
+        for (const file of [...(body.owned ?? []), ...(body.shared ?? [])]) {
+          if (file.name !== name || file.openable === false || typeof file.id !== "string") continue;
+          const createdAt = typeof file.createdAt === "number" ? file.createdAt : 0;
+          if (!match || createdAt > match.createdAt) match = { id: file.id, createdAt };
+        }
+        cursor = body.nextCursor;
+        if (!cursor) break;
+      }
+      if (!match) return json(res, 404, { error: "not_found" });
+      res.writeHead(302, { location: `/api/files/${encodeURIComponent(match.id)}/content` });
+      return res.end();
+    },
+  },
+  {
+    method: "GET",
     path: "/api/files/:id/content",
     handle: async (c) => {
       const { res, user } = c;

--- a/plugins/web-ui/src/markdown-sanitize.ts
+++ b/plugins/web-ui/src/markdown-sanitize.ts
@@ -7,10 +7,36 @@ export const MARKDOWN_SANITIZE_CONFIG: Config = {
   ADD_ATTR: ["target", "encoding"],
 };
 
+const SANDBOX_WORKSPACE_LINK = /\shref=(["'])sandbox:\/home\/sprite\/workspace\/([^"']+)\1/gi;
+
+function decodedBasename(path: string): string | null {
+  const encoded = path.split("/").at(-1);
+  if (!encoded) return null;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return null;
+  }
+}
+
+export function rewriteSandboxFileLinks(html: string): string {
+  return html.replace(SANDBOX_WORKSPACE_LINK, (match, quote: string, path: string) => {
+    const name = decodedBasename(path);
+    if (!name) return match;
+    const href = `/api/files/by-name/content?name=${encodeURIComponent(name)}`;
+    return ` href=${quote}${href}${quote}`;
+  });
+}
+
 let installed = false;
 
 export function installMarkdownSanitizer(): void {
   if (installed) return;
   installed = true;
-  marked.use({ hooks: { postprocess: (html: string) => String(DOMPurify.sanitize(html, MARKDOWN_SANITIZE_CONFIG)) } });
+  marked.use({
+    hooks: {
+      postprocess: (html: string) =>
+        String(DOMPurify.sanitize(rewriteSandboxFileLinks(html), MARKDOWN_SANITIZE_CONFIG)),
+    },
+  });
 }

--- a/plugins/web-ui/test/markdown-sanitize.test.ts
+++ b/plugins/web-ui/test/markdown-sanitize.test.ts
@@ -4,7 +4,7 @@ import { marked } from "marked";
 import katex from "katex";
 import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
-import { MARKDOWN_SANITIZE_CONFIG } from "../src/markdown-sanitize.ts";
+import { MARKDOWN_SANITIZE_CONFIG, rewriteSandboxFileLinks } from "../src/markdown-sanitize.ts";
 
 const DOMPurify = createDOMPurify(new JSDOM("").window as unknown as Window & typeof globalThis);
 const sanitize = (html: string): string => DOMPurify.sanitize(html, MARKDOWN_SANITIZE_CONFIG) as string;
@@ -12,7 +12,7 @@ const sanitize = (html: string): string => DOMPurify.sanitize(html, MARKDOWN_SAN
 const renderer = new marked.Renderer();
 const originalLink = renderer.link.bind(renderer);
 renderer.link = (token) => originalLink(token).replace("<a ", '<a target="_blank" rel="noopener noreferrer" ');
-const render = (md: string): string => sanitize(marked.parse(md, { async: false, renderer }));
+const render = (md: string): string => sanitize(rewriteSandboxFileLinks(marked.parse(md, { async: false, renderer })));
 
 test("strips every script-bearing vector marked would otherwise pass through", () => {
   const vectors: Array<[string, string]> = [
@@ -32,6 +32,11 @@ test("strips every script-bearing vector marked would otherwise pass through", (
       `${name} leaked: ${out}`,
     );
   }
+});
+
+test("turns sandbox workspace links into real file-library downloads", () => {
+  const out = render("[download](sandbox:/home/sprite/workspace/reports/interview-list.csv)");
+  assert.match(out, /href="\/api\/files\/by-name\/content\?name=interview-list\.csv"/);
 });
 
 test("preserves ordinary links (target=_blank), code fences, and inline PNG images", () => {

--- a/plugins/web-ui/test/sandbox-link-download.test.ts
+++ b/plugins/web-ui/test/sandbox-link-download.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const calls: string[] = [];
+const core = createServer((req: IncomingMessage, res) => {
+  calls.push(req.url ?? "");
+  if ((req.url ?? "").startsWith("/v1/files?")) {
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(
+      JSON.stringify({
+        owned: [
+          {
+            id: "artifact-1",
+            name: "interview-list.csv",
+            createdAt: 10,
+            openable: true,
+          },
+        ],
+        shared: [],
+      }),
+    );
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+});
+await new Promise<void>((resolve) => core.listen(0, resolve));
+const coreUrl = `http://localhost:${(core.address() as AddressInfo).port}`;
+
+process.env.NODE_ENV = "test";
+process.env.ALLOW_UNSIGNED_TEST_IDENTITY = "1";
+process.env.CORE_API_URL = coreUrl;
+process.env.CORE_SIGNING_SECRET = "sandbox-link-download-test";
+process.env.WEB_UI_PRINCIPALS = "alice";
+
+const { handler } = await import("../server/index.ts");
+const surface = createServer((req, res) => void handler(req, res));
+await new Promise<void>((resolve) => surface.listen(0, resolve));
+const base = `http://localhost:${(surface.address() as AddressInfo).port}`;
+
+test.after(() => {
+  surface.close();
+  core.close();
+});
+
+test("sandbox markdown download resolves an authorized file-library item", async () => {
+  const response = await fetch(`${base}/api/files/by-name/content?name=interview-list.csv`, {
+    headers: { cookie: "webuiuser=alice" },
+    redirect: "manual",
+  });
+  assert.equal(response.status, 302);
+  assert.equal(response.headers.get("location"), "/api/files/artifact-1/content");
+  assert.ok(calls.some((url) => url.startsWith("/v1/files?") && url.includes("viewer=alice")));
+});
+
+test("sandbox markdown download stays unavailable when no visible file matches", async () => {
+  const response = await fetch(`${base}/api/files/by-name/content?name=missing.csv`, {
+    headers: { cookie: "webuiuser=alice" },
+    redirect: "manual",
+  });
+  assert.equal(response.status, 404);
+});


### PR DESCRIPTION
Improves file-link behavior in conversation messages.

- verification: web UI tests, typecheck, lint, build, and browser click-through

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789859065&installation_model_id=19911&pr_number=642&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F642&signature=4884890c41f7263750da8a0eddec16e431eaa708980f6abe2acf0a62f47d4d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->