### PR TITLE
fix(keychain): keep using a valid connector token when its refresh fails

### DIFF
--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -692,9 +692,9 @@ export function createKeychain(deps: {
         inflightRefreshes.set(rec.id, pending);
         void pending.finally(() => inflightRefreshes.delete(rec.id));
       }
-      return pending;
-    }
-    if (oauthExpired(rec, t) && !refreshable) return null;
+      const refreshed = await pending;
+      if (refreshed || oauthExpired(rec, t)) return refreshed;
+    } else if (oauthExpired(rec, t) && !refreshable) return null;
     return tryDecrypt(rec, (r) => decryptSecret(r.secretEnc, deps.key));
   }
 

--- a/test/keychain.test.ts
+++ b/test/keychain.test.ts
@@ -1458,3 +1458,59 @@ test("turn e2e: manifest in the prompt, no secret without a grant, standing gran
   assert.equal((await built.app.turn(dm)).status, "ok");
   assert.ok(execScriptsMention("ghp_e2e", mark), "owner's personal scope gets their own keychain creds");
 });
+
+describe("a failed connector refresh does not discard a token that still works", () => {
+  const GMAIL = "gmail.googleapis.com";
+  type Rec = import("../src/credentials/keychain.ts").KeychainCredential;
+  function kcFailingRefresh(): Keychain {
+    return createKeychain({
+      creds: createMemoryMap<Rec>(),
+      grants: createMemoryMap(),
+      asks: createMemoryMap(),
+      key: KEY,
+      refreshConnector: async () => {
+        throw new Error("fetch failed");
+      },
+    });
+  }
+
+  it("falls back to the stored token while it is still valid", async () => {
+    const k = kcFailingRefresh();
+    await k.setConnectorToken(GMAIL, "alex@x", {
+      accessToken: "ya29.still-good",
+      refreshToken: "rt",
+      expiresAt: Date.now() + 5 * 60_000,
+    });
+    assert.equal(await k.connectorAccessToken(GMAIL, "alex@x"), "ya29.still-good");
+    const status = await k.connectorTokenStatus(GMAIL, "alex@x");
+    assert.equal(typeof status.refreshFailedAt, "number", "the failure is still recorded");
+    assert.equal(status.needsReconnect, undefined, "a usable token is not a reconnect prompt");
+  });
+
+  it("returns nothing once the stored token is past its skew", async () => {
+    const k = kcFailingRefresh();
+    await k.setConnectorToken(GMAIL, "alex@x", {
+      accessToken: "ya29.dead",
+      refreshToken: "rt",
+      expiresAt: Date.now() + 10_000,
+    });
+    assert.equal(await k.connectorAccessToken(GMAIL, "alex@x"), null);
+    assert.equal((await k.connectorTokenStatus(GMAIL, "alex@x")).needsReconnect, true);
+  });
+
+  it("still prefers a successful refresh over the stored token", async () => {
+    const k = createKeychain({
+      creds: createMemoryMap<Rec>(),
+      grants: createMemoryMap(),
+      asks: createMemoryMap(),
+      key: KEY,
+      refreshConnector: async () => ({ accessToken: "ya29.fresh", expiresAt: Date.now() + 3_600_000 }),
+    });
+    await k.setConnectorToken(GMAIL, "alex@x", {
+      accessToken: "ya29.aging",
+      refreshToken: "rt",
+      expiresAt: Date.now() + 5 * 60_000,
+    });
+    assert.equal(await k.connectorAccessToken(GMAIL, "alex@x"), "ya29.fresh");
+  });
+});


### PR DESCRIPTION
## Summary

A connector token refresh fires as soon as the token enters the refresh margin, and its result is returned unconditionally. One failed refresh therefore hands the turn nothing — even though the stored token usually has minutes of life left and would have worked fine.

That turns a brief network problem into a credential outage. Observed on a machine waking from sleep with DNS not yet up: a run of `[keychain] connector token refresh failed for <host>: fetch failed`, tools that then had no token at all, and scheduled work coming back as provider 401s and "needs reconnect" — for grants that were never revoked. Because the orchestrator walks every connector host, a single bad minute takes out the whole set.

This change falls back to the stored token when a refresh fails and the token has not yet reached its expiry skew. The failure is still stamped on the record, so a genuine revocation still surfaces as needs-reconnect the moment the token really expires; the outage window just stops taking working credentials down with it.

No retries, no new knobs, no added latency: the fallback path is the one that was already returning `null`.

## Test plan

`node --experimental-test-module-mocks --test test/keychain.test.ts` — 45/45 pass, `tsc --noEmit` and `eslint` clean. Three new cases:

- refresh throws while the stored token still has 5 minutes: the stored token is returned, `refreshFailedAt` is recorded, and status does **not** report needsReconnect (this one fails on `main`);
- refresh throws and the stored token is inside the expiry skew: nothing is returned and status reports needsReconnect;
- refresh succeeds: the fresh token still wins over the stored one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789865756&installation_model_id=19911&pr_number=644&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F644&signature=f545d4aae86e8fcfdd221ccfdcedae85635ebbf3201256c3fff3a08a10c9b5ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->