### PR TITLE
feat(codex): surface turn-level cache and spend telemetry

### DIFF
--- a/src/admin/metrics-sink.ts
+++ b/src/admin/metrics-sink.ts
@@ -36,6 +36,8 @@ export interface TurnMetricSample {
   cacheRead?: number;
   cacheWrite?: number;
   uncachedInput?: number;
+  outputTokens?: number;
+  costUsd?: number;
 }
 
 export function cacheHitRatio(s: { cacheRead?: number; cacheWrite?: number; uncachedInput?: number }): number | null {

--- a/src/admin/postgres-metrics-sink.ts
+++ b/src/admin/postgres-metrics-sink.ts
@@ -37,6 +37,8 @@ const COLUMNS: readonly EventColumn<keyof TurnMetricSample & string>[] = [
   ["cache_read", "cacheRead", "BIGINT", "number"],
   ["cache_write", "cacheWrite", "BIGINT", "number"],
   ["uncached_input", "uncachedInput", "BIGINT", "number"],
+  ["output_tokens", "outputTokens", "BIGINT", "number"],
+  ["cost_usd", "costUsd", "DOUBLE PRECISION", "number"],
 ];
 
 const EXTRA_SCHEMA_STATEMENTS = [

--- a/src/api/routes/admin/observability.ts
+++ b/src/api/routes/admin/observability.ts
@@ -150,6 +150,18 @@ export async function metrics(ctx: ApiCtx): Promise<void> {
     uncachedInputTotal,
   };
 
+  // Turn-level spend, straight off the usage the harnesses already meter:
+  // output tokens and provider-computed cost land on turn_metrics next to
+  // the cache telemetry, so an operator no longer joins session_llm_requests
+  // by hand to know what a scope or model spends.
+  const costSamples = samples.filter((s) => s.costUsd !== undefined || s.outputTokens !== undefined);
+  const spend = {
+    samples: costSamples.length,
+    turnsWithKnownCost: samples.filter((s) => s.costUsd !== undefined).length,
+    costUsdTotal: samples.reduce((n, s) => n + (s.costUsd ?? 0), 0),
+    outputTokensTotal: samples.reduce((n, s) => n + (s.outputTokens ?? 0), 0),
+  };
+
   const phaseFields: [string, (s: TurnMetricSample) => number | undefined][] = [
     ["total", (s) => s.totalMs],
     ["ttft", (s) => s.ttftMs],
@@ -225,6 +237,7 @@ export async function metrics(ctx: ApiCtx): Promise<void> {
     series,
     anatomy,
     cache,
+    spend,
     phases,
   });
 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2796,6 +2796,9 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
                 uncachedInput: result.cacheUsage.uncachedInput,
               }
             : {}),
+          ...(result.costUsage
+            ? { outputTokens: result.costUsage.outputTokens, costUsd: result.costUsage.costUsd }
+            : {}),
         });
         const onTurnEnd = memoryStrategy.onTurnEnd?.bind(memoryStrategy);
         if (!pausing && useMemory && memoryPolicy.capture !== "off" && onTurnEnd) {

--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -764,11 +764,12 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
       const usageTotals = [...callUsage.values()].reduce(
         (acc, usage) => {
           acc.input += usage.input;
+          acc.output += usage.output;
           acc.cacheRead += usage.cacheRead;
           acc.cacheWrite += usage.cacheWrite;
           return acc;
         },
-        { input: 0, cacheRead: 0, cacheWrite: 0 },
+        { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       );
       return {
         reply,
@@ -793,6 +794,12 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
                   finalResult.usage.cache_creation_input_tokens,
               ),
             },
+        // The SDK result carries no cost total, so spend is surfaced only
+        // when the per-message accumulator saw cost deltas; the fallback
+        // branch keeps output tokens but reports no known cost.
+        costUsage: callUsage.size
+          ? { outputTokens: usageTotals.output, costUsd: lastTotalCostUsd }
+          : { outputTokens: finalResult.usage.output_tokens ?? 0, costUsd: 0 },
         ...(tapeWriteFailed ? { tapeWriteFailed: true } : {}),
       };
     } finally {

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CODEX_MODEL_ID, modelSupportedByHarness } from "../model/pi-mod
 import { startSignalPoll, type RunSignalStore } from "../runs/run-signal-store.ts";
 import type { TaskStatus, TaskStore } from "../tasks/task-store.ts";
 import type { LlmCallUsage } from "../sessions/session-store.ts";
+import { usageToTurnTelemetry } from "./harness.ts";
 import type { ScopeId, SessionEntry } from "../types.ts";
 import { swallow } from "../util/errors.ts";
 import { countTokens } from "../util/tokens.ts";
@@ -142,17 +143,6 @@ export function codexUsageTotals(params: unknown): LlmCallUsage | null {
   const output = usageNumber(total, "outputTokens", "output_tokens");
   const cacheRead = usageNumber(total, "cachedInputTokens", "cached_input_tokens");
   return { input, output, cacheRead, cacheWrite: 0, totalTokens: input + output, costUsd: 0 };
-}
-
-export function usageToTurnTelemetry(usage: LlmCallUsage | null): {
-  cacheUsage: { cacheRead: number; cacheWrite: number; uncachedInput: number };
-  costUsage: { outputTokens: number; costUsd: number };
-} | null {
-  if (!usage) return null;
-  return {
-    cacheUsage: { cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite, uncachedInput: usage.input },
-    costUsage: { outputTokens: usage.output, costUsd: usage.costUsd },
-  };
 }
 
 function sumUsage(byThread: ReadonlyMap<string, LlmCallUsage>): LlmCallUsage | null {

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -144,6 +144,17 @@ export function codexUsageTotals(params: unknown): LlmCallUsage | null {
   return { input, output, cacheRead, cacheWrite: 0, totalTokens: input + output, costUsd: 0 };
 }
 
+export function usageToTurnTelemetry(usage: LlmCallUsage | null): {
+  cacheUsage: { cacheRead: number; cacheWrite: number; uncachedInput: number };
+  costUsage: { outputTokens: number; costUsd: number };
+} | null {
+  if (!usage) return null;
+  return {
+    cacheUsage: { cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite, uncachedInput: usage.input },
+    costUsage: { outputTokens: usage.output, costUsd: usage.costUsd },
+  };
+}
+
 function sumUsage(byThread: ReadonlyMap<string, LlmCallUsage>): LlmCallUsage | null {
   if (!byThread.size) return null;
   const total: LlmCallUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, costUsd: 0 };
@@ -832,6 +843,12 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
           payload: { text: reply, stopped: state.stopped || undefined },
           scopeLabel: turn.scopeLabel,
         });
+      // Turn-level usage straight off the same live thread totals the
+      // recordLlmRequest flush reports, so codex turns land in turn_metrics
+      // with cache and spend telemetry like pi and claude. The codex SDK
+      // reports no cost, so costUsd stays 0 (the value already persisted to
+      // session_llm_requests for the same calls).
+      const telemetry = usageToTurnTelemetry(sumUsage(state.usageByThread));
       return {
         reply,
         ...(state.stopped ? { stopped: true as const } : {}),
@@ -839,6 +856,7 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
         ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
         ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),
         modelCalls: state.modelCalls,
+        ...(telemetry ?? {}),
         ...(state.tapeWriteFailed ? { tapeWriteFailed: true } : {}),
       };
     } finally {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -109,6 +109,7 @@ export interface HarnessTurnResult {
   pausedOnApproval?: boolean;
   modelCalls?: number;
   cacheUsage?: { cacheRead: number; cacheWrite: number; uncachedInput: number };
+  costUsage?: { outputTokens: number; costUsd: number };
   compileMs?: number;
   tapeWriteFailed?: boolean;
 }

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -114,6 +114,17 @@ export interface HarnessTurnResult {
   tapeWriteFailed?: boolean;
 }
 
+export function usageToTurnTelemetry(usage: LlmCallUsage | null): {
+  cacheUsage: { cacheRead: number; cacheWrite: number; uncachedInput: number };
+  costUsage: { outputTokens: number; costUsd: number };
+} | null {
+  if (!usage) return null;
+  return {
+    cacheUsage: { cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite, uncachedInput: usage.input },
+    costUsage: { outputTokens: usage.output, costUsd: usage.costUsd },
+  };
+}
+
 export interface HarnessDetectInput {
   session: Session;
   message: string;

--- a/src/harness/mock-harness.ts
+++ b/src/harness/mock-harness.ts
@@ -682,6 +682,10 @@ export function createMockHarness(): Harness {
           }),
           { cacheRead: 0, cacheWrite: 0, uncachedInput: 0 },
         );
+        const costUsage = steps.reduce(
+          (acc, u) => ({ outputTokens: acc.outputTokens + u.output, costUsd: acc.costUsd + u.costUsd }),
+          { outputTokens: 0, costUsd: 0 },
+        );
         const base = collected.length
           ? {
               reply,
@@ -691,7 +695,7 @@ export function createMockHarness(): Harness {
             }
           : { reply, modelCalls };
         if (muteReply) base.reply = "";
-        return { ...base, ...(silent ? { silent: true as const } : {}), cacheUsage };
+        return { ...base, ...(silent ? { silent: true as const } : {}), cacheUsage, costUsage };
       },
 
       shouldRespond(detect: HarnessDetectInput): Promise<HarnessDetectResult> {

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -574,6 +574,21 @@ function piUsageToCallUsage(u: PiUsageShape | undefined): LlmCallUsage | null {
   };
 }
 
+function sumCostUsage(
+  stats: ReadonlyArray<{ usage: LlmCallUsage | null }>,
+): { outputTokens: number; costUsd: number } | null {
+  let saw = false;
+  let outputTokens = 0;
+  let costUsd = 0;
+  for (const s of stats) {
+    if (!s.usage) continue;
+    saw = true;
+    outputTokens += s.usage.output;
+    costUsd += s.usage.costUsd;
+  }
+  return saw ? { outputTokens, costUsd } : null;
+}
+
 function sumCacheUsage(
   stats: ReadonlyArray<{ usage: LlmCallUsage | null }>,
 ): { cacheRead: number; cacheWrite: number; uncachedInput: number } | null {
@@ -1989,6 +2004,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
             });
             await checkpointSubturn(finalEntry.seq);
             const cacheUsage = sumCacheUsage(callStats);
+            const costUsage = sumCostUsage(callStats);
             const base = {
               reply,
               stopped: true as const,
@@ -1996,7 +2012,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
               compileMs,
               ...(tapeWriteFailed ? { tapeWriteFailed: true } : {}),
             };
-            return cacheUsage ? { ...base, cacheUsage } : base;
+            return { ...base, ...(cacheUsage ? { cacheUsage } : {}), ...(costUsage ? { costUsage } : {}) };
           }
           const closingText = recoveryDead ? "" : (piLastAssistantTextOrThrow(entry.agentSession) ?? "");
           const closingTextWithWaiver = [closingText, grindWaiverNote].filter(Boolean).join("\n\n");
@@ -2011,6 +2027,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           const pendingApprovals = entry.ref.pendingApprovals ?? [];
           const modelCalls = entry.ref.modelCalls ?? 0;
           const cacheUsage = sumCacheUsage(callStats);
+          const costUsage = sumCostUsage(callStats);
           const silent = entry.ref.silentRequested ? { silent: true as const } : {};
           const base = pendingApprovals.length
             ? {
@@ -2023,7 +2040,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
                 compileMs,
               }
             : { reply, ...(tapeWriteFailed ? { tapeWriteFailed: true } : {}), modelCalls, ...silent, compileMs };
-          return cacheUsage ? { ...base, cacheUsage } : base;
+          return { ...base, ...(cacheUsage ? { cacheUsage } : {}), ...(costUsage ? { costUsage } : {}) };
         } finally {
           removeIsolatedDirs(entry);
         }

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -9,6 +9,7 @@ import {
   codexNonRetryable,
   codexProviderFailure,
   codexUsageTotals,
+  usageToTurnTelemetry,
   codexChildToolAllowed,
   codexReasoningEffort,
   codexReplayCallId,
@@ -71,7 +72,7 @@ rl.on("line", (line) => {
     send({ method: "item/started", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "collabAgentToolCall", id: "collab-1", tool: "spawnAgent", status: "inProgress", senderThreadId: "thread-1", receiverThreadIds: ["child-1"], prompt: "return ALPHA", agentsStates: { "child-1": { status: "running", message: null } } } } });
     send({ method: "thread/tokenUsage/updated", params: { threadId: "child-1", tokenUsage: { total: { inputTokens: 70 }, last: { inputTokens: 70 } } } });
     send({ method: "item/completed", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "collabAgentToolCall", id: "collab-1", tool: "spawnAgent", status: "completed", senderThreadId: "thread-1", receiverThreadIds: ["child-1"], prompt: "return ALPHA", agentsStates: { "child-1": { status: "completed", message: "ALPHA" } } } } });
-    send({ method: "thread/tokenUsage/updated", params: { threadId: "thread-1", tokenUsage: { total: { inputTokens: 250 }, last: { inputTokens: 150 } } } });
+    send({ method: "thread/tokenUsage/updated", params: { threadId: "thread-1", tokenUsage: { total: { inputTokens: 250, outputTokens: 60, cachedInputTokens: 120 }, last: { inputTokens: 150 } } } });
     send({ method: "item/agentMessage/delta", params: { threadId: "thread-1", turnId: "turn-1", itemId: "item-1", delta: "hello" } });
     send({ method: "item/completed", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "agentMessage", id: "item-1", text: "hello", phase: "final_answer", memoryCitation: null } } });
     return send({ method: "turn/completed", params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [], itemsView: "notLoaded" } } });
@@ -205,6 +206,16 @@ test("Codex harness drives app-server JSON-RPC with a read-only jail", async (t)
   assert.equal(result.reply, "hello");
   assert.deepEqual(deltas, ["hello"]);
   assert.deepEqual(modelCalls, [100, 70, 150]);
+  assert.deepEqual(
+    result.cacheUsage,
+    { cacheRead: 120, cacheWrite: 0, uncachedInput: 250 },
+    "turn-level cache telemetry comes off the live thread totals",
+  );
+  assert.deepEqual(
+    result.costUsage,
+    { outputTokens: 60, costUsd: 0 },
+    "turn-level spend is surfaced (codex reports no cost, so it stays 0)",
+  );
   assert.deepEqual(
     entries.map((entry) => entry.type),
     ["user", "tool_call", "tool_result", "assistant"],
@@ -496,6 +507,17 @@ test("Codex never classifies its own infrastructure failures as terminal", () =>
   }
   assert.equal(codexProviderFailure("Codex turn failed").message, "Codex turn failed");
   assert.ok(!(codexProviderFailure("socket hang up") instanceof NonRetryableTurnError));
+});
+
+test("Codex turn telemetry maps thread usage totals onto cache and spend", () => {
+  assert.deepEqual(
+    usageToTurnTelemetry({ input: 250, output: 60, cacheRead: 120, cacheWrite: 0, totalTokens: 430, costUsd: 0 }),
+    {
+      cacheUsage: { cacheRead: 120, cacheWrite: 0, uncachedInput: 250 },
+      costUsage: { outputTokens: 60, costUsd: 0 },
+    },
+  );
+  assert.equal(usageToTurnTelemetry(null), null, "a turn with no usage reports no telemetry");
 });
 
 test("Codex reads cumulative usage totals off the app-server's token notification", () => {

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -9,7 +9,7 @@ import {
   codexNonRetryable,
   codexProviderFailure,
   codexUsageTotals,
-  usageToTurnTelemetry,
+
   codexChildToolAllowed,
   codexReasoningEffort,
   codexReplayCallId,
@@ -20,6 +20,7 @@ import {
   createCodexHarness,
   prepareCodexHome,
 } from "../src/harness/codex-harness.ts";
+import { usageToTurnTelemetry } from "../src/harness/harness.ts";
 import type { HarnessLlmRequestRecord, HarnessTurnInput } from "../src/harness/harness.ts";
 import { NonRetryableTurnError } from "../src/core/turn-error.ts";
 import type { ScopeId, Session, SessionEntry } from "../src/types.ts";

--- a/test/turn-metrics-cost.test.ts
+++ b/test/turn-metrics-cost.test.ts
@@ -1,0 +1,66 @@
+import "./support/auto-fake-sprites.ts";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import type { TurnRequest } from "../src/types.ts";
+import { testConfig } from "./support/test-config.ts";
+
+function start() {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "cost-obs-")) }));
+  const server = createInsecureTestServer(built.app, {
+    admin: built.admin,
+    sessions: built.sessions,
+    auditLog: built.auditLog,
+    metrics: built.metrics,
+    runs: built.runs,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  return { base, built, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+const ALICE = { "x-admin-actor": "admin-alice@default-org" };
+const getJson = async (base: string, path: string, headers: Record<string, string> = ALICE): Promise<any> =>
+  (await fetch(base + path, { headers })).json();
+
+test("metrics: turn spend (output tokens + cost) is surfaced on the metrics endpoint", async () => {
+  const s = start();
+  try {
+    const turn: TurnRequest = {
+      surface: "test",
+      actor: { externalId: "U1" },
+      conversation: { kind: "dm", threadRef: "dm:U1:c1" },
+      text: "hello there",
+    };
+    assert.equal((await s.built.app.turn(turn)).status, "ok");
+
+    const m = await getJson(s.base, "/v1/admin/metrics?scope=org:default-org");
+    assert.ok(m.spend, "the metrics response carries a spend block");
+    assert.ok(m.spend.samples >= 1, "the turn carried spend telemetry");
+    assert.ok(m.spend.turnsWithKnownCost >= 1, "the mock harness reports known (if zero) cost");
+    assert.ok(m.spend.outputTokensTotal > 0, "output tokens are summed per turn");
+    assert.equal(typeof m.spend.costUsdTotal, "number", "cost total is numeric even when the mock reports 0");
+  } finally {
+    await s.close();
+  }
+});
+
+test("metrics: an empty scope yields a present-but-empty spend block", async () => {
+  const s = start();
+  try {
+    const m = await getJson(s.base, "/v1/admin/metrics?scope=personal:nobody");
+    assert.ok(m.spend, "spend block is always present");
+    assert.equal(m.spend.samples, 0);
+    assert.equal(m.spend.turnsWithKnownCost, 0);
+    assert.equal(m.spend.outputTokensTotal, 0);
+    assert.equal(m.spend.costUsdTotal, 0);
+  } finally {
+    await s.close();
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to #645: codex accumulated full per-thread usage live (`usageByThread`, the same totals its `recordLlmRequest` flush reports) but its turn result carried none of it, so codex turns landed in `turn_metrics` without the cache or spend telemetry pi and claude already report.

## Implementation

The turn result maps the summed thread totals through one pure `usageToTurnTelemetry` helper: `cacheUsage` (cacheRead/cacheWrite/uncachedInput) and `costUsage` (outputTokens, costUsd). The codex SDK reports no cost, so `costUsd` stays `0` — the same value already persisted to `session_llm_requests` for these calls, and consistent with #645's claude fallback convention.

**Stacked on #645** (the `costUsage` turn-result field and `turn_metrics` columns land there) — rebase or merge order: #645 first.

opencode still reports no turn telemetry: its usage is only fetched in the post-return flush, so wiring it needs a small restructure — noted for follow-up rather than smuggled into this change.

## Testing

- New pure unit test for the mapping (`usageToTurnTelemetry`): totals → cache + spend shape, `null` for a no-usage turn. Green.
- The JSON-RPC integration test's fake binary now emits `outputTokens`/`cachedInputTokens` in its final token-usage notification and asserts both telemetry fields on the turn result (passes where the fake-binary harness tests run; the 9 fake-binary tests fail identically with and without this change on this Windows host — `spawn` of a shebang script — so the stash differential for them is inconclusive locally).
- `tsc --noEmit` clean against the stacked base.

Follow-up to #586

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789879829&installation_model_id=19911&pr_number=646&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F646&signature=d8a2cb82a44c49950797be84636e9cd03a3f390bb9e8fb0734c3d7a6721e37d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->