### PR TITLE
feat(connectors): inject every connected account slot, not just the winning one

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -41,6 +41,7 @@ import {
   configuredConnectorProviders,
   connectorStatusIsStale,
   refreshConnectorStatus,
+  CONNECTOR_STATUS_ACCOUNT_TYPES,
 } from "../credentials/connector-status.ts";
 import { renderComputerBlock, renderResidentLoginsBlock, renderConnectedAppsBlock } from "./environment-facts.ts";
 import { PROVIDERS } from "../connectors/oauth.ts";
@@ -1069,11 +1070,16 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       }
       if (!strictReadOnly && deps.connectorTokens && conversation.kind === "dm") {
         for (const host of CONNECTOR_HOSTS) {
-          const token =
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id, "personal")) ??
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id)) ??
-            (await deps.connectorTokens.connectorAccessToken(host, actor.id, "company"));
+          const slots = new Map<string, string>();
+          for (const accountType of CONNECTOR_STATUS_ACCOUNT_TYPES) {
+            const slotToken = await deps.connectorTokens.connectorAccessToken(host, actor.id, accountType);
+            if (slotToken) slots.set(accountType ?? "default", slotToken);
+          }
+          const token = slots.get("personal") ?? slots.get("default") ?? slots.get("company");
           if (token) connectorEnv[envKey(host)] = token;
+          if (slots.size > 1) {
+            for (const [slot, slotToken] of slots) connectorEnv[`${envKey(host)}__${slot.toUpperCase()}`] = slotToken;
+          }
         }
       }
       perf.credsMs += Date.now() - credsStart;

--- a/test/connector-invariants.test.ts
+++ b/test/connector-invariants.test.ts
@@ -225,3 +225,30 @@ test("a read-only wake never reaches the sandbox (execute stripped), so no exec 
     "a read-only wake spins no sandbox exec",
   );
 });
+
+test("every connected account slot reaches the exec env, not just the winning one", async () => {
+  const built: BuiltApp = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "slots-")) }));
+  const host = "gmail.googleapis.com";
+  await built.connectorTokens.setConnectorToken(host, "U1", { accessToken: "u1-default" });
+  await built.connectorTokens.setConnectorToken(host, "U1", { accessToken: "u1-company" }, "company");
+
+  fakeSprites.reset();
+  const dm = await built.app.turn(turn("dm", "!run true"));
+  assert.equal(dm.status, "ok");
+  assert.ok(execScriptsMention(`export ${envKey(host)}=`), "the primary slot keeps the unsuffixed name");
+  assert.ok(execScriptsMention("u1-default"), "the default slot stays the primary token");
+  assert.ok(execScriptsMention(`${envKey(host)}__COMPANY=`), "the second slot gets its own variable");
+  assert.ok(execScriptsMention("u1-company"), "the second slot's token value is present");
+});
+
+test("a single connected slot injects only the unsuffixed variable", async () => {
+  const built: BuiltApp = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "one-slot-")) }));
+  const host = "gmail.googleapis.com";
+  await built.connectorTokens.setConnectorToken(host, "U1", { accessToken: "u1-only" });
+
+  fakeSprites.reset();
+  const dm = await built.app.turn(turn("dm", "!run true"));
+  assert.equal(dm.status, "ok");
+  assert.ok(execScriptsMention(`export ${envKey(host)}=`));
+  assert.ok(!execScriptsMention(`${envKey(host)}__`), "no per-slot variables when there is nothing to disambiguate");
+});


### PR DESCRIPTION
## Summary

A principal can connect the same provider more than once — the `default`, `personal`, and `company` slots each hold their own token, and `connectorTokenStatus` already reports them separately. A turn, however, only ever saw one: the first hit of personal → default → company landed in `VAULT_TOKEN_<HOST>` and the other slots were invisible to the agent.

So someone with a personal and a company Google account connected can reach exactly one of the two mailboxes, and has no way to name the other. Nothing surfaces the ambiguity either — the connector page shows the provider as simply "connected".

This change keeps the unsuffixed variable exactly as it was, same precedence and same value, and additionally exports `VAULT_TOKEN_<HOST>__DEFAULT` / `__PERSONAL` / `__COMPANY` for each slot that is actually connected, but only when more than one is. A single-slot connector's environment is byte-identical to before, so existing skills keep working as written, and a skill that wants a specific account can now address it.

The slot list comes from the existing `CONNECTOR_STATUS_ACCOUNT_TYPES`, so the injection and the status view stay in step if a slot is ever added.

## Test plan

`node --experimental-test-module-mocks --test test/connector-invariants.test.ts` — 10/10 pass, `tsc --noEmit` and `eslint` clean. Two new cases against the existing exec-env harness:

- two slots connected (default + company): the unsuffixed variable still carries the default slot's token, and the company slot arrives as its own variable (this test fails on `main`);
- one slot connected: only the unsuffixed variable is exported, no `__` variables at all.

Verified end to end on a live instance with two Google accounts in one workspace: before, the agent could only read one mailbox; after, it reads and reports both, and the existing single-account skills were unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789882361&installation_model_id=19911&pr_number=648&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F648&signature=077abb828f7499fbf36e2b47ee001a672d4d7609bbc80dcf46dd40b2983eb950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->