### PR TITLE
feat(web-ui): show non-admin users a slimmer member view

### DIFF
--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -275,7 +275,7 @@ export function scopeChip(scopeId: string | null, fallbackName?: string | null):
 }
 
 export function scopeFilterControl(current: string | null, onSelect: (scopeId: string | null) => void): TemplateResult {
-  const label = current ? metaForScope(current).title : "All contexts";
+  const label = current ? metaForScope(current).title : "All projects";
   const option = (scopeId: string | null, text: string, glyph: IconNode) => {
     const active = (current ?? null) === scopeId;
     return html`
@@ -298,11 +298,11 @@ export function scopeFilterControl(current: string | null, onSelect: (scopeId: s
   return html`
     <div class="menu-control form-menu-control scope-filter">
       <button class="menu-button" type="button" aria-haspopup="menu" aria-expanded="false" @click=${toggleFormMenu}>
-        ${icon(ListFilter, 14)}<span class="menu-label">Filter by: ${label}</span>${icon(ChevronDown, 14)}
+        ${icon(ListFilter, 14)}<span class="menu-label">${label}</span>${icon(ChevronDown, 14)}
       </button>
       <div class="menu-popover" role="menu" hidden>
-        <div class="menu-title">Filter by context</div>
-        ${option(null, "All contexts", Boxes)}
+        <div class="menu-title">Filter by project</div>
+        ${option(null, "All projects", Boxes)}
         ${contextsState.list.map((c) => option(c.scopeId, contextMeta(c).title, contextMeta(c).glyph))}
       </div>
     </div>

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { Box, Brain, Clock3, Files, GitFork, KeyRound, Rocket } from "lucide";
 import { api } from "./core-bridge";
+import { can } from "./shell-state";
 import { icon } from "./ui";
 
 /** A session's context carried into the crons/files/memory views so the whole
@@ -157,8 +158,13 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           : html`<div class="session-heading" title=${headingTitle}>${heading}</div>`
       }
       <div class="topbar-actions session-tools">
-        ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")} ${tool("apps", Rocket, "Apps")}
-        ${tool("skills", Box, "Skills")} ${tool("memory", Brain, "Memory")}
+        ${can("admin") ? tool("crons", Clock3, "Crons") : nothing} ${tool("files", Files, "Files")}
+        ${
+          can("admin")
+            ? html`${tool("apps", Rocket, "Apps")} ${tool("skills", Box, "Skills")}
+              ${tool("memory", Brain, "Memory")}`
+            : nothing
+        }
         ${tool("keychain", KeyRound, "Your keychain")}
       </div>
     </header>

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -70,10 +70,11 @@ import {
   personalScopeId,
   renameProject,
   scopeChip,
+  scopeTitle,
 } from "./contexts";
 import { groupDmLabel, groupDmText } from "./group-dm-label";
 import { transcriptModel } from "./model-options";
-import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, syncUrlFromState } from "./shell";
+import { appState, can, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, syncUrlFromState } from "./shell";
 import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
@@ -263,7 +264,9 @@ export function renderList(): void {
   const active = visible.filter((s) => !s.archived);
   const archived = visible.filter((s) => s.archived);
   const { pinned, rest } = splitPinned(active);
-  const activeItems = recentItemsFor(rest);
+  const activeItems: RecentItem[] = can("admin")
+    ? recentItemsFor(rest)
+    : rest.map((session) => ({ kind: "session", session }));
   const archivedItems: RecentItem[] = archived.map((session) => ({ kind: "session", session }));
   armMidnightRefresh();
   render(
@@ -518,21 +521,25 @@ export function drawChatsPage(): void {
               </button>`,
           )}
         </div>
-        <label class="list-select"
-          ><span>Surface</span>${fieldSelect({
-            compact: true,
-            value: chatsPageSurface,
-            onChange: (value) => {
-              chatsPageSurface = value as typeof chatsPageSurface;
-              drawChatsPage();
-            },
-            options: [
-              html`<option value="all">All surfaces</option>`,
-              html`<option value="web">Web</option>`,
-              html`<option value="slack">Slack</option>`,
-            ],
-          })}</label
-        >
+        ${
+          can("admin")
+            ? html`<label class="list-select"
+                ><span>Surface</span>${fieldSelect({
+                  compact: true,
+                  value: chatsPageSurface,
+                  onChange: (value) => {
+                    chatsPageSurface = value as typeof chatsPageSurface;
+                    drawChatsPage();
+                  },
+                  options: [
+                    html`<option value="all">All surfaces</option>`,
+                    html`<option value="web">Web</option>`,
+                    html`<option value="slack">Slack</option>`,
+                  ],
+                })}</label
+              >`
+            : nothing
+        }
       </div>`,
       rows,
       empty,
@@ -633,7 +640,11 @@ function chatPageRow(s: CoreSession): TemplateResult {
       >
         <span class="list-row-title">${statusMarks(s)}${groupDmTitle(s)}</span>
         <span class="list-row-meta">
-          ${scopeChip(s.scopeId, s.channelName ?? null)}
+          ${
+            can("admin") || scopeTitle(s.scopeId, s.channelName ?? null) !== "Personal"
+              ? scopeChip(s.scopeId, s.channelName ?? null)
+              : nothing
+          }
           ${surfaceOf(s) === "slack" ? html`<span class="surface surface-slack">${slackLogo(13)}</span>` : nothing}
           ${readOnly ? html`<span class="ro-lock" title="Read-only">${icon(Lock, 12)}</span>` : nothing}
           <span class="list-row-date">${listWhen(activityOf(s))}</span>

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -178,7 +178,6 @@ const ICON = {
   chats: MessageSquare,
   contexts: Folder,
   files: Files,
-  keychain: KeyRound,
   deploys: Rocket,
   webhooks: Webhook,
   crons: Clock,
@@ -450,6 +449,20 @@ export function mountShell(): void {
               <span class="avatar">${initials(appState.me?.user ?? "?")}</span>
               <span class="user-name">${appState.me?.user ?? ""}</span>
             </div>
+            <a
+              class="icon-btn subtle"
+              href=${deepLinkPath(UI_BASE, "keychain", null)}
+              title="Keychain"
+              aria-label="Keychain"
+              @click=${(e: MouseEvent) => {
+                if (!isPlainLeftClick(e)) return;
+                e.preventDefault();
+                setScopedSession(null);
+                switchView("keychain");
+              }}
+            >
+              ${icon(KeyRound, 17)}
+            </a>
             <theme-toggle .includeSystem=${true} title="Color scheme: light / dark / system"></theme-toggle>
             <button class="icon-btn subtle" title="Sign out" aria-label="Sign out" @click=${signOut}>
               ${icon(LogOut, 17)}
@@ -522,30 +535,30 @@ export function renderSidebarTop(): void {
         ${icon(ICON.newChat, 17)}<span>${splitState.active ? "New session" : "New chat"}</span>
       </button>
       <nav class="nav" @click=${onNavClick}>
-        ${navGroup(
-          "nav-workspace",
-          "Browse",
-          navWorkspaceOpen,
-          toggleNavWorkspace,
-          html`
-            ${navRow("contexts", ICON.contexts, "Projects")} ${navRow("chats", ICON.chats, "Chats")}
-            ${navRow("files", ICON.files, "Files")} ${navRow("crons", ICON.crons, "Crons")}
-            ${navRow("webhooks", ICON.webhooks, "Webhooks")} ${navRow("keychain", ICON.keychain, "Keychain")}
-            ${navRow("deploys", ICON.deploys, "Apps")} ${navRow("memory", ICON.memory, "Memory")}
-            ${navRow("skills", ICON.skills, "Skills")}
-            ${
-              can("admin")
-                ? html`<a class="navrow" href=${ADMIN_HOME_URL} title="Admin">
+        ${
+          can("admin")
+            ? navGroup(
+                "nav-workspace",
+                "Browse",
+                navWorkspaceOpen,
+                toggleNavWorkspace,
+                html`
+                  ${navRow("contexts", ICON.contexts, "Projects")} ${navRow("chats", ICON.chats, "Chats")}
+                  ${navRow("files", ICON.files, "Files")} ${navRow("crons", ICON.crons, "Crons")}
+                  ${navRow("webhooks", ICON.webhooks, "Webhooks")} ${navRow("deploys", ICON.deploys, "Apps")}
+                  ${navRow("memory", ICON.memory, "Memory")} ${navRow("skills", ICON.skills, "Skills")}
+                  <a class="navrow" href=${ADMIN_HOME_URL} title="Admin">
                     ${icon(ShieldCheck, 17)}<span>Admin</span>
-                  </a>`
-                : nothing
-            }
-          `,
-        )}
+                  </a>
+                `,
+              )
+            : html`${navRow("contexts", ICON.contexts, "Projects")} ${navRow("chats", ICON.chats, "Chats")}
+              ${navRow("files", ICON.files, "Files")}`
+        }
       </nav>
       ${html`
         <div class="section-label recents-label">
-          <span>Sessions</span>
+          <span>${can("admin") ? "Sessions" : "Recents"}</span>
           <button
             class="chat-search-open"
             type="button"
@@ -561,16 +574,20 @@ export function renderSidebarTop(): void {
           >
             ${icon(Search, 13)}
           </button>
-          <button
-            class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
-            type="button"
-            role="switch"
-            aria-checked=${sessionsState.webOnly ? "true" : "false"}
-            title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
-            @click=${toggleWebOnly}
-          >
-            <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
-          </button>
+          ${
+            can("admin")
+              ? html`<button
+                  class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
+                  type="button"
+                  role="switch"
+                  aria-checked=${sessionsState.webOnly ? "true" : "false"}
+                  title=${sessionsState.webOnly ? "Showing web chats only" : "Hide non-web conversations"}
+                  @click=${toggleWebOnly}
+                >
+                  <span>Web only</span><span class="mini-switch"><span class="mini-knob"></span></span>
+                </button>`
+              : nothing
+          }
         </div>
       `}
     `,
@@ -847,6 +864,7 @@ export async function boot(): Promise<void> {
   resetKeychainState();
   appState.me = (await r.json()) as Me;
   authMode = appState.me.mode ?? "portal";
+  if (!can("admin")) sessionsState.webOnly = true;
   clearPortalAttempt();
   const personalScope = `personal:${appState.me.user}`;
   const runtimeConfig = await fetchRuntimeConfig(personalScope);

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -47,7 +47,7 @@ import { hideTooltip, showTooltip } from "./tooltip";
 import { icon } from "./ui";
 import { contextsState, scopeTitle } from "./contexts";
 import type { DensityTier } from "./density";
-import { appState } from "./shell-state";
+import { appState, can } from "./shell-state";
 import { renderSidebarTop, switchView, syncUrlFromState } from "./shell";
 import { sleep } from "./chat";
 import {
@@ -1089,7 +1089,7 @@ class GroupActions implements IHeaderActionsRenderer {
             ${ref(this.placeMenu)}
             @click=${(e: Event) => e.stopPropagation()}
           >
-            ${PANE_TOOLS.map(
+            ${PANE_TOOLS.filter((t) => can("admin") || t.tool === "files" || t.tool === "keychain").map(
               (t) => html`
                 <button class="session-menu-option" type="button" role="menuitem" @click=${() => runTool(t.tool)}>
                   ${icon(t.glyph, 15)}<span>${t.label}</span>


### PR DESCRIPTION
Non-admin users of the web surface currently see every operator destination — Crons, Webhooks, Keychain, Apps, Memory, Skills — plus the grouped session tree with its web-only toggle, and a surface filter on the Chats page. For a chat-first end user that is noise: none of those pages are theirs to manage.

This renders a member view for users without the `admin` permission:

- The nav shrinks to Projects, Chats, Files, with no Browse group header.
- The sidebar session list becomes a flat "Recents" list: no project groups, counts, or per-group new-chat buttons. Web-only is forced on and its toggle is hidden.
- The Chats page loses the Surface filter, and the "Personal" scope chip disappears from personal-scope rows; chips still mark shared scopes.
- The session topbar and split-pane tool strips shrink to Files and Keychain.

Admins keep everything they had, with one change that applies to everyone: Keychain moves out of the nav into the sidebar footer, as a key icon next to theme and sign-out — it is settings, not a browsing destination. The scope filter also now reads "All projects" to match the nav's language.

Authorization is unchanged. The gated views stay reachable by deep link, and the core API remains the enforcement boundary — this is presentation only. `permissions` already arrives via `/me` from `/v1/admin/whoami`, so no server changes were needed.

Verified with the plugin suite (563 passing), typecheck, and lint, and by exercising both views in a real browser against a stub core serving synthetic data. Screenshots below are rendered against that synthetic data.

## Screenshots (synthetic data)

Member home and Chats page, and the admin view for contrast — attached below.

https://claude.ai/code/session_01HSFYCGJ6QKxv13nijJqyWj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789904627&installation_model_id=19911&pr_number=652&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F652&signature=cfd511483de2ae0ceca9bc88a0b7097faaa97d42bc48ed9d2a10708372fc9297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->