### PR TITLE
fix(web-ui): bump dompurify to 3.4.13 (GHSA-55q2-fjhq-7xh7)

### DIFF
--- a/plugins/web-ui/package-lock.json
+++ b/plugins/web-ui/package-lock.json
@@ -15,7 +15,7 @@
         "@mariozechner/mini-lit": "^0.2.0",
         "date-fns": "^4.4.0",
         "dockview-core": "^7.0.4",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "jszip": "^3.10.1",
         "lit": "^3.3.1",
         "lru-cache": "^11.5.2",
@@ -2471,9 +2471,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/plugins/web-ui/package.json
+++ b/plugins/web-ui/package.json
@@ -23,7 +23,7 @@
     "@mariozechner/mini-lit": "^0.2.0",
     "date-fns": "^4.4.0",
     "dockview-core": "^7.0.4",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "jszip": "^3.10.1",
     "lit": "^3.3.1",
     "lru-cache": "^11.5.2",


### PR DESCRIPTION
## Summary
- `plugins/web-ui` pins `dompurify` at `^3.4.12`, which is affected by GHSA-55q2-fjhq-7xh7 (IN_PLACE hook removal leaves a detached subtree executable, causing XSS)
- Fixed upstream in 3.4.13, already within the existing `^3.4.12` semver range — lockfile-only bump, no code changes needed
- dompurify is a real runtime dependency here (used in the chat/markdown-rendering surface), not dev-only tooling

## Test plan
- [x] `npm install dompurify@3.4.13` in `plugins/web-ui`, verified `package.json`/`package-lock.json` now resolve to 3.4.13
- [x] Diff scoped to exactly the two lockfile/manifest lines, no other changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789915842&installation_model_id=19911&pr_number=653&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F653&signature=a798d359c101f772789c3d6447ea9fa98c0f32a0381a07ba0bd7c93830aefaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->