### PR TITLE
Fix PostgreSQL search rollout safety

### DIFF
--- a/src/sessions/postgres-session-store.ts
+++ b/src/sessions/postgres-session-store.ts
@@ -264,7 +264,7 @@ export function createPostgresSessionStore(connectionString: string, opts: Store
     `CREATE INDEX IF NOT EXISTS session_entries_user_ts ON session_entries(created_at) WHERE type = 'user'`,
     `CREATE INDEX IF NOT EXISTS session_entries_session_created ON session_entries(session_id, created_at DESC)`,
     `CREATE OR REPLACE FUNCTION entry_search_text(payload text) RETURNS text
-        LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $entry_search_text$
+        LANGUAGE plpgsql IMMUTABLE PARALLEL UNSAFE AS $entry_search_text$
         DECLARE j json;
         BEGIN
           j := replace(payload, '\\u0000', '')::json;

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -593,7 +593,7 @@ test("pg sessions table indexes scoped activity pages", { skip }, async () => {
   }
 });
 
-test("pg safe JSON functions are marked parallel-unsafe", { skip }, async () => {
+test("pg JSON functions with exception handlers are marked parallel-unsafe", { skip }, async () => {
   const pg = (await import("pg")).default;
   const raw = new pg.Pool({ connectionString: URL });
   try {
@@ -610,13 +610,18 @@ test("pg safe JSON functions are marked parallel-unsafe", { skip }, async () => 
     const result = await raw.query(
       `SELECT proname, proparallel
          FROM pg_proc
-        WHERE oid IN ('safe_json(text)'::regprocedure, 'safe_jsonb(text)'::regprocedure)`,
+        WHERE oid IN (
+          'safe_json(text)'::regprocedure,
+          'safe_jsonb(text)'::regprocedure,
+          'entry_search_text(text)'::regprocedure
+        )`,
     );
     assert.deepEqual(
       new Map(result.rows.map((row) => [row.proname as string, row.proparallel as string])),
       new Map([
         ["safe_json", "u"],
         ["safe_jsonb", "u"],
+        ["entry_search_text", "u"],
       ]),
     );
     assert.equal(


### PR DESCRIPTION
## Summary
- mark `entry_search_text(text)` parallel-unsafe, matching PostgreSQL's requirements for its exception handler
- extend the existing database safety regression to cover the search parser

## Why
The v0.1.6 release candidate deployed successfully to Fly, but the live rollout gate rejected this function because it was declared `PARALLEL SAFE`. The declaration could also allow PostgreSQL to execute exception-handling PL/pgSQL in a parallel worker.

## Validation
- reproduced the regression against a real local PostgreSQL database before the fix
- 57 PostgreSQL, search, and post-deploy smoke tests pass after the fix
- root TypeScript typecheck, targeted ESLint, Prettier, and diff checks pass
- deployed the exact patched source to `qm-prod` on Fly
- `qm check --live` passes: machine health, S3 round-trip, portal HTTP 200, database rollout checks, and private live-session smoke
- `qm conformance` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789928544&installation_model_id=19911&pr_number=655&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F655&signature=50bab605e424cafd8433aea38a542a4c760eb9d906e69ffef0d3076abcab1a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->