### PR TITLE
fix(slack): deliver multi-file posts as one message with commentary

### DIFF
--- a/src/slack/attachments.ts
+++ b/src/slack/attachments.ts
@@ -191,18 +191,28 @@ export interface UploadClient {
   files: { uploadV2(args: any): Promise<unknown>; info(args: { file: string }): Promise<unknown> };
 }
 
-async function waitForShareCommit(client: UploadClient, channel: string, fileId: string): Promise<void> {
+async function waitForShareCommit(client: UploadClient, channel: string, fileId: string): Promise<string | undefined> {
   for (let i = 0; i < 60; i++) {
     let shares: any;
     try {
       shares = ((await client.files.info({ file: fileId })) as any)?.file?.shares ?? {};
     } catch {
-      return;
+      return undefined;
     }
     const here = [...(shares.public?.[channel] ?? []), ...(shares.private?.[channel] ?? [])];
-    if (here.some((s: any) => s?.ts)) return;
+    const shared = here.find((share: any) => share?.ts);
+    if (shared?.ts) return String(shared.ts);
     await sleep(250);
   }
+  return undefined;
+}
+
+function uploadedFileIds(response: any): string[] {
+  const files = response?.file ? [response.file] : (response?.files ?? []);
+  return files.flatMap((entry: any) => {
+    if (entry?.id) return [String(entry.id)];
+    return (entry?.files ?? []).flatMap((file: any) => (file?.id ? [String(file.id)] : []));
+  });
 }
 
 export async function uploadAttachments(
@@ -212,25 +222,33 @@ export async function uploadAttachments(
   attachments: readonly OutgoingAttachment[],
   fetchBlob: (blobId: string) => Promise<Buffer>,
   fetchArtifact?: (artifactId: string, viewerId: string) => Promise<Buffer>,
-): Promise<void> {
-  for (const a of attachments) {
+  opts: { initialComment?: string } = {},
+): Promise<{ uploaded: boolean; messageTs?: string }> {
+  const fileUploads: Array<{ filename: string; file: Buffer }> = [];
+  for (const attachment of attachments) {
     let file: Buffer;
     try {
-      file = await fetchBlob(a.blobId);
+      file = await fetchBlob(attachment.blobId);
     } catch (err) {
-      if (!fetchArtifact || !a.artifactId || !a.artifactViewerId) throw err;
-      file = await fetchArtifact(a.artifactId, a.artifactViewerId);
+      if (!fetchArtifact || !attachment.artifactId || !attachment.artifactViewerId) throw err;
+      file = await fetchArtifact(attachment.artifactId, attachment.artifactViewerId);
     }
-    if (file.length === 0) continue;
-    const res = (await client.files.uploadV2({
-      channel_id: channel,
-      ...(threadTs ? { thread_ts: threadTs } : {}),
-      filename: a.name,
-      file,
-    })) as any;
-    const fileId = res?.files?.[0]?.files?.[0]?.id ?? res?.files?.[0]?.id ?? res?.file?.id;
-    if (fileId) await waitForShareCommit(client, channel, fileId);
+    if (file.length > 0) fileUploads.push({ filename: attachment.name, file });
   }
+  if (!fileUploads.length) return { uploaded: false };
+
+  const response = await client.files.uploadV2({
+    channel_id: channel,
+    ...(threadTs ? { thread_ts: threadTs } : {}),
+    ...(opts.initialComment ? { initial_comment: opts.initialComment } : {}),
+    file_uploads: fileUploads,
+  });
+  let messageTs: string | undefined;
+  for (const fileId of uploadedFileIds(response)) {
+    const sharedTs = await waitForShareCommit(client, channel, fileId);
+    messageTs ??= sharedTs;
+  }
+  return { uploaded: true, ...(messageTs ? { messageTs } : {}) };
 }
 
 export function uploadFailureNote(err: unknown): string {

--- a/src/slack/deliveries.ts
+++ b/src/slack/deliveries.ts
@@ -1,4 +1,4 @@
-import { swallow, swallowAs } from "../util/errors.ts";
+import { errMessage, swallow, swallowAs } from "../util/errors.ts";
 import { performance } from "node:perf_hooks";
 import {
   botIdentityArgs,
@@ -192,6 +192,35 @@ export function createDeliveryPoller(deps: {
                     { type: "context", elements: [{ type: "mrkdwn", text: d.destination.debugFooter }] },
                   ]
                 : undefined);
+            let composedUploadError: unknown;
+            const canComposeUpload =
+              d.attachments?.length &&
+              !d.destination.identity &&
+              !footerBlocks &&
+              !runId &&
+              d.destination.unfurlLinks === undefined;
+            if (canComposeUpload) {
+              try {
+                const uploaded = await uploadAttachments(
+                  client,
+                  channel,
+                  threadTs,
+                  d.attachments!,
+                  fetchBlobFromCore,
+                  fetchFileArtifactFromCore,
+                  { initialComment: text },
+                );
+                if (uploaded.uploaded) {
+                  const root = threadTs ?? uploaded.messageTs;
+                  if (root) threads.mark(channel, root, true);
+                  mirrorSelfPost(channel, uploaded.messageTs, text, { sub: threadTs });
+                  return undefined;
+                }
+              } catch (error) {
+                composedUploadError = error;
+                console.error(`[slack-plugin] delivery ${d.id} attachment upload failed:`, (error as Error).message);
+              }
+            }
             const res = await postWithVerify(
               postClient,
               {
@@ -209,7 +238,13 @@ export function createDeliveryPoller(deps: {
             const root = threadTs ?? (res?.ts ? String(res.ts) : undefined);
             if (root) threads.mark(channel, root, true);
             if (!d.destination.identity) mirrorSelfPost(channel, res?.ts, text, { sub: threadTs });
-            await replayAttachments(root);
+            if (composedUploadError) {
+              await client.chat
+                .postMessage(slackReplyArgs(channel, uploadFailureNote(composedUploadError), root))
+                .catch(swallowAs("slack: post upload-failure note", undefined));
+            } else {
+              await replayAttachments(root);
+            }
             return undefined;
           } finally {
             slackApiMs = Math.round(performance.now() - tPost);
@@ -234,31 +269,58 @@ export function createDeliveryPoller(deps: {
             if (!text.trim() && !d.attachments?.length) return undefined;
             const channel = await openConversationFor(client, [d.destination.target]);
             const threadTs = d.destination.threadTs;
-            if (text.trim()) {
-              const posted = await client.chat.postMessage(
-                slackReplyArgs(channel, text, threadTs, { unfurlLinks: d.destination.unfurlLinks }),
-              );
-              mirrorSelfPost(channel, posted?.ts, text, { kind: "dm", sub: threadTs });
-            }
-            if (d.attachments?.length) {
+            let composedUpload = false;
+            let uploadError: unknown;
+            if (text.trim() && d.attachments?.length && d.destination.unfurlLinks === undefined) {
               try {
-                await uploadAttachments(
+                const uploaded = await uploadAttachments(
                   client,
                   channel,
                   threadTs,
                   d.attachments,
                   fetchBlobFromCore,
                   fetchFileArtifactFromCore,
+                  { initialComment: text },
                 );
-              } catch (err) {
-                console.error(
-                  `[slack-plugin] principal delivery ${d.id} attachment upload failed:`,
-                  (err as Error).message,
-                );
-                await client.chat
-                  .postMessage(slackReplyArgs(channel, uploadFailureNote(err), threadTs))
-                  .catch(swallowAs("slack: post principal upload-failure note", undefined));
+                if (uploaded.uploaded) {
+                  composedUpload = true;
+                  mirrorSelfPost(channel, uploaded.messageTs, text, { kind: "dm", sub: threadTs });
+                }
+              } catch (error) {
+                uploadError = error;
+                console.error(`[slack-plugin] principal delivery ${d.id} attachment upload failed:`, errMessage(error));
               }
+            }
+            if (!composedUpload) {
+              if (text.trim()) {
+                const posted = await client.chat.postMessage(
+                  slackReplyArgs(channel, text, threadTs, { unfurlLinks: d.destination.unfurlLinks }),
+                );
+                mirrorSelfPost(channel, posted?.ts, text, { kind: "dm", sub: threadTs });
+              }
+              if (d.attachments?.length && !uploadError) {
+                try {
+                  await uploadAttachments(
+                    client,
+                    channel,
+                    threadTs,
+                    d.attachments,
+                    fetchBlobFromCore,
+                    fetchFileArtifactFromCore,
+                  );
+                } catch (error) {
+                  uploadError = error;
+                  console.error(
+                    `[slack-plugin] principal delivery ${d.id} attachment upload failed:`,
+                    errMessage(error),
+                  );
+                }
+              }
+            }
+            if (uploadError) {
+              await client.chat
+                .postMessage(slackReplyArgs(channel, uploadFailureNote(uploadError), threadTs))
+                .catch(swallowAs("slack: post principal upload-failure note", undefined));
             }
             return { recipientThreadRef: dmThreadRef(channel, threadTs) };
           } finally {

--- a/test/slack-attachments.test.ts
+++ b/test/slack-attachments.test.ts
@@ -279,8 +279,53 @@ test("uploadAttachments fetches each blob and calls files.uploadV2 with the righ
   assert.equal(calls.length, 1);
   assert.equal(calls[0]!.channel_id, "C1");
   assert.equal(calls[0]!.thread_ts, "123.45");
-  assert.equal(calls[0]!.filename, "x.txt");
-  assert.equal(Buffer.from(calls[0]!.file as Uint8Array).toString("utf8"), "bytes-for-B1");
+  assert.deepEqual(
+    (calls[0]!.file_uploads as Array<{ filename: string; file: Buffer }>).map(({ filename, file }) => [
+      filename,
+      file.toString(),
+    ]),
+    [["x.txt", "bytes-for-B1"]],
+  );
+});
+
+test("uploadAttachments batches mixed files with commentary into one Slack message", async () => {
+  const calls: Record<string, unknown>[] = [];
+  const client = {
+    files: {
+      uploadV2: async (args: Record<string, unknown>) => {
+        calls.push(args);
+        return { files: [{ files: [{ id: "F1" }, { id: "F2" }, { id: "F3" }] }] };
+      },
+      info: async () => ({ file: { shares: { private: { C1: [{ ts: "123.456" }] } } } }),
+    },
+  };
+  const attachments = [
+    { name: "first.png", mimetype: "image/png", sizeBytes: 3, blobId: "B1" },
+    { name: "second.jpg", mimetype: "image/jpeg", sizeBytes: 3, blobId: "B2" },
+    { name: "notes.pdf", mimetype: "application/pdf", sizeBytes: 3, blobId: "B3" },
+  ];
+
+  await uploadAttachments(client, "C1", "123.45", attachments, async (id) => Buffer.from(id), undefined, {
+    initialComment: "two screenshots and the notes",
+  });
+
+  assert.equal(calls.length, 1, "one composed post should make one Slack upload call");
+  assert.equal(calls[0]!.channel_id, "C1");
+  assert.equal(calls[0]!.thread_ts, "123.45");
+  assert.equal(calls[0]!.initial_comment, "two screenshots and the notes");
+  assert.deepEqual(
+    (calls[0]!.file_uploads as Array<{ filename: string; file: Buffer }>).map(({ filename, file }) => [
+      filename,
+      file.toString(),
+    ]),
+    [
+      ["first.png", "B1"],
+      ["second.jpg", "B2"],
+      ["notes.pdf", "B3"],
+    ],
+  );
+  assert.equal(calls[0]!.filename, undefined);
+  assert.equal(calls[0]!.file, undefined);
 });
 
 test("uploadAttachments falls back to durable file artifacts when the transient blob is gone", async () => {
@@ -305,7 +350,8 @@ test("uploadAttachments falls back to durable file artifacts when the transient 
     fetchArtifact,
   );
   assert.equal(calls.length, 1);
-  assert.equal(Buffer.from(calls[0]!.file as Uint8Array).toString("utf8"), "artifact:A1:U1");
+  const [uploaded] = calls[0]!.file_uploads as Array<{ filename: string; file: Buffer }>;
+  assert.equal(uploaded!.file.toString(), "artifact:A1:U1");
 });
 
 test("uploadAttachments propagates an upload failure (so the caller can report it)", async () => {

--- a/test/slack-deliveries.test.ts
+++ b/test/slack-deliveries.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createDeliveryPoller } from "../src/slack/deliveries.ts";
+
+const mixedFiles = [
+  { name: "first.png", mimetype: "image/png", sizeBytes: 2, blobId: "B1" },
+  { name: "second.jpg", mimetype: "image/jpeg", sizeBytes: 2, blobId: "B2" },
+  { name: "notes.pdf", mimetype: "application/pdf", sizeBytes: 2, blobId: "B3" },
+];
+
+async function deliver(destination: Record<string, unknown> = {}) {
+  const delivery = {
+    id: "D1",
+    text: "two screenshots and the notes",
+    destination: { type: "slack", target: "C1:100.200", ...destination },
+    attachments: mixedFiles,
+    createdAt: 1,
+  };
+  const queues = new Map<string, unknown[]>([["slack", [delivery]]]);
+  const acknowledgements: string[] = [];
+  const uploads: Record<string, unknown>[] = [];
+  const posts: Record<string, unknown>[] = [];
+  const mirrors: Array<{ ts?: string; text: string }> = [];
+  const marks: Array<{ channel: string; ts: string }> = [];
+  const core = {
+    claimDeliveries: async (type: string) => queues.get(type)?.splice(0) ?? [],
+    ackDelivery: async (id: string) => void acknowledgements.push(id),
+  };
+  const client = {
+    files: {
+      uploadV2: async (args: Record<string, unknown>) => {
+        uploads.push(args);
+        return { files: [{ files: mixedFiles.map((_, index) => ({ id: `F${index + 1}` })) }] };
+      },
+      info: async () => ({ file: { shares: { private: { C1: [{ ts: "101.300" }] } } } }),
+    },
+    chat: {
+      postMessage: async (args: Record<string, unknown>) => {
+        posts.push(args);
+        return { ts: "separate-message" };
+      },
+    },
+  };
+  const poller = createDeliveryPoller({
+    core: core as never,
+    bridge: {
+      inFlightRuns: new Set<string>(),
+      fetchBlobFromCore: async (id: string) => Buffer.from(id),
+      fetchFileArtifactFromCore: async () => Buffer.from("artifact"),
+    } as never,
+    mirror: {
+      mirrorSelfPost: (_channel: string, ts: string | undefined, text: string) => void mirrors.push({ ts, text }),
+    } as never,
+    threads: { mark: (channel: string, ts: string) => void marks.push({ channel, ts }) } as never,
+    clientForIdentity: () => client,
+  });
+
+  await poller.pollDeliveries(client);
+  return { acknowledgements, uploads, posts, mirrors, marks };
+}
+
+test("Slack delivery composes text and mixed attachments into one message", async () => {
+  const { acknowledgements, uploads, posts, mirrors, marks } = await deliver();
+
+  assert.equal(uploads.length, 1);
+  assert.equal(posts.length, 0, "commentary must not be posted separately");
+  assert.equal(uploads[0]!.channel_id, "C1");
+  assert.equal(uploads[0]!.thread_ts, "100.200");
+  assert.equal(uploads[0]!.initial_comment, "two screenshots and the notes");
+  assert.deepEqual(
+    (uploads[0]!.file_uploads as Array<{ filename: string }>).map(({ filename }) => filename),
+    ["first.png", "second.jpg", "notes.pdf"],
+  );
+  assert.deepEqual(acknowledgements, ["D1"]);
+  assert.deepEqual(mirrors, [{ ts: "101.300", text: "two screenshots and the notes" }]);
+  assert.deepEqual(marks, [{ channel: "C1", ts: "100.200" }]);
+});
+
+test("Slack delivery keeps the separate-comment fallback when upload comments cannot carry post options", async () => {
+  const { uploads, posts } = await deliver({ unfurlLinks: false });
+
+  assert.equal(posts.length, 1);
+  assert.equal(posts[0]!.text, "two screenshots and the notes");
+  assert.equal(posts[0]!.unfurl_links, false);
+  assert.equal(uploads.length, 1, "the fallback still batches the files themselves");
+  assert.equal(uploads[0]!.initial_comment, undefined);
+  assert.equal((uploads[0]!.file_uploads as unknown[]).length, 3);
+});


### PR DESCRIPTION
Slack multi-file deliveries now upload all attachments in one call that carries the text as its comment, so related files land as a single message instead of separate posts. Surfaces that need post options the upload cannot express keep the previous separate-comment behavior.

- verification: `node --test test/slack-attachments.test.ts test/slack-deliveries.test.ts` — 28 passing; end-to-end twin run delivered one threaded message with two images + one text file and preserved commentary

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789947191&installation_model_id=19911&pr_number=657&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F657&signature=a97c99da7b1f872678a5249433a63e6bc4e2d579b77718ce95ad17bf125dae1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->