### PR TITLE
Generate model picker effort options from actual model support

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -34,6 +34,8 @@ import { errMessage, swallow } from "../../chassis/src/errors";
 import { icon } from "./ui";
 import {
   EFFORT_LEVELS,
+  effortOptionsFor,
+  supportsEffort,
   applyRuntimeOptions,
   defaultEffortForModel,
   defaultModelValue,
@@ -336,6 +338,9 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     );
     composerState.effortLevel =
       (config.effective.effortLevel as EffortLevel | undefined) ?? defaultEffortForModel(currentModelOption().model);
+    if (!supportsEffort(currentModelOption(), composerState.effortLevel)) {
+      composerState.effortLevel = effortOptionsFor(currentModelOption())[0]!.value;
+    }
     composerState.fastMode =
       config.effective.fastMode === true && modelSupportsFastMode(scopeKey(), config.effective.modelId);
     if (agent && (!ctx.chat.state.threadRef || !threadModelPicks.has(ctx.chat.state.threadRef)))
@@ -519,7 +524,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                             label: effortLabel(composerState.effortLevel),
                             title: "Effort",
                             selected: composerState.effortLevel,
-                            options: EFFORT_LEVELS,
+                            options: effortOptionsFor(currentModelOption()),
                             disabled: inputBlocked,
                             onSelect: (value: string) => selectEffort(value as EffortLevel, agent),
                           })
@@ -879,7 +884,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                       ? html`
                           <div class="menu-title">Effort</div>
                           <div class="settings-seg" role="group" aria-label="Effort">
-                            ${EFFORT_LEVELS.map(
+                            ${effortOptionsFor(selected).map(
                               (option) => html`
                                 <button
                                   class="settings-chip ${option.value === composerState.effortLevel ? "active" : ""}"
@@ -1559,9 +1564,12 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     const previousDefaultEffort = defaultEffortForModel(currentModelOption().model);
     if (ctx.chat.state.threadRef) rememberThreadPick(ctx.chat.state.threadRef, option.value);
     agent.state.model = option.model;
-    if (composerState.effortLevel === previousDefaultEffort) {
+    if (composerState.effortLevel === previousDefaultEffort || !supportsEffort(option, composerState.effortLevel)) {
       composerState.effortLevel = defaultEffortForModel(option.model);
       persistPreference(EFFORT_STORAGE_KEY, composerState.effortLevel);
+    }
+    if (!supportsEffort(option, composerState.effortLevel)) {
+      composerState.effortLevel = effortOptionsFor(option)[0]!.value;
     }
     if (composerState.openMenu !== "settings") composerState.openMenu = null;
     ctx.chat.drawActiveChat(agent);

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -496,7 +496,7 @@ export interface RuntimeConfig {
   scopeId: string;
   approvedHarnesses: string[];
   modelsByHarness: Record<string, string[]>;
-  modelCatalog: Record<string, { name: string; provider: string }>;
+  modelCatalog: Record<string, { name: string; provider: string; effortLevels?: readonly string[] }>;
   orgDefault: { harnessId: string; modelId: string; effortLevel?: string; fastMode?: boolean; revision: number };
   scopeOverride: {
     harnessId: string;

--- a/plugins/web-ui/src/model-options.ts
+++ b/plugins/web-ui/src/model-options.ts
@@ -1,5 +1,5 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { getBaseModel } from "./pi-models.ts";
+import { getBaseModel, supportedEffortLevels } from "./pi-models.ts";
 
 export type ModelOptionValue = string;
 export interface ModelOption {
@@ -10,6 +10,42 @@ export interface ModelOption {
   label: string;
   buttonLabel: string;
   groupLabel: string;
+}
+
+export interface RuntimeCatalogEntry {
+  name: string;
+  provider: string;
+  /** Server-verified effort levels for this model, when known. */
+  effortLevels?: readonly string[];
+}
+
+/** Levels a harness actually forwards; codex drops everything above xhigh. */
+const HARNESS_EFFORT_CAPS: Record<string, readonly string[]> = {
+  codex: ["auto", "low", "medium", "high", "xhigh"],
+};
+
+const effortOverrides = new Map<string, readonly string[]>();
+
+function noteEffortLevels(id: string, catalog: Readonly<Record<string, RuntimeCatalogEntry>>): void {
+  const levels = catalog[id]?.effortLevels;
+  if (levels?.length) effortOverrides.set(id, levels);
+}
+
+/**
+ * Effort options the given model/harness can actually run. Falls back to the
+ * full list when the model's capabilities are unknown.
+ */
+export function effortOptionsFor(option: ModelOption): Array<{ value: EffortLevel; label: string }> {
+  const override = effortOverrides.get(option.model.id);
+  const supported = override?.length ? [...override] : supportedEffortLevels(option.model);
+  const cap = HARNESS_EFFORT_CAPS[option.harnessId];
+  const allowed = new Set(cap ? supported.filter((level) => cap.includes(level)) : supported);
+  const filtered = EFFORT_LEVELS.filter((entry) => allowed.has(entry.value));
+  return filtered.length ? filtered : EFFORT_LEVELS;
+}
+
+export function supportsEffort(option: ModelOption, level: EffortLevel): boolean {
+  return effortOptionsFor(option).some((candidate) => candidate.value === level);
 }
 
 interface ModelMeta {
@@ -105,12 +141,13 @@ function buildOption(
   id: string,
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, RuntimeCatalogEntry>> = {},
 ): ModelOption | null {
   try {
     const dynamic = catalog[id];
     const meta = MODEL_CATALOG[id] ?? (dynamic ? { label: dynamic.name, buttonLabel: dynamic.name } : null);
     if (!meta) return null;
+    noteEffortLevels(id, catalog);
     const model = getBaseModel(id, dynamic);
     return {
       value: qualified ? `${harnessId}:${id}` : id,
@@ -129,7 +166,7 @@ function buildOptions(
   ids: readonly string[],
   harnessId = "pi",
   qualified = false,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, RuntimeCatalogEntry>> = {},
 ): ModelOption[] {
   const seen = new Set<string>();
   const out: ModelOption[] = [];
@@ -182,7 +219,7 @@ export function applyPickerModelIds(ids: readonly string[] | null | undefined, b
 export function runtimeModelOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, RuntimeCatalogEntry>> = {},
 ): ModelOption[] {
   const options = approvedHarnesses.flatMap((harnessId) => {
     const configured = buildOptions(modelsByHarness[harnessId] ?? [], harnessId, true, catalog);
@@ -198,7 +235,7 @@ export function applyRuntimeOptions(
   approvedHarnesses: readonly string[],
   modelsByHarness: Readonly<Record<string, readonly string[]>>,
   effective: { harnessId: string; modelId: string },
-  catalog: Readonly<Record<string, { name: string; provider: string }>> = {},
+  catalog: Readonly<Record<string, RuntimeCatalogEntry>> = {},
 ): void {
   const options = runtimeModelOptions(approvedHarnesses, modelsByHarness, catalog);
   const applied = { options, defaultValue: `${effective.harnessId}:${effective.modelId}` };

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -37,6 +37,23 @@ export function getBaseModel(id: string, fallback?: { name: string; provider: st
   throw new Error(`Unsupported model: ${id}`);
 }
 
+/**
+ * Effort levels a model can actually run, per its pi-ai capabilities:
+ * `reasoning: false` leaves only the provider default ("auto"), and a `null`
+ * entry in `thinkingLevelMap` marks that level as unsupported. "ultracode"
+ * aliases to "max" at turn time, so it tracks "max" support.
+ */
+export function supportedEffortLevels(model: PiModel): string[] {
+  if (!model.reasoning) return ["auto"];
+  const map = (model.thinkingLevelMap ?? {}) as Partial<Record<string, string | null>>;
+  const levels: string[] = ["auto"];
+  for (const level of ["low", "medium", "high", "xhigh", "max"]) {
+    if (map[level] !== null) levels.push(level);
+  }
+  if (map.max !== null) levels.push("ultracode");
+  return levels;
+}
+
 function cloneModel(model: PiModel, id: string, name: string): PiModel {
   return { ...structuredClone(model), id, name };
 }

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -8,6 +8,7 @@ import {
   modelProviderAvailabilityFor,
   modelSupportedByHarness,
   resolveModel,
+  supportedEffortLevelsForModel,
   serviceableModelIds,
   ALL_PROVIDERS_AVAILABLE,
   FAST_MODE_MODEL_IDS,
@@ -1205,10 +1206,19 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   const advertisedModelIds = new Set(Object.values(modelsByHarness).flat());
   const modelCatalog = Object.fromEntries(
     [...advertisedModelIds].flatMap((id) => {
-      const model = catalog.find((candidate) => candidate.id === id);
-      if (model) return [[id, { name: model.name, provider: model.provider }]];
       const resolved = resolveModel(id);
-      return resolved ? [[id, { name: resolved.name, provider: resolved.provider }]] : [];
+      if (resolved) {
+        return [
+          [
+            id,
+            { name: resolved.name, provider: resolved.provider, effortLevels: supportedEffortLevelsForModel(resolved) },
+          ],
+        ];
+      }
+      // Not resolvable server-side (e.g. a dynamic OpenRouter id): advertise the
+      // catalog entry without effort levels so the UI falls back to its defaults.
+      const listed = catalog.find((candidate) => candidate.id === id);
+      return listed ? [[id, { name: listed.name, provider: listed.provider }]] : [];
     }),
   );
   return {

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -184,6 +184,23 @@ export function resolveModel(id: string): PiModel | undefined {
   );
 }
 
+/**
+ * Effort levels a model can actually run, per its pi-ai capabilities:
+ * `reasoning: false` leaves only the provider default ("auto"), and a `null`
+ * entry in `thinkingLevelMap` marks that level as unsupported. "ultracode"
+ * aliases to "max" at turn time, so it tracks "max" support.
+ */
+export function supportedEffortLevelsForModel(model: PiModel): string[] {
+  if (!model.reasoning) return ["auto"];
+  const map = (model.thinkingLevelMap ?? {}) as Partial<Record<string, string | null>>;
+  const levels: string[] = ["auto"];
+  for (const level of ["low", "medium", "high", "xhigh", "max"]) {
+    if (map[level] !== null) levels.push(level);
+  }
+  if (map.max !== null) levels.push("ultracode");
+  return levels;
+}
+
 export function auxiliaryModelForProvider(provider: string): string | undefined {
   return MODEL_REGISTRY.find((m) => m.auxiliary && resolveModel(m.id)?.provider === provider)?.id;
 }

--- a/test/webui-effort-options.test.ts
+++ b/test/webui-effort-options.test.ts
@@ -1,0 +1,122 @@
+import "./support/auto-fake-sprites.ts";
+
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import type { Model } from "@earendil-works/pi-ai";
+import { supportedEffortLevelsForModel } from "../src/model/pi-models.ts";
+import {
+  applyRuntimeOptions,
+  effortOptionsFor,
+  getModelOptions,
+  supportsEffort,
+} from "../plugins/web-ui/src/model-options.ts";
+import { buildApp } from "../src/wiring.ts";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { testConfig } from "./support/test-config.ts";
+
+function fakeModel(overrides: Partial<Model<"openai-responses">> = {}): Model<"openai-responses"> {
+  return {
+    id: "fake-model",
+    name: "Fake Model",
+    api: "openai-responses",
+    provider: "openrouter",
+    baseUrl: "https://example.invalid/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_000,
+    ...overrides,
+  } as Model<"openai-responses">;
+}
+
+function modelOption(model: Model<"openai-responses">, harnessId = "pi") {
+  return {
+    value: `${harnessId}:${model.id}`,
+    harnessId,
+    harnessLabel: harnessId,
+    groupLabel: "Test",
+    model,
+    label: model.name,
+    buttonLabel: model.name,
+  };
+}
+
+test("supportedEffortLevelsForModel derives levels from reasoning and thinkingLevelMap", () => {
+  assert.deepEqual(supportedEffortLevelsForModel(fakeModel({ reasoning: false })), ["auto"]);
+  assert.deepEqual(
+    supportedEffortLevelsForModel(fakeModel({ thinkingLevelMap: { low: null, medium: null } })),
+    ["auto", "high", "xhigh", "max", "ultracode"],
+  );
+  // ultracode aliases to max at turn time, so a null max drops it too
+  assert.deepEqual(
+    supportedEffortLevelsForModel(fakeModel({ thinkingLevelMap: { max: null } })),
+    ["auto", "low", "medium", "high", "xhigh"],
+  );
+  assert.deepEqual(
+    supportedEffortLevelsForModel(fakeModel({ thinkingLevelMap: { high: "only-high" } })),
+    ["auto", "low", "medium", "high", "xhigh", "max", "ultracode"],
+  );
+});
+
+test("effortOptionsFor filters by model capability and harness cap, honoring server overrides", () => {
+  // non-reasoning models only offer the provider default
+  const nonReasoning = modelOption(fakeModel({ reasoning: false }));
+  assert.deepEqual(effortOptionsFor(nonReasoning).map((entry) => entry.value), ["auto"]);
+  assert.ok(!supportsEffort(nonReasoning, "ultracode"));
+
+  // codex never forwards max/ultracode even when the model supports them
+  assert.deepEqual(
+    effortOptionsFor(modelOption(fakeModel(), "codex")).map((entry) => entry.value),
+    ["auto", "low", "medium", "high", "xhigh"],
+  );
+
+  // a server-provided override wins over client-side derivation (dynamic models)
+  applyRuntimeOptions(null, ["pi"], { pi: ["claude-opus-5"] }, { harnessId: "pi", modelId: "claude-opus-5" }, {
+    "claude-opus-5": { name: "Claude Opus 5", provider: "anthropic", effortLevels: ["auto", "medium"] },
+  });
+  const dynamic = getModelOptions().find((entry) => entry.model.id === "claude-opus-5")!;
+  assert.deepEqual(effortOptionsFor(dynamic).map((entry) => entry.value), ["auto", "medium"]);
+});
+
+test("runtime-config advertises per-model effortLevels", async () => {
+  const modelCredentialFetch: typeof fetch = async () =>
+    Response.json({
+      data: [{ id: "deepseek/deepseek-chat-v3.1", name: "DeepSeek: DeepSeek V3.1", supported_parameters: ["tools"] }],
+    });
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "webui-effort-options-")),
+      openrouterApiKey: "effort-options-openrouter-key",
+    }),
+    { modelCredentialFetch },
+  );
+  const server = createInsecureTestServer(built.app, {
+    config: built.config,
+    modelCredentials: built.modelCredentials,
+    harnessId: "pi",
+    providerKeys: { anthropic: false, openai: false, openrouter: true },
+    modelCredentialFetch,
+    admin: built.admin,
+    auditLog: built.auditLog,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    const response = await fetch(`${base}/v1/runtime-config?principalId=alice&scopeId=personal%3Aalice`);
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      modelCatalog: Record<string, { name: string; provider: string; effortLevels?: string[] }>;
+      modelsByHarness: Record<string, string[]>;
+    };
+    const deepseek = body.modelCatalog["deepseek/deepseek-chat-v3.1"];
+    assert.ok(deepseek, "the openrouter catalog model should be advertised");
+    assert.ok(Array.isArray(deepseek.effortLevels), `expected effortLevels, got ${JSON.stringify(deepseek)}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
## Problem

The effort picker (Auto/Low/…/Ultracode) is a static list. Models whose provider capability data says they can't run a level — and harnesses that silently drop levels, like codex above `xhigh` — still offer them, so selecting one either errors or is quietly ignored.

## Fix

Derive the options from what each model actually supports:

- **Capability source**: pi-ai models carry `reasoning` and `thinkingLevelMap` (a `null` entry marks a level unsupported). New helpers (`src/model/pi-models.ts`, mirrored for the web-ui bundle) compute the supported set; `ultracode` aliases to `max` at turn time so it tracks max support; non-reasoning models get only `auto`.
- **Server truth**: `runtime-config` now advertises `effortLevels` per model in the catalog, resolved server-side. Dynamic OpenRouter ids that don't resolve to a full pi model omit the field so the UI keeps today's fallback behavior.
- **UI filtering**: the composer builds both the effort menu and settings chips via `effortOptionsFor()`, which intersects model support with a per-harness cap (codex tops out at `xhigh`, matching what its harness forwards). Stored and effective effort selections are clamped to a supported level when they no longer apply.

## Tests

- `test/webui-effort-options.test.ts`: level derivation from `reasoning`/`thinkingLevelMap`, ultracode↔max aliasing, codex cap, server override precedence for dynamic models, and an end-to-end check that `runtime-config` advertises `effortLevels`.
- Typecheck and eslint clean; adjacent suites (`pi-models`, `webui-model-allowlist`, `pi-harness-fast-mode`) pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789949201&installation_model_id=19911&pr_number=659&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F659&signature=52f5029e341a4b781614acb86c1e9c1dfcb0f652d176e03e68011a0059292421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->