### PR TITLE
fix(budget): bill metered LLM usage instead of a flat input-only estimate

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -44,7 +44,7 @@ import {
 } from "../credentials/connector-status.ts";
 import { renderComputerBlock, renderResidentLoginsBlock, renderConnectedAppsBlock } from "./environment-facts.ts";
 import { PROVIDERS } from "../connectors/oauth.ts";
-import { estimateCostUsd } from "../ratelimit/budget.ts";
+import { costFromUsage, estimateCostUsd } from "../ratelimit/budget.ts";
 import {
   mintCapabilityToken,
   CAPABILITY_TTL_MS,
@@ -2528,7 +2528,6 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             },
             recordModelCall: (rec) => {
               deps.modelGateway.recordCall({ at: Date.now(), scopeLabel: scopeId, ...rec });
-              void deps.budget?.record(actor.id, estimateCostUsd(rec.inputTokens));
             },
             recordLlmRequest: async (rec) => {
               try {
@@ -2536,6 +2535,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               } catch (err) {
                 console.error("[orchestrator] failed to persist LLM request snapshot:", errMessage(err));
               }
+              void deps.budget?.record(actor.id, costFromUsage(rec.usage));
             },
           });
         };

--- a/src/ratelimit/budget.ts
+++ b/src/ratelimit/budget.ts
@@ -16,6 +16,25 @@ export function estimateCostUsd(inputTokens: number, usdPerMTok = DEFAULT_AGENT_
   return (inputTokens / 1_000_000) * usdPerMTok;
 }
 
+export function costFromUsage(
+  usage:
+    | {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheWrite: number;
+        costUsd: number;
+      }
+    | null
+    | undefined,
+): number {
+  if (!usage) return 0;
+  if (Number.isFinite(usage.costUsd) && usage.costUsd > 0) return usage.costUsd;
+  const tokens = usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  if (!Number.isFinite(tokens) || tokens <= 0) return 0;
+  return estimateCostUsd(tokens);
+}
+
 export function createBudgetTracker(
   opts: { limitUsd?: number; orgLimitUsd?: number; windowMs?: number } = {},
 ): BudgetTracker {

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createBudgetTracker, estimateCostUsd } from "../src/ratelimit/budget.ts";
+import { costFromUsage, createBudgetTracker, estimateCostUsd } from "../src/ratelimit/budget.ts";
 import { DEFAULT_AGENT_INPUT_USD_PER_MTOK } from "../src/model/pi-models.ts";
 import { buildApp } from "../src/wiring.ts";
 import type { TurnRequest } from "../src/types.ts";
@@ -58,4 +58,29 @@ test("a principal over budget is refused by the app", async () => {
   const second = await app.turn(dm("again"));
   assert.equal(second.status, "refused");
   assert.match(second.reason ?? "", /budget exceeded/);
+});
+
+test("costFromUsage prefers the provider-reported cost when it is usable", () => {
+  assert.equal(costFromUsage({ input: 1_000_000, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0.03 }), 0.03);
+});
+
+test("costFromUsage falls back to a token-total estimate without a usable cost", () => {
+  const fallback = { input: 500_000, output: 300_000, cacheRead: 100_000, cacheWrite: 100_000, costUsd: 0 };
+  assert.equal(costFromUsage(fallback), DEFAULT_AGENT_INPUT_USD_PER_MTOK);
+  assert.equal(
+    costFromUsage({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: Number.NaN }),
+    0,
+    "no tokens and no cost means nothing to bill",
+  );
+});
+
+test("costFromUsage treats missing metering as zero cost", () => {
+  assert.equal(costFromUsage(null), 0);
+  assert.equal(costFromUsage(undefined), 0);
+});
+
+test("metered output tokens count against the budget even with no input growth", async () => {
+  const b = createBudgetTracker({ limitUsd: DEFAULT_AGENT_INPUT_USD_PER_MTOK, windowMs: 60_000 });
+  await b.record("U1", costFromUsage({ input: 0, output: 2_000_000, cacheRead: 0, cacheWrite: 0, costUsd: 0 }), 1000);
+  assert.equal((await b.check("U1", 1000)).allowed, false);
 });


### PR DESCRIPTION
Fixes #586

## Summary

Turn-level budget accounting now uses the metered usage each harness already reports per LLM request instead of a single flat, input-only estimate.

## Root cause

`recordModelCall` fires once per turn with an estimated input-token count only, and the budget recorded `estimateCostUsd(rec.inputTokens)` from it: every model priced at `DEFAULT_AGENT_INPUT_USD_PER_MTOK` (5), no output or cache tokens. The measured numbers existed on a second callback the budget never saw: `recordLlmRequest` receives `usage` (`input`, `output`, `cacheRead`, `cacheWrite`, provider-computed `costUsd`) for every step.

## What changed

- `costFromUsage()` in `src/ratelimit/budget.ts`: prefers the provider-reported `costUsd`, falls back to `(input+output+cacheRead+cacheWrite)` at the default rate when tokens are reported without cost, and returns 0 when nothing is reportable.
- The main turn path records budget from that metered usage inside the existing `recordLlmRequest` handler; the once-per-turn estimate is removed there so steps are not double-counted. Detect, compaction, and security-screen paths keep their existing estimates (they have no metered counterpart).

## Verification

- 4 new cases in `test/budget.test.ts`: provider cost preferred, token-total fallback, missing metering bills zero, and output-only usage tripping an input-blind limit.
- `npm test` budget suite 8/8 pass; full existing budget tests unchanged and green.
- `npm run typecheck` clean, eslint/oxlint clean on touched files.

This change was prepared with AI assistance under human direction and review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790079390&installation_model_id=19911&pr_number=662&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F662&signature=a70ad8d9c1ca34e00b08b41ab559a54a7dc2d310b8dcadc1607d56935eed71a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->