### PR TITLE
Surface guarded refusals for autonomous triggers

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -457,6 +457,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       if (!rl.allowed) {
         return {
           status: "refused",
+          refusalKind: "rate_limit",
           reason: `rate limit exceeded — try again in ${Math.ceil((rl.retryAfterMs ?? 0) / 1000)}s`,
         };
       }
@@ -466,6 +467,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         if (!b.allowed) {
           return {
             status: "refused",
+            refusalKind: "budget_limit",
             reason: `budget exceeded ($${b.spentUsd.toFixed(2)} of $${b.limitUsd}); try again later`,
           };
         }

--- a/src/slack/approvals.ts
+++ b/src/slack/approvals.ts
@@ -19,6 +19,7 @@ import {
   isBoundaryRefusal,
   recoveredApprovalContext,
   resolveReactionTargets,
+  safeRefusalDetail,
   slackReplyArgs,
   stripAckPrefix,
   toSlackMrkdwn,
@@ -347,7 +348,7 @@ export function createApprovals(deps: {
     await failAgentRequest(
       client,
       ctx,
-      result.reason ?? result.status,
+      safeRefusalDetail(result, result.status),
       opts.handoffMessageTs ?? opts.approvalMessageTs,
     );
   }
@@ -708,13 +709,16 @@ export function createApprovals(deps: {
         return;
       }
 
-      const failLink = isBoundaryRefusal(result.reason) ? null : (result.adminUrl ?? null);
+      const failLink =
+        result.refusalKind === "security_quarantine" || isBoundaryRefusal(result.reason)
+          ? null
+          : (result.adminUrl ?? null);
       const failDetail = failLink ? ` Full error: ${failLink}` : "";
       await updateSlackMessage(
         client,
         cardChannel,
         messageTs,
-        `I can't continue — ${result.reason ?? "refused"}.${failDetail}`,
+        `I can't continue — ${safeRefusalDetail(result)}.${failDetail}`,
       );
     } catch (err) {
       const msg = (err as Error).message;

--- a/src/slack/lib.ts
+++ b/src/slack/lib.ts
@@ -1,4 +1,10 @@
-export { isBoundaryRefusal, refusalDelivery, postThenAckRunDelivery, refusalNote } from "./refusals.ts";
+export {
+  isBoundaryRefusal,
+  refusalDelivery,
+  safeRefusalDetail,
+  postThenAckRunDelivery,
+  refusalNote,
+} from "./refusals.ts";
 export { inlineCode, clip, sleep } from "./util.ts";
 export {
   decodeSlackEntities,

--- a/src/slack/refusals.ts
+++ b/src/slack/refusals.ts
@@ -1,15 +1,23 @@
 import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../../plugins/chassis/src/security-quarantine.ts";
+import type { TurnResult } from "../types.ts";
 
 export function isBoundaryRefusal(reason: string | undefined): boolean {
   return (reason ?? "").startsWith("internal-only");
 }
 
 export function refusalDelivery(
-  result: { refusalKind?: "security_quarantine" },
+  result: { refusalKind?: TurnResult["refusalKind"] },
   unprompted: boolean,
 ): "thread" | "requester" | "silent" {
   if (unprompted) return "silent";
   return result.refusalKind === "security_quarantine" ? "thread" : "requester";
+}
+
+export function safeRefusalDetail(
+  result: { reason?: string; refusalKind?: TurnResult["refusalKind"] },
+  fallback = "refused",
+): string {
+  return result.refusalKind === "security_quarantine" ? "security quarantine" : (result.reason ?? fallback);
 }
 
 export async function postThenAckRunDelivery(opts: {
@@ -27,7 +35,7 @@ export async function postThenAckRunDelivery(opts: {
 }
 
 export function refusalNote(
-  result: { reason?: string; adminUrl?: string; refusalKind?: "security_quarantine" },
+  result: { reason?: string; adminUrl?: string; refusalKind?: TurnResult["refusalKind"] },
   kind: "dm" | "channel",
 ): string {
   if (result.refusalKind === "security_quarantine") {

--- a/src/slack/turn-handler.ts
+++ b/src/slack/turn-handler.ts
@@ -36,6 +36,7 @@ import {
   postWithVerify,
   processInboundFiles,
   refusalDelivery,
+  safeRefusalDetail,
   refusalNote,
   renderConversationView,
   resolveReactionTargets,
@@ -667,7 +668,7 @@ export function createTurnHandler(deps: {
       if (delivery === "silent") {
         if (queuedRunId && result.refusalKind === "security_quarantine") inFlightRuns.delete(queuedRunId);
         console.error(
-          `[slack-plugin] unprompted turn ${result.status} (staying quiet) ch=${inc.channel} ts=${inc.ts}: ${result.reason ?? "refused"}`,
+          `[slack-plugin] unprompted turn ${result.status} (staying quiet) ch=${inc.channel} ts=${inc.ts}: ${safeRefusalDetail(result)}`,
         );
         return;
       }

--- a/src/triggers/run-trigger.ts
+++ b/src/triggers/run-trigger.ts
@@ -22,6 +22,16 @@ const MEMBERSHIP_SKIP_NOTE = "the acting person is no longer a member of this tr
 const UNKNOWN_HOME_SKIP_NOTE =
   "this trigger's home scope is missing from the directory snapshot (roster sync gap) and the acting person has no session there — run skipped";
 
+function automatedRefusalText(result: TurnResult): string | null {
+  if (result.refusalKind === "budget_limit") {
+    return "⚠️ I couldn't finish that turn: budget exceeded";
+  }
+  if (result.refusalKind !== "rate_limit") return null;
+  const seconds = /^rate limit exceeded — try again in ([1-9]\d*)s$/u.exec(result.reason ?? "");
+  if (seconds) return `⚠️ I couldn't finish that turn: rate limit exceeded — try again in ${seconds[1]}s`;
+  return "⚠️ I couldn't finish that turn: rate limited";
+}
+
 export interface TriggerDeps {
   deliveries: DeliveryStore;
   idempotency: IdempotencyStore;
@@ -65,10 +75,6 @@ export interface TriggerOutcome {
   note?: string;
   reply?: string;
   sessionId?: string;
-}
-
-function isTriggerFailure(outcome: TriggerOutcome): boolean {
-  return outcome.ran && outcome.status !== undefined && outcome.status !== "ok" && outcome.status !== "silent";
 }
 
 const NO_UPDATE_SENTINEL = "[no-update]";
@@ -236,10 +242,36 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
   let note: string | undefined;
   let reply: string | undefined;
   let sessionId: string | undefined;
+  let guardedRefusalText: string | null = null;
+  let securityQuarantined = false;
   const ownerSkipNotice = async () => {
     await deps.deliveries.enqueue({
       destination: principalDestination(spec.owner, spec.owner),
       text: `Scheduled delivery skipped: ${consentNote}`,
+      idempotencyKey: `${spec.fireKey}:err`,
+      provenance: deliveryProvenance(spec, threadRef),
+      ...(spec.shadow ? { shadow: true } : {}),
+    });
+  };
+  const enqueueErrorNotice = async () => {
+    const errorNotice = spec.errorNotice;
+    const destination = spec.destination;
+    if (
+      !errorNotice ||
+      !destination ||
+      !consented ||
+      !deliverable ||
+      status === undefined ||
+      status === "ok" ||
+      status === "silent" ||
+      securityQuarantined ||
+      guardedRefusalText
+    ) {
+      return;
+    }
+    await deps.deliveries.enqueue({
+      destination,
+      text: errorNotice(note ?? status),
       idempotencyKey: `${spec.fireKey}:err`,
       provenance: deliveryProvenance(spec, threadRef),
       ...(spec.shadow ? { shadow: true } : {}),
@@ -293,12 +325,32 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
       idempotencyKey: spec.fireKey,
     });
     status = res.status;
-    reply = res.reply;
     sessionId = res.sessionId;
+    securityQuarantined = res.status === "refused" && res.refusalKind === "security_quarantine";
+    reply = securityQuarantined ? undefined : res.reply;
+    guardedRefusalText = res.status === "refused" && isPollSurface(spec.surface) ? automatedRefusalText(res) : null;
+    if (securityQuarantined) {
+      note = "refused: security quarantine";
+      return;
+    }
     if (res.status === "silent") return;
     if (res.status === "pending_approval") {
       note = "hit a require_approval command — failed closed (no human at fire/event time)";
       console.warn(`[trigger] ${spec.surface} ${spec.fireKey} ${note}`);
+      await enqueueErrorNotice();
+      return;
+    }
+    if (guardedRefusalText) {
+      note = res.reason ? `${res.status}: ${res.reason}` : res.status;
+      if (!spec.destination || !consented || !deliverable) return;
+      await reachEnqueue({
+        deliveries: deps.deliveries,
+        destination: spec.destination,
+        text: guardedRefusalText,
+        idempotencyKey: spec.fireKey,
+        provenance: deliveryProvenance(spec, threadRef, res),
+        ...(spec.shadow ? { shadow: true } : {}),
+      });
       return;
     }
     if (res.status === "ok" && (res.reply || res.attachments?.length)) {
@@ -328,6 +380,7 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
     }
     if (res.status === "ok") note = "produced no reply";
     else note = res.reason ? `${res.status}: ${res.reason}` : res.status;
+    await enqueueErrorNotice();
   });
 
   const outcome: TriggerOutcome = {
@@ -338,16 +391,6 @@ export async function runTrigger(deps: TriggerDeps, spec: TriggerSpec): Promise<
     ...(reply !== undefined ? { reply } : {}),
     ...(sessionId ? { sessionId } : {}),
   };
-
-  if (spec.errorNotice && spec.destination && consented && deliverable && isTriggerFailure(outcome)) {
-    await deps.deliveries.enqueue({
-      destination: spec.destination,
-      text: spec.errorNotice(note ?? status!),
-      idempotencyKey: `${spec.fireKey}:err`,
-      provenance: deliveryProvenance(spec, threadRef),
-      ...(spec.shadow ? { shadow: true } : {}),
-    });
-  }
 
   return outcome;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -502,7 +502,7 @@ export interface TurnResult {
   reply?: string;
   reactions?: string[];
   reason?: string;
-  refusalKind?: "security_quarantine";
+  refusalKind?: "budget_limit" | "rate_limit" | "security_quarantine";
   adminUrl?: string;
   runId?: string;
   steered?: true;

--- a/test/keychain-ask.test.ts
+++ b/test/keychain-ask.test.ts
@@ -397,15 +397,21 @@ test("fireAskResolution: a turn that fires but doesn't land falls back to a plai
     grantId: "g1",
   };
 
-  const deps = mkDeps(async () => ({ status: "refused", reason: "rate limit exceeded" }) as TurnResult);
+  const deps = mkDeps(
+    async () => ({ status: "refused", refusalKind: "rate_limit", reason: "rate limit exceeded" }) as TurnResult,
+  );
   await fireAskResolution(deps, ask);
-  let pending = (await deliveries.pending("slack")).filter((d) => d.text.includes(ask.id));
+  let allPending = await deliveries.pending("slack");
+  assert.equal(allPending.length, 1, "the caller-owned fallback is the only delivery");
+  let pending = allPending.filter((d) => d.text.includes(ask.id));
   assert.equal(pending.length, 1);
   assert.match(pending[0]!.text, /couldn't resume the task automatically/);
   assert.match(pending[0]!.text, /was approved/);
 
   await fireAskResolution(deps, ask);
-  pending = (await deliveries.pending("slack")).filter((d) => d.text.includes(ask.id));
+  allPending = await deliveries.pending("slack");
+  assert.equal(allPending.length, 1, "the caller-owned fallback remains the only delivery");
+  pending = allPending.filter((d) => d.text.includes(ask.id));
   assert.equal(pending.length, 1, "fallback is at-most-once");
 
   const notified = { ...ask, id: "fa11bacc1111", notifiedAt: 5 };

--- a/test/monitor-poller.test.ts
+++ b/test/monitor-poller.test.ts
@@ -278,14 +278,16 @@ test("fire-time authz fails closed: a deactivated owner disarms the watch withou
 });
 
 test("a wake whose turn didn't complete is reported to the destination, not silently dropped", async () => {
-  const h = await harness({ result: { status: "refused", reason: "rate limit exceeded" } });
+  const h = await harness({
+    result: { status: "refused", refusalKind: "rate_limit", reason: "rate limit exceeded" },
+  });
   const m = await h.arm();
   h.append("p-1", "line\n");
   await h.poller.tick();
 
   assert.equal(h.calls.length, 1);
   const pending = await h.deliveries.pending("slack");
-  assert.match(pending[0]?.text ?? "", /⚠️.*could not run.*rate limit/);
+  assert.equal(pending[0]?.text, "⚠️ I couldn't finish that turn: rate limited");
   const after = await h.monitors.get(m.id);
   assert.equal(after?.cursor, "line\n".length);
   assert.equal(after?.enabled, true);

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -89,6 +89,19 @@ test("internal DM turn runs end-to-end and records the session", async () => {
   assert.deepEqual(types, ["user", "assistant"]);
 });
 
+test("rate and budget guard refusals carry structured kinds", async () => {
+  const rateLimited = freshApp({ rateLimitPerWindow: 1 });
+  assert.equal((await rateLimited.app.turn(dm("first"))).status, "ok");
+  const rateResult = await rateLimited.app.turn(dm("second"));
+  assert.equal(rateResult.status, "refused");
+  assert.equal(rateResult.refusalKind, "rate_limit");
+
+  const budgetLimited = freshApp({ budgetUsdPerWindow: 0 });
+  const budgetResult = await budgetLimited.app.turn(dm("first"));
+  assert.equal(budgetResult.status, "refused");
+  assert.equal(budgetResult.refusalKind, "budget_limit");
+});
+
 test("org turn wall-clock governance reaches the harness and a per-turn cap only tightens", async () => {
   const { app, config } = freshApp();
   await config.setTurnWallClockSec(scopeId("org", "default-org"), 120);

--- a/test/run-trigger.test.ts
+++ b/test/run-trigger.test.ts
@@ -253,3 +253,113 @@ describe("runTrigger: an autonomous cron does NOT go live (it may be conditional
     assert.equal((await d.deliveries.pending("slack")).length, 1, "core delivers the cron reply via the enqueue path");
   });
 });
+
+describe("runTrigger: autonomous guard refusals are delivered safely", () => {
+  const cases = [
+    [
+      "budget_limit",
+      "budget exceeded ($12.34 of $20); try again later",
+      "⚠️ I couldn't finish that turn: budget exceeded",
+    ],
+    [
+      "rate_limit",
+      "rate limit exceeded — try again in 12s",
+      "⚠️ I couldn't finish that turn: rate limit exceeded — try again in 12s",
+    ],
+    ["rate_limit", "provider returned 429 too many requests", "⚠️ I couldn't finish that turn: rate limited"],
+  ];
+
+  for (const [refusalKind, reason, expected] of cases) {
+    it(`delivers one redacted notice for ${reason}`, async () => {
+      const d = deps(async () => ({ status: "refused", refusalKind, reason }) as TurnResult);
+      const out = await runTrigger(d, {
+        owner: "U1",
+        ownerScopeId: scopeId("personal", "U1"),
+        input: "scheduled work",
+        fireKey: `cron:guard:${reason}`,
+        surface: "cron",
+        destination: toChannel,
+        errorNotice: (detail) => `duplicate ${detail}`,
+      });
+      assert.equal(out.status, "refused");
+      assert.equal(out.note, `refused: ${reason}`);
+      const pending = await d.deliveries.pending("slack");
+      assert.equal(pending.length, 1);
+      assert.equal(pending[0]?.text, expected);
+    });
+  }
+
+  it("leaves caller-owned refusal handling intact when an unstructured reason mentions guard words", async () => {
+    const d = deps(async () => ({ status: "refused", reason: "command policy denied budget-429-report" }));
+    await runTrigger(d, {
+      owner: "U1",
+      ownerScopeId: scopeId("personal", "U1"),
+      input: "scheduled work",
+      fireKey: "cron:guard:unrelated",
+      surface: "cron",
+      destination: toChannel,
+      errorNotice: () => "caller fallback",
+    });
+    const pending = await d.deliveries.pending("slack");
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0]?.text, "caller fallback");
+  });
+
+  it("keeps autonomous security quarantine silent and redacts its outcome", async () => {
+    const reason = "provider quota 429 request-id=secret";
+    const d = deps(async () => ({
+      status: "refused",
+      refusalKind: "security_quarantine",
+      reason,
+      reply: "private-reply",
+    }));
+    const out = await runTrigger(d, {
+      owner: "U1",
+      ownerScopeId: scopeId("personal", "U1"),
+      input: "scheduled work",
+      fireKey: "cron:guard:quarantine",
+      surface: "cron",
+      destination: toChannel,
+      errorNotice: (detail) => `unsafe ${detail}`,
+    });
+    assert.equal(out.status, "refused");
+    assert.equal(out.note, "refused: security quarantine");
+    assert.equal(out.reply, undefined);
+    assert.equal(out.note.includes("secret"), false);
+    assert.equal((await d.deliveries.pending("slack")).length, 0);
+  });
+
+  it("retries an ordinary failure when its error notice could not be durably enqueued", async () => {
+    let runs = 0;
+    const d = deps(async () => {
+      runs += 1;
+      return { status: "refused", reason: "ordinary failure" };
+    });
+    const enqueue = d.deliveries.enqueue.bind(d.deliveries);
+    let enqueues = 0;
+    d.deliveries.enqueue = async (input) => {
+      enqueues += 1;
+      if (enqueues === 1) throw new Error("delivery store unavailable");
+      return enqueue(input);
+    };
+    const spec = {
+      owner: "U1",
+      ownerScopeId: scopeId("personal", "U1"),
+      input: "scheduled work",
+      fireKey: "cron:ordinary:error",
+      surface: "cron",
+      destination: toChannel,
+      errorNotice: (detail: string) => `caller fallback: ${detail}`,
+    };
+
+    await assert.rejects(runTrigger(d, spec), /delivery store unavailable/);
+    const retry = await runTrigger(d, spec);
+    const duplicate = await runTrigger(d, spec);
+
+    assert.equal(retry.ran, true);
+    assert.equal(duplicate.ran, false);
+    assert.equal(runs, 2);
+    assert.equal(enqueues, 2);
+    assert.equal((await d.deliveries.pending("slack"))[0]?.text, "caller fallback: refused: ordinary failure");
+  });
+});

--- a/test/secret-drop.test.ts
+++ b/test/secret-drop.test.ts
@@ -147,7 +147,7 @@ describe("fireDropResolution", () => {
       deliveries,
       idempotency: createIdempotencyStore(createMemoryMap<IdempotencyRecord>()),
       identity: createIdentityService(createMemoryMap()),
-      run: async () => ({ status: "pending_approval" }) as TurnResult,
+      run: async () => ({ status: "refused", refusalKind: "rate_limit", reason: "rate limit exceeded" }) as TurnResult,
     };
     const destination = { type: "slack", target: "C1", audienceScopeId: scopeId("channel", "C1") } as const;
     await fireDropResolution(deps, {
@@ -160,7 +160,9 @@ describe("fireDropResolution", () => {
       grantId: "g1",
       granted: true,
     });
-    const fb = (await deliveries.pending("slack")).filter((d) => d.idempotencyKey === "drop:dropF:fallback");
+    const pending = await deliveries.pending("slack");
+    assert.equal(pending.length, 1, "the caller-owned fallback is the only delivery");
+    const fb = pending.filter((d) => d.idempotencyKey === "drop:dropF:fallback");
     assert.equal(fb.length, 1, "the conversation hears the key arrived even when the resume turn didn't run");
     assert.match(fb[0]!.text, /saved to the keychain/);
   });

--- a/test/slack-approval-refusals.test.ts
+++ b/test/slack-approval-refusals.test.ts
@@ -1,0 +1,138 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApprovals } from "../src/slack/approvals.ts";
+import { createThreadTracker } from "../src/slack/lib.ts";
+import type { TurnResult } from "../src/types.ts";
+
+function slackClient() {
+  const updates: Array<{ channel: string; ts: string; text: string }> = [];
+  const posts: Array<Record<string, unknown>> = [];
+  const client = {
+    conversations: { open: async () => ({ channel: { id: "D2" } }) },
+    chat: {
+      postEphemeral: async () => ({}),
+      postMessage: async (message: Record<string, unknown>) => {
+        posts.push(message);
+        return { ts: String(posts.length) };
+      },
+      update: async (message: { channel: string; ts: string; text: string }) => {
+        updates.push(message);
+        return {};
+      },
+    },
+  };
+  return { client, posts, updates };
+}
+
+function actionHandlers(approvals: ReturnType<typeof createApprovals>) {
+  const handlers: Array<{ pattern: RegExp; handler: (args: any) => Promise<void> }> = [];
+  approvals.registerActions({ action: (pattern, handler) => handlers.push({ pattern, handler }) });
+  return {
+    approval: handlers.find(({ pattern }) => pattern.test("hilo_allow_once"))!.handler,
+    agentRequest: handlers.find(({ pattern }) => pattern.test("agent_request_run"))!.handler,
+  };
+}
+
+async function runAgentHandoff(result: TurnResult): Promise<string> {
+  const { client, posts, updates } = slackClient();
+  const approvals = createApprovals({
+    core: {} as any,
+    bridge: {
+      callCore: async () => result,
+      fetchBlobFromCore: async () => new Uint8Array(),
+      fetchFileArtifactFromCore: async () => new Uint8Array(),
+      reportRunEditRef: () => {},
+    } as any,
+    directory: {
+      classifyUserCached: async () => ({ actor: { externalId: "U2", displayName: "Pat" } }),
+    } as any,
+    threads: createThreadTracker(),
+    ids: {} as any,
+  });
+
+  await approvals.postAgentRequests(
+    client,
+    {
+      requesterId: "U1",
+      channel: "C1",
+      threadOnly: true,
+      kind: "channel",
+      audience: [{ externalId: "U2", displayName: "Pat" }],
+    },
+    [{ targetUserId: "U2", task: "Run a private check" }],
+  );
+  const dm = posts.find((message) => message.channel === "D2") as any;
+  const run = dm.blocks
+    .find((block: any) => block.type === "actions")
+    .elements.find((element: any) => element.action_id === "agent_request_run");
+  await actionHandlers(approvals).agentRequest({
+    ack: async () => {},
+    body: { user: { id: "U2" }, channel: { id: "D2" }, message: { ts: "2" } },
+    action: run,
+    client,
+  });
+
+  return updates.map(({ text }) => text).join("\n");
+}
+
+test("agent handoff redacts a security quarantine refusal", async () => {
+  const internalReason = "secret quarantine evidence";
+  const surfaced = await runAgentHandoff({
+    status: "refused",
+    refusalKind: "security_quarantine",
+    reason: internalReason,
+  });
+  assert.doesNotMatch(surfaced, new RegExp(internalReason));
+  assert.match(surfaced, /security quarantine/);
+});
+
+test("agent handoff preserves a reasonless failure status", async () => {
+  const surfaced = await runAgentHandoff({ status: "failed" });
+  assert.match(surfaced, /failed/);
+  assert.doesNotMatch(surfaced, /refused/);
+});
+
+test("approval continuation redacts quarantine detail and admin URL", async () => {
+  const { client, updates } = slackClient();
+  const internalReason = "secret quarantine evidence";
+  const adminUrl = "https://internal.invalid/run/123";
+  const approvals = createApprovals({
+    core: {} as any,
+    bridge: {
+      callCore: async () => ({
+        status: "refused",
+        refusalKind: "security_quarantine",
+        reason: internalReason,
+        adminUrl,
+      }),
+      fetchBlobFromCore: async () => new Uint8Array(),
+      fetchFileArtifactFromCore: async () => new Uint8Array(),
+      reportRunEditRef: () => {},
+    } as any,
+    directory: { classifyActor: async () => ({ externalId: "U1" }) } as any,
+    threads: createThreadTracker(),
+    ids: {} as any,
+  });
+  approvals.rememberSlackApprovals([{ requestId: "req-1", command: "run task", reason: "requires approval" }], {
+    requesterId: "U1",
+    channel: "C1",
+    approvalChannel: "C1",
+    threadOnly: false,
+    turn: {
+      actor: { externalId: "U1" },
+      conversation: { kind: "dm", threadRef: "dm:U1" },
+      text: "run task",
+    },
+  } as any);
+  await actionHandlers(approvals).approval({
+    ack: async () => {},
+    body: { user: { id: "U1" }, channel: { id: "C1" }, message: { ts: "1" } },
+    action: { action_id: "hilo_allow_once", value: "req-1" },
+    client,
+  });
+
+  const surfaced = updates.map(({ text }) => text).join("\n");
+  assert.doesNotMatch(surfaced, new RegExp(internalReason));
+  assert.doesNotMatch(surfaced, new RegExp(adminUrl));
+  assert.match(updates.at(-1)!.text, /I can't continue — security quarantine\./);
+});

--- a/test/slack-refusals.test.ts
+++ b/test/slack-refusals.test.ts
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { refusalNote, refusalDelivery, postThenAckRunDelivery, isBoundaryRefusal } from "../src/slack/lib.ts";
+import {
+  refusalNote,
+  refusalDelivery,
+  safeRefusalDetail,
+  postThenAckRunDelivery,
+  isBoundaryRefusal,
+} from "../src/slack/lib.ts";
 
 const ADMIN_URL = "https://portal.example.com/admin/?view=history&session=s-1";
 
@@ -48,6 +54,16 @@ test("refusalDelivery: quarantine posts in-thread only when addressed; every unp
   assert.equal(refusalDelivery({ refusalKind: "security_quarantine" }, true), "silent");
   assert.equal(refusalDelivery({}, true), "silent");
   assert.equal(refusalDelivery({}, false), "requester");
+});
+
+test("safeRefusalDetail: security quarantine never surfaces its internal reason", () => {
+  const detail = safeRefusalDetail({
+    refusalKind: "security_quarantine",
+    reason: "private-reason request-id=secret",
+  });
+  assert.equal(detail, "security quarantine");
+  assert.equal(safeRefusalDetail({ reason: "ordinary failure" }), "ordinary failure");
+  assert.equal(safeRefusalDetail({}, "failed"), "failed");
 });
 
 test("postThenAckRunDelivery: acknowledges only after the Slack post succeeds", async () => {


### PR DESCRIPTION
## Summary

- classify budget, rate-limit, and security-quarantine refusals on `TurnResult`
- deliver concise, idempotent budget and rate-limit notices for automated poll surfaces
- keep security-quarantine details silent for autonomous turns and redacted across Slack refusal paths
- preserve existing error-notice behavior without double-delivering guarded refusals

## Verification

- affected tests: 218 passed
- `npm run typecheck`
- ESLint and Oxlint on affected files
- Prettier and `git diff --check`
- synthetic rendering of the automated notices; no live Slack workspace was used

## Screenshot

![Synthetic automated refusal notices](https://raw.githubusercontent.com/wsr3005/qm-upstream-contributions/codex/pr-assets-guarded-refusals/docs/guarded-refusals.jpg)

The screenshot uses synthetic data. Security-quarantine details remain silent for autonomous turns.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790138901&installation_model_id=19911&pr_number=664&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F664&signature=6f35dd21f8bf08c2fd8a24238b8cdfcb2df3701f852bbb201e8db942550daa36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->