### PR TITLE
ADR: add a service-level credential source policy

### DIFF
--- a/adrs/service-level-credential-source-policy.md
+++ b/adrs/service-level-credential-source-policy.md
@@ -1,0 +1,26 @@
+QM already has two credential sources with different operators: a person's keychain and
+administrator-managed service credentials. A shared agent deployment needs to be able to
+say that one service may only come from the second source.
+
+Could scope config gain a small per-service credential-source policy? For example, an org
+could deny personal credentials for `artifactshare` while continuing to allow an admin to
+register a service credential for it. The default would remain today's behavior when no
+policy exists.
+
+The personal denial needs to hold at the boundaries, not just in the UI or prompt. Saving
+or importing a matching personal credential should fail, creating or approving a grant for
+one should fail, and an older matching credential should no longer materialize into a turn.
+That last check matters during rollout because stored credentials can predate the policy.
+
+Service credentials should keep using their existing ACL grants. An administrator can then
+grant the managed credential only to selected channel scopes, and the runtime already has a
+single place to decide whether the current conversation is entitled to it. This avoids a
+second channel allowlist and keeps service identity separate from user-supplied channel
+metadata.
+
+The resolved admin config and audit trail should make the effective policy visible. It
+would also be useful for static or live conformance to prove three things for a configured
+service: personal save is denied, a pre-existing personal credential cannot be loaded, and
+the managed credential is available only in its granted scopes.
+
+This is intended as a generic deployment control rather than a special case for one CLI.


### PR DESCRIPTION
An informal proposal for deployments where a shared agent must use only an administrator-managed credential for one service.

The policy would fail closed at personal save, grant, and runtime materialization boundaries, while existing service-credential grants remain the channel/scope restriction. No code is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790159938&installation_model_id=19911&pr_number=665&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F665&signature=0e8760ccb4c567195312ebd03225842fa8a15e470f02b79d10e10de02cdea90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->