### PR TITLE
Proposal: trusted conversation context in splitEnv

### DIFF
--- a/adrs/trusted-conversation-context-env.md
+++ b/adrs/trusted-conversation-context-env.md
@@ -1,0 +1,37 @@
+QM deployment layers can currently interpolate only `{actingSlackUserId}` into
+`auth.splitEnv`. Tools that need the current Slack conversation therefore have to ask the
+model to supply channel metadata as command arguments, even though the orchestrator has
+already derived that metadata from the platform event.
+
+Could `auth.splitEnv` gain placeholders for that trusted conversation context? A small set
+would cover the generic need:
+
+- `{conversationKind}` for `dm`, `channel`, or `group`
+- `{channelRef}` for the platform channel ID
+- `{channelName}` for the human-readable channel name
+- `{channelIsPrivate}` as `1` when private and `0` when explicitly public
+- `{actingPrincipalId}` for the normalized identity key used by the deployment
+- `{actingDisplayName}` for display-only attribution
+
+`{actingSlackUserId}` would remain available as a compatibility placeholder and existing
+templates would keep their current behavior. The conversation values should come from the
+normalized `Conversation` created by the surface adapter, and the acting values from its
+resolved actor. Neither source should be model-generated tool input or a second Slack
+lookup. A deployment that keys principals by verified email can use `actingPrincipalId`
+as an email; one that keys them by platform ID must not present it as an email.
+
+Missing values need deterministic, fail-closed behavior. A template that references
+`channelRef` or `channelName` in a DM, or before that value is known, should not be emitted.
+For `channelIsPrivate`, an unknown value should be treated as private (`1`); only an
+explicit `false` should produce `0`. `conversationKind` and `actingPrincipalId` should
+always be available. A template that references a missing display name should not be
+emitted.
+
+This lets a deployment inject machine-derived context into an ordinary CLI invocation
+without teaching the model to decide or reproduce security-relevant metadata. The CLI can
+still choose its own environment variable names, and the proposal remains independent of
+any one publishing service or organization.
+
+Conformance should cover public and private channels, DM/missing-field behavior, both
+principal-keying modes, and the rule that command arguments cannot alter the interpolated
+values.


### PR DESCRIPTION
## Summary

Proposes exposing qm-derived conversation metadata as generic `auth.splitEnv` placeholders.

The values come from the normalized platform conversation rather than model-authored arguments, with fail-closed handling for missing or unknown privacy metadata.

## Scope

This is an ADR-only proposal. It names no organization or downstream service.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790161309&installation_model_id=19911&pr_number=666&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F666&signature=5fe8eb55e4dbc5ac86c2ef620e19089ec416bacc06203a8b0dba0028867cc143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->