### PR TITLE
Support multiple allowed email domains for portal OIDC

### DIFF
--- a/adrs/oidc-multi-domain.md
+++ b/adrs/oidc-multi-domain.md
@@ -1,0 +1,27 @@
+# Support multiple allowed email domains for portal OIDC
+
+## Context
+
+We self-host QM and sign users in through an external OIDC provider (Entra ID).
+Our organization spans two email domains, so the portal single-domain
+`OIDC_ALLOWED_EMAIL_DOMAIN` (checked as `email.endsWith("@<domain>")`) cannot
+cover both. The only current workaround, `OIDC_ALLOWED_EMAILS`, requires listing
+every individual account — fragile as people join.
+
+## Proposal
+
+Add a comma-separated `OIDC_ALLOWED_EMAIL_DOMAINS` (plural) alongside the
+existing singular `OIDC_ALLOWED_EMAIL_DOMAIN`:
+
+- Both feed the same domain check in `resolvePrincipal` (`plugins/portal/src/oidc.ts`).
+- The singular var stays for backward compatibility.
+- The production trust-boundary validation (`plugins/portal/src/index.ts`) counts
+  the plural list as satisfying the boundary requirement.
+- A new validation rejects invalid entries in the comma-separated list.
+
+I have been running this as a local patch and it works; happy to share the diff if
+useful. Principal stays `OIDC_PRINCIPAL_CLAIM=email`.
+
+## Status
+
+Proposed — more detail in issue #672.


### PR DESCRIPTION
See issue #672.

Adds an ADR proposing `OIDC_ALLOWED_EMAIL_DOMAINS` (comma-separated) alongside the existing singular `OIDC_ALLOWED_EMAIL_DOMAIN`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790238615&installation_model_id=19911&pr_number=674&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F674&signature=f2c70fa6f6d65f2c03d3acad55da2b57ad30d40d67b9b3cc83cf9e451eec07da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->