### PR TITLE
Hydrate the OpenRouter catalog on cold runtime resolution

### DIFF
--- a/src/harness/harness-router.ts
+++ b/src/harness/harness-router.ts
@@ -74,11 +74,6 @@ export async function resolveRuntimeChoiceDurable(
     config.getBaseModelOwnDurable(orgScopeId),
     scope === orgScopeId ? null : config.getBaseModelOwnDurable(scope),
   ]);
-  // A dynamic OpenRouter model only exists in this process after the catalog
-  // has been fetched. A cold worker (fresh start, or one that never served the
-  // model picker) would otherwise reject a perfectly approved selection with
-  // "is not approved". Hydrate before resolving when any candidate model is
-  // unknown to the local registry.
   if (hydrateModelCatalog) {
     const candidates = [requested?.modelId, scopedStored?.modelId, orgStored?.modelId];
     if (candidates.some((modelId) => modelId && !resolveModel(modelId))) await hydrateModelCatalog();

--- a/src/harness/harness-router.ts
+++ b/src/harness/harness-router.ts
@@ -1,5 +1,11 @@
 import type { ScopedConfigStore } from "../resolution/config-store.ts";
-import { defaultModelForHarness, isHarnessId, modelSupportedByHarness, type HarnessId } from "../model/pi-models.ts";
+import {
+  defaultModelForHarness,
+  isHarnessId,
+  modelSupportedByHarness,
+  resolveModel,
+  type HarnessId,
+} from "../model/pi-models.ts";
 import type { ScopeId } from "../types.ts";
 import type { Harness, HarnessTurnInput } from "./harness.ts";
 import { NonRetryableTurnError } from "../core/turn-error.ts";
@@ -59,6 +65,7 @@ export async function resolveRuntimeChoiceDurable(
   scope: ScopeId,
   fallback: RuntimeChoice,
   requested?: Partial<RuntimeChoice>,
+  hydrateModelCatalog?: () => Promise<unknown>,
 ): Promise<RuntimeChoice> {
   const approved = (await config.getApprovedHarnessesDurable()) ?? [fallback.harnessId];
   const [orgStored, scopedStored, orgLegacy, scopedLegacy] = await Promise.all([
@@ -67,6 +74,15 @@ export async function resolveRuntimeChoiceDurable(
     config.getBaseModelOwnDurable(orgScopeId),
     scope === orgScopeId ? null : config.getBaseModelOwnDurable(scope),
   ]);
+  // A dynamic OpenRouter model only exists in this process after the catalog
+  // has been fetched. A cold worker (fresh start, or one that never served the
+  // model picker) would otherwise reject a perfectly approved selection with
+  // "is not approved". Hydrate before resolving when any candidate model is
+  // unknown to the local registry.
+  if (hydrateModelCatalog) {
+    const candidates = [requested?.modelId, scopedStored?.modelId, orgStored?.modelId];
+    if (candidates.some((modelId) => modelId && !resolveModel(modelId))) await hydrateModelCatalog();
+  }
   const view: Pick<ScopedConfigStore, "getApprovedHarnesses" | "getRuntimeSelection" | "getBaseModel"> = {
     getApprovedHarnesses: () => approved,
     getRuntimeSelection: (id: ScopeId) => {

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -182,6 +182,7 @@ import { createCodexHarness, codexHarnessConfigOptions } from "./harness/codex-h
 import { createClaudeHarness, claudeHarnessConfigOptions } from "./harness/claude-harness.ts";
 import { createPiHarness, piHarnessConfigOptions } from "./harness/pi-harness.ts";
 import { createHarnessRouter, resolveRuntimeChoiceDurable } from "./harness/harness-router.ts";
+import { selectableModelCatalog } from "./model/model-catalog.ts";
 import type { Harness } from "./harness/harness.ts";
 import { createSecurityScreenProxy, type SecurityScreener } from "./security/security-screener.ts";
 import { createMemoryTaskStore } from "./tasks/memory-task-store.ts";
@@ -820,11 +821,22 @@ export function buildApp(
     },
   };
   const judgeModelId = (): string => config.judgeModelId ?? auxiliaryModelFor(orgBaseModelId() ?? fallback.modelId);
+  const hydrateModelCatalog = async (): Promise<unknown> => {
+    if (!(await modelCredentials.availability()).openrouter) return undefined;
+    return selectableModelCatalog(overrides.modelCredentialFetch);
+  };
   const harness = createHarnessRouter(adapters, adapters.get(fallbackHarness)!, (input) =>
-    resolveRuntimeChoiceDurable(configStore, runtimeOrgScope, input.scopeLabel, fallback, {
-      ...(input.harness ? { harnessId: input.harness as HarnessId } : {}),
-      ...(input.model ? { modelId: input.model } : {}),
-    }),
+    resolveRuntimeChoiceDurable(
+      configStore,
+      runtimeOrgScope,
+      input.scopeLabel,
+      fallback,
+      {
+        ...(input.harness ? { harnessId: input.harness as HarnessId } : {}),
+        ...(input.model ? { modelId: input.model } : {}),
+      },
+      hydrateModelCatalog,
+    ),
   );
 
   const leaseTtlMs = config.leaseTtlMs;

--- a/test/runtime-selection.test.ts
+++ b/test/runtime-selection.test.ts
@@ -6,6 +6,7 @@ import {
   type PersistedBaseModel,
 } from "../src/resolution/config-store.ts";
 import { resolveRuntimeChoice, resolveRuntimeChoiceDurable } from "../src/harness/harness-router.ts";
+import { registerOpenRouterCatalogModel } from "../src/model/pi-models.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 
 const ORG = "org:default-org" as const;
@@ -107,4 +108,54 @@ test("a listener that throws cannot break the write that notified it", async () 
   config.setApprovedHarnesses(["pi"]);
   await config.setRuntimeSelectionLatest(ORG, { harnessId: "pi", modelId: "claude-opus-4-8" });
   assert.equal((await config.getRuntimeSelectionDurable(ORG))?.modelId, "claude-opus-4-8");
+});
+
+test("durable runtime resolution hydrates the model catalog before rejecting an unknown dynamic model", async () => {
+  const config = createMemoryConfigStore("default-org");
+  config.setApprovedHarnesses(["pi"]);
+  await config.setRuntimeSelectionLatest(PERSONAL, { harnessId: "pi", modelId: "testvendor/cold-router-model" });
+  await config.flushScope(PERSONAL);
+  const fallback = { harnessId: "pi" as const, modelId: "claude-opus-4-8" };
+
+  // Without a hydrator a cold process cannot resolve the dynamic model and
+  // silently falls back to the org default instead of serving the selection.
+  assert.deepEqual(await resolveRuntimeChoiceDurable(config, ORG, PERSONAL, fallback), fallback);
+
+  let hydrations = 0;
+  const hydrate = async () => {
+    hydrations += 1;
+    registerOpenRouterCatalogModel({
+      id: "testvendor/cold-router-model",
+      name: "Cold Router Model",
+      contextWindow: 1_048_576,
+      maxTokens: 131_072,
+      input: ["text"],
+      reasoning: true,
+      cost: { input: 0, output: 0 },
+    });
+  };
+  assert.deepEqual(await resolveRuntimeChoiceDurable(config, ORG, PERSONAL, fallback, undefined, hydrate), {
+    harnessId: "pi",
+    modelId: "testvendor/cold-router-model",
+  });
+  assert.equal(hydrations, 1);
+
+  // An explicitly requested dynamic model on a cold process hydrates too,
+  // instead of throwing "is not approved".
+  assert.deepEqual(
+    await resolveRuntimeChoiceDurable(
+      config,
+      ORG,
+      PERSONAL,
+      fallback,
+      { modelId: "testvendor/cold-router-model" },
+      hydrate,
+    ),
+    { harnessId: "pi", modelId: "testvendor/cold-router-model" },
+  );
+
+  // A warm registry skips the fetch entirely.
+  const before = hydrations;
+  await resolveRuntimeChoiceDurable(config, ORG, PERSONAL, fallback, undefined, hydrate);
+  assert.equal(hydrations, before);
 });

--- a/test/runtime-selection.test.ts
+++ b/test/runtime-selection.test.ts
@@ -117,8 +117,6 @@ test("durable runtime resolution hydrates the model catalog before rejecting an 
   await config.flushScope(PERSONAL);
   const fallback = { harnessId: "pi" as const, modelId: "claude-opus-4-8" };
 
-  // Without a hydrator a cold process cannot resolve the dynamic model and
-  // silently falls back to the org default instead of serving the selection.
   assert.deepEqual(await resolveRuntimeChoiceDurable(config, ORG, PERSONAL, fallback), fallback);
 
   let hydrations = 0;
@@ -140,8 +138,6 @@ test("durable runtime resolution hydrates the model catalog before rejecting an 
   });
   assert.equal(hydrations, 1);
 
-  // An explicitly requested dynamic model on a cold process hydrates too,
-  // instead of throwing "is not approved".
   assert.deepEqual(
     await resolveRuntimeChoiceDurable(
       config,
@@ -154,7 +150,6 @@ test("durable runtime resolution hydrates the model catalog before rejecting an 
     { harnessId: "pi", modelId: "testvendor/cold-router-model" },
   );
 
-  // A warm registry skips the fetch entirely.
   const before = hydrations;
   await resolveRuntimeChoiceDurable(config, ORG, PERSONAL, fallback, undefined, hydrate);
   assert.equal(hydrations, before);


### PR DESCRIPTION
## Problem

Selecting a dynamic OpenRouter catalog model (e.g. `stealth/ox-alpha`) intermittently fails a turn with:

```
runtime pi/stealth/ox-alpha is not approved
```

The selection is approved and present in the catalog; the failure is timing-dependent.

## Cause

Dynamic OpenRouter models are registered into the process-local model registry only after `selectableModelCatalog()` fetches the catalog. #656 added a pre-warm on the API turn entrypoint (`app-turn.ts`), but the harness router's resolution path in `wiring.ts` resolves the runtime again at run execution time with no warm-up. On a cold process (fresh worker start, or one that never served the picker), `resolveModel()` returns undefined, `modelSupportedByHarness()` fails, and `harness-router.ts` throws — so the same selection works when the process is warm and fails when it isn't, which is why it looked fixed and regressed.

## Fix

- `resolveRuntimeChoiceDurable` accepts an optional `hydrateModelCatalog` callback and awaits it before resolving whenever any candidate model (requested, scope, or org selection) is unknown to the local registry.
- `wiring.ts` passes a hydrator that fetches the OpenRouter catalog when an OpenRouter key is available, so the harness router path self-heals on cold processes.
- A warm registry never triggers a fetch (verified in the test).

## Testing

- new regression test in `test/runtime-selection.test.ts`: cold resolution without a hydrator falls back; with a hydrator it resolves the dynamic model (both via stored selection and explicit request); warm registry skips hydration
- `test/runtime-selection.test.ts` + `test/dynamic-openrouter-model.test.ts`: 8/8 pass
- `tsc --noEmit`, oxlint, prettier clean on touched files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790286953&installation_model_id=19911&pr_number=678&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F678&signature=3f9314fd06df0950f070e60f78cf378cf5fc7d60cc91a70b004a3ed95c3436af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->