### PR TITLE
Propose logging keychain entry names in the per-turn audit record

### DIFF
--- a/adrs/keychain-names-in-audit-log.md
+++ b/adrs/keychain-names-in-audit-log.md
@@ -1,0 +1,7 @@
+Was thinking through what an actual audit of a qm deployment would look like and hit a gap.
+
+Say someone asks "did any tool call in scope A ever have scope B's secrets available?" The audit log can't answer that today. You'd have to go back and figure out what keychain entries the sandbox resolved at the time, based on whatever the scope config and image looked like back then. Doable, but painful.
+
+So the ask: whenever credentials get injected into the sandbox, log which keychain entries were in play for that turn and who owns them. Names only, obviously not values. Should apply in every posture, and nothing else needs to change.
+
+Basically turns a leakage review from an archaeology project into a grep. However you want to shape the field is fine by me.

--- a/adrs/keychain-names-in-audit-log.md
+++ b/adrs/keychain-names-in-audit-log.md
@@ -1,7 +1,7 @@
-Was thinking through what an actual audit of a qm deployment would look like and hit a gap.
+Update after reading closer: the granted-credential path already does most of what I originally asked for. Every standing-grant injection records a `keychain.materialize` event with the credential id, grant id, and scope. So that half is covered.
 
-Say someone asks "did any tool call in scope A ever have scope B's secrets available?" The audit log can't answer that today. You'd have to go back and figure out what keychain entries the sandbox resolved at the time, based on whatever the scope config and image looked like back then. Doable, but painful.
+What's not covered is the other two ways credentials get into a sandbox. Own-keychain credentials skip the audit record entirely, since the event only fires when there's a grantId. Connector tokens get injected into the env with no audit at all. The log can reconstruct shared-credential exposure but goes dark on the injections that happen most often.
 
-So the ask: whenever credentials get injected into the sandbox, log which keychain entries were in play for that turn and who owns them. Names only, obviously not values. Should apply in every posture, and nothing else needs to change.
+The ask, narrowed: give own-credential and connector-token injections the same `keychain.materialize` treatment the granted path already has. Names and ids only, obviously not values. Same event shape, so nothing downstream changes.
 
-Basically turns a leakage review from an archaeology project into a grep. However you want to shape the field is fine by me.
+Same goal as before. A leakage review should be a grep, not an archaeology project. This just points the grep at the paths that are currently invisible.


### PR DESCRIPTION
Text proposal per CONTRIBUTING. Extend the existing keychain.materialize audit event to the two injection paths that currently skip it: own-keychain credentials and connector tokens. Granted credentials already log it, these don't. Names and ids only, no values.