### PR TITLE
Fix SVG attachment delivery in web chat

### DIFF
--- a/plugins/web-ui/src/ui.ts
+++ b/plugins/web-ui/src/ui.ts
@@ -82,7 +82,6 @@ const RENDERABLE_IMAGE_TYPES = new Set([
   "image/gif",
   "image/webp",
   "image/avif",
-  "image/svg+xml",
   "image/bmp",
   "image/apng",
   "image/x-icon",

--- a/plugins/web-ui/test/renderable-image-source.test.ts
+++ b/plugins/web-ui/test/renderable-image-source.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const ui = readFileSync(new URL("../src/ui.ts", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+
+test("SVG attachments fall back to a visible download chip", () => {
+  const renderableTypes = ui.match(/const RENDERABLE_IMAGE_TYPES = new Set\(\[([\s\S]*?)\]\);/)?.[1] ?? "";
+  assert.doesNotMatch(renderableTypes, /image\/svg\+xml/);
+  assert.match(chat, /if \(!browserRenderableImage\(file\.mimetype\)\) return imageChip/);
+});


### PR DESCRIPTION
Show SVG deliverables as named download chips instead of blank inline previews.

- verification: regression test covers SVG fallback while preserving PNG previews

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790306275&installation_model_id=19911&pr_number=680&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F680&signature=3c6636cf3bb356780e407646f423193560e75f286de9b93098544aab460d8eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->