### PR TITLE
Propose recording old and new values on governance-change audit events

### DIFF
--- a/adrs/governance-values-in-audit-detail.md
+++ b/adrs/governance-values-in-audit-detail.md
@@ -1,0 +1,9 @@
+Was digging through what the audit log actually captures when an admin changes governance settings. Answer: almost nothing.
+
+Change a scope's security posture (or command policy, egress, approval grant modes) and the event is just `security-posture.update` plus who and which scope. There's a `detail` field on the event but nothing fills it here. The config store also overwrites the old value in place, so the before state is gone. If someone asks "when did this scope get loosened to dangerous, and what was it before?" the log can only say an admin touched it at some point.
+
+So the ask: for governance resources, put the old and new value in detail. A short summary is fine for chunky ones like command policy. Chat titles already do this, `conversation.update` logs the patch, so the pattern exists. It's just missing where it matters most.
+
+Two things to be deliberate about. That audit call is shared with resources that carry secrets (service credentials, connectors), so this should be an explicit allowlist of governance resources rather than logging every admin write. Also the admin audit listing strips detail from responses today, so whatever gets recorded needs to be readable there too. Write-only evidence helps nobody.
+
+SECURITY.md already admits governance changes aren't versioned or revertible. This feels like the cheapest first step. At least the timeline of what the controls actually were becomes a grep instead of guesswork.


### PR DESCRIPTION
Text proposal per CONTRIBUTING. When an admin changes a scope's governance settings (security posture, command policy, egress, approval grant modes), fill the audit event's detail field with the old and new value, behind an explicit allowlist of governance resources. Full text in adrs/.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790309100&installation_model_id=19911&pr_number=681&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F681&signature=9e905b1b18b7002acb905c3a7190da0a2f712c8ba5299b17ee5349d0c09e0ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->