### PR TITLE
Make the pane canvas the Chats baseline

### DIFF
--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -77,11 +77,13 @@ import { appState, closeSidebarOnNarrowView, renderSidebarTop, showMainEmpty, sy
 import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
-  addBlankPane,
   beginSessionDrag,
   endSessionDrag,
   notifySessionsChanged,
   closeSessionSurfaces,
+  openBackgroundInCanvas,
+  openBlankInFocusedPane,
+  mountRestoredCanvas,
   drawCanvas,
   sessionInCanvas,
   splitInterceptsOpen,
@@ -385,12 +387,12 @@ function toggleRecentProject(scopeId: string): void {
   renderList();
 }
 
-function startProjectChat(event: Event, scopeId: string, name: string | null): void {
+function startProjectChat(event: Event, scopeId: string, _name: string | null): void {
   event.stopPropagation();
   closeSidebarOnNarrowView();
   sessionsState.collapsedProjectScopes.delete(scopeId);
-  if (addBlankPane(scopeId)) return;
-  addPendingSession(mainConversation().newChat({ scopeId, name }), scopeId, name);
+  openBlankInFocusedPane(scopeId);
+  renderList();
 }
 
 function projectMenuPopover(item: Extract<RecentItem, { kind: "project" }>): TemplateResult {
@@ -603,8 +605,7 @@ function statusMarks(s: CoreSession): TemplateResult {
 function openBackgroundInspector(e: Event, s: CoreSession): void {
   e.stopPropagation();
   e.preventDefault();
-  mainConversation().requestBackgroundPanel(s.id || null, s.threadRef);
-  void openSession(s);
+  if (!openBackgroundInCanvas(s)) void openSession(s);
 }
 
 function isActiveRow(s: CoreSession): boolean {
@@ -1192,6 +1193,7 @@ export async function openSession(s: CoreSession, entriesPrefetch?: Promise<Tran
     if (splitState.active) drawCanvas();
     syncUrlFromState(s.id || null);
   }
+  mountRestoredCanvas();
   if (splitInterceptsOpen(s)) return;
   closeSidebarOnNarrowView();
   if (projectName(s.scopeId) && sessionsState.collapsedProjectScopes.delete(s.scopeId)) renderList();

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -37,13 +37,14 @@ import { ensureDeliveryStream, mainConversation, onExitCanvas } from "./conversa
 import { clearAllDrafts, saveDraft, storedDraft } from "./drafts";
 import { deepLinkPath, isPlainLeftClick, parseDeepLink, UI_BASE } from "./deep-link";
 import {
-  addBlankPane,
   adoptRemoteSplit,
   canvasToast,
   drawCanvas,
   exitSplitIfActive,
   loadPersistedSplit,
   mountRestoredCanvas,
+  openBlankInFocusedPane,
+  openThreadInFocusedPane,
   restoredCanvasNeedsSessionList,
   splitState,
 } from "./split";
@@ -53,7 +54,6 @@ import {
   openSession,
   closeOpenSessionMenu,
   refreshSessions,
-  renderChatsPage,
   renderList,
   resetSessionsState,
   sessionsState,
@@ -513,13 +513,13 @@ export function renderSidebarTop(): void {
     html`
       <button
         class="new-chat"
-        title=${splitState.active ? "New session" : "New chat"}
+        title="New chat"
         @click=${() => {
           closeSidebarOnNarrowView();
-          if (!addBlankPane()) mainConversation().newChat();
+          openBlankInFocusedPane();
         }}
       >
-        ${icon(ICON.newChat, 17)}<span>${splitState.active ? "New session" : "New chat"}</span>
+        ${icon(ICON.newChat, 17)}<span>New chat</span>
       </button>
       <nav class="nav" @click=${onNavClick}>
         ${navGroup(
@@ -608,8 +608,8 @@ export function switchView(v: View): void {
   syncUrlFromState();
   switch (v) {
     case "chats":
-      if (splitState.active) drawCanvas();
-      else void renderChatsPage();
+      mountRestoredCanvas();
+      drawCanvas();
       renderList();
       break;
     case "webhooks":
@@ -644,8 +644,7 @@ export function switchView(v: View): void {
 function refreshActiveView(v: View): void {
   switch (v) {
     case "chats":
-      if (splitState.active) void refreshSessions({ silent: true, refreshContexts: true });
-      else void renderChatsPage();
+      void refreshSessions({ silent: true, refreshContexts: true });
       break;
     case "contexts":
       void renderContexts();
@@ -813,7 +812,7 @@ function openAppEditChat(slug: string): void {
     return;
   }
   if (!storedDraft(threadRef)) saveDraft(threadRef, `Update my deployed app "${slug}": `);
-  mainConversation().mountContinuable(threadRef, null, null, []);
+  openThreadInFocusedPane(threadRef);
   renderList();
 }
 
@@ -911,7 +910,7 @@ export async function boot(): Promise<void> {
   } else if (wantedSession) {
     const match = sessionsState.list.find((s) => s.id === wantedSession);
     if (match) {
-      exitSplitIfActive();
+      mountRestoredCanvas();
       await openSession(match, entriesPrefetch ?? undefined);
     } else if (mountRestoredCanvas()) {
       canvasToast("That conversation wasn't found, or you don't have access to it.");
@@ -922,9 +921,9 @@ export async function boot(): Promise<void> {
     }
   } else if (connectedProvider && sessionsState.list.length) {
     const recent = [...sessionsState.list].sort((a, b) => activityOf(b) - activityOf(a))[0]!;
-    exitSplitIfActive();
+    mountRestoredCanvas();
     await openSession(recent);
-  } else if (!mountRestoredCanvas() && !mainConversation().state.threadRef) {
-    mainConversation().newChat();
+  } else {
+    mountRestoredCanvas();
   }
 }

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -48,7 +48,7 @@ import { icon } from "./ui";
 import { contextsState, scopeTitle } from "./contexts";
 import type { DensityTier } from "./density";
 import { appState } from "./shell-state";
-import { renderSidebarTop, switchView, syncUrlFromState } from "./shell";
+import { renderSidebarTop, switchView } from "./shell";
 import { sleep } from "./chat";
 import {
   createConversation,
@@ -59,7 +59,6 @@ import {
 } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
-  openSession,
   openSessionInto,
   refreshSessions,
   sessionsReady,
@@ -85,6 +84,7 @@ interface PaneParams {
   sessionId?: string;
   threadRef?: string;
   scopeId?: string;
+  background?: boolean;
 }
 
 type PendingSeed = { kind: "v2"; layout: SerializedDockview } | { kind: "v1"; seeds: PaneSeed[] };
@@ -98,7 +98,6 @@ const paneContents = new Map<string, PaneContent>();
 const paneTabs = new Set<PaneTab>();
 const groupActions = new Set<GroupActions>();
 let sessionDrag: { sessionId: string; threadRef: string } | null = null;
-let singleOverlay: HTMLElement | null = null;
 let toastMsg = "";
 let toastTimer: number | null = null;
 let headerSignature = "";
@@ -198,6 +197,7 @@ function buildDock(): DockviewApi {
   });
   const guarded = new WeakSet<IDockviewGroupPanel>();
   api.onDidLayoutChange(() => {
+    host.classList.toggle("one-pane", api.panels.length === 1);
     for (const group of api.groups) {
       if (guarded.has(group)) continue;
       guarded.add(group);
@@ -247,6 +247,7 @@ function disposeDock(): void {
 function ensureCanvas(): boolean {
   if (!appState.mainEl) return false;
   if (canvasHost && canvasHost.parentElement === appState.mainEl && dockApi) return true;
+  if (dockApi) lastLayout = dockApi.toJSON();
   disposeDock();
   canvasHost = document.createElement("div");
   canvasHost.className = "split-canvas";
@@ -321,22 +322,6 @@ function largestGroupPanel(api: DockviewApi): { panel: IDockviewPanel; wide: boo
   return best && { panel: best.panel, wide: best.wide };
 }
 
-function activateCanvas(first: PaneParams, second: PaneParams, edge: SplitEdge): void {
-  mainConversation().teardown();
-  mainConversation().composer.resetComposer();
-  splitState.active = true;
-  lastLayout = null;
-  pendingSeed = null;
-  if (!ensureCanvas()) return;
-  const anchor = addPane(first);
-  const fresh = addPane(second, { referencePanel: anchor.id, direction: edgeToDirection(edge) });
-  fresh.api.setActive();
-  persist();
-  renderSidebarTop();
-  syncUrlFromState();
-  renderList();
-}
-
 function edgeToDirection(edge: SplitEdge): "left" | "right" | "above" | "below" {
   if (edge === "top") return "above";
   if (edge === "bottom") return "below";
@@ -361,13 +346,12 @@ function adoptPersisted(raw: unknown): void {
   if (o.v === 2) {
     if (typeof o.updatedAt === "number") persistedUpdatedAt = o.updatedAt;
     pendingSeed = null;
-    splitState.active = false;
-    if (o.active !== true || !o.layout || typeof o.layout !== "object") return;
+    splitState.active = true;
+    if (!o.layout || typeof o.layout !== "object") return;
     const panels = (o.layout as { panels?: object }).panels;
     const n = panels && typeof panels === "object" ? Object.keys(panels).length : 0;
-    if (n < 2 || n > MAX_PANES || serializedTileCount(o.layout) > MAX_TILES) return;
+    if (n < 1 || n > MAX_PANES || serializedTileCount(o.layout) > MAX_TILES) return;
     pendingSeed = { kind: "v2", layout: o.layout as SerializedDockview };
-    splitState.active = true;
     return;
   }
   const seeds = v1PaneSeeds(raw);
@@ -377,6 +361,7 @@ function adoptPersisted(raw: unknown): void {
 }
 
 export function loadPersistedSplit(): void {
+  splitState.active = true;
   let raw: unknown;
   try {
     raw = JSON.parse(localStorage.getItem(STORE_KEY) ?? "null");
@@ -415,16 +400,11 @@ export function restoredCanvasNeedsSessionList(): boolean {
 }
 
 export function mountRestoredCanvas(): boolean {
-  if (splitState.active && (dockApi?.panels.length ?? 0) > 0) return true;
-  if (!splitState.active || (!pendingSeed && !lastLayout)) return false;
-  if (!ensureCanvas()) {
-    splitState.active = false;
-    return false;
-  }
-  if ((dockApi?.panels.length ?? 0) === 0) {
-    exitSplitIfActive();
-    return false;
-  }
+  splitState.active = true;
+  if ((dockApi?.panels.length ?? 0) > 0) return true;
+  if (!ensureCanvas() || !dockApi) return false;
+  if (dockApi.panels.length === 0) addPane({});
+  persist();
   renderSidebarTop();
   renderList();
   return true;
@@ -468,6 +448,20 @@ export function splitInterceptsOpen(s: CoreSession): boolean {
   return true;
 }
 
+export function openBackgroundInCanvas(s: CoreSession): boolean {
+  if (!s.id || !mountRestoredCanvas() || !dockApi) return false;
+  const showing = paneShowing(s.id);
+  if (showing) {
+    showing.api.setActive();
+    paneContents.get(showing.id)?.conversation.requestBackgroundPanel(s.id, s.threadRef);
+    return true;
+  }
+  const target = splitState.focusedId ?? dockApi.activePanel?.id ?? dockApi.panels[0]?.id ?? "";
+  openInPane(target, s.id, s.threadRef, true);
+  renderList();
+  return true;
+}
+
 function focusExistingPane(sessionId: string, exceptPaneId?: string): boolean {
   const dup = paneShowing(sessionId);
   if (!dup) return false;
@@ -478,11 +472,14 @@ function focusExistingPane(sessionId: string, exceptPaneId?: string): boolean {
   return true;
 }
 
-function openInPane(paneId: string, sessionId: string, threadRef: string): void {
+function openInPane(paneId: string, sessionId: string, threadRef: string, background = false): void {
   if (!dockApi || focusExistingPane(sessionId, paneId)) return;
   const target = dockApi.getPanel(paneId);
   if (!target) return;
-  const fresh = addPane({ sessionId, threadRef }, { referencePanel: target.id, direction: "within" });
+  const fresh = addPane(
+    { sessionId, threadRef, ...(background ? { background: true } : {}) },
+    { referencePanel: target.id, direction: "within" },
+  );
   dockApi.removePanel(target);
   fresh.api.setActive();
   persist();
@@ -518,7 +515,7 @@ function tabIntoPane(paneId: string, params: PaneParams, index?: number): boolea
 }
 
 export function addBlankPane(scopeId?: string): boolean {
-  if (!splitState.active || !dockApi) return false;
+  if (!mountRestoredCanvas() || !dockApi) return false;
   if (appState.currentView !== "chats") switchView("chats");
   if (!ensureCanvas() || !dockApi) return false;
   const at = largestGroupPanel(dockApi);
@@ -527,6 +524,26 @@ export function addBlankPane(scopeId?: string): boolean {
   const target = (capped ? dockApi.activePanel : null) ?? at.panel;
   splitPane(target.id, at.wide ? "right" : "bottom", scopeId ? { scopeId } : {});
   return true;
+}
+
+function replaceFocusedPane(params: PaneParams): boolean {
+  if (appState.currentView !== "chats") switchView("chats");
+  if (!mountRestoredCanvas() || !dockApi) return false;
+  const target = dockApi.getPanel(splitState.focusedId ?? "") ?? dockApi.activePanel ?? dockApi.panels[0];
+  if (!target) return false;
+  const fresh = addPane(params, { referencePanel: target.id, direction: "within" });
+  dockApi.removePanel(target);
+  fresh.api.setActive();
+  persist();
+  return true;
+}
+
+export function openBlankInFocusedPane(scopeId?: string): boolean {
+  return replaceFocusedPane(scopeId ? { scopeId } : {});
+}
+
+export function openThreadInFocusedPane(threadRef: string, scopeId?: string): boolean {
+  return replaceFocusedPane({ threadRef, ...(scopeId ? { scopeId } : {}) });
 }
 
 function paneSplitWithBlank(panel: IDockviewPanel): void {
@@ -543,47 +560,17 @@ function closePanels(panels: IDockviewPanel[]): void {
 }
 
 function reconcileAfterClose(): void {
-  const rest = dockApi?.panels ?? [];
-  if (rest.length === 0) {
-    exitSplitIfActive();
-    mainConversation().newChat();
-    return;
-  }
-  if (rest.length === 1) {
-    const lone = rest[0]!;
-    const params = panelParams(lone);
-    if (params.sessionId) {
-      void maximizePane(params);
-    } else {
-      exitSplitIfActive();
-      mainConversation().newChat();
-    }
-    return;
-  }
+  if (!dockApi) return;
+  if (dockApi.panels.length === 0) addPane({});
   persist();
 }
 
-async function maximizePane(params: PaneParams): Promise<void> {
-  if (!params.sessionId) {
-    canvasToast("Start the chat first, then open it full screen");
-    return;
-  }
-  const find = (): CoreSession | undefined => sessionsState.list.find((s) => s.id === params.sessionId);
-  let session = find();
-  if (!session) {
-    try {
-      await refreshSessions({ silent: true });
-    } catch {
-      void 0;
-    }
-    session = find();
-    if (!session) {
-      canvasToast("Still syncing this conversation — try again in a moment");
-      return;
-    }
-  }
-  exitSplitIfActive();
-  void openSession(session);
+function maximizePane(params: PaneParams): void {
+  if (!dockApi) return;
+  const panel = dockApi.panels.find((candidate) => panelParams(candidate) === params) ?? dockApi.activePanel;
+  if (!panel) return;
+  if (panel.api.isMaximized()) panel.api.exitMaximized();
+  else panel.api.maximize();
 }
 
 function focusPane(paneId: string): void {
@@ -611,8 +598,7 @@ function drawToast(): void {
 export function beginSessionDrag(s: CoreSession): void {
   if (!s.id) return;
   sessionDrag = { sessionId: s.id, threadRef: s.threadRef };
-  if (splitState.active) refreshSessionDrag();
-  else showSingleDropOverlay();
+  refreshSessionDrag();
 }
 
 function refreshSessionDrag(): void {
@@ -626,7 +612,6 @@ function refreshSessionDrag(): void {
 export function endSessionDrag(): void {
   if (!sessionDrag) return;
   sessionDrag = null;
-  hideSingleDropOverlay();
   canvasHost?.classList.remove("session-dragging");
   if (splitState.active) syncAllZones();
 }
@@ -662,10 +647,6 @@ function splitZonesTpl(act: (edge: DropEdge) => () => void): TemplateResult {
   `;
 }
 
-function zonesTpl(act: (edge: DropEdge) => () => void): TemplateResult {
-  return html`${zoneTpl("center", "Open here", act("center"))} ${splitZonesTpl(act)}`;
-}
-
 function paneZonesTpl(paneId: string): TemplateResult | typeof nothing {
   const drag = sessionDrag;
   if (!drag || !dockApi) return nothing;
@@ -694,45 +675,6 @@ function paneZoneAct(paneId: string): (edge: DropEdge) => () => void {
     if (focusExistingPane(drag.sessionId)) return;
     splitPane(paneId, edge, { sessionId: drag.sessionId, threadRef: drag.threadRef });
   };
-}
-
-function currentChatParams(): PaneParams | null {
-  const conv = mainConversation();
-  const chatState = conv.state;
-  if (!chatState.host) return null;
-  if (chatState.sessionId)
-    return { sessionId: chatState.sessionId, ...(chatState.threadRef ? { threadRef: chatState.threadRef } : {}) };
-  const untouched =
-    !chatState.pendingSend && !conv.composer.state.draft.trim() && (chatState.agent?.state.messages.length ?? 0) === 0;
-  return untouched ? {} : null;
-}
-
-function showSingleDropOverlay(): void {
-  if (splitState.active || appState.currentView !== "chats" || !appState.mainEl || singleOverlay) return;
-  const act = (edge: DropEdge) => () => {
-    const drag = sessionDrag;
-    endSessionDrag();
-    if (!drag) return;
-    const session = sessionsState.list.find((s) => s.id === drag.sessionId);
-    const current = edge === "center" ? null : currentChatParams();
-    if (edge === "center" || mainConversation().state.sessionId === drag.sessionId || !current) {
-      if (session) void openSession(session);
-      return;
-    }
-    activateCanvas(current, { sessionId: drag.sessionId, threadRef: drag.threadRef }, edge);
-  };
-  const drag = sessionDrag;
-  const splittable =
-    Boolean(drag) && mainConversation().state.sessionId !== drag?.sessionId && currentChatParams() !== null;
-  singleOverlay = document.createElement("div");
-  singleOverlay.className = "split-zones split-zones-single";
-  render(splittable ? zonesTpl(act) : zoneTpl("center", "Open here", act("center")), singleOverlay);
-  appState.mainEl.appendChild(singleOverlay);
-}
-
-function hideSingleDropOverlay(): void {
-  singleOverlay?.remove();
-  singleOverlay = null;
 }
 
 export function drawCanvas(): void {
@@ -899,10 +841,14 @@ class PaneContent implements IContentRenderer {
     if (this.loaded || this.disposed) return;
     this.loaded = true;
     this.syncDensity();
-    const { sessionId, threadRef, scopeId } = this.params;
+    const { sessionId, threadRef, scopeId, background } = this.params;
     const wanted =
       sessionId ?? (threadRef ? (sessionsState.list.find((s) => s.threadRef === threadRef)?.id ?? null) : null);
     if (!wanted) {
+      if (threadRef) {
+        this.conversation.mountContinuable(threadRef, null, scopeId ?? null, []);
+        return;
+      }
       const context = scopeId ? contextsState.list.find((c) => c.scopeId === scopeId) : undefined;
       this.conversation.newChat(context ? { scopeId: context.scopeId, name: context.name ?? null } : undefined);
       return;
@@ -925,6 +871,11 @@ class PaneContent implements IContentRenderer {
         [],
       );
       return;
+    }
+    if (background) {
+      this.conversation.requestBackgroundPanel(session.id, session.threadRef);
+      this.panel?.api.updateParameters({ sessionId, threadRef, ...(scopeId ? { scopeId } : {}) });
+      persist();
     }
     await openSessionInto(this.conversation, session);
     if (this.disposed) return;

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -6,7 +6,6 @@ const read = (f: string): string => readFileSync(new URL(`../src/${f}`, import.m
 const split = read("split.ts");
 const sessions = read("sessions.ts");
 const shell = read("shell.ts");
-const chat = read("chat.ts");
 const layout = read("split-layout.ts");
 const css = read("shell.css");
 
@@ -18,25 +17,19 @@ const fn = (src: string, name: string): string => {
   return body;
 };
 
-test("no new-chat affordance can cost the user their canvas", () => {
-  assert.match(split, /export function addBlankPane\(scopeId\?: string\): boolean \{/);
-  const add = fn(split, "addBlankPane");
-  assert.match(add, /if \(!splitState\.active \|\| !dockApi\) return false;/, "no canvas ⇒ the caller must fall back");
-  assert.match(add, /return true;\n\}$/, "having split, the canvas owns the click");
-  assert.doesNotMatch(add.slice(add.indexOf("splitPane(")), /return false/, "a full canvas must not fall through");
+test("the canvas owns ordinary new-chat actions even with one pane", () => {
+  const replace = fn(split, "openBlankInFocusedPane");
+  assert.match(replace, /replaceFocusedPane/);
+  assert.match(shell, /openBlankInFocusedPane\(\);/);
+  assert.doesNotMatch(shell, /if \(!addBlankPane\(\)\) mainConversation/);
 
-  assert.match(shell, /if \(!addBlankPane\(\)\) mainConversation\(\)\.newChat\(\);/);
-  const plus = fn(sessions, "startProjectChat");
-  const claimed = plus.indexOf("addBlankPane(scopeId)");
-  assert.ok(claimed > 0, "the project + must offer the click to the canvas");
-  assert.match(plus.slice(claimed), /^addBlankPane\(scopeId\)\) return;/m, "and bail out when the canvas takes it");
-  assert.ok(
-    plus.indexOf("addPendingSession(mainConversation().newChat(") > claimed,
-    "only then may it mount a single chat",
-  );
+  const project = fn(sessions, "startProjectChat");
+  assert.match(project, /openBlankInFocusedPane\(scopeId\)/);
+  assert.doesNotMatch(project, /mainConversation\(\)\.newChat/);
 
-  assert.match(fn(split, "exitSplitIfActive"), /splitState\.active = false;/);
-  assert.doesNotMatch(fn(split, "exitSplitIfActive"), /removeItem|lastLayout = null/);
+  const close = fn(split, "reconcileAfterClose");
+  assert.match(close, /if \(dockApi\.panels\.length === 0\) addPane\(\{\}\)/);
+  assert.doesNotMatch(close, /exitSplitIfActive|maximizePane|mainConversation/);
 });
 
 test("a pane opened from a project's + starts its chat in that project", () => {
@@ -96,7 +89,7 @@ test("a strip drop lands where a dragged pane header would, not merely at the en
 
 test("the pane body no longer offers a tab zone", () => {
   assert.doesNotMatch(layout, /"tab"/, "DropEdge must drop the zone that no longer exists");
-  const zones = fn(split, "zonesTpl") + fn(split, "splitZonesTpl");
+  const zones = fn(split, "paneZonesTpl") + fn(split, "splitZonesTpl");
   assert.doesNotMatch(zones, /"tab"/);
   assert.match(zones, /zoneTpl\("center", "Open here"/);
   for (const edge of ["left", "right", "top", "bottom"]) assert.match(zones, new RegExp(`zoneTpl\\("${edge}"`));
@@ -115,45 +108,24 @@ test("the tile cap only judges dockview's own panel drags", () => {
   assert.ok(bail < hold.indexOf("dropAddsTile"), "before the tile arithmetic, not after");
 });
 
-test("boot mounts a restored canvas before it awaits the session list", () => {
+test("boot mounts a one-pane canvas before it awaits the session list", () => {
   const boot = shell.match(/export async function boot\(\): Promise<void> \{[\s\S]*?\n\}/)?.[0] ?? "";
   assert.ok(boot, "boot not found");
   const early = boot.indexOf("if (bareEntry && !restoredCanvasNeedsSessionList()) mountRestoredCanvas();");
   const listAwait = boot.indexOf("await refreshSessions({ showLoading: true });");
-  assert.ok(early > 0, "boot must offer the canvas its head start");
-  assert.ok(listAwait > 0, "boot still loads the session list");
-  assert.ok(early < listAwait, "the mount must come BEFORE the list fetch the panes never read");
+  assert.ok(early > 0 && early < listAwait, "the baseline canvas mounts before session refresh when it can");
+  assert.match(boot.slice(listAwait), /\} else \{\s*mountRestoredCanvas\(\);\s*\}/);
 
-  assert.match(boot, /const bareEntry = !viewIntent && !wantedSession && wanted !== "app-edit" && !connectedProvider;/);
-
-  assert.match(
-    boot.slice(listAwait),
-    /\} else if \(!mountRestoredCanvas\(\) && !mainConversation\(\)\.state\.threadRef\) \{/,
-  );
   const mount = fn(split, "mountRestoredCanvas");
-  assert.match(mount, /^ {2}if \(splitState\.active && \(dockApi\?\.panels\.length \?\? 0\) > 0\) return true;/m);
+  assert.match(mount, /splitState\.active = true;/);
+  assert.match(mount, /if \(dockApi\.panels\.length === 0\) addPane\(\{\}\)/);
 });
 
-test("boot's fallback never replaces a chat the user mounted during the wait", () => {
-  const boot = shell.match(/export async function boot\(\): Promise<void> \{[\s\S]*?\n\}/)?.[0] ?? "";
-  const listAwait = boot.indexOf("await refreshSessions({ showLoading: true });");
-  const tail = boot.slice(listAwait);
-  assert.match(tail, /\} else if \(!mountRestoredCanvas\(\) && !mainConversation\(\)\.state\.threadRef\) \{/);
-  const guard = tail.indexOf("!mainConversation().state.threadRef");
-  const mint = tail.indexOf("newChat();", guard);
-  assert.ok(guard > 0 && mint > guard, "the guard must gate the mint, not follow it");
-
-  assert.match(chat, /^ {2}function mountContinuable\(/m);
-  assert.match(fn(chat, "mountContinuable"), /chatState\.threadRef = threadRef;/);
-
-  const reconcile = fn(split, "reconcileAfterClose");
-  assert.match(
-    reconcile,
-    /exitSplitIfActive\(\);\s*\n\s*mainConversation\(\)\.newChat\(\);/,
-    "a blank lone survivor mounts a new chat",
-  );
-  assert.match(reconcile, /void maximizePane\(params\);/, "a lone survivor with a session is maximized");
-  assert.match(fn(split, "exitSplitIfActive"), /splitState\.active = false;/);
+test("one-pane layouts persist and restore as first-class canvas layouts", () => {
+  const adopt = fn(split, "adoptPersisted");
+  assert.match(adopt, /if \(n < 1 \|\| n > MAX_PANES/);
+  assert.doesNotMatch(adopt, /o\.active !== true|n < 2/);
+  assert.match(fn(split, "loadPersistedSplit"), /splitState\.active = true;/);
 });
 
 test("a pane gives the conversation the same height chain the full-screen .main does", () => {

--- a/plugins/web-ui/test/split-drop-legitimacy.test.ts
+++ b/plugins/web-ui/test/split-drop-legitimacy.test.ts
@@ -40,14 +40,9 @@ test("targets and highlights stay honest when the layout changes mid-drag", () =
   );
 });
 
-test("the single-view overlay hides splits the drop cannot honor", () => {
-  const single = split.match(/^function showSingleDropOverlay\([\s\S]*?\n\}/m)?.[0] ?? "";
-  assert.ok(single, "showSingleDropOverlay not found");
-  assert.match(
-    single,
-    /currentChatParams\(\) !== null/,
-    "a dirty unsaved chat cannot seed a pane, so no split targets",
-  );
-  assert.match(single, /state\.sessionId !== drag\?\.sessionId/, "dropping the chat onto itself cannot split");
-  assert.match(single, /splittable \? zonesTpl\(act\) : zoneTpl\("center", "Open here", act\("center"\)\)/);
+test("session drags always target the canvas — there is no single-view handoff", () => {
+  const begin = split.match(/^export function beginSessionDrag\([\s\S]*?\n}/m)?.[0] ?? "";
+  assert.ok(begin, "beginSessionDrag not found");
+  assert.match(begin, /refreshSessionDrag\(\);/);
+  assert.doesNotMatch(split, /showSingleDropOverlay|currentChatParams|activateCanvas/);
 });

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -25,7 +25,7 @@ test("the tile cap counts tiles and turns the overflow into a tab", () => {
 });
 
 test("a revived canvas is bounded by both caps and cannot blow the stack", () => {
-  assert.match(split, /if \(n < 2 \|\| n > MAX_PANES \|\| serializedTileCount\(o\.layout\) > MAX_TILES\) return;/);
+  assert.match(split, /if \(n < 1 \|\| n > MAX_PANES \|\| serializedTileCount\(o\.layout\) > MAX_TILES\) return;/);
 
   const tiles = (...kids: object[]): object => ({ grid: { root: branch(...kids) } });
   assert.equal(serializedTileCount(tiles(leaf(["a", "b", "c"]), leaf(["d"]))), 2, "tabs are not tiles");


### PR DESCRIPTION
Makes the pane canvas the baseline Chats runtime, including one-pane layouts, so adding panes preserves active conversation state.

- verification: web UI suite (565 passed)
- verification: typecheck, ESLint, and Prettier
- verification: browser flows for deep links, session replacement, New chat, split/collapse, drafts, and attachments
