### PR TITLE
Refactor approval continuation ownership

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -50,13 +50,14 @@ import {
   makeCoreStreamFn,
   makeOpenerStreamFn,
   makeRunResumeStreamFn,
-  queueApprovalTurn,
+  resolveApproval,
   TAIL_TURNS,
   type ApprovalDecision,
   type AssistantWork,
   type CoreSession,
   type DeliveredFile,
   type PendingApproval,
+  type RunPoll,
   type SessionBackgroundOutput,
   type SessionBackgroundView,
   type SessionEntry,
@@ -520,9 +521,9 @@ export function createChatSurface(
     drawActiveChat(agent);
     try {
       const threadRef = chatState.threadRef;
-      await queueApprovalTurn(threadRef, agent, decision, currentTurnOptions);
+      const runId = await resolveApproval(decision);
       if (chatState.normalStreamFn && chatState.onWork)
-        await resumeTrackedRun(agent, threadRef, chatState.normalStreamFn, chatState.onWork);
+        await resumeRun(agent, threadRef, chatState.normalStreamFn, chatState.onWork, runId);
     } catch (err) {
       if (agent === chatState.agent) {
         ctx.composer.state.error = err instanceof Error ? err.message : "Could not send the approval.";
@@ -538,6 +539,12 @@ export function createChatSurface(
           void 0;
         }
         await refreshTranscriptFromEntries(agent);
+      }
+      const active = chatState.agent;
+      if (active) {
+        await active.waitForIdle();
+        await syncPendingApprovals(active);
+        drawActiveChat(active);
       }
     }
   }
@@ -562,6 +569,17 @@ export function createChatSurface(
 
   function hasUnresolvedApproval(): boolean {
     return activePendingApprovals().length > 0;
+  }
+
+  async function syncPendingApprovals(agent: Agent, messages = agent.state.messages): Promise<void> {
+    const id = chatState.sessionId;
+    if (!id || agent !== chatState.agent) return;
+    const r = await api<{ approvals: PendingApproval[] }>(`/api/sessions/${encodeURIComponent(id)}/approvals`).catch(
+      () => null,
+    );
+    if (!r || id !== chatState.sessionId || agent !== chatState.agent) return;
+    for (const message of messages) delete (message as AssistantWork).work?.pendingApprovals;
+    attachPendingApprovals(messages, r.approvals ?? [], transcriptModel());
   }
 
   async function refreshTranscriptFromEntries(agent: Agent): Promise<void> {
@@ -591,14 +609,7 @@ export function createChatSurface(
         generation,
         refreshedInherited ? entriesToMessages(refreshedInherited, transcriptModel()) : null,
       );
-      try {
-        const r = await api<{ approvals: PendingApproval[] }>(
-          `/api/sessions/${encodeURIComponent(sessionId)}/approvals`,
-        );
-        attachPendingApprovals(messages, r.approvals ?? [], transcriptModel());
-      } catch {
-        void 0;
-      }
+      await syncPendingApprovals(agent, messages);
       if (
         !forkOriginController.isCurrentRefresh(generation) ||
         sessionId !== chatState.sessionId ||
@@ -656,24 +667,16 @@ export function createChatSurface(
     }
   }
 
-  async function resumeTrackedRun(
+  async function resumeRun(
     agent: Agent,
     threadRef: string,
     normalStreamFn: Agent["streamFn"],
     onWork: (work: WorkBlock) => void,
+    runId: string,
+    initialRun?: RunPoll,
   ): Promise<boolean> {
-    if (!agent.state.messages.length) return false;
-    let activeRun: Awaited<ReturnType<typeof activeRunForThread>>;
-    try {
-      activeRun = await activeRunForThread(threadRef);
-    } catch {
-      return false;
-    }
-    if (agent === chatState.agent && threadRef === chatState.threadRef)
-      ctx.composer.setQueuedRuns(threadRef, activeRun.queued);
     if (
-      !activeRun.runId ||
-      !activeRun.run ||
+      !agent.state.messages.length ||
       agent !== chatState.agent ||
       appState.currentView !== "chats" ||
       agent.state.isStreaming
@@ -696,7 +699,7 @@ export function createChatSurface(
       .map((m) => messageText(m).trim())
       .filter(Boolean)
       .join("\n\n");
-    agent.streamFn = makeRunResumeStreamFn(activeRun.runId, activeRun.run, onWork, runSlot, seedText);
+    agent.streamFn = makeRunResumeStreamFn(runId, initialRun, onWork, runSlot, seedText);
     try {
       await agent.continue();
     } catch (err) {
@@ -709,6 +712,24 @@ export function createChatSurface(
       }
     }
     return true;
+  }
+
+  async function resumeTrackedRun(
+    agent: Agent,
+    threadRef: string,
+    normalStreamFn: Agent["streamFn"],
+    onWork: (work: WorkBlock) => void,
+  ): Promise<boolean> {
+    let activeRun: Awaited<ReturnType<typeof activeRunForThread>>;
+    try {
+      activeRun = await activeRunForThread(threadRef);
+    } catch {
+      return false;
+    }
+    if (agent === chatState.agent && threadRef === chatState.threadRef)
+      ctx.composer.setQueuedRuns(threadRef, activeRun.queued);
+    if (!activeRun.runId || !activeRun.run) return false;
+    return resumeRun(agent, threadRef, normalStreamFn, onWork, activeRun.runId, activeRun.run);
   }
 
   function adoptActiveSessionFromList(agent: Agent): void {

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -646,22 +646,13 @@ export function makeRunResumeStreamFn(
   return fn as unknown as StreamFn;
 }
 
-export async function queueApprovalTurn(
-  threadRef: string,
-  agent: Agent,
-  decision: ApprovalDecision,
-  getTurnOptions?: () => TurnOptions,
-): Promise<QueuedRun> {
-  const { text, attachments } = await latestUserTurn(agent);
-  const submit = await api<{ runId?: string }>("/api/turn", {
+export async function resolveApproval(decision: ApprovalDecision): Promise<string> {
+  const submit = await api<{ runId?: string }>(`/api/approvals/${encodeURIComponent(decision.requestId)}`, {
     method: "POST",
-    body: JSON.stringify({
-      ...turnRequestBody(threadRef, text, agent.state.model, agent, getTurnOptions, attachments),
-      approval: decision,
-    }),
+    body: JSON.stringify({ approved: decision.approved, ...(decision.scope ? { scope: decision.scope } : {}) }),
   });
   if (!submit.runId) throw new Error("Could not continue after the approval.");
-  return { runId: submit.runId, text };
+  return submit.runId;
 }
 
 export function makeOpenerStreamFn(

--- a/plugins/web-ui/test/approval-continuation-source.test.ts
+++ b/plugins/web-ui/test/approval-continuation-source.test.ts
@@ -5,9 +5,12 @@ import test from "node:test";
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
 
-test("approval continuations attach to the visible run while sibling cards stay independent", () => {
-  assert.match(chat, /await queueApprovalTurn[\s\S]{0,300}await resumeTrackedRun/);
+test("approval continuations attach their exact run while sibling cards stay independent", () => {
+  assert.match(chat, /const runId = await resolveApproval[\s\S]{0,300}await resumeRun/);
+  assert.match(chat, /makeRunResumeStreamFn\(runId, initialRun/);
   assert.match(chat, /!chatState\.resolvingApprovals\.has\(approval\.requestId\)/);
+  assert.match(chat, /await active\.waitForIdle\(\);[\s\S]{0,100}await syncPendingApprovals\(active\)/);
+  assert.match(chat, /delete .*pendingApprovals;[\s\S]{0,100}attachPendingApprovals/);
   assert.match(composer, /resolvingApprovals\.has\(a\.requestId\)/);
   assert.doesNotMatch(composer, /const busy = ctx\.chat\.state\.resolvingApprovals\.size > 0/);
 });

--- a/plugins/web-ui/test/approval-refusal-feedback.test.ts
+++ b/plugins/web-ui/test/approval-refusal-feedback.test.ts
@@ -1,26 +1,18 @@
 import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
-import type { Api, Model } from "@earendil-works/pi-ai";
-import type { Agent } from "@earendil-works/pi-agent-core";
-import { queueApprovalTurn } from "../src/core-bridge.ts";
+import { resolveApproval } from "../src/core-bridge.ts";
 
-const MODEL = { id: "m", api: "anthropic", provider: "anthropic" } as unknown as Model<Api>;
-const agent = {
-  state: { model: MODEL, messages: [{ role: "user", content: "resolve conflicts" }], isStreaming: false },
-} as unknown as Agent;
 const realFetch = globalThis.fetch;
 afterEach(() => (globalThis.fetch = realFetch));
 
-test("an approval returns its continuation run without polling it", async () => {
-  let body: { approval?: unknown } = {};
-  globalThis.fetch = (async (_input, init) => {
-    body = JSON.parse(String(init?.body));
-    return { ok: true, status: 200, text: async () => JSON.stringify({ runId: "r-1" }) } as Response;
+test("approval resolution delegates replay to its dedicated endpoint", async () => {
+  let request = { url: "", body: "" };
+  globalThis.fetch = (async (input, init) => {
+    request = { url: String(input), body: String(init?.body) };
+    return { ok: true, status: 202, text: async () => JSON.stringify({ runId: "r-1" }) } as Response;
   }) as typeof fetch;
 
-  assert.deepEqual(await queueApprovalTurn("web:u:t", agent, { requestId: "a-1", approved: true, scope: "once" }), {
-    runId: "r-1",
-    text: "resolve conflicts",
-  });
-  assert.deepEqual(body.approval, { requestId: "a-1", approved: true, scope: "once" });
+  assert.equal(await resolveApproval({ requestId: "a/1", approved: true, scope: "once" }), "r-1");
+  assert.match(request.url, /\/api\/approvals\/a%2F1$/);
+  assert.deepEqual(JSON.parse(request.body), { approved: true, scope: "once" });
 });

--- a/plugins/web-ui/test/steer-recovery-source.test.ts
+++ b/plugins/web-ui/test/steer-recovery-source.test.ts
@@ -20,7 +20,7 @@ test("a server-side run starting for an open conversation attaches the view (wor
 });
 
 test("resuming a tracked run pulls the transcript first so the triggering message is on screen", () => {
-  const at = chat.indexOf("async function resumeTrackedRun");
+  const at = chat.indexOf("async function resumeRun");
   assert.ok(at >= 0);
   const body = chat.slice(at, chat.indexOf("agent.streamFn = makeRunResumeStreamFn", at));
   assert.match(body, /await refreshTranscriptFromEntries\(agent\);/);


### PR DESCRIPTION
Moves approval replay behind the dedicated resolution endpoint and attaches the exact continuation run returned by core.

- stacked on #686
- verification: focused approval tests (16 passed)
- verification: web bundle build passed
- diff: 44 additions, 49 deletions
