### PR TITLE
Fix model picker viewport clipping

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -979,6 +979,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                             @input=${(e: InputEvent) => {
                               composerState.menuQuery = (e.currentTarget as HTMLInputElement).value;
                               ctx.chat.drawActiveChat();
+                              requestAnimationFrame(() => placeComposerMenu(args.kind));
                             }}
                           />
                         </label>`
@@ -1017,16 +1018,37 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     `;
   }
 
+  function placeComposerMenu(kind: ComposerMenu): void {
+    const popover = ctx.chat.state.host?.querySelector<HTMLElement>(`#composer-${kind}-menu`);
+    const anchor = popover?.parentElement;
+    if (!popover || !anchor) return;
+    const viewport = window.visualViewport;
+    const viewportTop = viewport?.offsetTop ?? 0;
+    const viewportBottom = viewportTop + (viewport?.height ?? window.innerHeight);
+    const anchorRect = anchor.getBoundingClientRect();
+    const margin = 12;
+    const gap = 8;
+    const availableAbove = Math.max(0, anchorRect.top - viewportTop - margin - gap);
+    const availableBelow = Math.max(0, viewportBottom - anchorRect.bottom - margin - gap);
+    const placeBelow = availableBelow > availableAbove;
+    const availableHeight = placeBelow ? availableBelow : availableAbove;
+    popover.classList.toggle("drop-down", placeBelow);
+    popover.style.setProperty("--menu-available-height", `${Math.floor(availableHeight)}px`);
+  }
+
   function toggleComposerMenu(e: Event, kind: ComposerMenu): void {
     e.stopPropagation();
     const opening = composerState.openMenu !== kind;
     composerState.openMenu = opening ? kind : null;
     composerState.menuQuery = "";
     ctx.chat.drawActiveChat();
-    if (opening && kind === "model") {
-      requestAnimationFrame(() =>
-        ctx.chat.state.host?.querySelector<HTMLInputElement>(".model-control .menu-search input")?.focus(),
-      );
+    if (opening) {
+      requestAnimationFrame(() => {
+        placeComposerMenu(kind);
+        if (kind !== "model") return;
+        ctx.chat.state.host?.querySelector<HTMLInputElement>(".model-control .menu-search input")?.focus();
+        requestAnimationFrame(() => placeComposerMenu(kind));
+      });
     }
   }
 

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2605,7 +2605,7 @@ a.chat-row-open {
   z-index: 30;
   width: 230px;
   max-width: calc(100vw - 36px);
-  max-height: min(320px, 52vh);
+  max-height: min(320px, var(--menu-available-height, 52vh));
   overflow-y: auto;
   padding: 6px;
   border: 1px solid var(--border);
@@ -2619,6 +2619,10 @@ a.chat-row-open {
   right: 0;
   left: auto;
   width: 230px;
+}
+.menu-popover.drop-down {
+  top: calc(100% + 8px);
+  bottom: auto;
 }
 .menu-title {
   padding: 6px 8px 5px;
@@ -4596,7 +4600,7 @@ a.chat-row-open {
     width: min(286px, calc(100vw - 30px));
   }
   .menu-popover {
-    max-height: 42vh;
+    max-height: min(320px, var(--menu-available-height, 42vh));
   }
   .message-bubble {
     max-width: 94%;

--- a/plugins/web-ui/test/composer-source.test.ts
+++ b/plugins/web-ui/test/composer-source.test.ts
@@ -87,3 +87,10 @@ test("long model menus stay searchable and show the selected effort", () => {
   assert.match(composer, /option\.groupLabel/);
   assert.match(composer, /suffix: `· \$\{effortLabel\(composerState\.effortLevel\)}`/);
 });
+
+test("composer menus stay inside the visible viewport", () => {
+  assert.match(composer, /function placeComposerMenu\(kind: ComposerMenu\)/);
+  assert.match(composer, /window\.visualViewport/);
+  assert.match(composer, /--menu-available-height/);
+  assert.match(composer, /classList\.toggle\("drop-down", placeBelow\)/);
+});


### PR DESCRIPTION
Keeps composer menus within the visible viewport while preserving the grouped, searchable model list.

- verification: 24 focused tests, web UI typecheck, ESLint, Prettier
- browser: clipped top reproduced; fixed menu remained inside viewport

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790361847&installation_model_id=19911&pr_number=688&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F688&signature=58eb1840e40dd1e3beb8e5a0a73d4171450858f023acc3b254b0cf6c2a57e4a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->