### PR TITLE
fix: unify email-auth and directory identity

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/backends/fly.ts
+++ b/cli/src/backends/fly.ts
@@ -220,6 +220,29 @@ function stageSecret(app: string, name: string, value: string): void {
   if (result.status !== 0) throw new CliError(`failed to stage ${name} on ${app}`);
 }
 
+export function stageFlyEmailAllowlist(
+  config: QmConfig,
+  configDir: string,
+  selectedWorkloads: ReadonlySet<string>,
+): void {
+  const values = readEnvFile(join(configDir, ".env"));
+  const value = deploymentSecretValue("AUTH_ALLOWED_EMAILS", values.get("AUTH_ALLOWED_EMAILS"));
+  if (value === undefined) return;
+  if (isInvalidSecret("AUTH_ALLOWED_EMAILS", value)) {
+    throw new CliError("required secret AUTH_ALLOWED_EMAILS is missing or invalid");
+  }
+  const secret = computedSecrets(config).find((candidate) => candidate.name === "AUTH_ALLOWED_EMAILS");
+  if (!secret) return;
+  const staged: string[] = [];
+  for (const [workload, names] of secretDestinations(secret)) {
+    if (!selectedWorkloads.has(workload)) continue;
+    const app = `${appPrefixOf(config)}-${workload}`;
+    for (const name of names) stageSecret(app, name, value);
+    staged.push(app);
+  }
+  if (staged.length) step(`AUTH_ALLOWED_EMAILS: staged from .env on ${staged.join(", ")}`);
+}
+
 function flySensitive(args: string[], failure: string): string {
   const result = spawnSync(flyBin(), args, { encoding: "utf8" });
   if (result.status !== 0) throw new CliError(failure);
@@ -1106,6 +1129,10 @@ export async function flyUp(config: QmConfig, configDir: string, opts: FlyUpOpts
       note("");
       ok(`deployment images for ${ctx.appPrefix} built.`);
       return;
+    }
+
+    if (!opts.dryRun) {
+      stageFlyEmailAllowlist(config, configDir, new Set([...services, ...plugins.map((plugin) => plugin.name)]));
     }
 
     const gateSecrets = (app: string, header: string, path: string, required: string[], timingKey: string): boolean => {

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -336,6 +336,20 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
   },
   {
     name: "AUTH_ALLOWED_EMAILS",
+    service: "core",
+    required: {
+      when: {
+        kind: "all",
+        conditions: [
+          { kind: "service-enabled", service: "auth" },
+          { kind: "env-absent", service: "auth", name: "AUTH_ALLOWED_EMAIL_DOMAIN" },
+        ],
+      },
+    },
+    description: "Email-auth principals protected from unrelated directory-source deactivation.",
+  },
+  {
+    name: "AUTH_ALLOWED_EMAILS",
     service: "portal",
     envName: "OIDC_ALLOWED_EMAILS",
     required: {

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ import { derivedTomlFor } from "../src/backends/fly.ts";
 import { serviceEnvironment } from "../src/backends/aws.ts";
 import { dockerServiceEnv } from "../src/backends/docker.ts";
 import { computedSecrets, runtimeSecretNames, secretsForService } from "../src/secrets.ts";
+import { stageFlyEmailAllowlist } from "../src/backends/fly.ts";
 import { isReservedContainerName, SERVICE_NAMES, serviceDef } from "../src/services.ts";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -162,6 +163,7 @@ test("without a configured domain the allowlist becomes a required secret on bot
   assert.ok(allowed.required);
   assert.deepEqual(runtimeSecretNames("auth", allowed), ["AUTH_ALLOWED_EMAILS"]);
   assert.deepEqual(runtimeSecretNames("portal", allowed), ["OIDC_ALLOWED_EMAILS"]);
+  assert.deepEqual(runtimeSecretNames("core", allowed), ["AUTH_ALLOWED_EMAILS"]);
   const names = new Set(computedSecrets(config).map((secret) => secret.name));
   for (const name of ["SMTP_HOST", "SMTP_USERNAME", "SMTP_PASSWORD"]) assert.ok(names.has(name), name);
   assert.ok(!names.has("RESEND_API_KEY"));
@@ -215,4 +217,31 @@ test("a broker deployment with no allowlist at all is refused once secret values
     validatePortalTrust(config, "config", new Map([["AUTH_ALLOWED_EMAILS", "admin@example.com"]])),
   );
   assert.doesNotThrow(() => validatePortalTrust(brokerConfig(), "config", new Map()));
+});
+
+test("fly up staging copies a changed .env email allowlist to auth, portal, and core", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-allowlist-up-"));
+  const fly = join(dir, "fly");
+  const log = join(dir, "fly.log");
+  writeFileSync(
+    fly,
+    `#!/usr/bin/env node
+const fs=require("node:fs"); fs.appendFileSync(${JSON.stringify(log)}, process.argv.slice(2).join(" ")+" value="+fs.readFileSync(0,"utf8")+"\\n");`,
+  );
+  chmodSync(fly, 0o755);
+  writeFileSync(join(dir, ".env"), "AUTH_ALLOWED_EMAILS=new@example.com,other@example.com\n");
+  const config = configWith(configText({ env: `{ "auth": { "AUTH_EMAIL_TRANSPORT": "smtp" } }` }));
+  const prior = process.env.FLY_BIN;
+  process.env.FLY_BIN = fly;
+  try {
+    stageFlyEmailAllowlist(config, dir, new Set(["core", "auth", "portal"]));
+  } finally {
+    if (prior === undefined) delete process.env.FLY_BIN;
+    else process.env.FLY_BIN = prior;
+  }
+  const calls = readFileSync(log, "utf8");
+  const prefix = "acme";
+  assert.match(calls, new RegExp(`-a ${prefix}-core AUTH_ALLOWED_EMAILS=- value=new@example.com,other@example.com`));
+  assert.match(calls, new RegExp(`-a ${prefix}-auth AUTH_ALLOWED_EMAILS=- value=new@example.com,other@example.com`));
+  assert.match(calls, new RegExp(`-a ${prefix}-portal OIDC_ALLOWED_EMAILS=- value=new@example.com,other@example.com`));
 });

--- a/src/api/app-messaging.ts
+++ b/src/api/app-messaging.ts
@@ -89,6 +89,12 @@ export function createMessagingMethods(
   const contextRequests = deps.contextRequests ?? createMemoryMap<SurfaceContextRequest>();
   const contextRequestListeners = new Set<(request: SurfaceContextRequest) => void>();
   const contextRequestTokens = new Map<string, string>();
+  const emailAuthMembers = deps.emailAuthMembers ?? [];
+  const mergedDirectoryMembers = async () => {
+    const stored = await deps.directory.list();
+    const seen = new Set(stored.map((member) => personKey(member.principalId)));
+    return [...stored, ...emailAuthMembers.filter((member) => !seen.has(personKey(member.principalId)))];
+  };
 
   return {
     async createCron(input) {
@@ -394,20 +400,30 @@ export function createMessagingMethods(
         ...(isPrivate !== undefined ? { isPrivate } : {}),
       });
     },
-    resolveRecipient(query) {
-      return deps.directory.resolve(query);
+    async resolveRecipient(query) {
+      const stored = await deps.directory.resolve(query);
+      if (stored.kind !== "none") return stored;
+      const key = personKey(query);
+      const member = emailAuthMembers.find(
+        (candidate) => personKey(candidate.principalId) === key || personKey(candidate.displayName) === key,
+      );
+      return member ? { kind: "one", member } : { kind: "none" };
     },
     resolveChannel(query) {
       return deps.directory.resolveChannel(query);
     },
     directoryMembers() {
-      return deps.directory.list();
+      return mergedDirectoryMembers();
     },
     directoryChannels() {
       return deps.directory.listChannels();
     },
-    directoryMember(principalId) {
-      return deps.directory.get(principalId);
+    async directoryMember(principalId) {
+      return (
+        (await deps.directory.get(principalId)) ??
+        emailAuthMembers.find((member) => personKey(member.principalId) === personKey(principalId)) ??
+        null
+      );
     },
     samePerson(a, b) {
       return samePersonInDirectory(deps.directory, a, b);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -537,6 +537,7 @@ export interface AppDeps {
   webhooks: WebhookStore;
   deliveries: DeliveryStore;
   directory: DirectoryStore;
+  emailAuthMembers?: DirectoryMember[];
   projects?: ProjectStore;
   deploy: DeployService;
   deploymentLayer?: DeploymentLayerRuntime;

--- a/src/api/routes/admin/users.ts
+++ b/src/api/routes/admin/users.ts
@@ -29,12 +29,12 @@ export async function listUsers(ctx: ApiCtx): Promise<void> {
 }
 
 export async function searchDirectory(ctx: ApiCtx): Promise<void> {
-  const { res, deps, url } = ctx;
+  const { res, deps, app, url } = ctx;
   const actor = await authorizeAdmin(ctx, orgScope(deps));
   if (!actor) return;
   const q = (url.searchParams.get("q") ?? "").trim();
   if (!q || !deps.directory) return sendJson(res, 200, { members: [] });
-  const r = await deps.directory.resolve(q);
+  const r = await app.resolveRecipient(q);
   let members: DirectoryMember[] = [];
   if (r.kind === "one") members = [r.member];
   else if (r.kind === "ambiguous") members = r.candidates;

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export interface Config {
   piSystemCacheSplit: boolean;
   sessionTapeMode: "shadow" | "serve";
   adminGrants?: string;
+  emailAuthPrincipals?: string[];
   rateLimitPerWindow: number;
   rateLimitWindowMs: number;
   budgetUsdPerWindow?: number;
@@ -795,6 +796,17 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     ...(modelProvider ? { modelProvider } : {}),
     providerBaseUrls,
     ...(env.ADMIN_GRANTS ? { adminGrants: env.ADMIN_GRANTS } : {}),
+    ...(env.AUTH_ALLOWED_EMAILS
+      ? {
+          emailAuthPrincipals: [
+            ...new Set(
+              env.AUTH_ALLOWED_EMAILS.split(",")
+                .map((email) => email.trim().toLowerCase())
+                .filter(Boolean),
+            ),
+          ],
+        }
+      : {}),
     piCaptureRequests: boolEnvStrict("PI_CAPTURE_REQUESTS", env.PI_CAPTURE_REQUESTS) ?? true,
     piSystemCacheSplit: boolEnvStrict("PI_SYSTEM_CACHE_SPLIT", env.PI_SYSTEM_CACHE_SPLIT) ?? false,
     sessionTapeMode: env.SESSION_TAPE_MODE === "shadow" ? "shadow" : "serve",

--- a/src/deployment/secret-schema.ts
+++ b/src/deployment/secret-schema.ts
@@ -12,6 +12,7 @@ type SecretGate =
   | "google-oauth"
   | "dropbox-oauth"
   | "linear-oauth"
+  | "email-auth"
   | "model-anthropic"
   | "model-openai"
   | "model-openrouter";
@@ -27,6 +28,7 @@ export const CORE_SECRET_SPECS: readonly RuntimeSecretSpec[] = [
   { name: "CORE_SIGNING_SECRET", requiredWhen: "production" },
   { name: "PORTAL_IDENTITY_SECRET", requiredWhen: "production" },
   { name: "SKILL_SIGNING_SECRET", requiredWhen: "production" },
+  { name: "AUTH_ALLOWED_EMAILS", requiredWhen: "email-auth" },
   { name: "OPENAI_API_KEY", requiredWhen: ["codex", "model-openai"] },
   { name: "ANTHROPIC_API_KEY", requiredWhen: "model-anthropic" },
   { name: "OPENROUTER_API_KEY", requiredWhen: "model-openrouter" },
@@ -53,6 +55,7 @@ const GATE_PREDICATES: Readonly<Record<SecretGate, (env: NodeJS.ProcessEnv) => b
   "google-oauth": (env) => Boolean(env.GOOGLE_OAUTH_CLIENT_ID),
   "dropbox-oauth": (env) => Boolean(env.DROPBOX_OAUTH_CLIENT_ID),
   "linear-oauth": (env) => Boolean(env.LINEAR_OAUTH_CLIENT_ID),
+  "email-auth": (env) => env.AUTH_ALLOWED_EMAILS !== undefined,
   "model-anthropic": (env) => env.MODEL_PROVIDER?.trim() === "anthropic",
   "model-openai": (env) => env.MODEL_PROVIDER?.trim() === "openai",
   "model-openrouter": (env) => env.MODEL_PROVIDER?.trim() === "openrouter",

--- a/src/identity/identity-service.ts
+++ b/src/identity/identity-service.ts
@@ -30,16 +30,24 @@ export interface IdentityService extends IdentityProvider {
   refresh(): Promise<void>;
 }
 
-export function createIdentityService(backing?: DurableMap<DeactivationRecord>): IdentityService {
+export function createIdentityService(
+  backing?: DurableMap<DeactivationRecord>,
+  opts: { directorySyncProtected?: readonly string[] } = {},
+): IdentityService {
   const store = backing ?? createMemoryMap<DeactivationRecord>();
   const deactivated = new Map<string, DeactivationRecord>();
+  const directorySyncProtected = new Set((opts.directorySyncProtected ?? []).map(personKey).filter(Boolean));
   const REFRESH_TTL_MS = 10_000;
   let refreshedAt = 0;
   let refreshP: Promise<void> | null = null;
   let hydrateP: Promise<void> | null = null;
 
   function classify(externalId: string, isExternalGuest?: boolean): Principal {
-    const type: Principal["type"] = deactivated.has(personKey(externalId)) || isExternalGuest ? "guest" : "internal";
+    const record = deactivated.get(personKey(externalId));
+    const inactive =
+      record?.source === "manual" ||
+      (record?.source === "directory-sync" && !directorySyncProtected.has(personKey(externalId)));
+    const type: Principal["type"] = inactive || isExternalGuest ? "guest" : "internal";
     return { id: externalId, type };
   }
 
@@ -65,7 +73,7 @@ export function createIdentityService(backing?: DurableMap<DeactivationRecord>):
     async recordDirectorySync(removedIds: string[], presentIds: string[]): Promise<DirectorySyncOutcome> {
       const outcome: DirectorySyncOutcome = { deactivated: [], reactivated: [] };
       for (const id of removedIds) {
-        if (deactivated.has(personKey(id))) continue;
+        if (directorySyncProtected.has(personKey(id)) || deactivated.has(personKey(id))) continue;
         await deactivate(id, "directory-sync");
         outcome.deactivated.push(id);
       }

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -429,7 +429,9 @@ export function buildApp(
       ...(config.openrouterApiKey ? { openrouter: config.openrouterApiKey } : {}),
     },
   });
-  const identity = createIdentityService(artifactMap<DeactivationRecord>("deactivated_principals"));
+  const identity = createIdentityService(artifactMap<DeactivationRecord>("deactivated_principals"), {
+    directorySyncProtected: config.emailAuthPrincipals,
+  });
   void identity.hydrate();
   const leaderLease: LeaderLease = pgArtifactMap
     ? createPostgresLeaderLease(pgArtifactMap.pool)
@@ -1178,6 +1180,15 @@ export function buildApp(
     webhooks,
     deliveries,
     directory,
+    ...(config.emailAuthPrincipals?.length
+      ? {
+          emailAuthMembers: config.emailAuthPrincipals.map((principalId) => ({
+            principalId,
+            displayName: principalId,
+            type: "internal" as const,
+          })),
+        }
+      : {}),
     projects,
     environments,
     deploy: deployService,

--- a/test/admin-users.test.ts
+++ b/test/admin-users.test.ts
@@ -238,7 +238,12 @@ test("/v1/admin/users/:principalId: a grant-holder with no sessions still resolv
 });
 
 test("/v1/admin/directory: org_admin resolves a name or id to candidates; empty query → []; non-admin denied", async () => {
-  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "admin-dir-")) }));
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "admin-dir-")),
+      emailAuthPrincipals: ["new@example.com"],
+    }),
+  );
   const server = createInsecureTestServer(built.app, {
     admin: built.admin,
     sessions: built.sessions,
@@ -264,6 +269,14 @@ test("/v1/admin/directory: org_admin resolves a name or id to candidates; empty 
       "name prefix resolves the member",
     );
     assert.ok(!d.members.some((m: any) => m.principalId === "jane@example.com"), "non-matching member excluded");
+
+    const onboarded = await fetch(`${base}/v1/admin/directory?q=${encodeURIComponent("new@example.com")}`, {
+      headers: { "x-admin-actor": "admin-alice@default-org" },
+    });
+    assert.equal(onboarded.status, 200);
+    assert.deepEqual(((await onboarded.json()) as any).members, [
+      { principalId: "new@example.com", displayName: "new@example.com" },
+    ]);
 
     const empty = await fetch(`${base}/v1/admin/directory`, {
       headers: { "x-admin-actor": "admin-alice@default-org" },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,6 +27,14 @@ test("ORG_BRAND_* parses into a validated branding default", () => {
   assert.deepEqual(loadConfig({ ORG_BRAND_SELF_LABEL: "{{straylight}}" }).brandingDefault, { selfLabel: "straylight" });
 });
 
+test("AUTH_ALLOWED_EMAILS becomes a normalized email-auth principal set", () => {
+  assert.equal(loadConfig({}).emailAuthPrincipals, undefined);
+  assert.deepEqual(
+    loadConfig({ AUTH_ALLOWED_EMAILS: " New@Example.com,other@example.com,new@example.com " }).emailAuthPrincipals,
+    ["new@example.com", "other@example.com"],
+  );
+});
+
 test("store kinds default to memory and accept postgres", () => {
   const def = loadConfig({});
   assert.equal(def.sessionStore, "memory");

--- a/test/identity-offboarding.test.ts
+++ b/test/identity-offboarding.test.ts
@@ -38,6 +38,7 @@ describe("offboarding: directory sync and the /v1/principals routes drive deacti
       testConfig({
         dataDir: mkdtempSync(join(tmpdir(), "offboarding-")),
         signingSecret: SECRET,
+        emailAuthPrincipals: ["allowed@example.com"],
       }),
     );
     await built.identity.hydrate();
@@ -65,6 +66,24 @@ describe("offboarding: directory sync and the /v1/principals routes drive deacti
     assert.equal(built.identity.classify("U-leave").type, "internal");
     assert.ok(
       (await built.auditLog.events()).some((e) => e.action === "principal.reactivate" && e.principalId === "U-leave"),
+    );
+  });
+
+  it("a Slack roster omission does not deactivate or hide a configured email-auth principal", async () => {
+    await built.app.upsertDirectory([member("U-stay"), member("allowed@example.com")]);
+    await built.app.upsertDirectory([member("U-stay")]);
+
+    assert.equal(built.identity.classify("allowed@example.com").type, "internal");
+    const resolved = await built.app.resolveRecipient("allowed@example.com");
+    assert.equal(resolved.kind, "one");
+    if (resolved.kind === "one") {
+      assert.equal(resolved.member.principalId, "allowed@example.com");
+      assert.equal(resolved.member.displayName, "allowed@example.com");
+    }
+    assert.ok(
+      !(await built.auditLog.events()).some(
+        (e) => e.action === "principal.deactivate" && e.principalId === "allowed@example.com",
+      ),
     );
   });
 


### PR DESCRIPTION
Keeps email-auth allowlists synchronized with runtime identity and directory behavior.

- verification: typecheck, lint, format, and focused identity/CLI suites
- verification: before/after dev reproductions for #190, #191, and #304

Fixes #190
Fixes #304

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790365845&installation_model_id=19911&pr_number=689&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F689&signature=161926eaffa2f225f29ff7647e62bf4970f3ea5fcdf5355ab5772a09ef46bc23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->