### PR TITLE
Fix Docker auth broker private routing

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -366,7 +366,7 @@ export function dockerServiceEnv(config: QmConfig, service: ServiceName): Record
       out,
       brokerWiring(service, {
         publicUrl: config.publicUrl,
-        authBaseUrl: "http://auth:8080",
+        authBaseUrl: `http://${dockerPrefix(config)}-auth.internal:8080`,
         ...(config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN
           ? { allowedEmailDomain: config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN }
           : {}),
@@ -477,6 +477,8 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     ctx.network,
     "--network-alias",
     service,
+    "--network-alias",
+    `${cname(ctx, service)}.internal`,
     "--restart",
     "no",
   ];

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -97,8 +97,8 @@ test("a configured botName brands the docker service env for core and auth", () 
 test("docker and AWS wire the broker with parity", () => {
   const docker = configWith(configText());
   const dockerPortal = dockerServiceEnv(docker, "portal");
-  assert.equal(dockerPortal.AUTH_BROKER_UPSTREAM, "http://auth:8080");
-  assert.equal(dockerPortal.OIDC_TOKEN_ENDPOINT, "http://auth:8080/token");
+  assert.equal(dockerPortal.AUTH_BROKER_UPSTREAM, "http://qm-acme-auth.internal:8080");
+  assert.equal(dockerPortal.OIDC_TOKEN_ENDPOINT, "http://qm-acme-auth.internal:8080/token");
   assert.equal(dockerPortal.OIDC_ISSUER, "https://agent.example.com/idp");
   assert.equal(dockerServiceEnv(docker, "auth").AUTH_REDIRECT_URI, "https://agent.example.com/auth/callback");
   assert.equal(dockerServiceEnv(docker, "web-ui").AUTH_BROKER_UPSTREAM, undefined);

--- a/cli/test/e2e/docker-lifecycle.e2e.test.ts
+++ b/cli/test/e2e/docker-lifecycle.e2e.test.ts
@@ -99,6 +99,20 @@ test(
         assert.ok(!inspect(portal).Mounts.some((mount) => mount.Destination === "/var/run/docker.sock"));
       });
 
+      await t.test("services receive their private-network aliases", () => {
+        const portal = suffix(deploymentContainers(org), "portal")!;
+        const aliases = JSON.parse(
+          execFileSync(
+            "docker",
+            ["inspect", "-f", `{{json (index .NetworkSettings.Networks "qm-${org}").Aliases}}`, portal],
+            {
+              encoding: "utf8",
+            },
+          ),
+        ) as string[];
+        assert.ok(aliases.includes(`qm-${org}-portal.internal`), aliases.join(", "));
+      });
+
       await t.test("computed secrets from the deployment ./.env reach the core container", () => {
         const core = suffix(deploymentContainers(org), "core")!;
         const got = execFileSync("docker", ["exec", core, "printenv", "CORE_SIGNING_SECRET"], {


### PR DESCRIPTION
Give Docker services deployment-scoped `.internal` aliases and route the built-in auth broker through the matching alias so portal accepts its private cleartext OIDC endpoints.

- verification: focused auth tests and CLI typecheck
- verification: Docker DNS resolution and lifecycle alias assertion

Credits the diagnosis and reference fix in #553.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790374143&installation_model_id=19911&pr_number=692&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F692&signature=8f7c46dd1fe8dc2e3b2fa0ddc059969e5f930877d0e01ee61ff226fafddffe90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->