### PR TITLE
Preserve pane scroll across layout changes

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1082,17 +1082,14 @@ export function createChatSurface(
               : nothing
           }
           ${glanceTier || ctx.pane ? nothing : sessionTopbar()}
-          ${
-            glanceTier
-              ? paneGlance(agent, messages, glanceTier)
-              : html`<section class="chat-scroll" @scroll=${onTranscriptScroll}>
-                  <div class="message-stack ${messages.length || chatState.forkSession ? "" : "empty-stack"}">
-                    ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing}
-                    ${messageContent}
-                    ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
-                  </div>
-                </section>`
-          }
+          ${glanceTier ? paneGlance(agent, messages, glanceTier) : nothing}
+          <section class="chat-scroll" @scroll=${onTranscriptScroll}>
+            <div class="message-stack ${messages.length || chatState.forkSession ? "" : "empty-stack"}">
+              ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing}
+              ${messageContent}
+              ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
+            </div>
+          </section>
           <div class="chat-bottom-dock">
             ${backgroundActivityStrip()} ${liveWorkDock(agent)} ${ctx.composer.composerForm(agent)}
           </div>

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1085,8 +1085,7 @@ export function createChatSurface(
           ${glanceTier ? paneGlance(agent, messages, glanceTier) : nothing}
           <section class="chat-scroll" @scroll=${onTranscriptScroll}>
             <div class="message-stack ${messages.length || chatState.forkSession ? "" : "empty-stack"}">
-              ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing}
-              ${messageContent}
+              ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing} ${messageContent}
               ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
             </div>
           </section>

--- a/plugins/web-ui/src/conversations.ts
+++ b/plugins/web-ui/src/conversations.ts
@@ -48,9 +48,11 @@ export function mainConversation(): Conversation {
   return main;
 }
 
-export function paneDensity(el: HTMLElement): DensityTier {
+export function paneDensity(el: HTMLElement): DensityTier | null {
   const r = el.getBoundingClientRect();
-  return densityTierFor(r.width || el.clientWidth, r.height || el.clientHeight);
+  const width = r.width || el.clientWidth;
+  const height = r.height || el.clientHeight;
+  return width > 0 && height > 0 ? densityTierFor(width, height) : null;
 }
 
 let exitCanvas: () => void = () => {};

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -7244,6 +7244,11 @@ h3.ambient-field-label {
 [data-density] .composer-error {
   flex-basis: 100%;
 }
+[data-density="card"] .chat-scroll,
+[data-density="strip"] .chat-scroll {
+  display: none;
+}
+
 .pane-card {
   min-height: 0;
   overflow: hidden;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -827,13 +827,14 @@ class PaneContent implements IContentRenderer {
         return;
       }
       this.syncDensity();
-      this.conversation.drawActiveChat(undefined, { forceScroll: true });
     });
     if (p.api.isVisible) void this.load();
   }
 
   private syncDensity(): void {
-    this.element.dataset.density = this.density = paneDensity(this.element);
+    const next = paneDensity(this.element);
+    if (!next || next === this.density) return;
+    this.element.dataset.density = this.density = next;
     for (const handler of this.redrawOnResize) handler();
   }
 

--- a/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
+++ b/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
@@ -5,22 +5,22 @@ import test from "node:test";
 const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 
-test("re-activating a pane tab force-scrolls the transcript (already-loaded panes snap to bottom)", () => {
+test("pane visibility changes preserve the transcript viewport", () => {
   const handler = split.match(/onDidVisibilityChange\(\(e\) => \{[\s\S]*?\}\);/)?.[0] ?? "";
-  assert.match(handler, /drawActiveChat\(undefined, \{ forceScroll: true \}\)/);
-  assert.match(handler, /if \(!this\.loaded\)/, "only already-loaded panes redraw; first show still loads");
-  const density = handler.indexOf("this.syncDensity()");
-  const draw = handler.indexOf("drawActiveChat(undefined, { forceScroll: true })");
-  assert.ok(
-    density >= 0 && density < draw,
-    "density resyncs before the forced redraw — a hidden pane measured 0\u00d70 and would render scroller-less glance UI",
+  assert.doesNotMatch(handler, /forceScroll/, "grid visibility is presentation state, not scroll intent");
+  assert.match(handler, /this\.syncDensity\(\)/, "shown panes still refresh their responsive presentation");
+});
+
+test("responsive pane summaries do not replace the transcript scroller", () => {
+  assert.match(chat, /glanceTier\s*\?\s*paneGlance\([^)]+\)\s*:\s*nothing[\s\S]*?<section class="chat-scroll"/);
+  assert.doesNotMatch(
+    chat,
+    /glanceTier\s*\?\s*paneGlance\([^)]+\)\s*:\s*html`<section class="chat-scroll"/,
+    "presentation changes must not destroy the element that owns scrollTop",
   );
 });
 
-test("a forced transcript scroll bypasses the smooth scroll-behavior (snaps instantly)", () => {
-  const fn = chat.match(/function scrollTranscript\(force = false\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
-  const setAuto = fn.indexOf('scroller.style.scrollBehavior = "auto"');
-  const write = fn.indexOf("scroller.scrollTop = scroller.scrollHeight");
-  assert.ok(setAuto >= 0, "forced path must set scroll-behavior:auto");
-  assert.ok(write > setAuto, "the snap write must come after behavior is set to auto");
+test("hidden panes retain their last meaningful density", () => {
+  const fn = split.match(/private syncDensity\(\): void \{[\s\S]*?\n  \}/)?.[0] ?? "";
+  assert.match(fn, /if \(!next\s*\|\|\s*next === this\.density\) return;/);
 });

--- a/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
+++ b/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
@@ -21,6 +21,6 @@ test("responsive pane summaries do not replace the transcript scroller", () => {
 });
 
 test("hidden panes retain their last meaningful density", () => {
-  const fn = split.match(/private syncDensity\(\): void \{[\s\S]*?\n  \}/)?.[0] ?? "";
+  const fn = split.match(/private syncDensity\(\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
   assert.match(fn, /if \(!next\s*\|\|\s*next === this\.density\) return;/);
 });


### PR DESCRIPTION
Preserve each pane’s transcript viewport across tab, split, and responsive layout changes by keeping scroll ownership stable and separating layout visibility from scroll intent.

- verification: 22 focused pane/scroll tests pass
- verification: Web UI typecheck passes
- verification: production build and browser grid-transition reproduction pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790450127&installation_model_id=19911&pr_number=698&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F698&signature=131e35d16d75ca25322e1e956e5eef3187217ffee924e6e8c906d5f0744cb384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->