### PR TITLE
fix: web theme toggle shows light/dark only, never the system icon

### DIFF
--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -88,6 +88,10 @@ setSigninRequiredHandler((detail) => {
 
 onExitCanvas(() => exitSplitIfActive());
 
+if (typeof window !== "undefined" && !localStorage.getItem("theme")) {
+  localStorage.setItem("theme", window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+}
+
 export const ADMIN_BASE = (() => {
   const base = ((import.meta as unknown as { env?: { BASE_URL?: string } }).env?.BASE_URL ?? "/").replace(/\/$/, "");
   return base ? base.replace(/\/[^/]+$/, "/admin") : "/admin";
@@ -455,7 +459,7 @@ export function mountShell(): void {
               <span class="avatar">${initials(appState.me?.user ?? "?")}</span>
               <span class="user-name">${appState.me?.user ?? ""}</span>
             </div>
-            <theme-toggle .includeSystem=${true} title="Color scheme: light / dark / system"></theme-toggle>
+            <theme-toggle .includeSystem=${false} title="Color scheme: light / dark"></theme-toggle>
             <button class="icon-btn subtle" title="Sign out" aria-label="Sign out" @click=${signOut}>
               ${icon(LogOut, 17)}
             </button>


### PR DESCRIPTION
## Problem

The web UI's theme toggle (`<theme-toggle>` from `@mariozechner/mini-lit`) would sometimes render the **computer/monitor (system) icon** instead of sun/moon.

Root cause is in the third-party component:
- It treats *absence* of a `localStorage.theme` key as `"system"`.
- `getIcon()` returns the `Monitor` icon whenever `theme === "system"` — regardless of the `includeSystem` prop.

So any user who never set a theme (fresh load), or whose 3-state cycle landed on system, got the computer icon. We can't edit the compiled dependency, so this is fixed at our only consumer, `plugins/web-ui/src/shell.ts`.

## Fix

- `.includeSystem=${false}` — the toggle cycles **light ↔ dark** only and can never land on system.
- On load, seed a concrete `light`/`dark` into `localStorage.theme` from the OS `prefers-color-scheme` when none is set, so the element never initializes to `"system"` and never paints the Monitor icon.

## Behavior

First load reflects the user's OS preference (light or dark); after that the toggle just flips light↔dark. This intentionally drops OS-follow behavior in favor of an explicit two-state toggle — the reported bug was the system/computer state being unwanted.

## Verification

- `tsc --noEmit` clean, prettier + oxlint clean on the changed file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463101&installation_model_id=19911&pr_number=703&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F703&signature=a7a41d3d6ddea51f02c82f5e0c6310fc3b4fc9b5ec56f311e3ebef34b0fa541e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->