### PR TITLE
Fix tab row shifting on hover

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -7052,13 +7052,11 @@ h3.ambient-field-label {
   background: var(--secondary);
 }
 
-/* Per-tab close: an 18px slot, revealed on hover — the cron-row actions pattern. The tab
-   the user is in always reserves it; the rest hand those pixels to their label until
-   hovered, which in a narrow strip is the difference between a title and a syllable. Tab
-   widths come off a fixed basis, so the slot opening resizes nothing but its own label.
-   `margin-left: auto` parks the slot against the chip's trailing edge: a tab is sized by
-   that basis, not by its title, so anchoring the close to the end of the text strands it
-   mid-chip on every title shorter than the tab. */
+/* Per-tab close: an 18px slot, revealed on hover — the cron-row actions pattern. Every
+   tab reserves the slot even while it is transparent, so hovering never changes intrinsic
+   tab width or makes dockview reflow the strip. `margin-left: auto` parks the slot against
+   the chip's trailing edge: a tab is sized by its basis, not by its title, so anchoring the
+   close to the end of the text strands it mid-chip on every short title. */
 .split-tab-close {
   width: 18px;
   height: 18px;
@@ -7066,21 +7064,13 @@ h3.ambient-field-label {
   margin-left: auto;
   border-radius: 5px;
   opacity: 0;
-  transition:
-    opacity 0.12s ease,
-    width 0.12s ease,
-    min-width 0.12s ease;
+  transition: opacity 0.12s ease;
 }
 
 /* When the archive button is present it takes the auto margin; the close button that
    follows sits snug beside it instead of splitting the leftover space. */
 .split-tab-archive + .split-tab-close {
   margin-left: 2px;
-}
-
-.dv-tab:not(.dv-active-tab):not(:hover):not(:focus-within) .split-tab-close {
-  width: 0;
-  min-width: 0;
 }
 
 .dv-tab.dv-active-tab .split-tab-close {

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -88,14 +88,17 @@ test("tabs share the strip evenly down to a legible floor", () => {
   assert.match(multi, /max-width: 220px;/);
 });
 
+test("hovering a tab does not change its action-slot width", () => {
+  const close = css.match(/^\.split-tab-close \{[^}]*\}/m)?.[0] ?? "";
+  assert.doesNotMatch(close, /transition:[^}]*\b(?:width|min-width)\b/s);
+  assert.doesNotMatch(css, /:not\(:hover\):not\(:focus-within\) \.split-tab-close \{[^}]*(?:width|min-width): 0;/);
+});
+
 test("the per-tab close floats to the end of the tab", () => {
   const close = css.match(/^\.split-tab-close \{[^}]*\}/m)?.[0] ?? "";
   assert.match(close, /margin-left: auto;/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*flex: 1 1 auto;/);
   assert.match(css, /\.split-pane-title-text \{[^}]*margin-right: 6px;/);
-  const collapsed = css.match(/:not\(:hover\):not\(:focus-within\) \.split-tab-close \{[^}]*\}/)?.[0] ?? "";
-  assert.ok(collapsed, "the collapsed-slot rule not found");
-  assert.doesNotMatch(collapsed, /margin-left:/);
 });
 
 test("the tab overflow menu is lifted above the panes and styled", () => {


### PR DESCRIPTION
Keeps tab widths stable by reserving action space before hover and limiting the hover transition to opacity.

- verification: focused tab-layout tests pass (10/10)
- verification: web UI tests and typecheck pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463426&installation_model_id=19911&pr_number=704&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F704&signature=efd337465a1259c73eeb3557596f219cfd26635e3e874edd7b917fe4c7a35a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->