### PR TITLE
Remove the per-PR CLI version bump gate

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,39 +89,6 @@ jobs:
           npm run typecheck:contract
           node --test "deploy/stacks/*/test/*.test.ts"
 
-  cli-version:
-    name: CLI version bump
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Require a version bump when the published package changes
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
-          changed=$(git diff --name-only "$base" "$HEAD_SHA" -- \
-            cli/bin cli/src cli/templates cli/manifest.json cli/package.json \
-            cli/package-lock.json cli/README.md cli/LICENSE cli/tsconfig.json cli/tsconfig.build.json)
-          [ -n "$changed" ] || exit 0
-          base_version=$(git show "${base}:cli/package.json" | jq -r .version)
-          head_version=$(git show "${HEAD_SHA}:cli/package.json" | jq -r .version)
-          highest=$(printf '%s\n%s\n' "$base_version" "$head_version" | sort -V | tail -1)
-          if [ "$base_version" = "$head_version" ] || [ "$highest" != "$head_version" ]; then
-            printf '%s\n' "$changed" >&2
-            echo "these files ship in @yc-software/qm; bump cli/package.json past $base_version" >&2
-            exit 1
-          fi
-          case "$head_version" in
-            [0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "cli/package.json version must be semver, got $head_version" >&2; exit 1 ;;
-          esac
-
   coauthor-trailers:
     name: Co-author trailers
     if: github.event_name == 'pull_request'

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -7,6 +7,10 @@ on:
         description: Commit SHA whose published images the package should pin
         required: false
         type: string
+      version:
+        description: Version to publish, overriding cli/package.json
+        required: false
+        type: string
     outputs:
       manifest:
         description: The image manifest the published package pins
@@ -15,6 +19,9 @@ on:
     inputs:
       images_ref:
         description: Commit SHA whose published images the package should pin
+        required: false
+      version:
+        description: Version to publish, overriding cli/package.json
         required: false
 
 permissions:
@@ -77,8 +84,14 @@ jobs:
           printf 'manifest=%s\n' "$(jq -c . cli/manifest.json)" >> "$GITHUB_OUTPUT"
       - name: Publish
         working-directory: cli
+        env:
+          VERSION: ${{ inputs.version }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
+          if [ -n "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version --allow-same-version > /dev/null
+          fi
           version=$(jq -r .version package.json)
           if npm view "@yc-software/qm@$version" version > /dev/null 2>&1; then
             published=$(mktemp -d)
@@ -95,5 +108,3 @@ jobs:
           if [ "$version" = 0.1.5 ]; then
             npm deprecate @yc-software/qm@1.0.5 "Published with an incorrect version number; use 0.1.5."
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
     outputs:
       tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
@@ -29,17 +30,27 @@ jobs:
             echo "releases are cut from main; this run is on $GITHUB_REF" >&2
             exit 1
           fi
-          version=$(jq -r .version cli/package.json)
-          case "$version" in
+          pkg=$(jq -r .version cli/package.json)
+          case "$pkg" in
             [0-9]*.[0-9]*.[0-9]*) ;;
-            *) echo "cli/package.json version must be semver, got $version" >&2; exit 1 ;;
+            *) echo "cli/package.json version must be semver, got $pkg" >&2; exit 1 ;;
           esac
+          tagged=$(gh api --paginate "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" -q '.[].ref' \
+            | sed 's|^refs/tags/||' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1 || true)
+          published=$(npm view @yc-software/qm version 2>/dev/null || true)
+          base=$(printf '%s\n%s\n' "${tagged:-0.0.0}" "${published:-0.0.0}" | sort -V | tail -1)
+          if [ "$(printf '%s\n%s\n' "$base" "$pkg" | sort -V | tail -1)" = "$pkg" ] && [ "$pkg" != "$base" ]; then
+            version=$pkg
+          else
+            IFS=. read -r major minor patch <<< "$base"
+            version="$major.$minor.$((patch + 1))"
+          fi
           tag="v$version"
           if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" > /dev/null 2>&1; then
-            echo "$tag is already released; bump cli/package.json before releasing again" >&2
+            echo "$tag already exists; refusing to move it" >&2
             exit 1
           fi
-          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+          printf 'tag=%s\nversion=%s\n' "$tag" "$version" >> "$GITHUB_OUTPUT"
 
   images:
     name: Images
@@ -52,12 +63,16 @@ jobs:
 
   cli:
     name: CLI
-    needs: images
+    needs:
+      - preflight
+      - images
     permissions:
       contents: read
       id-token: write
     secrets: inherit
     uses: ./.github/workflows/publish-cli.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}
 
   release:
     name: Tag and publish the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,12 @@ jobs:
             echo "releases are cut from main; this run is on $GITHUB_REF" >&2
             exit 1
           fi
-          tag="v$(jq -r .version cli/package.json)"
+          version=$(jq -r .version cli/package.json)
+          case "$version" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "cli/package.json version must be semver, got $version" >&2; exit 1 ;;
+          esac
+          tag="v$version"
           if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" > /dev/null 2>&1; then
             echo "$tag is already released; bump cli/package.json before releasing again" >&2
             exit 1

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,9 +22,9 @@ This package is published to npm as `@yc-software/qm`, with npm provenance attes
 building workflow. A release is one dispatch of `.github/workflows/release.yml` from
 `main`: it signs and pushes the first-party images, publishes the package pinning their
 digests, and then tags `v<version>` and creates the GitHub release with the resolved
-digests attached. The version comes from `cli/package.json`, which CI requires a pull
-request to bump whenever it changes what the package ships; a tag that already exists
-stops the release rather than moving. The checked-in image manifest is a sentinel that
+digests attached. The version comes from `cli/package.json`, bumped when a release is cut rather than by
+every pull request that touches the package; a tag that already exists stops the release
+rather than moving. The checked-in image manifest is a sentinel that
 a deployment overrides with real digests. The packed-artifact test exercises the consumer
 path locally.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,9 +22,9 @@ This package is published to npm as `@yc-software/qm`, with npm provenance attes
 building workflow. A release is one dispatch of `.github/workflows/release.yml` from
 `main`: it signs and pushes the first-party images, publishes the package pinning their
 digests, and then tags `v<version>` and creates the GitHub release with the resolved
-digests attached. The version comes from `cli/package.json`, bumped in a PR before dispatching a release
-rather than by every pull request that touches the package; a tag that already exists
-stops the release rather than moving. The checked-in image manifest is a sentinel that
+digests attached. Each release picks its own version: a patch bump past the latest released version, or
+`cli/package.json`'s version when a PR raised it higher (for a minor or major bump); a
+tag that already exists stops the release rather than moving. The checked-in image manifest is a sentinel that
 a deployment overrides with real digests. The packed-artifact test exercises the consumer
 path locally.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,9 +22,9 @@ This package is published to npm as `@yc-software/qm`, with npm provenance attes
 building workflow. A release is one dispatch of `.github/workflows/release.yml` from
 `main`: it signs and pushes the first-party images, publishes the package pinning their
 digests, and then tags `v<version>` and creates the GitHub release with the resolved
-digests attached. The version comes from `cli/package.json`, bumped when a release is cut rather than by
-every pull request that touches the package; a tag that already exists stops the release
-rather than moving. The checked-in image manifest is a sentinel that
+digests attached. The version comes from `cli/package.json`, bumped in a PR before dispatching a release
+rather than by every pull request that touches the package; a tag that already exists
+stops the release rather than moving. The checked-in image manifest is a sentinel that
 a deployment overrides with real digests. The packed-artifact test exercises the consumer
 path locally.
 

--- a/test/release-workflows.test.ts
+++ b/test/release-workflows.test.ts
@@ -134,7 +134,9 @@ test("one dispatchable workflow drives the whole release, main-only and in order
 test("the release refuses a tag it already published and writes the tag last", () => {
   const workflow = readFileSync(".github/workflows/release.yml", "utf8");
 
-  assert.match(workflow, /tag="v\$\(jq -r \.version cli\/package\.json\)"/);
+  assert.match(workflow, /version=\$\(jq -r \.version cli\/package\.json\)/);
+  assert.match(workflow, /cli\/package\.json version must be semver/);
+  assert.match(workflow, /tag="v\$version"/);
   assert.match(workflow, /is already released; bump cli\/package\.json before releasing again/);
   assert.ok(
     workflow.indexOf("already released") < workflow.indexOf("gh release create"),

--- a/test/release-workflows.test.ts
+++ b/test/release-workflows.test.ts
@@ -126,18 +126,24 @@ test("one dispatchable workflow drives the whole release, main-only and in order
     workflow,
     /^ {2}images:\n[\s\S]*?needs: preflight\n[\s\S]*?uses: \.\/\.github\/workflows\/release-package\.yml$/m,
   );
-  assert.match(workflow, /^ {2}cli:\n[\s\S]*?needs: images\n[\s\S]*?uses: \.\/\.github\/workflows\/publish-cli\.yml$/m);
+  assert.match(
+    workflow,
+    /^ {2}cli:\n[\s\S]*?needs:\n {6}- preflight\n {6}- images\n[\s\S]*?uses: \.\/\.github\/workflows\/publish-cli\.yml\n {4}with:\n {6}version: \$\{\{ needs\.preflight\.outputs\.version \}\}$/m,
+  );
   assert.match(workflow, /^ {2}release:\n[\s\S]*?needs:\n {6}- preflight\n {6}- cli$/m);
   assert.match(workflow, /concurrency:\n {2}group: release\n {2}cancel-in-progress: false/);
 });
 
-test("the release refuses a tag it already published and writes the tag last", () => {
+test("the release bumps its own version past everything already released", () => {
   const workflow = readFileSync(".github/workflows/release.yml", "utf8");
 
-  assert.match(workflow, /version=\$\(jq -r \.version cli\/package\.json\)/);
+  assert.match(workflow, /pkg=\$\(jq -r \.version cli\/package\.json\)/);
   assert.match(workflow, /cli\/package\.json version must be semver/);
+  assert.match(workflow, /matching-refs\/tags\/v/);
+  assert.match(workflow, /npm view @yc-software\/qm version/);
+  assert.match(workflow, /version="\$major\.\$minor\.\$\(\(patch \+ 1\)\)"/);
   assert.match(workflow, /tag="v\$version"/);
-  assert.match(workflow, /is already released; bump cli\/package\.json before releasing again/);
+  assert.match(workflow, /already exists; refusing to move it/);
   assert.ok(
     workflow.indexOf("already released") < workflow.indexOf("gh release create"),
     "the tag gate runs before anything is published",


### PR DESCRIPTION
Drops the `cli-version` job from CI, which required every PR touching the published package to bump `cli/package.json`.

The release-time protections stay: `release.yml` refuses a tag that already exists, and `publish-cli.yml` refuses to republish a version pinning different image digests. So the version is bumped once when cutting a release, not on every PR.

Also updates `cli/README.md` to match.

Note: if "CLI version bump" is a required check in branch protection, it needs to be removed there too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790474136&installation_model_id=19911&pr_number=710&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F710&signature=aec3c2925032d9fbf2218840ef38161e9c36f4595b637cb705c03574fa58727b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->