### PR TITLE
Add model discovery for custom providers

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -7254,6 +7254,7 @@
           api("GET", "/api/slack-installation"),
           api("GET", "/api/connector-catalog"),
           api("GET", "/api/scopes/" + encodeURIComponent(orgScope())),
+          loadCustomProviders(),
         ]);
         if (!models.ok || !slack.ok || !catalog.ok || !config.ok) {
           setStatus("st-onboarding-model", "Setup status could not be loaded. Try again.", "err", true);

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -575,6 +575,18 @@
         gap: 12px;
         align-items: end;
       }
+      .custom-provider-models-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        margin-bottom: 5px;
+      }
+      .custom-provider-models-heading button {
+        flex: 0 0 auto;
+        padding: 4px 9px;
+        font-size: 12px;
+      }
       @media (max-width: 900px) {
         .setup-grid {
           grid-template-columns: 1fr;
@@ -3979,7 +3991,10 @@
                     placeholder="Write-only; blank on edit keeps the stored key"
                 /></label>
                 <label
-                  >Models (one per line: id | name | context | maxTokens)
+                  ><span class="custom-provider-models-heading"
+                    ><span>Models (one per line: id | name | context | maxTokens)</span
+                    ><button type="button" id="custom-provider-fetch-models">Fetch models</button></span
+                  >
                   <textarea
                     id="custom-provider-models"
                     rows="3"
@@ -7353,6 +7368,36 @@
             return model;
           });
       }
+      function formatCustomModels(models) {
+        return models
+          .map((model) => {
+            const parts = [model.id, model.name || "", model.contextWindow ?? "", model.maxTokens ?? ""];
+            while (parts.at(-1) === "") parts.pop();
+            return parts.join(" | ");
+          })
+          .join("\n");
+      }
+      function mergeCustomModels(current, discovered) {
+        const merged = new Map();
+        current.forEach((model) => {
+          if (model.id && !merged.has(model.id)) merged.set(model.id, model);
+        });
+        discovered.forEach((model) => {
+          const existing = merged.get(model.id);
+          merged.set(model.id, existing ? { ...existing, name: model.name || existing.name } : model);
+        });
+        return { models: [...merged.values()].slice(0, 200), omitted: Math.max(0, merged.size - 200) };
+      }
+      function customProviderFormFingerprint() {
+        return JSON.stringify([
+          $("custom-provider-id").value,
+          $("custom-provider-name").value,
+          $("custom-provider-protocol").value,
+          $("custom-provider-url").value,
+          $("custom-provider-key").value,
+          $("custom-provider-models").value,
+        ]);
+      }
       async function loadCustomProviders() {
         const res = await api("GET", "/api/custom-providers");
         if (!res.ok) return;
@@ -7383,11 +7428,7 @@
             $("custom-provider-protocol").value = provider.protocol;
             $("custom-provider-url").value = provider.baseUrl;
             $("custom-provider-key").value = "";
-            $("custom-provider-models").value = provider.models
-              .map((model) =>
-                [model.id, model.name, model.contextWindow, model.maxTokens].filter((part) => part != null).join(" | "),
-              )
-              .join("\n");
+            $("custom-provider-models").value = formatCustomModels(provider.models);
           };
           const remove = document.createElement("button");
           remove.className = "danger";
@@ -7408,6 +7449,52 @@
           rows.appendChild(tr);
         });
       }
+      $("custom-provider-fetch-models").onclick = async () => {
+        const baseUrl = $("custom-provider-url").value.trim();
+        if (!baseUrl) {
+          setStatus("st-custom-provider", "Enter a base URL before fetching models.", "err");
+          return;
+        }
+        const button = $("custom-provider-fetch-models");
+        const apiKey = $("custom-provider-key").value.trim();
+        const formFingerprint = customProviderFormFingerprint();
+        button.disabled = true;
+        setStatus("st-custom-provider", "Fetching models...", "saving", true);
+        let result;
+        try {
+          result = await api("POST", "/api/custom-providers/models", {
+            providerId: $("custom-provider-id").value.trim(),
+            protocol: $("custom-provider-protocol").value,
+            baseUrl,
+            ...(apiKey ? { apiKey } : {}),
+          });
+        } catch {
+          setStatus("st-custom-provider", "Could not reach the QM admin API.", "err", true);
+          return;
+        } finally {
+          button.disabled = false;
+        }
+        if (!result.ok) {
+          setStatus("st-custom-provider", result.data?.message || "Could not fetch models.", "err", true);
+          return;
+        }
+        if (formFingerprint !== customProviderFormFingerprint()) {
+          setStatus("st-custom-provider", "The provider form changed; fetched models were not applied.", "err", true);
+          return;
+        }
+        const current = parseCustomModels($("custom-provider-models").value);
+        const merged = mergeCustomModels(current, result.data?.models || []);
+        $("custom-provider-models").value = formatCustomModels(merged.models);
+        setStatus(
+          "st-custom-provider",
+          merged.omitted
+            ? `Fetched ${result.data.models.length} models. Kept 200 and omitted ${merged.omitted}; review and save.`
+            : result.data?.truncated
+              ? `Fetched ${result.data.models.length} models; more are available upstream. Review and save.`
+              : `Fetched ${result.data.models.length} models. Review and save.`,
+          "ok",
+        );
+      };
       $("custom-provider-save").onclick = async () => {
         const id = $("custom-provider-id").value.trim();
         const name = $("custom-provider-name").value.trim();

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -289,7 +289,7 @@ const WRITES = new Map<string, string[]>([
   ["users", ["PUT", "POST"]],
   ["slack-installation", ["PUT", "DELETE"]],
   ["model-providers", ["PUT", "DELETE"]],
-  ["custom-providers", ["PUT", "DELETE"]],
+  ["custom-providers", ["POST", "PUT", "DELETE"]],
 ]);
 
 const READS = [

--- a/plugins/admin/test/custom-providers.test.ts
+++ b/plugins/admin/test/custom-providers.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+
+const calls: Array<{ method: string; url: string; body: string; actor: string | null; signed: boolean }> = [];
+const core = createServer((req: IncomingMessage, res) => {
+  let body = "";
+  req.on("data", (chunk) => (body += chunk));
+  req.on("end", () => {
+    calls.push({
+      method: req.method ?? "",
+      url: req.url ?? "",
+      body,
+      actor: (req.headers["x-admin-actor"] as string) ?? null,
+      signed: Boolean(req.headers["x-timestamp"] && req.headers["x-signature"]),
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ models: [{ id: "acme-chat", name: "Acme Chat" }], total: 1, truncated: false }));
+  });
+});
+await new Promise<void>((resolve) => core.listen(0, resolve));
+const corePort = (core.address() as AddressInfo).port;
+
+process.env.CORE_API_URL = `http://localhost:${corePort}`;
+process.env.CORE_SIGNING_SECRET = "admin-custom-provider-proxy-secret";
+
+const { server } = await import("../src/index.ts");
+await new Promise<void>((resolve) => server.listen(0, resolve));
+const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+test.after(() => {
+  server.close();
+  if (core.listening) core.close();
+});
+
+test("model discovery POST is signed and forwarded to Core", async () => {
+  const payload = {
+    providerId: "acme",
+    protocol: "openai",
+    baseUrl: "https://llm.acme.test/v1",
+    apiKey: "sk-write-only",
+  };
+  const response = await fetch(`${base}/api/custom-providers/models`, {
+    method: "POST",
+    headers: { cookie: "admin=U-admin", "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    models: [{ id: "acme-chat", name: "Acme Chat" }],
+    total: 1,
+    truncated: false,
+  });
+  assert.deepEqual(calls.at(-1), {
+    method: "POST",
+    url: "/v1/admin/custom-providers/models",
+    body: JSON.stringify(payload),
+    actor: "U-admin@acme",
+    signed: true,
+  });
+});
+
+test("model discovery POST rejects signed-out callers before Core", async () => {
+  const before = calls.length;
+  const response = await fetch(`${base}/api/custom-providers/models`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ protocol: "openai", baseUrl: "https://llm.acme.test/v1", apiKey: "secret" }),
+  });
+  assert.equal(response.status, 401);
+  assert.equal(calls.length, before);
+});
+
+test("custom provider UI exposes model discovery and merges returned names", () => {
+  const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+  assert.match(html, /id="custom-provider-fetch-models"/);
+  assert.match(html, /api\("POST", "\/api\/custom-providers\/models"/);
+  assert.match(html, /mergeCustomModels\(current, result\.data\?\.models \|\| \[\]\)/);
+  assert.match(html, /formFingerprint !== customProviderFormFingerprint\(\)/);
+  const start = html.indexOf("function formatCustomModels");
+  const end = html.indexOf("async function loadCustomProviders", start);
+  assert.ok(start > 0 && end > start);
+  const fields: Record<string, { value: string }> = {
+    "custom-provider-id": { value: "acme" },
+    "custom-provider-name": { value: "Acme" },
+    "custom-provider-protocol": { value: "openai" },
+    "custom-provider-url": { value: "https://acme.test/v1" },
+    "custom-provider-key": { value: "secret" },
+    "custom-provider-models": { value: "model-a" },
+  };
+  const context: Record<string, unknown> = { $: (id: string) => fields[id] };
+  runInNewContext(html.slice(start, end), context);
+  const merge = context.mergeCustomModels as (
+    current: Array<{ id: string; name?: string }>,
+    discovered: Array<{ id: string; name?: string }>,
+  ) => { models: Array<{ id: string; name?: string }>; omitted: number };
+  const current = Array.from({ length: 199 }, (_, index) => ({ id: `current-${index}` }));
+  const merged = merge(current, [
+    { id: "current-0", name: "Updated" },
+    { id: "new-1", name: "New One" },
+    { id: "new-2", name: "New Two" },
+  ]);
+  assert.equal(merged.models.length, 200);
+  assert.equal(merged.omitted, 1);
+  assert.equal(merged.models[0]?.name, "Updated");
+  assert.equal(merged.models.at(-1)?.id, "new-1");
+  const fingerprint = context.customProviderFormFingerprint as () => string;
+  const before = fingerprint();
+  fields["custom-provider-id"]!.value = "other";
+  assert.notEqual(fingerprint(), before);
+});

--- a/plugins/admin/test/custom-providers.test.ts
+++ b/plugins/admin/test/custom-providers.test.ts
@@ -26,6 +26,8 @@ const corePort = (core.address() as AddressInfo).port;
 
 process.env.CORE_API_URL = `http://localhost:${corePort}`;
 process.env.CORE_SIGNING_SECRET = "admin-custom-provider-proxy-secret";
+process.env.NODE_ENV = "test";
+process.env.ALLOW_UNSIGNED_TEST_IDENTITY = "1";
 
 const { server } = await import("../src/index.ts");
 await new Promise<void>((resolve) => server.listen(0, resolve));
@@ -110,4 +112,12 @@ test("custom provider UI exposes model discovery and merges returned names", () 
   const before = fingerprint();
   fields["custom-provider-id"]!.value = "other";
   assert.notEqual(fingerprint(), before);
+});
+
+test("onboarding loads saved custom providers on first render", () => {
+  const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+  const start = html.indexOf("async function loadOnboarding()");
+  const end = html.indexOf('$("onboarding-model-provider").onchange', start);
+  assert.ok(start > 0 && end > start);
+  assert.match(html.slice(start, end), /loadCustomProviders\(\)/);
 });

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -38,7 +38,12 @@ import {
   putSlackInstallation,
 } from "./admin/slack-installation.ts";
 import { deleteModelProvider, getModelProviders, putModelProvider } from "./admin/model-providers.ts";
-import { deleteCustomProvider, getCustomProviders, putCustomProvider } from "./admin/custom-providers.ts";
+import {
+  deleteCustomProvider,
+  discoverCustomProviderModels,
+  getCustomProviders,
+  putCustomProvider,
+} from "./admin/custom-providers.ts";
 import { deleteMcpServer, getMcpServers, putMcpServer } from "./admin/mcp-servers.ts";
 import { listSecurityFlags, releaseSecurityTaint } from "./admin/security.ts";
 
@@ -71,6 +76,7 @@ const routes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "DELETE", path: "/v1/admin/mcp-servers/:id", auth: "either", handle: deleteMcpServer },
   { method: "DELETE", path: "/v1/admin/model-providers/:provider", auth: "either", handle: deleteModelProvider },
   { method: "GET", path: "/v1/admin/custom-providers", auth: "either", handle: getCustomProviders },
+  { method: "POST", path: "/v1/admin/custom-providers/models", auth: "either", handle: discoverCustomProviderModels },
   { method: "PUT", path: "/v1/admin/custom-providers/:provider", auth: "either", handle: putCustomProvider },
   { method: "DELETE", path: "/v1/admin/custom-providers/:provider", auth: "either", handle: deleteCustomProvider },
   { method: "PUT", path: "/v1/admin/scopes/:scope/:resource", auth: "either", handle: putScopeConfig },

--- a/src/api/routes/admin/custom-providers.ts
+++ b/src/api/routes/admin/custom-providers.ts
@@ -3,9 +3,14 @@ import {
   type CustomProviderSpec,
   type CustomProviderProtocol,
 } from "../../../model/custom-providers.ts";
+import { parseProviderBaseUrl } from "../../../model/provider-endpoints.ts";
 import { sendJson } from "../../http.ts";
 import type { ApiCtx } from "../route.ts";
 import { audit, authorizeAdmin, orgScope } from "../shared.ts";
+
+const MAX_MODELS_RESPONSE_BYTES = 2 * 1024 * 1024;
+const MAX_DISCOVERED_MODELS = 200;
+const MODEL_FIELD_DELIMITERS = /[\u0000-\u001f\u007f|]/;
 
 async function actor(ctx: ApiCtx) {
   const scope = orgScope(ctx.deps);
@@ -17,26 +22,88 @@ async function actor(ctx: ApiCtx) {
  * A gateway may not implement a models listing, so callers can skip
  * with {"validate": false} — the registration is admin-only either way.
  */
+function modelsRequest(protocol: CustomProviderProtocol, baseUrl: string, apiKey: string, limit?: number) {
+  const url = protocol === "anthropic" ? new URL(`${baseUrl}/v1/models`) : new URL(`${baseUrl}/models`);
+  if (limit !== undefined) url.searchParams.set("limit", String(limit));
+  return {
+    url: url.toString(),
+    headers:
+      protocol === "anthropic"
+        ? { "x-api-key": apiKey, "anthropic-version": "2023-06-01" }
+        : { authorization: `Bearer ${apiKey}` },
+  };
+}
+
+async function boundedModelsJson(response: Response): Promise<unknown> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_MODELS_RESPONSE_BYTES)
+    throw new Error("models response is too large");
+  if (!response.body) throw new Error("models response has no body");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    bytes += chunk.value.byteLength;
+    if (bytes > MAX_MODELS_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new Error("models response is too large");
+    }
+    text += decoder.decode(chunk.value, { stream: true });
+  }
+  text += decoder.decode();
+  return JSON.parse(text) as unknown;
+}
+
+async function fetchModels(
+  ctx: ApiCtx,
+  protocol: CustomProviderProtocol,
+  baseUrl: string,
+  apiKey: string,
+  options: { timeoutMs?: number; limit?: number } = {},
+): Promise<Response | null> {
+  const request = modelsRequest(protocol, baseUrl, apiKey, options.limit);
+  try {
+    return await (ctx.deps.modelCredentialFetch ?? fetch)(request.url, {
+      headers: request.headers,
+      signal: AbortSignal.timeout(options.timeoutMs ?? 5_000),
+    });
+  } catch {
+    return null;
+  }
+}
+
 async function validateKey(
   ctx: ApiCtx,
   protocol: CustomProviderProtocol,
   baseUrl: string,
   apiKey: string,
 ): Promise<boolean> {
-  const url = protocol === "anthropic" ? `${baseUrl}/v1/models` : `${baseUrl}/models`;
-  const headers: Record<string, string> =
-    protocol === "anthropic"
-      ? { "x-api-key": apiKey, "anthropic-version": "2023-06-01" }
-      : { authorization: `Bearer ${apiKey}` };
-  try {
-    const response = await (ctx.deps.modelCredentialFetch ?? fetch)(url, {
-      headers,
-      signal: AbortSignal.timeout(5_000),
-    });
-    return response.ok;
-  } catch {
-    return false;
+  return Boolean((await fetchModels(ctx, protocol, baseUrl, apiKey))?.ok);
+}
+
+function discoveredModels(payload: unknown): Array<{ id: string; name?: string }> {
+  const container = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+  let candidates: unknown[] = [];
+  if (Array.isArray(payload)) candidates = payload;
+  else if (Array.isArray(container?.data)) candidates = container.data;
+  else if (Array.isArray(container?.models)) candidates = container.models;
+  const models = new Map<string, { id: string; name?: string }>();
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const item = candidate as Record<string, unknown>;
+    const id = typeof item.id === "string" ? item.id.trim() : "";
+    if (!id || id.length > 200 || MODEL_FIELD_DELIMITERS.test(id) || models.has(id)) continue;
+    const rawName = [item.name, item.display_name, item.displayName].find(
+      (value) => typeof value === "string" && value.trim(),
+    );
+    const candidateName = typeof rawName === "string" ? rawName.trim().slice(0, 200) : undefined;
+    const name = candidateName && !MODEL_FIELD_DELIMITERS.test(candidateName) ? candidateName : undefined;
+    models.set(id, { id, ...(name ? { name } : {}) });
   }
+  return [...models.values()];
 }
 
 export async function getCustomProviders(ctx: ApiCtx): Promise<void> {
@@ -50,6 +117,95 @@ export async function getCustomProviders(ctx: ApiCtx): Promise<void> {
     scopeLabel: orgScope(ctx.deps),
   });
   return sendJson(ctx.res, 200, { providers: await ctx.deps.customProviders.statuses() });
+}
+
+export async function discoverCustomProviderModels(ctx: ApiCtx): Promise<void> {
+  const authorized = await actor(ctx);
+  if (!authorized) return;
+  if (!ctx.deps.customProviders) return sendJson(ctx.res, 404, { error: "not_found" });
+  const body = ctx.body as {
+    providerId?: unknown;
+    protocol?: unknown;
+    baseUrl?: unknown;
+    apiKey?: unknown;
+  };
+  if (
+    typeof body.protocol !== "string" ||
+    !(CUSTOM_PROVIDER_PROTOCOLS as readonly string[]).includes(body.protocol) ||
+    typeof body.baseUrl !== "string"
+  ) {
+    return sendJson(ctx.res, 400, { error: "bad_request", message: "protocol and baseUrl are required" });
+  }
+  let baseUrl: string;
+  try {
+    baseUrl = parseProviderBaseUrl("custom provider baseUrl", body.baseUrl);
+  } catch (error) {
+    return sendJson(ctx.res, 400, { error: "bad_request", message: (error as Error).message });
+  }
+  const providerId = typeof body.providerId === "string" ? body.providerId.trim() : "";
+  const suppliedKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+  const apiKey =
+    suppliedKey ||
+    (providerId
+      ? await ctx.deps.customProviders.resolveMatchingKey(providerId, body.protocol as CustomProviderProtocol, baseUrl)
+      : null);
+  if (!apiKey) {
+    return sendJson(ctx.res, 400, {
+      error: "missing_api_key",
+      message: "Enter an API key, or use the unchanged endpoint of a saved provider.",
+    });
+  }
+  const response = await fetchModels(ctx, body.protocol as CustomProviderProtocol, baseUrl, apiKey, {
+    timeoutMs: 10_000,
+    ...(body.protocol === "anthropic" ? { limit: MAX_DISCOVERED_MODELS } : {}),
+  });
+  if (!response) {
+    return sendJson(ctx.res, 502, {
+      error: "model_discovery_failed",
+      message: `Could not reach ${baseUrl}.`,
+    });
+  }
+  if (!response.ok) {
+    const rejected = response.status === 401 || response.status === 403;
+    return sendJson(ctx.res, rejected ? 400 : 502, {
+      error: rejected ? "invalid_api_key" : "model_discovery_failed",
+      message: rejected
+        ? `${baseUrl} rejected this API key.`
+        : `${baseUrl} returned HTTP ${response.status} while listing models.`,
+    });
+  }
+  let payload: unknown;
+  try {
+    payload = await boundedModelsJson(response);
+  } catch {
+    return sendJson(ctx.res, 502, {
+      error: "invalid_models_response",
+      message: `${baseUrl} returned an invalid models response.`,
+    });
+  }
+  const models = discoveredModels(payload);
+  if (models.length === 0) {
+    return sendJson(ctx.res, 502, {
+      error: "invalid_models_response",
+      message: `${baseUrl} returned no recognizable models.`,
+    });
+  }
+  audit(ctx.deps, {
+    principalId: authorized.id,
+    action: "custom-providers.discover-models",
+    resource: providerId || "new-provider",
+    scopeLabel: orgScope(ctx.deps),
+  });
+  const hasMore =
+    body.protocol === "anthropic" &&
+    payload !== null &&
+    typeof payload === "object" &&
+    (payload as Record<string, unknown>).has_more === true;
+  return sendJson(ctx.res, 200, {
+    models: models.slice(0, MAX_DISCOVERED_MODELS),
+    total: models.length,
+    truncated: hasMore || models.length > MAX_DISCOVERED_MODELS,
+  });
 }
 
 export async function putCustomProvider(ctx: ApiCtx): Promise<void> {

--- a/src/model/custom-provider-store.ts
+++ b/src/model/custom-provider-store.ts
@@ -32,6 +32,7 @@ export interface CustomProviderStore {
   statuses(): Promise<CustomProviderStatus[]>;
   /** Plaintext key for one provider, or null when absent/disabled. */
   resolveKey(id: string): Promise<string | null>;
+  resolveMatchingKey(id: string, protocol: CustomProviderSpec["protocol"], baseUrl: string): Promise<string | null>;
   upsert(spec: CustomProviderSpec, apiKey: string | undefined, updatedBy: string): Promise<void>;
   delete(id: string, updatedBy: string): Promise<boolean>;
 }
@@ -74,6 +75,13 @@ export function createCustomProviderStore(input: {
     async resolveKey(id) {
       const saved = await input.backing.get(id);
       if (!saved || saved.disabled || !saved.apiKeyEnc) return null;
+      return decryptSecret(saved.apiKeyEnc, key);
+    },
+
+    async resolveMatchingKey(id, protocol, baseUrl) {
+      const saved = await input.backing.get(id);
+      if (!saved || saved.disabled || !saved.apiKeyEnc || saved.protocol !== protocol || saved.baseUrl !== baseUrl)
+        return null;
       return decryptSecret(saved.apiKeyEnc, key);
     },
 

--- a/test/custom-provider-route.test.ts
+++ b/test/custom-provider-route.test.ts
@@ -119,6 +119,214 @@ test("a rejected key blocks registration unless validate:false", async () => {
   }
 });
 
+test("model discovery reads compatible listings with protocol credentials", async () => {
+  const requests: Array<{ url: string; authorization: string | null }> = [];
+  const srv = start(async (input, init) => {
+    requests.push({
+      url: String(input),
+      authorization: new Headers(init?.headers).get("authorization"),
+    });
+    return Response.json({
+      data: [
+        { id: "acme-large", name: "Acme Large" },
+        { id: "acme-small", display_name: "Acme Small" },
+        { id: "acme-large", name: "Duplicate" },
+        { id: "unsafe|model", name: "Unsafe ID" },
+        { id: "safe-model", name: "Unsafe\nName" },
+        { object: "model" },
+      ],
+    });
+  });
+  try {
+    const response = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({
+        protocol: "openai",
+        baseUrl: "https://llm.acme.internal/v1/",
+        apiKey: "sk-discovery",
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      models: [
+        { id: "acme-large", name: "Acme Large" },
+        { id: "acme-small", name: "Acme Small" },
+        { id: "safe-model" },
+      ],
+      total: 3,
+      truncated: false,
+    });
+    assert.deepEqual(requests, [{ url: "https://llm.acme.internal/v1/models", authorization: "Bearer sk-discovery" }]);
+    const denied = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: USER,
+      body: JSON.stringify({ protocol: "openai", baseUrl: "https://llm.acme.internal/v1", apiKey: "secret" }),
+    });
+    assert.notEqual(denied.status, 200);
+    assert.equal(requests.length, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("Anthropic model discovery requests the full local limit and reports more pages", async () => {
+  let request: { url: string; key: string | null; version: string | null } | undefined;
+  const srv = start(async (input, init) => {
+    const headers = new Headers(init?.headers);
+    request = {
+      url: String(input),
+      key: headers.get("x-api-key"),
+      version: headers.get("anthropic-version"),
+    };
+    return Response.json({
+      data: [{ id: "claude-acme", display_name: "Claude Acme" }],
+      has_more: true,
+      last_id: "claude-acme",
+    });
+  });
+  try {
+    const response = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({
+        protocol: "anthropic",
+        baseUrl: "https://llm.acme.internal",
+        apiKey: "sk-ant-discovery",
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(request, {
+      url: "https://llm.acme.internal/v1/models?limit=200",
+      key: "sk-ant-discovery",
+      version: "2023-06-01",
+    });
+    assert.deepEqual(await response.json(), {
+      models: [{ id: "claude-acme", name: "Claude Acme" }],
+      total: 1,
+      truncated: true,
+    });
+  } finally {
+    await srv.close();
+  }
+});
+
+test("model discovery reuses a saved write-only key", async () => {
+  let authorization = "";
+  const srv = start(async (_input, init) => {
+    authorization = new Headers(init?.headers).get("authorization") ?? "";
+    return Response.json({ models: [{ id: "saved-model", displayName: "Saved Model" }] });
+  });
+  try {
+    const saved = await fetch(`${srv.base}/v1/admin/custom-providers/acme-gateway`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ ...BODY, validate: false }),
+    });
+    assert.equal(saved.status, 200);
+    const response = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({
+        providerId: "acme-gateway",
+        protocol: "openai",
+        baseUrl: BODY.baseUrl,
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(authorization, "Bearer sk-acme-secret");
+    assert.deepEqual(((await response.json()) as { models: unknown }).models, [
+      { id: "saved-model", name: "Saved Model" },
+    ]);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("model discovery does not send a saved key to a changed endpoint", async () => {
+  let requests = 0;
+  const srv = start(async () => {
+    requests += 1;
+    return Response.json({ data: [{ id: "model" }] });
+  });
+  try {
+    const saved = await fetch(`${srv.base}/v1/admin/custom-providers/acme-gateway`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ ...BODY, validate: false }),
+    });
+    assert.equal(saved.status, 200);
+    const response = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({
+        providerId: "acme-gateway",
+        protocol: "openai",
+        baseUrl: "https://different.acme.internal/v1",
+      }),
+    });
+    assert.equal(response.status, 400);
+    assert.equal(((await response.json()) as { error: string }).error, "missing_api_key");
+    assert.equal(requests, 0);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("model discovery reports missing keys and invalid listings", async () => {
+  const srv = start(async () => Response.json({ data: [{ object: "model" }] }));
+  try {
+    const missing = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ protocol: "openai", baseUrl: BODY.baseUrl }),
+    });
+    assert.equal(missing.status, 400);
+    assert.equal(((await missing.json()) as { error: string }).error, "missing_api_key");
+    const invalid = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ protocol: "openai", baseUrl: BODY.baseUrl, apiKey: "sk-invalid-list" }),
+    });
+    assert.equal(invalid.status, 502);
+    assert.equal(((await invalid.json()) as { error: string }).error, "invalid_models_response");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("model discovery rejects declared and streamed oversized responses", async () => {
+  const oversized = 2 * 1024 * 1024 + 1;
+  let mode: "declared" | "streamed" = "declared";
+  const srv = start(async () => {
+    if (mode === "declared") {
+      return new Response("{}", { headers: { "content-length": String(oversized) } });
+    }
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(oversized));
+          controller.close();
+        },
+      }),
+    );
+  });
+  try {
+    for (const nextMode of ["declared", "streamed"] as const) {
+      mode = nextMode;
+      const response = await fetch(`${srv.base}/v1/admin/custom-providers/models`, {
+        method: "POST",
+        headers: ADMIN,
+        body: JSON.stringify({ protocol: "openai", baseUrl: BODY.baseUrl, apiKey: "sk-oversized" }),
+      });
+      assert.equal(response.status, 502);
+      assert.equal(((await response.json()) as { error: string }).error, "invalid_models_response");
+    }
+  } finally {
+    await srv.close();
+  }
+});
+
 test("bad specs are refused with a reason", async () => {
   const srv = start();
   try {

--- a/test/custom-providers.test.ts
+++ b/test/custom-providers.test.ts
@@ -104,6 +104,12 @@ test("store round-trip: upsert encrypts the key, statuses never leak it, delete 
   assert.equal(raw!.apiKeyEnc!.includes("sk-secret-123"), false);
 
   assert.equal(await store.resolveKey("acme-gateway"), "sk-secret-123");
+  assert.equal(
+    await store.resolveMatchingKey("acme-gateway", "openai", "https://llm.acme.internal/v1"),
+    "sk-secret-123",
+  );
+  assert.equal(await store.resolveMatchingKey("acme-gateway", "anthropic", "https://llm.acme.internal/v1"), null);
+  assert.equal(await store.resolveMatchingKey("acme-gateway", "openai", "https://other.test/v1"), null);
   assert.deepEqual(await store.enabled(), [GATEWAY]);
 
   // Upsert without a key keeps the existing one.


### PR DESCRIPTION
## Summary

- add a `Fetch models` action to the Custom providers form
- proxy model discovery through the Admin plugin to a new admin-only Core route
- support OpenAI-compatible `data`/`models` listings and Anthropic model listings
- merge discovered names with existing model metadata and cap the editable result at 200 models

## Safety

- keep API keys write-only and reuse a saved key only when protocol and normalized endpoint match the same durable record
- cap upstream model-list responses at 2 MiB
- reject model IDs and names that would corrupt the line-based form grammar
- ignore stale responses when the provider form changes while a request is in flight
- preserve existing key-validation request behavior

## Testing

- affected Core/custom-provider tests: 25 passed
- Admin plugin suite: 82 passed
- root, contract, and Admin TypeScript checks passed
- ESLint, oxlint, Prettier, and `git diff --check` passed
- independent security/correctness review completed with no remaining blockers

## Demo

Verified in a live local dev instance through the production-style Portal -> Admin -> Core path. A temporary OpenAI-compatible `/v1/models` endpoint returned `live-chat` and `live-reasoner`; the running admin shell exposed the new `Fetch models` control and returned both models through `/admin/api/custom-providers/models`.

Browser capture was unavailable in the current automation environment, so this PR does not include a screenshot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790483876&installation_model_id=19911&pr_number=711&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F711&signature=4931c20478eea2933608b500b69d8995300fa39dcc23990c5486b4690b93a37e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->