### PR TITLE
Seed editable personal environment defaults

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -8,7 +8,7 @@ definitions:
       memory: 4096
   steps:
     - step: &validate
-        name: Validate QM and First Touch layer
+        name: Validate QM deployment
         runs-on:
           - self.hosted
           - linux.arm64
@@ -32,7 +32,7 @@ definitions:
           - terraform -chdir="$QM_DEPLOYMENT_DIR/infra" validate
 
     - step: &deploy-production
-        name: Deploy First Touch QM to production
+        name: Deploy QM to production
         runs-on:
           - self.hosted
           - linux.arm64

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,78 @@
+image: node:24-bookworm
+
+definitions:
+  caches:
+    npm: ~/.npm
+  services:
+    docker:
+      memory: 4096
+  steps:
+    - step: &validate
+        name: Validate QM and First Touch layer
+        runs-on:
+          - self.hosted
+          - linux.arm64
+        caches:
+          - npm
+        script:
+          - set -euo pipefail
+          - apt-get update
+          - apt-get install -y --no-install-recommends curl unzip
+          - curl -fsSL https://releases.hashicorp.com/terraform/1.13.0/terraform_1.13.0_linux_arm64.zip -o /tmp/terraform.zip
+          - unzip -q /tmp/terraform.zip -d /usr/local/bin
+          - npm ci
+          - npm run typecheck
+          - npm --prefix cli run typecheck
+          - npm --prefix cli run build
+          - test -n "$QM_DEPLOYMENT_DIR"
+          - npm --prefix "$QM_DEPLOYMENT_DIR" ci
+          - npm --prefix "$QM_DEPLOYMENT_DIR" run validate
+          - terraform -chdir="$QM_DEPLOYMENT_DIR/infra" fmt -check
+          - terraform -chdir="$QM_DEPLOYMENT_DIR/infra" init -backend=false
+          - terraform -chdir="$QM_DEPLOYMENT_DIR/infra" validate
+
+    - step: &deploy-production
+        name: Deploy First Touch QM to production
+        runs-on:
+          - self.hosted
+          - linux.arm64
+        oidc: true
+        deployment: production
+        services:
+          - docker
+        caches:
+          - npm
+        script:
+          - set -euo pipefail
+          - apt-get update
+          - test "$BITBUCKET_BRANCH" = "main"
+          - apt-get install -y --no-install-recommends curl unzip docker.io
+          - curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip -o /tmp/awscliv2.zip
+          - unzip -q /tmp/awscliv2.zip -d /tmp
+          - /tmp/aws/install --update
+          - test -n "$QM_DEPLOYMENT_DIR"
+          - test -n "$AWS_ROLE_ARN"
+          - test -n "$AWS_REGION"
+          - export AWS_ROLE_SESSION_NAME="qm-${BITBUCKET_BUILD_NUMBER}"
+          - export AWS_WEB_IDENTITY_TOKEN_FILE=/tmp/bitbucket-oidc-token
+          - export AWS_DEFAULT_REGION="$AWS_REGION"
+          - install -m 600 /dev/null "$AWS_WEB_IDENTITY_TOKEN_FILE"
+          - printf '%s' "$BITBUCKET_STEP_OIDC_TOKEN" > "$AWS_WEB_IDENTITY_TOKEN_FILE"
+          - rm -f /tmp/awscliv2.zip
+          - aws sts get-caller-identity --query Arn --output text | grep -F ":assumed-role/$(basename "$AWS_ROLE_ARN")/"
+          - npm ci
+          - npm --prefix cli run build
+          - node cli/bin/qm.ts up --config "$QM_DEPLOYMENT_DIR/qm.config.jsonc" --build-from=. --yes
+          - export QM_PUBLIC_URL=$(node cli/bin/qm.ts config get publicUrl --config "$QM_DEPLOYMENT_DIR/qm.config.jsonc")
+          - curl --fail --silent --show-error --retry 20 --retry-delay 15 --retry-all-errors "$QM_PUBLIC_URL/healthz"
+
+pipelines:
+  pull-requests:
+    "**":
+      - step: *validate
+  branches:
+    main:
+      - step: *validate
+      - step:
+          <<: *deploy-production
+          trigger: manual

--- a/cli/README.md
+++ b/cli/README.md
@@ -48,6 +48,8 @@ sandbox/
   tools/<id>/tool.json
   tools/<id>/<binary>
   skills/<id>/SKILL.md
+  personal/skills/<id>/SKILL.md
+  personal/workspace/<path>
   Dockerfile
 plugins/<name>/Dockerfile
 infra/

--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -2639,20 +2639,12 @@ function assertAwsPublicRouting(
   }
   if (targetGroups.length !== ingress.length) throw new Error("ALB has target groups for private or unknown services");
   const defaults = listener.DefaultActions ?? [];
-  if (hasPortal) {
-    if (
-      defaults.length !== 1 ||
-      defaults[0]?.Type !== "forward" ||
-      defaults[0].TargetGroupArn !== targets.get("portal")
-    ) {
-      throw new Error("portal listener default does not route only to portal");
-    }
-  } else if (
+  if (!hasPortal && (
     defaults.length !== 1 ||
     defaults[0]?.Type !== "fixed-response" ||
     defaults[0].FixedResponseConfig?.StatusCode !== "404" ||
     defaults[0].TargetGroupArn
-  ) {
+  )) {
     throw new Error("non-portal listener default must return a fixed 404 response");
   }
   const rules =
@@ -2665,15 +2657,42 @@ function assertAwsPublicRouting(
           Values?: string[];
           PathPatternConfig?: { Values?: string[] };
           HostHeaderConfig?: { Values?: string[] };
+          HttpHeaderConfig?: { HttpHeaderName?: string; Values?: string[] };
         }>;
       }>;
-    }>(aws, ["elbv2", "describe-rules", "--listener-arn", listener.ListenerArn!]).Rules ?? [];
+  }>(aws, ["elbv2", "describe-rules", "--listener-arn", listener.ListenerArn!]).Rules ?? [];
   const nonDefault = rules.filter((rule) => !rule.IsDefault);
-  if (hasPortal && !coreHosts.length && nonDefault.length)
+  const defaultPortalForward =
+    defaults.length === 1 &&
+    defaults[0]?.Type === "forward" &&
+    defaults[0].TargetGroupArn === targets.get("portal");
+  const originGate = nonDefault.find((rule) => {
+    const action = rule.Actions?.length === 1 ? rule.Actions[0] : undefined;
+    const condition = rule.Conditions?.length === 1 ? rule.Conditions[0] : undefined;
+    return (
+      action?.Type === "forward" &&
+      action.TargetGroupArn === targets.get("portal") &&
+      condition?.Field === "http-header" &&
+      !!condition.HttpHeaderConfig?.HttpHeaderName?.trim() &&
+      !!condition.HttpHeaderConfig.Values?.length
+    );
+  });
+  const headerGatedPortal =
+    !coreHosts.length &&
+    defaults.length === 1 &&
+    defaults[0]?.Type === "fixed-response" &&
+    defaults[0].FixedResponseConfig?.StatusCode === "403" &&
+    !defaults[0].TargetGroupArn &&
+    originGate !== undefined;
+  if (hasPortal && !defaultPortalForward && !headerGatedPortal) {
+    throw new Error("portal listener must default to portal or require a single header-gated portal rule");
+  }
+  const routingRules = originGate ? nonDefault.filter((rule) => rule !== originGate) : nonDefault;
+  if (hasPortal && !coreHosts.length && routingRules.length)
     throw new Error("portal mode must not expose non-default ALB rules");
   if (hasPortal && coreHosts.length) {
     const found: string[] = [];
-    for (const rule of nonDefault) {
+    for (const rule of routingRules) {
       const action = rule.Actions?.length === 1 ? rule.Actions[0] : undefined;
       const condition = rule.Conditions?.length === 1 ? rule.Conditions[0] : undefined;
       const values =
@@ -2692,7 +2711,7 @@ function assertAwsPublicRouting(
     }
   }
   if (!hasPortal) {
-    const coreRule = nonDefault.filter(
+    const coreRule = routingRules.filter(
       (rule) =>
         rule.Actions?.length === 1 &&
         rule.Actions[0]?.Type === "forward" &&
@@ -2705,7 +2724,7 @@ function assertAwsPublicRouting(
     if (coreRule.length !== 1) {
       throw new Error("non-portal ALB must route only /v1/* directly to core");
     }
-    if (nonDefault.length !== 1) throw new Error("non-portal ALB has unexpected non-default rules");
+    if (routingRules.length !== 1) throw new Error("non-portal ALB has unexpected non-default rules");
   }
   return targets;
 }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -53,6 +53,10 @@ the scaffolded \`.gitignore\`.
 
 - A skill is \`sandbox/skills/<id>/SKILL.md\`: markdown with \`name\` and
   \`description\` frontmatter that teaches the agent a workflow and when to use it.
+- A personal starter skill is \`sandbox/personal/skills/<id>/SKILL.md\`. Each user
+  receives an editable copy; later layer updates never overwrite or restore it.
+- A personal workspace default is any text file under \`sandbox/personal/workspace/\`.
+  Missing files are created on the user's next computer provision and existing files stay unchanged.
 - A tool is \`sandbox/tools/<id>/tool.json\`: a descriptor whose minimal form is
   \`{ "id": ..., "advertise": ..., "install": { "binary": ... } }\`, with the
   executable next to it when the binary is not already in the base image.

--- a/cli/src/deployment-layer.ts
+++ b/cli/src/deployment-layer.ts
@@ -15,6 +15,8 @@ export interface DeploymentLayerBundle {
   contract: 1;
   tools: DeploymentLayerFile[];
   skills: DeploymentLayerFile[];
+  personalSkills?: DeploymentLayerFile[];
+  personalWorkspace?: DeploymentLayerFile[];
 }
 
 export interface DeploymentLayerState {
@@ -88,7 +90,13 @@ export function deploymentLayerBundle(sandboxDir: string): DeploymentLayerBundle
         })
         .sort(pathOrder)
     : [];
-  return { contract: 1, tools, skills: walkText(join(sandboxDir, "skills"), "skills") };
+  return {
+    contract: 1,
+    tools,
+    skills: walkText(join(sandboxDir, "skills"), "skills"),
+    personalSkills: walkText(join(sandboxDir, "personal", "skills"), "personal/skills"),
+    personalWorkspace: walkText(join(sandboxDir, "personal", "workspace"), "personal/workspace"),
+  };
 }
 
 function normalizedLayerBody(value: unknown): string {
@@ -98,7 +106,16 @@ function normalizedLayerBody(value: unknown): string {
   if (bundle.contract !== 1 || !Array.isArray(bundle.tools) || !Array.isArray(bundle.skills)) {
     throw new CliError("deployment layer bundle requires contract: 1, tools[], and skills[]");
   }
-  const files = (kind: "tools" | "skills", entries: unknown[]): DeploymentLayerFile[] =>
+  if (bundle.personalSkills !== undefined && !Array.isArray(bundle.personalSkills)) {
+    throw new CliError("deployment layer personalSkills must be an array");
+  }
+  if (bundle.personalWorkspace !== undefined && !Array.isArray(bundle.personalWorkspace)) {
+    throw new CliError("deployment layer personalWorkspace must be an array");
+  }
+  const files = (
+    kind: "tools" | "skills" | "personalSkills" | "personalWorkspace",
+    entries: unknown[],
+  ): DeploymentLayerFile[] =>
     entries
       .map((entry) => {
         if (!entry || typeof entry !== "object" || Array.isArray(entry))
@@ -110,13 +127,19 @@ function normalizedLayerBody(value: unknown): string {
         return { path: file.path, content: file.content, ...(file.executable === true ? { executable: true } : {}) };
       })
       .sort(pathOrder);
-  return JSON.stringify({ contract: 1, tools: files("tools", bundle.tools), skills: files("skills", bundle.skills) });
+  return JSON.stringify({
+    contract: 1,
+    tools: files("tools", bundle.tools),
+    skills: files("skills", bundle.skills),
+    ...(bundle.personalSkills ? { personalSkills: files("personalSkills", bundle.personalSkills) } : {}),
+    ...(bundle.personalWorkspace ? { personalWorkspace: files("personalWorkspace", bundle.personalWorkspace) } : {}),
+  });
 }
 
 export function deploymentLayerBody(sandboxDir: string): string {
   const bundle = existsSync(sandboxDir)
     ? deploymentLayerBundle(sandboxDir)
-    : { contract: 1 as const, tools: [], skills: [] };
+    : { contract: 1 as const, tools: [], skills: [], personalSkills: [], personalWorkspace: [] };
   const body = normalizedLayerBody(bundle);
   if (Buffer.byteLength(body) > 1_000_000)
     throw new CliError("deployment layer exceeds the core API's 1 MB request limit");

--- a/cli/src/slack-manifests.ts
+++ b/cli/src/slack-manifests.ts
@@ -52,12 +52,25 @@ export function usesSlackOidc(config: QmConfig): boolean {
 export function renderSlackManifests(config: QmConfig): SlackManifests {
   const name = config.botName ?? "qm";
   const bot = JSON.parse(template("slack-manifest.json")) as {
-    display_information: { name: string; description: string };
-    features: { bot_user: { display_name: string } };
+    display_information: { name: string; description: string; background_color: string };
+    features: { bot_user: { display_name: string }; agent_view: { agent_description: string } };
   };
+  const slackEnv = config.env?.slack ?? {};
+  const background = slackEnv.SLACK_BACKGROUND_COLOR?.trim();
+  if (background && !/^#[0-9a-f]{6}$/i.test(background)) {
+    throw new Error("env.slack.SLACK_BACKGROUND_COLOR must be a six-digit hex color");
+  }
   bot.display_information.name = name;
-  bot.display_information.description = `${name} workspace agent for ${config.orgId}`;
+  const description = slackEnv.SLACK_APP_DESCRIPTION?.trim() || `${name} workspace agent for ${config.orgId}`;
+  if (description.length > 140) throw new Error("env.slack.SLACK_APP_DESCRIPTION must be at most 140 characters");
+  bot.display_information.description = description;
+  if (background) bot.display_information.background_color = background;
   bot.features.bot_user.display_name = name;
+  const agentDescription = slackEnv.SLACK_AGENT_DESCRIPTION?.trim();
+  if (agentDescription && agentDescription.length > 300) {
+    throw new Error("env.slack.SLACK_AGENT_DESCRIPTION must be at most 300 characters");
+  }
+  if (agentDescription) bot.features.agent_view.agent_description = agentDescription;
 
   const sso = JSON.parse(template("slack-sso-manifest.json")) as {
     display_information: { name: string; description: string };

--- a/cli/templates/aws/microvm-agent/Dockerfile
+++ b/cli/templates/aws/microvm-agent/Dockerfile
@@ -14,7 +14,7 @@ RUN dnf install -y \
 
 RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
        -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.97.0-1 \
+  && dnf install -y gh-2.98.0-1 \
   && dnf clean all \
   && gh --version
 

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -96,7 +96,7 @@ else if (a.includes("lambda-microvms list-microvm-image-versions")) console.log(
 else if (a.includes("elbv2 describe-load-balancers")) console.log(JSON.stringify({ LoadBalancers: [{ LoadBalancerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/test/1", DNSName: process.env.AWS_FAKE_ALB_DNS || "agent.acme.example", State: { Code: "active" } }] }));
 else if (a.includes("elbv2 describe-listeners")) {
   const protocol = process.env.AWS_FAKE_LISTENER_PROTOCOL || "HTTPS";
-  const defaults = process.env.AWS_FAKE_DEFAULT_FORWARD === "1" ? [{ Type: "forward", TargetGroupArn: ${JSON.stringify(targetArn)} }] : ${frontService === "portal" ? JSON.stringify([{ Type: "forward", TargetGroupArn: targetArn }]) : JSON.stringify([{ Type: "fixed-response", FixedResponseConfig: { StatusCode: "404" } }])};
+  const defaults = process.env.AWS_FAKE_ORIGIN_GATE === "1" ? [{ Type: "fixed-response", FixedResponseConfig: { StatusCode: "403" } }] : process.env.AWS_FAKE_DEFAULT_FORWARD === "1" ? [{ Type: "forward", TargetGroupArn: ${JSON.stringify(targetArn)} }] : ${frontService === "portal" ? JSON.stringify([{ Type: "forward", TargetGroupArn: targetArn }]) : JSON.stringify([{ Type: "fixed-response", FixedResponseConfig: { StatusCode: "404" } }])};
   const listeners = [{ ListenerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/1/2", Protocol: protocol, Port: protocol === "HTTPS" ? 443 : 80, Certificates: protocol === "HTTPS" ? [{ CertificateArn: "arn:aws:acm:us-west-2:123456789012:certificate/test" }] : [], DefaultActions: defaults }];
   if (process.env.AWS_FAKE_EXTRA_HTTP_LISTENER === "redirect") listeners.push({ ListenerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/1/3", Protocol: "HTTP", Port: 80, Certificates: [], DefaultActions: [{ Type: "redirect", RedirectConfig: { Protocol: "HTTPS", Port: "443", StatusCode: "HTTP_301" } }] });
   if (process.env.AWS_FAKE_EXTRA_HTTP_LISTENER === "forward") listeners.push({ ListenerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/test/1/3", Protocol: "HTTP", Port: 80, Certificates: [], DefaultActions: [{ Type: "forward", TargetGroupArn: ${JSON.stringify(targetArn)} }] });
@@ -110,6 +110,7 @@ else if (a.includes("elbv2 describe-rules")) {
   if (rules[0] && process.env.AWS_FAKE_EXTRA_ACTION === "1") rules[0].Actions.push({ Type: "authenticate-oidc" });
   if (rules[0] && process.env.AWS_FAKE_EXTRA_CONDITION === "1") rules[0].Conditions.push({ Field: "host-header", HostHeaderConfig: { Values: ["other.example"] } });
   if (process.env.AWS_FAKE_EXTRA_RULE === "1") rules.push({ IsDefault: false, Actions: [{ Type: "fixed-response", FixedResponseConfig: { StatusCode: "503" } }], Conditions: [{ Field: "path-pattern", PathPatternConfig: { Values: ["/v1/*"] } }] });
+  if (process.env.AWS_FAKE_ORIGIN_GATE === "1") rules.push({ IsDefault: false, Actions: [{ Type: "forward", TargetGroupArn: ${JSON.stringify(targetArn)} }], Conditions: [{ Field: "http-header", HttpHeaderConfig: { HttpHeaderName: "X-Origin-Verify", Values: ["secret"] } }] });
   console.log(JSON.stringify({ Rules: rules }));
 }
 else if (a.includes("elbv2 describe-target-health")) console.log(JSON.stringify({ TargetHealthDescriptions: [{ TargetHealth: { State: process.env.AWS_FAKE_UNHEALTHY_TARGET === "1" ? "unhealthy" : "healthy" } }] }));
@@ -921,6 +922,22 @@ test("AWS deploy requires the live core-only ALB to default 404 and expose exact
       portal.restore();
     }
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("AWS deploy accepts a header-gated portal origin with a fixed 403 default", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-aws-origin-gate-"));
+  const fake = statefulAws(dir, config);
+  const prior = process.env.AWS_FAKE_ORIGIN_GATE;
+  process.env.AWS_FAKE_ORIGIN_GATE = "1";
+  try {
+    await awsUp(config, dir, { dryRun: true });
+    assert.match(readFileSync(fake.log, "utf8"), /elbv2 describe-rules/);
+  } finally {
+    if (prior === undefined) delete process.env.AWS_FAKE_ORIGIN_GATE;
+    else process.env.AWS_FAKE_ORIGIN_GATE = prior;
+    fake.restore();
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -30,6 +30,14 @@ function writeLayer(dir: string): void {
   );
   writeFileSync(join(dir, "sandbox", "tools", "t", "t"), "#!/usr/bin/env bash\necho hi\n");
   chmodSync(join(dir, "sandbox", "tools", "t", "t"), 0o755);
+  mkdirSync(join(dir, "sandbox", "personal", "skills", "starter"), { recursive: true });
+  writeFileSync(
+    join(dir, "sandbox", "personal", "skills", "starter", "SKILL.md"),
+    "---\nname: starter\ndescription: starter skill\n---\nstarter\n",
+  );
+  mkdirSync(join(dir, "sandbox", "personal", "workspace", "config"), { recursive: true });
+  writeFileSync(join(dir, "sandbox", "personal", "workspace", "AGENTS.md"), "personal defaults\n");
+  writeFileSync(join(dir, "sandbox", "personal", "workspace", "config", "personal.yaml"), "enabled: false\n");
 }
 
 function coreNormalizedHash(dir: string): string {
@@ -41,7 +49,29 @@ function coreNormalizedHash(dir: string): string {
     { path: "tools/t/tool.json", content: readFileSync(join(dir, "sandbox", "tools", "t", "tool.json"), "utf8") },
   ];
   const order = (a: { path: string }, b: { path: string }): number => a.path.localeCompare(b.path);
-  const bundle = { contract: 1, tools: tools.sort(order), skills: skillFiles.sort(order) };
+  const personalSkills = [
+    {
+      path: "personal/skills/starter/SKILL.md",
+      content: readFileSync(join(dir, "sandbox", "personal", "skills", "starter", "SKILL.md"), "utf8"),
+    },
+  ];
+  const personalWorkspace = [
+    {
+      path: "personal/workspace/AGENTS.md",
+      content: readFileSync(join(dir, "sandbox", "personal", "workspace", "AGENTS.md"), "utf8"),
+    },
+    {
+      path: "personal/workspace/config/personal.yaml",
+      content: readFileSync(join(dir, "sandbox", "personal", "workspace", "config", "personal.yaml"), "utf8"),
+    },
+  ];
+  const bundle = {
+    contract: 1,
+    tools: tools.sort(order),
+    skills: skillFiles.sort(order),
+    personalSkills: personalSkills.sort(order),
+    personalWorkspace: personalWorkspace.sort(order),
+  };
   return createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
 }
 
@@ -54,6 +84,14 @@ test("the CLI bundle hashes byte-identically to the core's full-path normalizati
       bundle.skills.map((file) => file.path),
       ["skills/a-b/SKILL.md", "skills/a/SKILL.md"],
       "full-path order, not per-directory walk order",
+    );
+    assert.deepEqual(
+      bundle.personalSkills?.map((file) => file.path),
+      ["personal/skills/starter/SKILL.md"],
+    );
+    assert.deepEqual(
+      bundle.personalWorkspace?.map((file) => file.path),
+      ["personal/workspace/AGENTS.md", "personal/workspace/config/personal.yaml"],
     );
     const cliHash = createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
     assert.equal(cliHash, coreNormalizedHash(dir));

--- a/cli/test/slack-manifests.test.ts
+++ b/cli/test/slack-manifests.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert";
-import { usesSlackOidc } from "../src/slack-manifests.ts";
+import { renderSlackManifests, usesSlackOidc } from "../src/slack-manifests.ts";
 import type { QmConfig } from "../src/config.ts";
 
 function configWithPortalEnv(env: Record<string, string>): QmConfig {
@@ -21,4 +21,45 @@ test("usesSlackOidc matches by hostname, not substring", () => {
   // malformed values fail closed
   assert.equal(usesSlackOidc(configWithPortalEnv({ OIDC_ISSUER: "slack.com" })), false);
   assert.equal(usesSlackOidc(configWithPortalEnv({})), false);
+});
+
+test("Slack manifest branding comes from the deployment environment", () => {
+  const config = {
+    botName: "Acme Agent",
+    orgId: "acme",
+    publicUrl: "https://agent.example.com",
+    env: {
+      slack: {
+        SLACK_APP_DESCRIPTION: "Acme private workspace agent",
+        SLACK_AGENT_DESCRIPTION: "Your Acme teammate",
+        SLACK_BACKGROUND_COLOR: "#123abc",
+      },
+    },
+  } as unknown as QmConfig;
+  const manifest = renderSlackManifests(config).bot;
+  assert.match(manifest, /description: Acme private workspace agent/);
+  assert.match(manifest, /agent_description: Your Acme teammate/);
+  assert.match(manifest, /background_color: "#123abc"/);
+});
+
+test("Slack manifest branding rejects invalid colors", () => {
+  const config = {
+    botName: "Acme Agent",
+    orgId: "acme",
+    publicUrl: "https://agent.example.com",
+    env: { slack: { SLACK_BACKGROUND_COLOR: "blue" } },
+  } as unknown as QmConfig;
+  assert.throws(() => renderSlackManifests(config), /six-digit hex color/);
+});
+
+test("Slack manifest branding rejects descriptions over Slack limits", () => {
+  const config = {
+    botName: "Acme Agent",
+    orgId: "acme",
+    publicUrl: "https://agent.example.com",
+    env: { slack: { SLACK_APP_DESCRIPTION: "a".repeat(141), SLACK_AGENT_DESCRIPTION: "b".repeat(301) } },
+  } as unknown as QmConfig;
+  assert.throws(() => renderSlackManifests(config), /at most 140 characters/);
+  config.env.slack!.SLACK_APP_DESCRIPTION = "valid";
+  assert.throws(() => renderSlackManifests(config), /at most 300 characters/);
 });

--- a/deploy/layers/README.md
+++ b/deploy/layers/README.md
@@ -28,7 +28,7 @@ deploy/layers/<org>/
   .gitignore               scaffolded; keeps .env and tfstate out of Git
   .env.example             computed secret names, never values
   .env                     local secret values; never committed
-  sandbox/                 org tools and skills for agent computers
+  sandbox/                 org tools, shared skills, and personal defaults for agent computers
   plugins/<name>/          org-specific service images
   infra/                   provider infrastructure and tfvars, on AWS targets
   slack-app-manifest.yml   generated bot manifest

--- a/docs/deploy-directory.md
+++ b/docs/deploy-directory.md
@@ -15,9 +15,12 @@ sandbox/
   tools/<id>/<binary>
   skills/<id>/SKILL.md
   skills/<id>/<text assets>
+  personal/skills/<id>/SKILL.md
+  personal/skills/<id>/<text assets>
+  personal/workspace/<path>
 ```
 
-The Dockerfile is optional when every declared binary is present in its tool directory. Skill assets delivered through the deployment-layer API are text in v1; binaries belong in the sandbox image.
+The Dockerfile is optional when every declared binary is present in its tool directory. Skill assets and personal workspace defaults delivered through the deployment-layer API are text in v1; binaries belong in the sandbox image. `skills/` publishes centrally managed organization skills. `personal/skills/` creates an editable copy in each personal scope when that user first lists skills or starts a turn. `personal/workspace/` creates missing files relative to that user's workspace when its persistent computer is next provisioned. Existing files, edited skills, and archived skills are never replaced or restored. Adding a new default reaches existing personal environments lazily without creating computers ahead of use. Scratch, channel, group, team, organization, and attached shared environments do not receive personal defaults.
 
 ## Configuration
 
@@ -96,7 +99,7 @@ Deployment-specific safety belongs here too. For example, an ambiently authentic
 
 ## Delivery and pins
 
-When `sandbox/` exists, every `up` sends its descriptors and complete text skill trees to source-authenticated `PUT /v1/deployment-layer`. Without `sandbox/`, `up` skips layer sync and leaves the deployed layer unchanged. Core validates submitted bundles again, stores them in Postgres table `deployment_layer`, versions them by a canonical SHA-256 content hash, records an audit event, hydrates them before serving, and returns the restorable bundle with its metadata and resolved runtime state from source-authenticated `GET /v1/deployment-layer`. Removed layer-owned skills are archived. Filesystem `DEPLOYMENT_LAYER` remains a bootstrap input for local and recovery use.
+When `sandbox/` exists, every `up` sends its descriptors, complete organization and personal skill trees, and personal workspace defaults to source-authenticated `PUT /v1/deployment-layer`. Without `sandbox/`, `up` skips layer sync and leaves the deployed layer unchanged. Core validates submitted bundles again, stores them in Postgres table `deployment_layer`, versions them by a canonical SHA-256 content hash, records an audit event, hydrates them before serving, and returns the restorable bundle with its metadata and resolved runtime state from source-authenticated `GET /v1/deployment-layer`. Removed layer-owned organization skills are archived. Personal defaults are initial values rather than managed projections, so changing or removing one does not rewrite user-owned copies. Filesystem `DEPLOYMENT_LAYER` remains a bootstrap input for local and recovery use.
 
 The sandbox handoff is a substrate image pin plus a layer content hash. Docker and Fly use `sandbox publish` to push an OCI image, resolve its immutable digest, and record it in the config. AWS with `sandbox.backend: "aws"` (or no sandbox block) uses `infra build-image` to package the guest agent as a Lambda MicroVM image and records its immutable image version and execution role; with `sandbox.backend: "sprites"`, `sandbox publish` pushes the layer image and records its digest pin in the durable deployment manifest, which `up`, `check --live`, and `rollback` resolve. Service task definitions and sandbox root filesystems use immutable pins, not mutable tags.
 

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -277,7 +277,9 @@ export function createSessionMethods(
       const sandbox = deps.sandbox;
       const rec = await deps.processes.get(processId);
       if (!rec || rec.kind !== "background" || rec.sessionRef !== session.threadRef) return null;
-      const handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }]);
+      const handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }], {
+        personalDefaults: false,
+      });
       try {
         const read = await sandbox.readProcess(handle, processId, { sinceCursor, maxBytes: 65_536, waitMs: 0 });
         return {

--- a/src/api/app-skills.ts
+++ b/src/api/app-skills.ts
@@ -221,6 +221,7 @@ export function createSkillMethods(
       return deps.skills.archive(id);
     },
     async listVisibleSkills(principalId) {
+      await deps.personalDefaults?.ensure(scopeId("personal", principalId));
       const actor = deps.identity.classify(principalId);
       const sharedHomes = [
         ...new Set(
@@ -379,37 +380,39 @@ export function createSkillMethods(
       });
     },
     async createOwnedSkill(input) {
-      const name = input.name.trim();
-      const description = input.description.trim();
-      const body = input.body.trim();
-      if (!name || !description || !body) throw new Error("skill requires a non-empty name, description, and body");
-      const homeScope = input.homeScope ?? scopeId("personal", input.principalId);
-      const homeKind = parseScopeId(homeScope).kind;
-      if (homeKind !== "personal" && homeKind !== "channel" && homeKind !== "group") {
-        throw new Error(
-          "a skill cannot be created directly in an org or team scope — promote a published skill instead",
-        );
-      }
-      const existing = (await deps.skills.list()).find((s) => s.scopeId === homeScope && s.manifest.name === name);
-      if (existing && existing.status !== "archived") return null;
-      if (existing) await deps.skills.delete(existing.id);
-      const manifest: SkillManifest = {
-        name,
-        description,
-        requiredCapabilities: input.requiredCapabilities ?? [],
-        body,
-      };
-      const skill = await deps.skills.create({ scopeId: homeScope, manifest, createdBy: input.principalId });
-      await deps.skills.review(skill.id, "system:skill-authoring", manifest.requiredCapabilities);
-      const published = await deps.skills.publish(skill.id);
-      deps.auditLog.record({
-        at: Date.now(),
-        principalId: input.principalId,
-        action: "skill_create",
-        resource: skill.id,
-        scopeLabel: homeScope,
+      return withSkillMutationLock(deps, async () => {
+        const name = input.name.trim();
+        const description = input.description.trim();
+        const body = input.body.trim();
+        if (!name || !description || !body) throw new Error("skill requires a non-empty name, description, and body");
+        const homeScope = input.homeScope ?? scopeId("personal", input.principalId);
+        const homeKind = parseScopeId(homeScope).kind;
+        if (homeKind !== "personal" && homeKind !== "channel" && homeKind !== "group") {
+          throw new Error(
+            "a skill cannot be created directly in an org or team scope — promote a published skill instead",
+          );
+        }
+        const existing = (await deps.skills.list()).find((s) => s.scopeId === homeScope && s.manifest.name === name);
+        if (existing && existing.status !== "archived") return null;
+        if (existing) await deps.skills.delete(existing.id);
+        const manifest: SkillManifest = {
+          name,
+          description,
+          requiredCapabilities: input.requiredCapabilities ?? [],
+          body,
+        };
+        const skill = await deps.skills.create({ scopeId: homeScope, manifest, createdBy: input.principalId });
+        await deps.skills.review(skill.id, "system:skill-authoring", manifest.requiredCapabilities);
+        const published = await deps.skills.publish(skill.id);
+        deps.auditLog.record({
+          at: Date.now(),
+          principalId: input.principalId,
+          action: "skill_create",
+          resource: skill.id,
+          scopeLabel: homeScope,
+        });
+        return published;
       });
-      return published;
     },
     async deleteOwnedSkill({ principalId, id, liveActor }) {
       const skill = await deps.skills.get(id);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -79,6 +79,7 @@ import type { AmbientJudgmentStore } from "../surface-cache/ambient-judgment-sto
 import type { AckEmojiPickStore } from "../surface-cache/ack-emoji-pick-store.ts";
 import type { Deployment } from "../deploy/deploy-store.ts";
 import type { DeploymentLayerRuntime } from "../deployment/load-layer.ts";
+import type { PersonalDefaultsService } from "../personal-defaults.ts";
 import { type ArtifactHome, type ArtifactType } from "./artifact-share.ts";
 import type {
   DeployService,
@@ -541,6 +542,7 @@ export interface AppDeps {
   projects?: ProjectStore;
   deploy: DeployService;
   deploymentLayer?: DeploymentLayerRuntime;
+  personalDefaults?: PersonalDefaultsService;
   files: FileArtifactStore;
   approvals?: DurableMap<PendingApprovalRecord>;
   sessionStateBus?: SessionStateBus;

--- a/src/api/routes/reach.ts
+++ b/src/api/routes/reach.ts
@@ -163,7 +163,9 @@ async function reachNow(ctx: ApiCtx): Promise<void> {
             }),
         }
       : undefined;
-    const handle = await sandbox.provision([{ scopeId: envScope, mountPath: "", mode: "rw" }]);
+    const handle = await sandbox.provision([{ scopeId: envScope, mountPath: "", mode: "rw" }], {
+      personalDefaults: false,
+    });
     try {
       const r = await collectNamedOutbound(sandbox, handle, files, blobTransfer, register);
       const bad = [

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -896,6 +896,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           : "";
 
       await deps.skillsReady;
+      if (scopeId === personalScope(actor.id)) await deps.personalDefaults?.ensure(skillScopes[0]);
       const configuredProviders = deps.resolveConnectorClient
         ? await configuredConnectorProviders(deps.resolveConnectorClient).catch(
             swallowAs("orchestrator: configured connector providers", []),

--- a/src/core/orchestrator/sandboxes.ts
+++ b/src/core/orchestrator/sandboxes.ts
@@ -1,4 +1,4 @@
-import type { Principal, Resolution, ScopeId, Session } from "../../types.ts";
+import { personalScope, type Principal, type Resolution, type ScopeId, type Session } from "../../types.ts";
 import type { GapPhase } from "../../sessions/session-store.ts";
 import { type SandboxHandle, supportsProcessSessions } from "../../sandbox/sandbox.ts";
 import { reconcileProcesses } from "../../processes/reconcile.ts";
@@ -189,6 +189,7 @@ export function createTurnSandboxes(ctx: TurnSandboxContext) {
     const handle = await deps.sandbox.provision(resolution.layers, {
       env: connectorEnv,
       egress: resolution.egress,
+      personalDefaults: scopeId === personalScope(actor.id),
       ...(egressTokenForTurn ? { egressToken: egressTokenForTurn } : {}),
       ...(onSandboxStatus ? { onStatus: onSandboxStatus } : {}),
     });
@@ -450,6 +451,7 @@ export function createTurnSandboxes(ctx: TurnSandboxContext) {
       ],
       {
         egress: resolution.egress,
+        personalDefaults: target.startsWith("personal:"),
         ...(egressTokenForTurn ? { egressToken: egressTokenForTurn } : {}),
         ...(onSandboxStatus ? { onStatus: onSandboxStatus } : {}),
       },

--- a/src/core/orchestrator/types.ts
+++ b/src/core/orchestrator/types.ts
@@ -55,6 +55,7 @@ import type { SkillStore } from "../../skills/skill-store.ts";
 import type { OAuthClientResolver } from "../../connectors/oauth.ts";
 import type { SkillBundleStore } from "../../skills/skill-bundle-store.ts";
 import type { BrokeredLayerTool, DeploymentLayerRuntime } from "../../deployment/load-layer.ts";
+import type { PersonalDefaultsService } from "../../personal-defaults.ts";
 import type { FileArtifactStore } from "../../files/file-artifact-store.ts";
 import type { MiniappStore } from "../../miniapps/miniapp.ts";
 import type { DeployService } from "../../deploy/deploy-service.ts";
@@ -171,6 +172,7 @@ export interface OrchestratorDeps {
   layerBrokerFor?: (tool: BrokeredLayerTool) => AwsRoleBroker | undefined;
   brokeredTools?: readonly BrokeredLayerTool[];
   deploymentLayer?: DeploymentLayerRuntime;
+  personalDefaults?: PersonalDefaultsService;
   surfaceContext?: SurfaceContextPuller;
   surfaceSearch?: SurfaceSearchStore;
   surfaceCache?: SurfaceCache;

--- a/src/cron/job-queue.ts
+++ b/src/cron/job-queue.ts
@@ -1,6 +1,7 @@
 import { PgBoss } from "pg-boss";
 import { createSweeper, type Sweeper } from "../util/sweeper.ts";
 import { errMessage } from "../util/errors.ts";
+import { pgConnectionConfig } from "../persistence/pg-pool.ts";
 
 export interface CronFireJob {
   cronId: string;
@@ -30,7 +31,7 @@ export function createPgBossCronQueue(
   schema: string = "pgboss",
   fireConcurrency: number = 1,
 ): CronJobQueue {
-  const boss = new PgBoss({ connectionString: databaseUrl, schema, max: 5 });
+  const boss = new PgBoss({ ...pgConnectionConfig(databaseUrl), schema, max: 5 });
   boss.on("error", (e) => console.error("[cron-queue] pg-boss error:", errMessage(e)));
   let ticker: Sweeper | null = null;
   let started = false;

--- a/src/deployment/deployment-layer-store.ts
+++ b/src/deployment/deployment-layer-store.ts
@@ -2,14 +2,8 @@ import { createHash } from "node:crypto";
 import { createNoopAdvisoryLock, type AdvisoryLock } from "../persistence/advisory-lock.ts";
 import type { DurableMap } from "../persistence/durable-map.ts";
 import type { ScopeId } from "../types.ts";
-import {
-  safeSkillFilePath,
-  type Skill,
-  type SkillFile,
-  type SkillManifest,
-  type SkillStore,
-} from "../skills/skill-store.ts";
-import { foreignSkillCollision, parseSeedSkill, sameManifest, upsertSeedSkill } from "../skills/seed.ts";
+import { safeSkillFilePath, type Skill, type SkillManifest, type SkillStore } from "../skills/skill-store.ts";
+import { foreignSkillCollision, sameManifest, upsertSeedSkill } from "../skills/seed.ts";
 import {
   bundleFilePaths,
   detectPathCollisions,
@@ -22,6 +16,12 @@ import { createKeyedQueue, sleep } from "../util/async.ts";
 import { errMessage } from "../util/errors.ts";
 import { parseToolDescriptor, type ToolDescriptor } from "./deployment-layer.ts";
 import { replaceDeploymentLayer, resolvedDeploymentLayer, type DeploymentLayerRuntime } from "./load-layer.ts";
+import {
+  assertNoPersonalWorkspaceConflicts,
+  parseDefaultSkillTrees,
+  safePersonalWorkspacePath,
+  type PersonalDefaultFile,
+} from "../personal-defaults.ts";
 
 interface DeploymentLayerFile {
   path: string;
@@ -33,6 +33,8 @@ export interface DeploymentLayerBundle {
   contract: 1;
   tools: DeploymentLayerFile[];
   skills: DeploymentLayerFile[];
+  personalSkills?: DeploymentLayerFile[];
+  personalWorkspace?: DeploymentLayerFile[];
 }
 
 export interface StoredDeploymentLayer {
@@ -103,7 +105,17 @@ function normalizedBundle(input: DeploymentLayerBundle): DeploymentLayerBundle {
   if (input.contract !== 1 || !Array.isArray(input.tools) || !Array.isArray(input.skills)) {
     throw new Error("deployment layer requires contract: 1, tools[], and skills[]");
   }
-  const normalize = (kind: "tools" | "skills", files: DeploymentLayerFile[]): DeploymentLayerFile[] => {
+  if (input.personalSkills !== undefined && !Array.isArray(input.personalSkills)) {
+    throw new Error("deployment layer personalSkills must be an array");
+  }
+  if (input.personalWorkspace !== undefined && !Array.isArray(input.personalWorkspace)) {
+    throw new Error("deployment layer personalWorkspace must be an array");
+  }
+  const normalize = (
+    kind: "tools" | "skills" | "personalSkills" | "personalWorkspace",
+    files: DeploymentLayerFile[],
+    prefix: string,
+  ): DeploymentLayerFile[] => {
     const seen = new Set<string>();
     return files
       .map((file) => {
@@ -120,16 +132,33 @@ function normalizedBundle(input: DeploymentLayerBundle): DeploymentLayerBundle {
             `deployment layer ${kind} entry contains an unpaired Unicode surrogate, which the store cannot persist: ${file.path}`,
           );
         }
-        const path = safeSkillFilePath(file.path);
-        if (!path.startsWith(`${kind}/`))
-          throw new Error(`deployment layer ${kind} path must start with ${kind}/: ${path}`);
+        const path = kind === "personalWorkspace" ? safePersonalWorkspacePath(file.path) : safeSkillFilePath(file.path);
+        if (!path.startsWith(`${prefix}/`))
+          throw new Error(`deployment layer ${kind} path must start with ${prefix}/: ${path}`);
         if (seen.has(path)) throw new Error(`duplicate deployment layer path: ${path}`);
         seen.add(path);
         return { path, content: file.content, ...(file.executable === true ? { executable: true } : {}) };
       })
       .sort(pathOrder);
   };
-  return { contract: 1, tools: normalize("tools", input.tools), skills: normalize("skills", input.skills) };
+  const personalSkills =
+    input.personalSkills === undefined
+      ? undefined
+      : normalize("personalSkills", input.personalSkills, "personal/skills");
+  const personalWorkspace =
+    input.personalWorkspace === undefined
+      ? undefined
+      : normalize("personalWorkspace", input.personalWorkspace, "personal/workspace");
+  assertNoPersonalWorkspaceConflicts(
+    (personalWorkspace ?? []).map((file) => ({ ...file, path: file.path.slice("personal/workspace/".length) })),
+  );
+  return {
+    contract: 1,
+    tools: normalize("tools", input.tools, "tools"),
+    skills: normalize("skills", input.skills, "skills"),
+    ...(personalSkills ? { personalSkills } : {}),
+    ...(personalWorkspace ? { personalWorkspace } : {}),
+  };
 }
 
 function toolDescriptors(files: DeploymentLayerFile[]): ToolDescriptor[] {
@@ -145,52 +174,6 @@ function toolDescriptors(files: DeploymentLayerFile[]): ToolDescriptor[] {
     ids.add(tool.id);
   }
   return tools;
-}
-
-function skillManifests(files: DeploymentLayerFile[]): SkillManifest[] {
-  const byDir = new Map<string, DeploymentLayerFile[]>();
-  for (const file of files) {
-    const match = file.path.match(/^skills\/([^/]+)\/(.+)$/);
-    if (!match) throw new Error(`deployment layer skill path must be skills/<id>/<file>: ${file.path}`);
-    const dir = match[1]!;
-    const list = byDir.get(dir) ?? [];
-    list.push(file);
-    byDir.set(dir, list);
-  }
-  const manifests: SkillManifest[] = [];
-  const names = new Set<string>();
-  for (const [dir, entries] of [...byDir].sort(([a], [b]) => {
-    if (a < b) return -1;
-    if (a > b) return 1;
-    return 0;
-  })) {
-    const root = entries.find((file) => file.path === `skills/${dir}/SKILL.md`);
-    if (!root) throw new Error(`deployment layer skill ${dir} has no SKILL.md`);
-    const manifest = parseSeedSkill(root.content);
-    if (names.has(manifest.name)) throw new Error(`duplicate deployment skill name: ${manifest.name}`);
-    names.add(manifest.name);
-    const assets: SkillFile[] = entries
-      .filter((file) => file !== root)
-      .map((file) => ({
-        path: safeSkillFilePath(file.path.slice(`skills/${dir}/`.length)),
-        content: file.content,
-        ...(file.executable === true ? { executable: true } : {}),
-      }));
-    manifest.files = assets;
-    manifests.push(manifest);
-  }
-  const claimed = new Map<string, string>();
-  for (const manifest of manifests) {
-    const paths = skillRecordPaths(manifest.name, manifest.files);
-    const collisions = detectPathCollisions(paths, claimed);
-    if (collisions.length) {
-      throw new Error(
-        `deployment skill "${manifest.name}" materializes over ${collisions[0]!.path}, already claimed by ${collisions[0]!.owner}`,
-      );
-    }
-    for (const path of paths) claimed.set(path, `deployment skill "${manifest.name}"`);
-  }
-  return manifests;
 }
 
 function contentHash(bundle: DeploymentLayerBundle): string {
@@ -225,8 +208,26 @@ function validateBundle(
 } {
   const bundle = normalizedBundle(input);
   const tools = toolDescriptors(bundle.tools);
-  const manifests = skillManifests(bundle.skills);
-  return { bundle, manifests, runtime: resolvedDeploymentLayer(dir, tools) };
+  const manifests = parseDefaultSkillTrees(
+    bundle.skills.map((file) => ({ ...file, path: file.path.slice("skills/".length) })),
+    "deployment skill",
+  );
+  const personalSkillManifests = parseDefaultSkillTrees(
+    (bundle.personalSkills ?? []).map((file) => ({
+      ...file,
+      path: file.path.slice("personal/skills/".length),
+    })),
+    "personal default skill",
+  );
+  const personalWorkspaceFiles: PersonalDefaultFile[] = (bundle.personalWorkspace ?? []).map((file) => ({
+    ...file,
+    path: safePersonalWorkspacePath(file.path.slice("personal/workspace/".length)),
+  }));
+  return {
+    bundle,
+    manifests,
+    runtime: resolvedDeploymentLayer(dir, tools, personalSkillManifests, personalWorkspaceFiles),
+  };
 }
 
 export function createDeploymentLayerStore(opts: {

--- a/src/deployment/load-layer.ts
+++ b/src/deployment/load-layer.ts
@@ -10,6 +10,14 @@ import {
 import { credentialServiceForPath } from "../credentials/resident-paths.ts";
 import type { ResidentAuthConnector } from "../credentials/resident-auth.ts";
 import type { CommandRule } from "../types.ts";
+import {
+  assertNoPersonalWorkspaceConflicts,
+  parseDefaultSkillTrees,
+  safePersonalWorkspacePath,
+  type PersonalDefaultFile,
+} from "../personal-defaults.ts";
+import { isProbablyBinary } from "../skills/seed.ts";
+import { safeSkillFilePath, type SkillManifest } from "../skills/skill-store.ts";
 
 export interface DeploymentLayerRuntime {
   dir: string;
@@ -21,6 +29,8 @@ export interface DeploymentLayerRuntime {
   splitEnvTemplates: Record<string, string>[];
   commandRules: CommandRule[];
   brokeredTools: BrokeredLayerTool[];
+  personalSkillManifests: SkillManifest[];
+  personalWorkspaceFiles: PersonalDefaultFile[];
 }
 
 export interface BrokeredLayerTool {
@@ -41,6 +51,8 @@ export function emptyDeploymentLayer(): DeploymentLayerRuntime {
     splitEnvTemplates: [],
     commandRules: [],
     brokeredTools: [],
+    personalSkillManifests: [],
+    personalWorkspaceFiles: [],
   };
 }
 
@@ -73,7 +85,12 @@ function toolService(tool: ToolDescriptor, why: string): string {
   );
 }
 
-export function resolvedDeploymentLayer(dir: string, tools: ToolDescriptor[]): DeploymentLayerRuntime {
+export function resolvedDeploymentLayer(
+  dir: string,
+  tools: ToolDescriptor[],
+  personalSkillManifests: SkillManifest[] = [],
+  personalWorkspaceFiles: PersonalDefaultFile[] = [],
+): DeploymentLayerRuntime {
   assertDisjointCredentialLinks(tools);
   const withAuth = tools.filter((t) => t.auth);
   const brokered = withAuth.filter((t) => t.auth!.broker);
@@ -114,6 +131,8 @@ export function resolvedDeploymentLayer(dir: string, tools: ToolDescriptor[]): D
         broker: t.auth!.broker!,
       };
     }),
+    personalSkillManifests,
+    personalWorkspaceFiles,
   };
 }
 
@@ -128,12 +147,43 @@ export function replaceDeploymentLayer(target: DeploymentLayerRuntime, source: D
     "splitEnvTemplates",
     "commandRules",
     "brokeredTools",
+    "personalSkillManifests",
+    "personalWorkspaceFiles",
   ] as const) {
     target[key].splice(0, target[key].length, ...(source[key] as never[]));
   }
 }
 
 const JUNK_FILE = /^(?:\.DS_Store|Thumbs\.db|\._.*)$/;
+
+function readTextTree(root: string, pathOf: (path: string) => string): PersonalDefaultFile[] {
+  if (!existsSync(root)) return [];
+  const files: PersonalDefaultFile[] = [];
+  const walk = (dir: string, prefix: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (JUNK_FILE.test(entry.name)) continue;
+      const path = join(dir, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(path, rel);
+        continue;
+      }
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`${path} must be a regular file`);
+      const bytes = readFileSync(path);
+      if (isProbablyBinary(bytes)) {
+        throw new Error(`${path} must be a text file`);
+      }
+      files.push({
+        path: pathOf(rel),
+        content: bytes.toString("utf8"),
+        ...((stat.mode & 0o111) !== 0 ? { executable: true } : {}),
+      });
+    }
+  };
+  walk(root, "");
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
 
 export function loadDeploymentLayer(dir: string): DeploymentLayerRuntime {
   if (!existsSync(dir)) {
@@ -166,5 +216,13 @@ export function loadDeploymentLayer(dir: string): DeploymentLayerRuntime {
       tools.push(desc);
     }
   }
-  return resolvedDeploymentLayer(dir, tools);
+  const personalSkills = readTextTree(join(dir, "personal", "skills"), safeSkillFilePath);
+  const personalWorkspaceFiles = readTextTree(join(dir, "personal", "workspace"), safePersonalWorkspacePath);
+  assertNoPersonalWorkspaceConflicts(personalWorkspaceFiles);
+  return resolvedDeploymentLayer(
+    dir,
+    tools,
+    parseDefaultSkillTrees(personalSkills, "personal default skill"),
+    personalWorkspaceFiles,
+  );
 }

--- a/src/deployment/postdeploy-smoke.ts
+++ b/src/deployment/postdeploy-smoke.ts
@@ -1,4 +1,4 @@
-import { resolvePgCaTrust } from "../persistence/pg-pool.ts";
+import { pgConnectionConfig, resolvePgCaTrust } from "../persistence/pg-pool.ts";
 import { randomUUID } from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { PORTAL_IDENTITY_HEADER } from "../auth/portal-identity.ts";
@@ -263,13 +263,15 @@ async function checkDatabase(config: PostdeployConfig): Promise<void> {
   const { databaseUrl } = config;
   if (!databaseUrl) throw new Error("postdeploy smoke requires DATABASE_URL");
   const pg = (await import("pg")).default;
-  const client = new pg.Client({
-    connectionString: databaseUrl,
-    ...resolvePgCaTrust({
-      ...(config.databaseCaCert ? { cert: config.databaseCaCert } : {}),
-      ...(config.databaseCaCertFile ? { certFile: config.databaseCaCertFile } : {}),
-    }),
-  });
+  const client = new pg.Client(
+    pgConnectionConfig(
+      databaseUrl,
+      resolvePgCaTrust({
+        ...(config.databaseCaCert ? { cert: config.databaseCaCert } : {}),
+        ...(config.databaseCaCertFile ? { certFile: config.databaseCaCertFile } : {}),
+      }),
+    ),
+  );
   await client.connect();
   try {
     const unsafe = await client.query(PARALLEL_EXCEPTION_QUERY);

--- a/src/monitors/monitor-poller.ts
+++ b/src/monitors/monitor-poller.ts
@@ -255,7 +255,9 @@ export function createMonitorPoller(deps: MonitorPollerDeps): MonitorPoller {
         let handle = handles.get(rec.scopeId);
         if (!handle) {
           try {
-            handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }]);
+            handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }], {
+              personalDefaults: false,
+            });
           } catch (e) {
             await deps.monitors.recordError(m.id, errMessage(e));
             continue;

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -113,8 +113,17 @@ export function pgConnectionConfig(
   ssl?: { ca: string; rejectUnauthorized: true };
 } {
   if (!trust.ssl) return { connectionString };
-  const url = new URL(connectionString);
-  for (const name of ["sslmode", "sslcert", "sslkey", "sslrootcert"]) url.searchParams.delete(name);
+  if (!/^postgres(?:ql)?:\/\//i.test(connectionString)) throw new Error("DATABASE_URL is invalid");
+  let url: URL;
+  try {
+    url = new URL(connectionString);
+  } catch {
+    throw new Error("DATABASE_URL is invalid");
+  }
+  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") throw new Error("DATABASE_URL is invalid");
+  for (const name of ["ssl", "sslmode", "sslcert", "sslkey", "sslrootcert", "sslnegotiation", "uselibpqcompat"]) {
+    url.searchParams.delete(name);
+  }
   return { connectionString: url.toString(), ssl: trust.ssl };
 }
 

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -79,11 +79,13 @@ async function applyDdl(pool: Pool, statements: string[]): Promise<void> {
  * applied to every pg pool and client this process opens — database CA trust
  * is inherently process-global, like NODE_EXTRA_CA_CERTS.
  */
-export function resolvePgCaTrust(opts: { cert?: string; certFile?: string }): { ssl?: { ca: string } } {
-  if (opts.cert?.trim()) return { ssl: { ca: opts.cert } };
+type PgCaTrust = { ssl?: { ca: string; rejectUnauthorized: true } };
+
+export function resolvePgCaTrust(opts: { cert?: string; certFile?: string }): PgCaTrust {
+  if (opts.cert?.trim()) return { ssl: { ca: opts.cert, rejectUnauthorized: true } };
   if (opts.certFile?.trim()) {
     try {
-      return { ssl: { ca: readFileSync(opts.certFile, "utf8") } };
+      return { ssl: { ca: readFileSync(opts.certFile, "utf8"), rejectUnauthorized: true } };
     } catch (e) {
       throw new Error(`DATABASE_CA_CERT_FILE is set but unreadable (${opts.certFile}): ${errMessage(e)}`, {
         cause: e,
@@ -93,14 +95,27 @@ export function resolvePgCaTrust(opts: { cert?: string; certFile?: string }): { 
   return {};
 }
 
-let installedCaTrust: { ssl?: { ca: string } } = {};
+let installedCaTrust: PgCaTrust = {};
 
 export function configurePgCaTrust(opts: { cert?: string; certFile?: string }): void {
   installedCaTrust = resolvePgCaTrust(opts);
 }
 
-export function pgCaOptions(): { ssl?: { ca: string } } {
+export function pgCaOptions(): PgCaTrust {
   return installedCaTrust;
+}
+
+export function pgConnectionConfig(
+  connectionString: string,
+  trust: PgCaTrust = pgCaOptions(),
+): {
+  connectionString: string;
+  ssl?: { ca: string; rejectUnauthorized: true };
+} {
+  if (!trust.ssl) return { connectionString };
+  const url = new URL(connectionString);
+  for (const name of ["sslmode", "sslcert", "sslkey", "sslrootcert"]) url.searchParams.delete(name);
+  return { connectionString: url.toString(), ssl: trust.ssl };
 }
 
 export function createPgPool(connectionString: string, statements: string[]): PgPool {
@@ -111,7 +126,7 @@ export function createPgPool(connectionString: string, statements: string[]): Pg
     if (!poolP) {
       poolP = (async () => {
         const pg = (await import("pg")).default;
-        const p = new pg.Pool({ connectionString, ...pgCaOptions() });
+        const p = new pg.Pool(pgConnectionConfig(connectionString));
         p.on("error", (err) => console.error("[pg] idle client error:", errMessage(err)));
         try {
           await applyDdl(p, schema);

--- a/src/personal-defaults.ts
+++ b/src/personal-defaults.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from "node:crypto";
+import type { AdvisoryLock } from "./persistence/advisory-lock.ts";
+import { createNoopAdvisoryLock } from "./persistence/advisory-lock.ts";
+import type { Sandbox, SandboxHandle, ProvisionOptions } from "./sandbox/sandbox.ts";
+import { detectPathCollisions, SKILL_MATERIALIZATION_LOCK, skillRecordPaths } from "./skills/skill-collision.ts";
+import { parseSeedSkill } from "./skills/seed.ts";
+import { safeSkillFilePath, type SkillFile, type SkillManifest, type SkillStore } from "./skills/skill-store.ts";
+import { parseScopeId, type ScopeId, type WorkspaceLayer } from "./types.ts";
+import { createKeyedQueue } from "./util/async.ts";
+import { swallowAs } from "./util/errors.ts";
+import { shq } from "./util/shell.ts";
+
+export interface PersonalDefaultFile {
+  path: string;
+  content: string;
+  executable?: boolean;
+}
+
+export interface PersonalDefaultsService {
+  ensure(scopeId: ScopeId | undefined): Promise<void>;
+}
+
+export const PERSONAL_DEFAULT_CREATED_BY = "system:personal-default";
+export const PERSONAL_DEFAULT_REVIEWER = "system:personal-default-reviewer";
+
+const INSTALL_DEFAULT_SCRIPT = `const fs=require("node:fs"),cp=require("node:child_process"),c=fs.constants;
+const [root,temp,target]=process.argv.slice(1),parts=target.split("/"),base=parts.pop();
+let fd;
+try {
+  fd=fs.openSync(root,c.O_RDONLY|c.O_DIRECTORY|c.O_NOFOLLOW);
+  for(const part of parts){
+    const next="/proc/self/fd/"+fd+"/"+part;
+    try{fs.mkdirSync(next)}catch(error){if(error.code!=="EEXIST")throw error}
+    const nextFd=fs.openSync(next,c.O_RDONLY|c.O_DIRECTORY|c.O_NOFOLLOW);
+    fs.closeSync(fd);
+    fd=nextFd;
+  }
+  const result=cp.spawnSync("ln",["-T",root+"/"+temp,"/proc/self/fd/3/"+base],{stdio:["ignore","ignore","ignore",fd]});
+  if(result.status!==0){
+    try{fs.lstatSync("/proc/self/fd/"+fd+"/"+base);process.exit(0)}catch{}
+    process.exit(result.status??1);
+  }
+} finally {
+  if(fd!==undefined)try{fs.closeSync(fd)}catch{}
+  try{fs.unlinkSync(root+"/"+temp)}catch{}
+}`;
+
+export function safePersonalWorkspacePath(path: string): string {
+  if (!path || path.startsWith("/") || path.includes("\\") || /^[A-Za-z]:/.test(path)) {
+    throw new Error(`invalid personal workspace path: ${path}`);
+  }
+  const parts = path.split("/");
+  if (parts.some((part) => !part || part === "." || part === ".." || part.includes("\0"))) {
+    throw new Error(`invalid personal workspace path: ${path}`);
+  }
+  return parts.join("/");
+}
+
+export function assertNoPersonalWorkspaceConflicts(files: readonly PersonalDefaultFile[]): void {
+  const paths = files.map((file) => safePersonalWorkspacePath(file.path)).sort();
+  for (const [index, path] of paths.entries()) {
+    const descendant = paths[index + 1];
+    if (descendant?.startsWith(`${path}/`)) {
+      throw new Error(`personal workspace defaults conflict: ${path} is an ancestor of ${descendant}`);
+    }
+  }
+}
+
+export function parseDefaultSkillTrees(files: readonly PersonalDefaultFile[], label: string): SkillManifest[] {
+  const byDir = new Map<string, PersonalDefaultFile[]>();
+  for (const file of files) {
+    const path = safeSkillFilePath(file.path);
+    const slash = path.indexOf("/");
+    if (slash < 1) throw new Error(`${label} path must be <id>/<file>: ${path}`);
+    const dir = path.slice(0, slash);
+    const entries = byDir.get(dir) ?? [];
+    entries.push({ ...file, path });
+    byDir.set(dir, entries);
+  }
+  const manifests: SkillManifest[] = [];
+  const names = new Set<string>();
+  for (const [dir, entries] of [...byDir].sort(([a], [b]) => a.localeCompare(b))) {
+    const root = entries.find((file) => file.path === `${dir}/SKILL.md`);
+    if (!root) throw new Error(`${label} ${dir} has no SKILL.md`);
+    const manifest = parseSeedSkill(root.content);
+    if (names.has(manifest.name)) throw new Error(`duplicate ${label} name: ${manifest.name}`);
+    names.add(manifest.name);
+    manifest.files = entries
+      .filter((file) => file !== root)
+      .map((file): SkillFile => ({
+        path: safeSkillFilePath(file.path.slice(dir.length + 1)),
+        content: file.content,
+        ...(file.executable === true ? { executable: true } : {}),
+      }));
+    manifests.push(manifest);
+  }
+  const claimed = new Map<string, string>();
+  for (const manifest of manifests) {
+    const collisions = detectPathCollisions(skillRecordPaths(manifest.name, manifest.files), claimed);
+    if (collisions.length) {
+      throw new Error(
+        `${label} "${manifest.name}" materializes over ${collisions[0]!.path}, already claimed by ${collisions[0]!.owner}`,
+      );
+    }
+    for (const path of skillRecordPaths(manifest.name, manifest.files)) {
+      claimed.set(path, `${label} "${manifest.name}"`);
+    }
+  }
+  return manifests;
+}
+
+export function createPersonalDefaultsService(opts: {
+  skills: SkillStore;
+  manifests: () => readonly SkillManifest[];
+  advisoryLock?: AdvisoryLock;
+}): PersonalDefaultsService {
+  const queue = createKeyedQueue<string>();
+  const advisoryLock = opts.advisoryLock ?? createNoopAdvisoryLock();
+  const completed = new Map<ScopeId, string>();
+  return {
+    async ensure(scopeId): Promise<void> {
+      if (!scopeId || parseScopeId(scopeId).kind !== "personal") return;
+      const manifests = opts.manifests();
+      if (!manifests.length) return;
+      const revision = manifests
+        .map((manifest) => manifest.name)
+        .sort()
+        .join("\0");
+      if (completed.get(scopeId) === revision) return;
+      const existingBeforeLock = (await opts.skills.list()).filter((skill) => skill.scopeId === scopeId);
+      const needsEnsure = existingBeforeLock.some(
+        (skill) =>
+          manifests.some((manifest) => manifest.name === skill.manifest.name) &&
+          skill.createdBy === PERSONAL_DEFAULT_CREATED_BY &&
+          skill.status !== "published" &&
+          skill.status !== "archived",
+      );
+      const existingNames = new Set(existingBeforeLock.map((skill) => skill.manifest.name));
+      if (!needsEnsure && manifests.every((manifest) => existingNames.has(manifest.name))) {
+        completed.set(scopeId, revision);
+        return;
+      }
+      await queue(scopeId, () =>
+        advisoryLock.withLock(SKILL_MATERIALIZATION_LOCK, async () => {
+          if (completed.get(scopeId) === revision) return;
+          const existing = (await opts.skills.list()).filter((skill) => skill.scopeId === scopeId);
+          for (const source of manifests) {
+            const found = existing.find((skill) => skill.manifest.name === source.name);
+            if (found) {
+              if (
+                found.createdBy === PERSONAL_DEFAULT_CREATED_BY &&
+                found.status !== "published" &&
+                found.status !== "archived"
+              ) {
+                await opts.skills.review(found.id, PERSONAL_DEFAULT_REVIEWER, found.manifest.requiredCapabilities);
+                await opts.skills.publish(found.id);
+              }
+              continue;
+            }
+            const manifest = structuredClone(source);
+            const skill = await opts.skills.create({
+              scopeId,
+              manifest,
+              createdBy: PERSONAL_DEFAULT_CREATED_BY,
+            });
+            await opts.skills.review(skill.id, PERSONAL_DEFAULT_REVIEWER, manifest.requiredCapabilities);
+            await opts.skills.publish(skill.id);
+            existing.push(skill);
+          }
+          completed.set(scopeId, revision);
+        }),
+      );
+    },
+  };
+}
+
+export async function materializePersonalWorkspaceDefaults(
+  sandbox: Sandbox,
+  handle: SandboxHandle,
+  files: readonly PersonalDefaultFile[],
+): Promise<void> {
+  for (const file of [...files].sort((a, b) => a.path.localeCompare(b.path))) {
+    const path = safePersonalWorkspacePath(file.path);
+    const exists = await sandbox.run(handle, `[ -e ${shq(path)} ] || [ -L ${shq(path)} ]`);
+    if (exists.code === 0) continue;
+    const temp = `.personal-default-${randomUUID()}`;
+    await sandbox.writeFile(handle, temp, file.content);
+    if (file.executable === true) {
+      const executable = await sandbox.run(handle, `chmod +x -- ${shq(temp)}`);
+      if (executable.code !== 0) throw new Error(`could not mark personal workspace default executable: ${path}`);
+    }
+    const installed = await sandbox.run(
+      handle,
+      `node -e ${shq(INSTALL_DEFAULT_SCRIPT)} ${shq(handle.rootDir)} ${shq(temp)} ${shq(path)}`,
+    );
+    if (installed.code === 0) continue;
+    throw new Error(`could not create personal workspace default: ${path}`);
+  }
+}
+
+export function withPersonalWorkspaceDefaults(sandbox: Sandbox, files: () => readonly PersonalDefaultFile[]): Sandbox {
+  const queue = createKeyedQueue<string>();
+  return {
+    ...sandbox,
+    async provision(layers: WorkspaceLayer[], opts?: ProvisionOptions): Promise<SandboxHandle> {
+      const defaults = files();
+      const writable = layers.find((layer) => layer.mode === "rw")?.scopeId;
+      if (
+        !defaults.length ||
+        opts?.scratch ||
+        opts?.personalDefaults !== true ||
+        !writable ||
+        parseScopeId(writable).kind !== "personal"
+      ) {
+        return sandbox.provision(layers, opts);
+      }
+      return queue(writable, async () => {
+        const handle = await sandbox.provision(layers, opts);
+        try {
+          await materializePersonalWorkspaceDefaults(sandbox, handle, defaults);
+          return handle;
+        } catch (error) {
+          await sandbox
+            .teardown(handle)
+            .catch(swallowAs("personal defaults: teardown after failed provision", undefined));
+          throw error;
+        }
+      });
+    },
+  };
+}

--- a/src/processes/process-reaper.ts
+++ b/src/processes/process-reaper.ts
@@ -20,7 +20,9 @@ export function createReaperKillHook(
   const termGraceMs = opts?.termGraceMs ?? 5_000;
   const killGraceMs = opts?.killGraceMs ?? 2_000;
   return async (rec) => {
-    const handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }]);
+    const handle = await sandbox.provision([{ scopeId: rec.scopeId, mode: "rw", mountPath: "" }], {
+      personalDefaults: false,
+    });
     try {
       await sandbox.signalProcess(handle, rec.processId, "TERM");
       let status = await awaitProcessExit(sandbox, handle, rec.processId, termGraceMs);

--- a/src/sandbox/aws-sandbox.ts
+++ b/src/sandbox/aws-sandbox.ts
@@ -6,7 +6,7 @@ import { createNoopAdvisoryLock, type AdvisoryLock } from "../persistence/adviso
 import { createMemoryMap, type DurableMap } from "../persistence/durable-map.ts";
 import { createKeyedQueue } from "../util/async.ts";
 import { scopeStorageKey } from "../util/scope-storage-key.ts";
-import { swallow, swallowAs, errMessage } from "../util/errors.ts";
+import { swallowAs, errMessage } from "../util/errors.ts";
 import { shq } from "../util/shell.ts";
 import { nonInteractiveShellPrefix } from "./sandbox-env.ts";
 import { createExecProcessSessions, type ExecProcessIo } from "./exec-process-session.ts";
@@ -195,8 +195,8 @@ export function createAwsSandbox(workspace: WorkspaceStore, opts: AwsSandboxOpti
       const status =
         (e as { $metadata?: { httpStatusCode?: number }; status?: number })?.$metadata?.httpStatusCode ??
         (e as { status?: number })?.status;
-      if (!/NoSuchKey|NotFound/.test(code) && status !== 404) swallow("aws-sandbox: hydrate", e);
-      return false;
+      if (/NoSuchKey|NotFound/.test(code) || status === 404) return false;
+      throw e;
     }
     if (!bytes || !bytes.length) return false;
     await writeAbsBytes(id, HOME_TAR, bytes);
@@ -262,15 +262,21 @@ export function createAwsSandbox(workspace: WorkspaceStore, opts: AwsSandboxOpti
           if (alive && stale) {
             endpointById.set(stored.microvmId, stored.endpoint);
             await ensureRunning(stored.microvmId).catch(() => {});
-            await snapshotHome(scope, stored.microvmId).catch((e) =>
-              reportError("sandbox_snapshot", "rotate_snapshot_failed", errMessage(e), scope),
-            );
+            await snapshotHome(scope, stored.microvmId);
             await api.terminate(stored.microvmId).catch(() => {});
           }
         }
         const body = await launchBody(scope);
         scopeByMicrovm.set(body.id, scope);
-        const hydrated = await hydrateHome(scope, body.id);
+        let hydrated: boolean;
+        try {
+          hydrated = await hydrateHome(scope, body.id);
+        } catch (error) {
+          scopeByMicrovm.delete(body.id);
+          endpointById.delete(body.id);
+          await api.terminate(body.id).catch(() => {});
+          throw error;
+        }
         await store.put(scope, {
           microvmId: body.id,
           endpoint: body.endpoint,

--- a/src/sandbox/sandbox-migration-runner.ts
+++ b/src/sandbox/sandbox-migration-runner.ts
@@ -5,7 +5,7 @@ import { shq } from "../util/shell.ts";
 import { copyHome, type CopyHomeResult } from "./sandbox-migrate.ts";
 import type { SandboxBackendName, SandboxRoute } from "./sandbox-routing.ts";
 import { capabilitiesLostMovingTo, type ProvisionOptions, type Sandbox, type SandboxHandle } from "./sandbox.ts";
-import type { WorkspaceLayer } from "../types.ts";
+import { parseScopeId, type ScopeId, type WorkspaceLayer } from "../types.ts";
 
 export interface SandboxMigrationOptions {
   backends: Partial<Record<SandboxBackendName, Sandbox>>;
@@ -74,6 +74,8 @@ export function createSandboxMigrationRunner(opts: SandboxMigrationOptions): San
       );
     }
     const provOpts = (await opts.provisionOptions?.(scopeId)) ?? {};
+    provOpts.personalDefaults ??= parseScopeId(scopeId as ScopeId).kind === "personal";
+    provOpts.personalDefaults ??= parseScopeId(scopeId as ScopeId).kind === "personal";
     const fromHandle = await fromSandbox.provision(scopeLayers(scopeId), provOpts);
     const toHandle = await toSandbox.provision(scopeLayers(scopeId), provOpts);
     const fromHome = fromHandle.homeDir ?? fromSandbox.profile.spec?.homeDir ?? "/root";

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -66,6 +66,7 @@ export interface ProvisionOptions {
   egressToken?: string;
   scratch?: { key: string };
   routeScopeId?: string;
+  personalDefaults?: boolean;
   onStatus?: (text: string) => void;
 }
 

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -65,6 +65,7 @@ import { createPostgresDeliveryStore } from "./delivery/postgres-delivery-store.
 import { wireRunResultDeliveries } from "./delivery/run-result-delivery.ts";
 import { createDirectoryStore, type DirectoryStore } from "./directory/directory-store.ts";
 import { createPostgresDirectoryStore } from "./directory/postgres-directory-store.ts";
+import { createPersonalDefaultsService, withPersonalWorkspaceDefaults } from "./personal-defaults.ts";
 import {
   createMemoryEnvironmentStore,
   createPostgresEnvironmentStore,
@@ -564,6 +565,11 @@ export function buildApp(
   const resolution = createResolutionService(config.orgId, configStore, acl);
 
   const workspace = createLocalWorkspaceStore(config.dataDir);
+  const personalDefaults = createPersonalDefaultsService({
+    skills,
+    manifests: () => deploymentLayer.personalSkillManifests,
+    advisoryLock,
+  });
   const blobTransfer: BlobTransferStore =
     config.transferStore === "s3" && config.s3Bucket
       ? createS3BlobTransferStore({
@@ -598,44 +604,54 @@ export function buildApp(
       message: e.message,
       scopeLabel: (e.scopeLabel ?? "unknown") as ScopeId,
     });
+  const withPersonalDefaults = (backend: Sandbox): Sandbox =>
+    withPersonalWorkspaceDefaults(backend, () => deploymentLayer.personalWorkspaceFiles);
   const buildLocal = (): Sandbox =>
-    createLocalSandbox(workspace, {
-      ...config.localSandbox,
-      onError: sandboxOnError,
-    });
+    withPersonalDefaults(
+      createLocalSandbox(workspace, {
+        ...config.localSandbox,
+        onError: sandboxOnError,
+      }),
+    );
   const buildSprites = (): Sandbox =>
-    createSpritesSandbox(workspace, {
-      ...config.spritesSandbox,
-      blobTransfer,
-      extraTools: deploymentLayer.advertisedTools,
-      credentialPaths: deploymentLayer.credentialPaths,
-      ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
-      ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
-      ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
-      onError: sandboxOnError,
-    });
+    withPersonalDefaults(
+      createSpritesSandbox(workspace, {
+        ...config.spritesSandbox,
+        blobTransfer,
+        extraTools: deploymentLayer.advertisedTools,
+        credentialPaths: deploymentLayer.credentialPaths,
+        ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
+        ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
+        ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
+        onError: sandboxOnError,
+      }),
+    );
   const buildSmolmachines = (): Sandbox =>
-    createSmolmachinesSandbox(workspace, {
-      ...config.smolmachinesSandbox,
-      blobTransfer,
-      extraTools: deploymentLayer.advertisedTools,
-      credentialPaths: deploymentLayer.credentialPaths,
-      ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
-      ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
-      ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
-      onError: sandboxOnError,
-    });
+    withPersonalDefaults(
+      createSmolmachinesSandbox(workspace, {
+        ...config.smolmachinesSandbox,
+        blobTransfer,
+        extraTools: deploymentLayer.advertisedTools,
+        credentialPaths: deploymentLayer.credentialPaths,
+        ...(config.signingSecret ? { signingSecret: config.signingSecret } : {}),
+        ...(config.capabilitySecret ? { capabilitySecret: config.capabilitySecret } : {}),
+        ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
+        onError: sandboxOnError,
+      }),
+    );
   const buildAws = (): Sandbox => {
     if (!config.awsSandbox.s3Bucket) throw new Error("SANDBOX_BACKEND=aws requires AWS_SANDBOX_S3_BUCKET");
-    return createAwsSandbox(workspace, {
-      ...config.awsSandbox,
-      s3Bucket: config.awsSandbox.s3Bucket,
-      advisoryLock,
-      extraTools: deploymentLayer.advertisedTools,
-      credentialPaths: deploymentLayer.credentialPaths,
-      store: artifactMap<StoredMicrovm>("aws_sandbox_bodies"),
-      onError: sandboxOnError,
-    });
+    return withPersonalDefaults(
+      createAwsSandbox(workspace, {
+        ...config.awsSandbox,
+        s3Bucket: config.awsSandbox.s3Bucket,
+        advisoryLock,
+        extraTools: deploymentLayer.advertisedTools,
+        credentialPaths: deploymentLayer.credentialPaths,
+        store: artifactMap<StoredMicrovm>("aws_sandbox_bodies"),
+        onError: sandboxOnError,
+      }),
+    );
   };
   const buildBackend: Record<Config["sandboxBackend"], () => Sandbox> = {
     local: buildLocal,
@@ -1082,6 +1098,7 @@ export function buildApp(
     layerBrokerFor,
     brokeredTools,
     deploymentLayer,
+    personalDefaults,
   };
   const orchestrator = createOrchestrator(orchestratorDeps);
 
@@ -1209,6 +1226,7 @@ export function buildApp(
     environments,
     deploy: deployService,
     deploymentLayer,
+    personalDefaults,
     ...(processes ? { processes } : {}),
     monitors,
     sandbox,

--- a/test/aws-sandbox.test.ts
+++ b/test/aws-sandbox.test.ts
@@ -98,6 +98,22 @@ test("durable $HOME: state survives the body dying via the S3 snapshot", async (
   assert.equal(await sb.readFile(h2, "notes/todo.txt"), "buy milk");
 });
 
+test("snapshot read failures abort provisioning instead of starting with an empty home", async () => {
+  const fake = installFakeMicrovm();
+  const send = fake.s3.send;
+  fake.s3.send = async (command) => {
+    if ((command as { constructor: { name: string } }).constructor.name === "GetObjectCommand") {
+      throw new Error("S3 unavailable");
+    }
+    return send(command);
+  };
+  const sb = makeSandbox(fake, { snapshotIntervalMs: 0 });
+
+  await assert.rejects(sb.provision(rw(scopeId("personal", "U-fail-closed"))), /S3 unavailable/);
+  assert.equal(fake.s3store.size, 0);
+  assert.equal([...fake.bodies.values()][0]?.state, "TERMINATED");
+});
+
 test("a body nearing the 8h cap is rotated: snapshot, terminate, relaunch, rehydrate", async () => {
   const fake = installFakeMicrovm();
   const sb = makeSandbox(fake, { rotateAfterSeconds: 0, snapshotIntervalMs: 0 });
@@ -111,6 +127,26 @@ test("a body nearing the 8h cap is rotated: snapshot, terminate, relaunch, rehyd
   assert.notEqual(h2.id, h1.id);
   assert.equal(fake.bodies.get(h1.id)!.state, "TERMINATED", "old body terminated");
   assert.equal(await sb.readFile(h2, "keep.txt"), "v1", "state carried across the rotation");
+});
+
+test("rotation keeps the old body when its final snapshot fails", async () => {
+  const fake = installFakeMicrovm();
+  const sb = makeSandbox(fake, { rotateAfterSeconds: 0, snapshotIntervalMs: 0 });
+  const layers = rw(scopeId("personal", "U-rotate-fail"));
+  const h1 = await sb.provision(layers);
+  await sb.writeFile(h1, "keep.txt", "v1");
+  await sb.teardown(h1);
+  const send = fake.s3.send;
+  fake.s3.send = async (command) => {
+    if ((command as { constructor: { name: string } }).constructor.name === "PutObjectCommand") {
+      throw new Error("S3 unavailable");
+    }
+    return send(command);
+  };
+  await sleep(3);
+
+  await assert.rejects(sb.provision(layers), /S3 unavailable/);
+  assert.notEqual(fake.bodies.get(h1.id)?.state, "TERMINATED");
 });
 
 test("reapDeepIdle terminates a parked body but keeps its durable S3 state", async () => {

--- a/test/deployment-layer-load.test.ts
+++ b/test/deployment-layer-load.test.ts
@@ -149,6 +149,27 @@ test("loadDeploymentLayer: a dir with no tools/ is a valid, empty layer", () => 
   assert.deepEqual(layer.advertisedTools, []);
 });
 
+test("loadDeploymentLayer resolves personal skill and workspace defaults", () => {
+  const dir = mkdtempSync(join(tmpdir(), "layer-personal-"));
+  mkdirSync(join(dir, "personal", "skills", "starter"), { recursive: true });
+  writeFileSync(
+    join(dir, "personal", "skills", "starter", "SKILL.md"),
+    "---\nname: starter\ndescription: Starter skill.\n---\nStarter workflow.\n",
+  );
+  writeFileSync(join(dir, "personal", "skills", "starter", "reference.md"), "reference\n");
+  mkdirSync(join(dir, "personal", "workspace", "config"), { recursive: true });
+  writeFileSync(join(dir, "personal", "workspace", "AGENTS.md"), "personal defaults\n");
+  writeFileSync(join(dir, "personal", "workspace", "config", "personal.yaml"), "enabled: false\n");
+
+  const layer = loadDeploymentLayer(dir);
+  assert.equal(layer.personalSkillManifests[0]?.name, "starter");
+  assert.equal(layer.personalSkillManifests[0]?.files?.[0]?.path, "reference.md");
+  assert.deepEqual(layer.personalWorkspaceFiles, [
+    { path: "AGENTS.md", content: "personal defaults\n" },
+    { path: "config/personal.yaml", content: "enabled: false\n" },
+  ]);
+});
+
 test("loadDeploymentLayer throws when the configured dir itself is missing", () => {
   assert.throws(() => loadDeploymentLayer("/definitely/does/not/exist"), /does not exist/);
 });

--- a/test/deployment-layer-store.test.ts
+++ b/test/deployment-layer-store.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import {
   createDeploymentLayerStore,
   DeploymentLayerPersistedError,
@@ -86,6 +87,78 @@ test("the durable deployment layer versions by content, hydrates runtime state, 
   );
   assert.equal(hydratedRuntime.advertisedTools[0], "acme v2");
   assert.equal((await hydrated.hydrate())?.version, 2);
+});
+
+test("the durable deployment layer hydrates personal defaults without publishing them to the org", async () => {
+  const backing = createMemoryMap<StoredDeploymentLayer>();
+  const skills = createSkillStore({ signingSecret: "layer-test" });
+  const org = scopeId("org", "default-org");
+  const runtime = emptyDeploymentLayer();
+  const store = createDeploymentLayerStore({ backing, runtime, skills, scopeId: org });
+  const bundle: DeploymentLayerBundle = {
+    contract: 1,
+    tools: [],
+    skills: [],
+    personalSkills: [
+      {
+        path: "personal/skills/starter/SKILL.md",
+        content: "---\nname: starter\ndescription: Starter skill.\n---\nStarter workflow.\n",
+      },
+    ],
+    personalWorkspace: [{ path: "personal/workspace/AGENTS.md", content: "personal defaults\n" }],
+  };
+
+  await store.put(bundle, "test");
+  assert.equal(runtime.personalSkillManifests[0]?.name, "starter");
+  assert.deepEqual(runtime.personalWorkspaceFiles, [{ path: "AGENTS.md", content: "personal defaults\n" }]);
+  assert.equal((await skills.resolve("starter", [org])).skill, null);
+
+  const hydratedRuntime = emptyDeploymentLayer();
+  const hydrated = createDeploymentLayerStore({ backing, runtime: hydratedRuntime, skills, scopeId: org });
+  await hydrated.hydrate();
+  assert.equal(hydratedRuntime.personalSkillManifests[0]?.name, "starter");
+  assert.deepEqual(hydratedRuntime.personalWorkspaceFiles, [{ path: "AGENTS.md", content: "personal defaults\n" }]);
+});
+
+test("legacy deployment bundles retain their recorded content hash", async () => {
+  const backing = createMemoryMap<StoredDeploymentLayer>();
+  const bundle: DeploymentLayerBundle = { contract: 1, tools: [], skills: [] };
+  const store = createDeploymentLayerStore({
+    backing,
+    runtime: emptyDeploymentLayer(),
+    skills: createSkillStore({ signingSecret: "layer-test" }),
+    scopeId: scopeId("org", "default-org"),
+  });
+
+  const record = await store.put(bundle, "test");
+  assert.equal(record.contentHash, createHash("sha256").update(JSON.stringify(bundle)).digest("hex"));
+  assert.equal(record.bundle.personalSkills, undefined);
+  assert.equal(record.bundle.personalWorkspace, undefined);
+});
+
+test("personal workspace defaults reject file and descendant path conflicts", async () => {
+  const store = createDeploymentLayerStore({
+    backing: createMemoryMap<StoredDeploymentLayer>(),
+    runtime: emptyDeploymentLayer(),
+    skills: createSkillStore({ signingSecret: "layer-test" }),
+    scopeId: scopeId("org", "default-org"),
+  });
+
+  await assert.rejects(
+    store.put(
+      {
+        contract: 1,
+        tools: [],
+        skills: [],
+        personalWorkspace: [
+          { path: "personal/workspace/config", content: "file\n" },
+          { path: "personal/workspace/config/default.yaml", content: "enabled: false\n" },
+        ],
+      },
+      "test",
+    ),
+    /personal workspace defaults conflict/,
+  );
 });
 
 test("invalid descriptors never replace the durable current layer", async () => {

--- a/test/personal-defaults.test.ts
+++ b/test/personal-defaults.test.ts
@@ -1,0 +1,221 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPersonalDefaultsService,
+  materializePersonalWorkspaceDefaults,
+  parseDefaultSkillTrees,
+  PERSONAL_DEFAULT_CREATED_BY,
+  safePersonalWorkspacePath,
+  withPersonalWorkspaceDefaults,
+  type PersonalDefaultFile,
+} from "../src/personal-defaults.ts";
+import { createSkillStore } from "../src/skills/skill-store.ts";
+import type { Sandbox, SandboxHandle } from "../src/sandbox/sandbox.ts";
+import { scopeId, type WorkspaceLayer } from "../src/types.ts";
+
+const manifest = () =>
+  parseDefaultSkillTrees(
+    [
+      {
+        path: "starter/SKILL.md",
+        content: "---\nname: starter\ndescription: Starter skill.\n---\nUse the starter workflow.\n",
+      },
+      { path: "starter/reference.md", content: "reference\n" },
+    ],
+    "personal default skill",
+  )[0]!;
+
+test("personal skill defaults install once and preserve edits and archives", async () => {
+  const skills = createSkillStore({ signingSecret: "test" });
+  const service = createPersonalDefaultsService({ skills, manifests: () => [manifest()] });
+  const personal = scopeId("personal", "person@example.com");
+
+  await Promise.all([service.ensure(personal), service.ensure(personal), service.ensure(personal)]);
+  let stored = (await skills.list()).filter((skill) => skill.scopeId === personal);
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0]!.status, "published");
+  assert.equal(stored[0]!.manifest.files?.[0]?.path, "reference.md");
+
+  await skills.update(stored[0]!.id, { ...stored[0]!.manifest, body: "personally edited" });
+  await service.ensure(personal);
+  stored = (await skills.list()).filter((skill) => skill.scopeId === personal);
+  assert.equal(stored[0]!.manifest.body, "personally edited");
+
+  await skills.archive(stored[0]!.id);
+  await createPersonalDefaultsService({ skills, manifests: () => [manifest()] }).ensure(personal);
+  stored = (await skills.list()).filter((skill) => skill.scopeId === personal);
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0]!.status, "archived");
+
+  await service.ensure(scopeId("channel", "general"));
+  assert.equal((await skills.list()).length, 1);
+});
+
+test("personal skill defaults add newly introduced names without changing existing names", async () => {
+  const skills = createSkillStore({ signingSecret: "test" });
+  let manifests = [manifest()];
+  const service = createPersonalDefaultsService({ skills, manifests: () => manifests });
+  const personal = scopeId("personal", "person@example.com");
+
+  await service.ensure(personal);
+  const first = (await skills.list())[0]!;
+  await skills.update(first.id, { ...first.manifest, body: "personal" });
+  manifests = [
+    manifest(),
+    parseDefaultSkillTrees(
+      [{ path: "second/SKILL.md", content: "---\nname: second\ndescription: Second skill.\n---\nSecond.\n" }],
+      "personal default skill",
+    )[0]!,
+  ];
+  await service.ensure(personal);
+
+  const stored = (await skills.list()).filter((skill) => skill.scopeId === personal);
+  assert.equal(stored.length, 2);
+  assert.equal(stored.find((skill) => skill.manifest.name === "starter")?.manifest.body, "personal");
+  assert.equal(stored.find((skill) => skill.manifest.name === "second")?.status, "published");
+});
+
+test("personal skill defaults repair an interrupted unpublished install", async () => {
+  const skills = createSkillStore({ signingSecret: "test" });
+  const personal = scopeId("personal", "person@example.com");
+  const source = manifest();
+  const draft = await skills.create({ scopeId: personal, manifest: source, createdBy: PERSONAL_DEFAULT_CREATED_BY });
+
+  await createPersonalDefaultsService({ skills, manifests: () => [source] }).ensure(personal);
+  assert.equal((await skills.get(draft.id))?.status, "published");
+});
+
+test("empty personal defaults do not acquire the fleet skill lock", async () => {
+  const skills = createSkillStore({ signingSecret: "test" });
+  let locks = 0;
+  const service = createPersonalDefaultsService({
+    skills,
+    manifests: () => [],
+    advisoryLock: {
+      async withLock(_key, fn) {
+        locks++;
+        return fn();
+      },
+    },
+  });
+
+  await service.ensure(scopeId("personal", "person@example.com"));
+  assert.equal(locks, 0);
+});
+
+function memorySandbox(files: Map<string, string>, runs: string[]): Sandbox {
+  const handle: SandboxHandle = { id: "box", rootDir: "/root/workspace" };
+  return {
+    profile: { backend: "test", writablePersistence: "resident_disk", processSessions: false },
+    async provision() {
+      return handle;
+    },
+    async run(_handle, command) {
+      runs.push(command);
+      if (command.startsWith("[ -e ")) {
+        const path = command.match(/\[ -e '([^']+)' \]/)?.[1];
+        return { stdout: "", stderr: "", code: path && files.has(path) ? 0 : 1, timedOut: false };
+      }
+      if (command.startsWith("node -e ")) {
+        const args = [...command.matchAll(/'([^']*)'/g)].map((match) => match[1]!);
+        const source = args.at(-2)!;
+        const destination = args.at(-1)!;
+        if (files.has(destination)) return { stdout: "", stderr: "exists", code: 1, timedOut: false };
+        files.set(destination, files.get(source) ?? "");
+        files.delete(source);
+      }
+      return { stdout: "", stderr: "", code: 0, timedOut: false };
+    },
+    async readFile(_handle, path) {
+      return files.get(path) ?? null;
+    },
+    async writeFile(_handle, path, data) {
+      files.set(path, data);
+    },
+    async writeFileBytes(_handle, path, data) {
+      files.set(path, Buffer.from(data).toString("utf8"));
+    },
+    async readFileBytes(_handle, path) {
+      const value = files.get(path);
+      return value === undefined ? null : Buffer.from(value);
+    },
+    async listDir() {
+      return [];
+    },
+    async removeDir() {},
+    async teardown() {},
+  };
+}
+
+test("personal workspace defaults write missing files and preserve existing content", async () => {
+  const files = new Map([["AGENTS.md", "personal\n"]]);
+  const runs: string[] = [];
+  const sandbox = memorySandbox(files, runs);
+  await materializePersonalWorkspaceDefaults(sandbox, { id: "box", rootDir: "/root/workspace" }, [
+    { path: "AGENTS.md", content: "default\n" },
+    { path: ".claude/hooks/guard.mjs", content: "guard\n", executable: true },
+  ]);
+
+  assert.equal(files.get("AGENTS.md"), "personal\n");
+  assert.equal(files.get(".claude/hooks/guard.mjs"), "guard\n");
+  assert.ok(runs.some((command) => /chmod \+x/.test(command)));
+  assert.ok(runs.some((command) => /O_NOFOLLOW/.test(command) && /\/proc\/self\/fd/.test(command)));
+});
+
+test("sandbox wrapper seeds personal scopes lazily and skips scratch and shared scopes", async () => {
+  const files = new Map<string, string>();
+  const runs: string[] = [];
+  const base = memorySandbox(files, runs);
+  let defaults: PersonalDefaultFile[] = [{ path: "AGENTS.md", content: "default\n" }];
+  const sandbox = withPersonalWorkspaceDefaults(base, () => defaults);
+  const personal: WorkspaceLayer[] = [
+    { scopeId: scopeId("personal", "person@example.com"), mode: "rw", mountPath: "" },
+  ];
+
+  await sandbox.provision(personal, { personalDefaults: true });
+  assert.equal(files.get("AGENTS.md"), "default\n");
+  files.set("AGENTS.md", "personal\n");
+  defaults = [...defaults, { path: "config/personal.yaml", content: "enabled: false\n" }];
+  await sandbox.provision(personal, { personalDefaults: true });
+  assert.equal(files.get("AGENTS.md"), "personal\n");
+  assert.equal(files.get("config/personal.yaml"), "enabled: false\n");
+
+  files.clear();
+  await sandbox.provision(personal, { scratch: { key: "scratch" } });
+  assert.equal(files.size, 0);
+  await sandbox.provision(personal, { personalDefaults: false });
+  assert.equal(files.size, 0);
+  await sandbox.provision([{ scopeId: scopeId("channel", "general"), mode: "rw", mountPath: "" }]);
+  assert.equal(files.size, 0);
+});
+
+test("sandbox wrapper tears down a provisioned computer when default materialization fails", async () => {
+  const files = new Map<string, string>();
+  const base = memorySandbox(files, []);
+  let teardowns = 0;
+  const failing: Sandbox = {
+    ...base,
+    async writeFile() {
+      throw new Error("write failed");
+    },
+    async teardown() {
+      teardowns++;
+    },
+  };
+  const sandbox = withPersonalWorkspaceDefaults(failing, () => [{ path: "AGENTS.md", content: "default\n" }]);
+
+  await assert.rejects(
+    sandbox.provision([{ scopeId: scopeId("personal", "person@example.com"), mode: "rw", mountPath: "" }], {
+      personalDefaults: true,
+    }),
+    /write failed/,
+  );
+  assert.equal(teardowns, 1);
+});
+
+test("personal workspace paths reject absolute and traversal paths", () => {
+  assert.equal(safePersonalWorkspacePath(".claude/settings.json"), ".claude/settings.json");
+  assert.throws(() => safePersonalWorkspacePath("../secret"), /invalid personal workspace path/);
+  assert.throws(() => safePersonalWorkspacePath("/root/secret"), /invalid personal workspace path/);
+  assert.throws(() => safePersonalWorkspacePath("C:/secret"), /invalid personal workspace path/);
+});

--- a/test/pg-ca-options.test.ts
+++ b/test/pg-ca-options.test.ts
@@ -13,15 +13,17 @@ test("no CA configured → no ssl override (connection string semantics untouche
 });
 
 test("PEM content wires into ssl.ca", () => {
-  assert.deepEqual(resolvePgCaTrust({ cert: PEM }), { ssl: { ca: PEM } });
+  assert.deepEqual(resolvePgCaTrust({ cert: PEM }), { ssl: { ca: PEM, rejectUnauthorized: true } });
 });
 
 test("a cert file is read; inline PEM wins when both are set", () => {
   const dir = mkdtempSync(join(tmpdir(), "pgca-"));
   const file = join(dir, "root.crt");
   writeFileSync(file, PEM);
-  assert.deepEqual(resolvePgCaTrust({ certFile: file }), { ssl: { ca: PEM } });
-  assert.deepEqual(resolvePgCaTrust({ cert: PEM, certFile: "/nope" }), { ssl: { ca: PEM } });
+  assert.deepEqual(resolvePgCaTrust({ certFile: file }), { ssl: { ca: PEM, rejectUnauthorized: true } });
+  assert.deepEqual(resolvePgCaTrust({ cert: PEM, certFile: "/nope" }), {
+    ssl: { ca: PEM, rejectUnauthorized: true },
+  });
 });
 
 test("an unreadable cert file fails loudly, not as silent no-verify", () => {

--- a/test/pg-pool.test.ts
+++ b/test/pg-pool.test.ts
@@ -83,11 +83,14 @@ test("concurrentIndexName recognizes retryable concurrent index creation", () =>
 
 test("explicit CA trust overrides connection-string SSL controls without weakening verification", () => {
   const config = pgConnectionConfig(
-    "postgresql://user:pass@db.example/qm?sslmode=verify-full&application_name=qm",
+    "postgresql://user:pass@db.example/qm?ssl=0&sslmode=no-verify&sslnegotiation=direct&uselibpqcompat=true&application_name=qm",
     resolvePgCaTrust({ cert: "PEM" }),
   );
   const url = new URL(config.connectionString);
   assert.equal(url.searchParams.has("sslmode"), false);
+  assert.equal(url.searchParams.has("ssl"), false);
+  assert.equal(url.searchParams.has("sslnegotiation"), false);
+  assert.equal(url.searchParams.has("uselibpqcompat"), false);
   assert.equal(url.searchParams.get("application_name"), "qm");
   assert.deepEqual(config.ssl, { ca: "PEM", rejectUnauthorized: true });
 });
@@ -95,6 +98,23 @@ test("explicit CA trust overrides connection-string SSL controls without weakeni
 test("connection-string SSL controls remain unchanged without explicit CA trust", () => {
   const connectionString = "postgresql://user:pass@db.example/qm?sslmode=require";
   assert.deepEqual(pgConnectionConfig(connectionString, {}), { connectionString });
+});
+
+test("invalid database URLs fail without retaining credential-bearing input", () => {
+  const secret = "do-not-leak";
+  assert.throws(
+    () => pgConnectionConfig(`not a postgres URL ${secret}`, resolvePgCaTrust({ cert: "PEM" })),
+    (error: unknown) =>
+      error instanceof Error &&
+      error.message === "DATABASE_URL is invalid" &&
+      !JSON.stringify(error).includes(secret) &&
+      !("input" in error),
+  );
+  assert.throws(
+    () => pgConnectionConfig("postgresql:opaque", resolvePgCaTrust({ cert: "PEM" })),
+    /DATABASE_URL is invalid/,
+  );
+  assert.doesNotThrow(() => pgConnectionConfig("postgresql:///qm", resolvePgCaTrust({ cert: "PEM" })));
 });
 
 function pathToUrl(p: string): string {

--- a/test/pg-pool.test.ts
+++ b/test/pg-pool.test.ts
@@ -2,7 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { createPgPool, assertOneStatement, concurrentIndexName } from "../src/persistence/pg-pool.ts";
+import {
+  createPgPool,
+  assertOneStatement,
+  concurrentIndexName,
+  pgConnectionConfig,
+  resolvePgCaTrust,
+} from "../src/persistence/pg-pool.ts";
 
 test("createPgPool is lazy: building it neither connects nor throws (no DB needed)", async () => {
   const pg = createPgPool("postgres://does-not-exist:0/none", ["SELECT 1"]);
@@ -73,6 +79,22 @@ test("concurrentIndexName recognizes retryable concurrent index creation", () =>
     "session_search",
   );
   assert.equal(concurrentIndexName("CREATE INDEX IF NOT EXISTS session_search ON sessions(id)"), undefined);
+});
+
+test("explicit CA trust overrides connection-string SSL controls without weakening verification", () => {
+  const config = pgConnectionConfig(
+    "postgresql://user:pass@db.example/qm?sslmode=verify-full&application_name=qm",
+    resolvePgCaTrust({ cert: "PEM" }),
+  );
+  const url = new URL(config.connectionString);
+  assert.equal(url.searchParams.has("sslmode"), false);
+  assert.equal(url.searchParams.get("application_name"), "qm");
+  assert.deepEqual(config.ssl, { ca: "PEM", rejectUnauthorized: true });
+});
+
+test("connection-string SSL controls remain unchanged without explicit CA trust", () => {
+  const connectionString = "postgresql://user:pass@db.example/qm?sslmode=require";
+  assert.deepEqual(pgConnectionConfig(connectionString, {}), { connectionString });
 });
 
 function pathToUrl(p: string): string {

--- a/test/skills-visible.test.ts
+++ b/test/skills-visible.test.ts
@@ -2,7 +2,7 @@ import "./support/auto-fake-sprites.ts";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildApp } from "../src/wiring.ts";
@@ -45,6 +45,28 @@ test("listVisibleSkills returns a principal's personal + org skills with scope l
   const byName = new Map(visible.map((r) => [r.skill!.manifest.name, r]));
   assert.equal(byName.get("make-digest")!.skill!.scopeId, scopeId("personal", "U1"));
   assert.equal(byName.get("deploy-bot")!.skill!.scopeId, scopeId("org", "default-org"));
+});
+
+test("listVisibleSkills initializes deployment personal skill defaults", async () => {
+  const layer = mkdtempSync(join(tmpdir(), "ap-skvis-layer-"));
+  mkdirSync(join(layer, "personal", "skills", "starter"), { recursive: true });
+  writeFileSync(
+    join(layer, "personal", "skills", "starter", "SKILL.md"),
+    "---\nname: starter\ndescription: Starter skill.\n---\nStarter workflow.\n",
+  );
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "ap-skvis-")),
+      orgId: "acme",
+      seedSkills: false,
+      deploymentLayerDir: layer,
+    }),
+  );
+
+  const visible = await built.app.listVisibleSkills("U1");
+  const starter = visible.find((entry) => entry.skill?.manifest.name === "starter")?.skill;
+  assert.equal(starter?.scopeId, scopeId("personal", "U1"));
+  assert.equal(starter?.createdBy, "system:personal-default");
 });
 
 test("a personal skill shadows a same-named org skill (most-specific wins, shadow surfaced)", async () => {


### PR DESCRIPTION
## Summary

- add optional personal skill and workspace defaults to deployment layers
- initialize editable personal skills without replacing edits or archived records
- create missing workspace defaults safely on first personal computer use
- preserve legacy deployment bundle hashes and skip scratch or shared environments
- fail closed when AWS personal snapshots cannot be read or rotated
- support header-gated AWS portal origins and refresh the pinned MicroVM build toolchain
- preserve explicit Postgres CA trust across pools, pg-boss, and post-deploy smoke without allowing URL SSL overrides
- make Slack manifest descriptions and background color deployment-configurable with Slack limit validation
- add a generic Bitbucket validation and manual production deployment pipeline

## Validation

- root and CLI TypeScript checks
- focused deployment-layer, skill, route, AWS sandbox, Postgres CA, and Slack manifest tests
- live read-only AWS routing plan against a header-gated origin
- independent fresh-context reviews with no remaining critical, high, or medium findings

## Notes

- Full repository formatting remains blocked by the checkout baseline: npm run format:check reports existing style differences across 1,302 files.
- Windows cannot execute the temporary POSIX AWS CLI fixtures; the affected AWS verifier is covered by Linux CI and the live read-only routing plan.