### PR TITLE
slack: expand thread replies in on-demand surface reads

### DIFF
--- a/src/api/agent-api-catalog.ts
+++ b/src/api/agent-api-catalog.ts
@@ -427,7 +427,7 @@ const FAMILIES: AgentApiFamily[] = [
         method: "POST",
         path: "/v1/surface-context",
         summary:
-          "fetch recent messages from a channel/DM YOU can see (count/before/match) — a private channel only if you're a member; directory-resolved, never a raw address",
+          "fetch recent messages from a channel/DM YOU can see (count/before/match) — recent threads come expanded, and threadTs (a parent message's ts) pulls one full thread; a private channel only if you're a member; directory-resolved, never a raw address",
       },
       {
         method: "POST",

--- a/src/api/agent-api-catalog.ts
+++ b/src/api/agent-api-catalog.ts
@@ -427,7 +427,7 @@ const FAMILIES: AgentApiFamily[] = [
         method: "POST",
         path: "/v1/surface-context",
         summary:
-          "fetch recent messages from a channel/DM YOU can see (count/before/match) — recent threads come expanded, and threadTs (a parent message's ts) pulls one full thread; a private channel only if you're a member; directory-resolved, never a raw address",
+          "fetch recent messages from a channel/DM YOU can see (count/before/match) — recent threads come expanded, and threadTs (a parent message's ts, alongside channel) pulls that one thread in full; a private channel only if you're a member; directory-resolved, never a raw address",
       },
       {
         method: "POST",

--- a/src/api/routes/context.ts
+++ b/src/api/routes/context.ts
@@ -77,6 +77,7 @@ async function createSurfaceContextRequest(ctx: ApiCtx): Promise<void> {
   );
   const before = typeof b.before === "string" && b.before.trim() ? b.before.trim() : undefined;
   const match = typeof b.match === "string" && b.match.trim() ? b.match.trim().slice(0, 200) : undefined;
+  const threadTs = typeof b.threadTs === "string" && b.threadTs.trim() ? b.threadTs.trim() : undefined;
 
   const resolved = await resolveSurfaceTarget(ctx, b);
   if (!resolved) return;
@@ -84,6 +85,7 @@ async function createSurfaceContextRequest(ctx: ApiCtx): Promise<void> {
     ...resolved.target,
     viewer: capability.actorId,
     count,
+    ...(threadTs ? { threadTs } : {}),
     ...(before ? { before } : {}),
     ...(match ? { match } : {}),
   };

--- a/src/api/routes/context.ts
+++ b/src/api/routes/context.ts
@@ -78,6 +78,18 @@ async function createSurfaceContextRequest(ctx: ApiCtx): Promise<void> {
   const before = typeof b.before === "string" && b.before.trim() ? b.before.trim() : undefined;
   const match = typeof b.match === "string" && b.match.trim() ? b.match.trim().slice(0, 200) : undefined;
   const threadTs = typeof b.threadTs === "string" && b.threadTs.trim() ? b.threadTs.trim() : undefined;
+  if (threadTs && !/^\d+\.\d+$/.test(threadTs)) {
+    return sendJson(res, 400, {
+      error: "bad_request",
+      message: "threadTs must be a message ts like 1712345678.123456 (the thread parent's ts)",
+    });
+  }
+  if (threadTs && !(typeof b.channel === "string" && b.channel.trim())) {
+    return sendJson(res, 400, {
+      error: "bad_request",
+      message: "threadTs goes with a named channel — a plain read already follows the current conversation's thread",
+    });
+  }
 
   const resolved = await resolveSurfaceTarget(ctx, b);
   if (!resolved) return;

--- a/src/slack/conversation-view.ts
+++ b/src/slack/conversation-view.ts
@@ -26,6 +26,36 @@ const MEMBERS_SHOW_MAX = 40;
 
 export const slackFileName = (f: SlackFile): string => f.name || f.title || f.id || "file";
 
+export async function expandThreadReplies(
+  client: any,
+  channel: string,
+  history: any[],
+  opts: { maxThreads: number; page?: Record<string, unknown> },
+): Promise<any[]> {
+  const threadParents = history.filter((m: any) => m.ts && Number(m.reply_count) > 0).slice(-opts.maxThreads);
+  const expanded = await Promise.all(
+    threadParents.map(async (p: any) => {
+      try {
+        return (
+          (
+            await client.conversations.replies({
+              channel,
+              ts: p.ts,
+              limit: EXPANDED_THREAD_REPLY_LIMIT,
+              ...(opts.page ?? {}),
+            })
+          ).messages ?? []
+        );
+      } catch {
+        return [];
+      }
+    }),
+  );
+  const byTs = new Map<string, any>();
+  for (const m of [...history, ...expanded.flat()]) if (m?.ts) byTs.set(m.ts, m);
+  return [...byTs.values()];
+}
+
 export function reactionTallies(raw: unknown): ReactionTally[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -120,22 +150,7 @@ export function createConversationSerializer(deps: {
       const history = ((await client.conversations.history({ channel, limit: RECENT_HISTORY_LIMIT })).messages ?? [])
         .slice()
         .reverse();
-      const threadParents = history.filter((m: any) => m.ts && Number(m.reply_count) > 0).slice(-MAX_EXPANDED_THREADS);
-      const expanded = await Promise.all(
-        threadParents.map(async (p: any) => {
-          try {
-            return (
-              (await client.conversations.replies({ channel, ts: p.ts, limit: EXPANDED_THREAD_REPLY_LIMIT }))
-                .messages ?? []
-            );
-          } catch {
-            return [];
-          }
-        }),
-      );
-      const byTs = new Map<string, any>();
-      for (const m of [...history, ...expanded.flat()]) if (m?.ts) byTs.set(m.ts, m);
-      return [...byTs.values()];
+      return expandThreadReplies(client, channel, history, { maxThreads: MAX_EXPANDED_THREADS });
     } catch {
       return [];
     }

--- a/src/slack/conversation-view.ts
+++ b/src/slack/conversation-view.ts
@@ -19,6 +19,7 @@ import { messageWithForwardedContent } from "./forwards.ts";
 export const RECENT_HISTORY_LIMIT = 200;
 export const RECENT_THREAD_LIMIT = 200;
 const MAX_EXPANDED_THREADS = 5;
+export const CONTEXT_EXPANDED_THREADS = 10;
 const EXPANDED_THREAD_REPLY_LIMIT = RECENT_THREAD_LIMIT;
 export const MAX_NAME_LOOKUPS = 10;
 const RECENT_KEEP_SUBTYPES = new Set(["file_share", "bot_message", "thread_broadcast"]);
@@ -30,23 +31,17 @@ export async function expandThreadReplies(
   client: any,
   channel: string,
   history: any[],
-  opts: { maxThreads: number; page?: Record<string, unknown> },
+  maxThreads: number,
 ): Promise<any[]> {
-  const threadParents = history.filter((m: any) => m.ts && Number(m.reply_count) > 0).slice(-opts.maxThreads);
+  const threadParents = history.filter((m: any) => m.ts && Number(m.reply_count) > 0).slice(-maxThreads);
   const expanded = await Promise.all(
     threadParents.map(async (p: any) => {
       try {
         return (
-          (
-            await client.conversations.replies({
-              channel,
-              ts: p.ts,
-              limit: EXPANDED_THREAD_REPLY_LIMIT,
-              ...(opts.page ?? {}),
-            })
-          ).messages ?? []
+          (await client.conversations.replies({ channel, ts: p.ts, limit: EXPANDED_THREAD_REPLY_LIMIT })).messages ?? []
         );
-      } catch {
+      } catch (e) {
+        swallow("slack: thread expansion", e);
         return [];
       }
     }),
@@ -150,7 +145,7 @@ export function createConversationSerializer(deps: {
       const history = ((await client.conversations.history({ channel, limit: RECENT_HISTORY_LIMIT })).messages ?? [])
         .slice()
         .reverse();
-      return expandThreadReplies(client, channel, history, { maxThreads: MAX_EXPANDED_THREADS });
+      return expandThreadReplies(client, channel, history, MAX_EXPANDED_THREADS);
     } catch {
       return [];
     }

--- a/src/slack/conversation.ts
+++ b/src/slack/conversation.ts
@@ -18,6 +18,19 @@ function compareSlackTimestamps(a: { ts: string }, b: { ts: string }): number {
   return 0;
 }
 
+function keepRecentWithParents(
+  all: readonly RecentMessage[],
+  matched: readonly RecentMessage[],
+  window: number,
+): RecentMessage[] {
+  const byTs = new Map(all.map((m) => [m.ts, m] as const));
+  const chosen = new Map<string, RecentMessage>(matched.slice(-window).map((m) => [m.ts, m] as const));
+  for (const m of Array.from(chosen.values())) {
+    if (m.parentTs && !chosen.has(m.parentTs) && byTs.has(m.parentTs)) chosen.set(m.parentTs, byTs.get(m.parentTs)!);
+  }
+  return [...chosen.values()].sort(compareSlackTimestamps);
+}
+
 export function buildContextWindow(
   scanned: readonly RecentMessage[],
   opts: { count: number; match?: string; scanHasMore?: boolean; nameById?: ReadonlyMap<string, string> },
@@ -26,7 +39,7 @@ export function buildContextWindow(
   const needle = opts.match?.trim().toLowerCase();
   const matched = needle ? asc.filter((m) => (m.text ?? "").toLowerCase().includes(needle)) : asc;
   const count = Math.max(1, Math.floor(opts.count));
-  const kept = matched.slice(-count);
+  const kept = keepRecentWithParents(asc, matched, count);
   const messages = kept.map((m) => {
     const time = formatSlackTs(m.ts);
     return {
@@ -38,7 +51,7 @@ export function buildContextWindow(
       ...(m.files?.length ? { files: m.files } : {}),
     };
   });
-  const droppedMatches = matched.length > kept.length;
+  const droppedMatches = matched.length > count;
   let nextBefore = opts.scanHasMore ? asc[0]?.ts : undefined;
   if (droppedMatches) nextBefore = kept[0]?.ts;
   return {
@@ -84,12 +97,7 @@ export function recentWindow(
   if (!usable.length) return [];
   const window = Math.max(1, Math.floor(limit));
   const sorted = [...usable].sort(compareSlackTimestamps);
-  const byTs = new Map(sorted.map((m) => [m.ts, m] as const));
-  const chosen = new Map<string, RecentMessage>(sorted.slice(-window).map((m) => [m.ts, m] as const));
-  for (const m of Array.from(chosen.values())) {
-    if (m.parentTs && !chosen.has(m.parentTs) && byTs.has(m.parentTs)) chosen.set(m.parentTs, byTs.get(m.parentTs)!);
-  }
-  return [...chosen.values()].sort(compareSlackTimestamps);
+  return keepRecentWithParents(sorted, sorted, window);
 }
 
 function arrangeForDisplay(messages: readonly RecentMessage[]): Array<{ message: RecentMessage; isReply: boolean }> {

--- a/src/slack/surface-context.ts
+++ b/src/slack/surface-context.ts
@@ -16,13 +16,12 @@ import type { CoreBridge } from "./core-bridge.ts";
 import type { Directory } from "./directory.ts";
 import {
   type ConversationSerializer,
+  CONTEXT_EXPANDED_THREADS,
   RECENT_HISTORY_LIMIT,
   RECENT_THREAD_LIMIT,
   expandThreadReplies,
   slackFileName,
 } from "./conversation-view.ts";
-
-const CONTEXT_EXPANDED_THREADS = 10;
 
 export function createSurfaceContextFulfiller(deps: {
   core: SlackCoreClient;
@@ -83,7 +82,7 @@ export function createSurfaceContextFulfiller(deps: {
     }
     const res = await client.conversations.history({ channel, limit: RECENT_HISTORY_LIMIT, ...page });
     const history = ((res.messages ?? []) as any[]).slice().reverse();
-    const raw = await expandThreadReplies(client, channel, history, { maxThreads: CONTEXT_EXPANDED_THREADS, page });
+    const raw = before ? history : await expandThreadReplies(client, channel, history, CONTEXT_EXPANDED_THREADS);
     return { raw, hasMore: Boolean(res.has_more) };
   }
 
@@ -210,10 +209,15 @@ export function createSurfaceContextFulfiller(deps: {
       }
       let channel: string;
       let threadTs: string | undefined;
+      let requestedThread: string | undefined;
       if (typeof q.conversationTarget === "string" && q.conversationTarget) {
         ({ channel, threadTs } = parseDeliveryTarget(q.conversationTarget));
       } else if (typeof q.channelId === "string" && q.channelId) {
         channel = q.channelId;
+        if (typeof q.threadTs === "string" && q.threadTs) {
+          requestedThread = q.threadTs;
+          threadTs = q.threadTs;
+        }
         const info = await directory.getChannelInfo(client, channel);
         if (!info) return post({ error: "I can't see that channel" });
         if (isExternallyShared(info)) return post({ error: "that channel is externally shared, so I won't read it" });
@@ -222,22 +226,35 @@ export function createSurfaceContextFulfiller(deps: {
       } else {
         return post({ error: "malformed context request" });
       }
-      if (typeof q.threadTs === "string" && q.threadTs) threadTs = q.threadTs;
       if (q.file && typeof q.file.ts === "string" && q.file.ts) {
         return await post(await fetchSurfaceFile(client, channel, threadTs, q.file));
       }
       const count = Math.max(1, Math.min(RECENT_THREAD_LIMIT, Number(q.count) || 100));
       const before = typeof q.before === "string" && q.before ? q.before : undefined;
-      const [chanPage, threadPage] = await Promise.all([
-        fetchContextHistory(client, channel, undefined, before),
-        threadTs
-          ? fetchContextHistory(client, channel, threadTs, before)
-          : Promise.resolve({ raw: [] as any[], hasMore: false }),
-      ]);
-      const byTs = new Map<string, any>();
-      for (const m of [...chanPage.raw, ...threadPage.raw]) if (m?.ts) byTs.set(m.ts, m);
-      const raw = [...byTs.values()];
-      const hasMore = chanPage.hasMore || threadPage.hasMore;
+      let raw: any[];
+      let hasMore: boolean;
+      if (requestedThread) {
+        try {
+          ({ raw, hasMore } = await fetchContextHistory(client, channel, requestedThread, before));
+        } catch (err) {
+          if ((err as any)?.data?.error === "thread_not_found")
+            return post({
+              error: `I can't find a thread whose parent message is ts ${requestedThread} in that channel — threadTs must be the parent's ts`,
+            });
+          throw err;
+        }
+      } else {
+        const [chanPage, threadPage] = await Promise.all([
+          fetchContextHistory(client, channel, undefined, before),
+          threadTs
+            ? fetchContextHistory(client, channel, threadTs, before)
+            : Promise.resolve({ raw: [] as any[], hasMore: false }),
+        ]);
+        const byTs = new Map<string, any>();
+        for (const m of [...chanPage.raw, ...threadPage.raw]) if (m?.ts) byTs.set(m.ts, m);
+        raw = [...byTs.values()];
+        hasMore = chanPage.hasMore || threadPage.hasMore;
+      }
       const nameById = new Map<string, string>();
       const shaped = await serializer.shapeRecentMessages(client, raw, "", nameById);
       await post(

--- a/src/slack/surface-context.ts
+++ b/src/slack/surface-context.ts
@@ -18,8 +18,11 @@ import {
   type ConversationSerializer,
   RECENT_HISTORY_LIMIT,
   RECENT_THREAD_LIMIT,
+  expandThreadReplies,
   slackFileName,
 } from "./conversation-view.ts";
+
+const CONTEXT_EXPANDED_THREADS = 10;
 
 export function createSurfaceContextFulfiller(deps: {
   core: SlackCoreClient;
@@ -79,7 +82,9 @@ export function createSurfaceContextFulfiller(deps: {
       return { raw: res.messages ?? [], hasMore: Boolean(res.has_more) };
     }
     const res = await client.conversations.history({ channel, limit: RECENT_HISTORY_LIMIT, ...page });
-    return { raw: ((res.messages ?? []) as any[]).slice().reverse(), hasMore: Boolean(res.has_more) };
+    const history = ((res.messages ?? []) as any[]).slice().reverse();
+    const raw = await expandThreadReplies(client, channel, history, { maxThreads: CONTEXT_EXPANDED_THREADS, page });
+    return { raw, hasMore: Boolean(res.has_more) };
   }
 
   async function findMessageAt(
@@ -217,6 +222,7 @@ export function createSurfaceContextFulfiller(deps: {
       } else {
         return post({ error: "malformed context request" });
       }
+      if (typeof q.threadTs === "string" && q.threadTs) threadTs = q.threadTs;
       if (q.file && typeof q.file.ts === "string" && q.file.ts) {
         return await post(await fetchSurfaceFile(client, channel, threadTs, q.file));
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,6 +280,7 @@ export interface SurfaceContextQuery {
   conversationTarget?: string;
   channelId?: string;
   channelName?: string;
+  threadTs?: string;
   count: number;
   viewer?: string;
   before?: string;

--- a/test/surface-context-read.test.ts
+++ b/test/surface-context-read.test.ts
@@ -24,6 +24,7 @@ function harness() {
   };
   const directory = {
     classifyUserCached: async (_client: unknown, id: string) => ({ actor: { displayName: `name-${id}` } }),
+    getChannelInfo: async () => ({ is_member: true }),
   };
   const serializer = createConversationSerializer({
     ids: {
@@ -37,13 +38,23 @@ function harness() {
     directory: directory as never,
     externalParticipantsEnabled: async () => true,
   });
+  const historyCalls: Array<Record<string, unknown>> = [];
   const replyCalls: string[] = [];
   const client = {
     conversations: {
-      history: async () => ({ messages: HISTORY }),
+      history: async (args: Record<string, unknown>) => {
+        historyCalls.push(args);
+        return { messages: HISTORY };
+      },
       replies: async ({ ts }: { ts: string }) => {
         replyCalls.push(ts);
-        return { messages: THREADS[ts] ?? [] };
+        const messages = THREADS[ts];
+        if (!messages) {
+          const err = new Error("thread_not_found") as Error & { data: { error: string } };
+          err.data = { error: "thread_not_found" };
+          throw err;
+        }
+        return { messages };
       },
     },
   };
@@ -63,32 +74,46 @@ function harness() {
       status: "pending",
       query,
     });
-    return ((fulfilled[0] as { result: { messages: Array<{ ts: string; text: string; threadTs?: string }> } }).result ??
-      {}) as { messages: Array<{ ts: string; text: string; threadTs?: string }> };
+    return (fulfilled[0] as { result?: { messages: Array<{ ts: string; text: string; threadTs?: string }> }; error?: string })!;
   };
-  return { pull, replyCalls };
+  return { pull, historyCalls, replyCalls };
 }
 
 describe("surface-context channel reads", () => {
   it("expands recent threads when reading a channel top-level, not just parents", async () => {
     const { pull, replyCalls } = harness();
-    const result = await pull({ conversationTarget: "C1", count: 50 });
-    assert.deepEqual(replyCalls, ["1.000000"], "each recent thread parent is expanded once");
+    const outcome = await pull({ conversationTarget: "C1", count: 50 });
+    assert.deepEqual(replyCalls, ["1.000000"], "each recent thread parent is expanded exactly once");
     assert.deepEqual(
-      result.messages.map((m) => m.ts),
+      outcome.result!.messages.map((m) => m.ts),
       ["1.000000", "2.000000", "3.000000", "4.000000"],
       "thread replies ride along with the top-level history, in order",
     );
-    assert.equal(result.messages[1]!.threadTs, "1.000000", "a reply carries its parent's ts");
+    assert.equal(outcome.result!.messages[1]!.threadTs, "1.000000", "a reply carries its parent's ts");
   });
 
-  it("pulls one full thread when the query names a threadTs", async () => {
-    const { pull, replyCalls } = harness();
-    const result = await pull({ conversationTarget: "C1", threadTs: "1.000000", count: 50 });
-    assert.ok(replyCalls.includes("1.000000"), "the named thread is fetched directly");
-    assert.ok(
-      result.messages.some((m) => m.text === "second reply"),
-      "the thread's replies are in the window",
+  it("skips thread expansion on a paged (before) read, keeping the cursor a pure history walk", async () => {
+    const { pull, historyCalls, replyCalls } = harness();
+    await pull({ conversationTarget: "C1", count: 50, before: "4.000000" });
+    assert.equal(historyCalls[0]!.latest, "4.000000");
+    assert.deepEqual(replyCalls, [], "no replies calls on a paged scan");
+  });
+
+  it("pulls exactly and only the named thread when the query carries a threadTs", async () => {
+    const { pull, historyCalls, replyCalls } = harness();
+    const outcome = await pull({ channelId: "C1", threadTs: "1.000000", count: 50 });
+    assert.deepEqual(replyCalls, ["1.000000"], "one replies call, no duplicate via expansion");
+    assert.deepEqual(historyCalls, [], "no channel history competes with the thread for the window");
+    assert.deepEqual(
+      outcome.result!.messages.map((m) => m.text),
+      ["thread parent", "first reply", "second reply"],
     );
+  });
+
+  it("names the threadTs problem instead of failing the whole read when the thread doesn't exist", async () => {
+    const { pull } = harness();
+    const outcome = await pull({ channelId: "C1", threadTs: "9.999999", count: 50 });
+    assert.match(String(outcome.error), /9\.999999/);
+    assert.match(String(outcome.error), /parent/);
   });
 });

--- a/test/surface-context-read.test.ts
+++ b/test/surface-context-read.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createSurfaceContextFulfiller } from "../src/slack/surface-context.ts";
+import { createConversationSerializer } from "../src/slack/conversation-view.ts";
+import type { SurfaceContextQuery } from "../src/types.ts";
+
+const HISTORY = [
+  { ts: "4.000000", user: "U2", text: "newest top-level" },
+  { ts: "1.000000", user: "U1", text: "thread parent", reply_count: 2 },
+];
+
+const THREADS: Record<string, unknown[]> = {
+  "1.000000": [
+    { ts: "1.000000", user: "U1", text: "thread parent", reply_count: 2 },
+    { ts: "2.000000", thread_ts: "1.000000", user: "U2", text: "first reply" },
+    { ts: "3.000000", thread_ts: "1.000000", user: "U1", text: "second reply" },
+  ],
+};
+
+function harness() {
+  const fulfilled: unknown[] = [];
+  const core = {
+    fulfillContextRequest: async (_id: string, outcome: unknown) => void fulfilled.push(outcome),
+  };
+  const directory = {
+    classifyUserCached: async (_client: unknown, id: string) => ({ actor: { displayName: `name-${id}` } }),
+  };
+  const serializer = createConversationSerializer({
+    ids: {
+      ownTeamId: "T1",
+      botUserId: "UBOT",
+      ownBotId: "BBOT",
+      botHandle: "qm",
+      ownWorkspaceUrl: "",
+      identityMode: "email",
+    },
+    directory: directory as never,
+    externalParticipantsEnabled: async () => true,
+  });
+  const replyCalls: string[] = [];
+  const client = {
+    conversations: {
+      history: async () => ({ messages: HISTORY }),
+      replies: async ({ ts }: { ts: string }) => {
+        replyCalls.push(ts);
+        return { messages: THREADS[ts] ?? [] };
+      },
+    },
+  };
+  const f = createSurfaceContextFulfiller({
+    core: core as never,
+    bridge: {} as never,
+    directory: directory as never,
+    serializer,
+    botToken: "xoxb-test",
+    clientOptions: {},
+  });
+  const pull = async (query: SurfaceContextQuery) => {
+    await f.fulfillSurfaceContext(client, {
+      id: "req",
+      source: "slack",
+      createdAt: Date.now(),
+      status: "pending",
+      query,
+    });
+    return ((fulfilled[0] as { result: { messages: Array<{ ts: string; text: string; threadTs?: string }> } }).result ??
+      {}) as { messages: Array<{ ts: string; text: string; threadTs?: string }> };
+  };
+  return { pull, replyCalls };
+}
+
+describe("surface-context channel reads", () => {
+  it("expands recent threads when reading a channel top-level, not just parents", async () => {
+    const { pull, replyCalls } = harness();
+    const result = await pull({ conversationTarget: "C1", count: 50 });
+    assert.deepEqual(replyCalls, ["1.000000"], "each recent thread parent is expanded once");
+    assert.deepEqual(
+      result.messages.map((m) => m.ts),
+      ["1.000000", "2.000000", "3.000000", "4.000000"],
+      "thread replies ride along with the top-level history, in order",
+    );
+    assert.equal(result.messages[1]!.threadTs, "1.000000", "a reply carries its parent's ts");
+  });
+
+  it("pulls one full thread when the query names a threadTs", async () => {
+    const { pull, replyCalls } = harness();
+    const result = await pull({ conversationTarget: "C1", threadTs: "1.000000", count: 50 });
+    assert.ok(replyCalls.includes("1.000000"), "the named thread is fetched directly");
+    assert.ok(
+      result.messages.some((m) => m.text === "second reply"),
+      "the thread's replies are in the window",
+    );
+  });
+});

--- a/test/surface-context.test.ts
+++ b/test/surface-context.test.ts
@@ -146,6 +146,27 @@ describe("surface-context pulls", async () => {
     assert.equal((await asking).status, 200);
   });
 
+  it("rejects a malformed threadTs and a threadTs without a channel, before parking anything", async () => {
+    const malformed = await post(
+      "/v1/surface-context",
+      { channel: "#eng", threadTs: "not-a-ts" },
+      { "x-agent-capability": await cap() },
+    );
+    assert.equal(malformed.status, 400);
+    assert.match(((await malformed.json()) as any).message, /threadTs/);
+
+    const channelless = await post(
+      "/v1/surface-context",
+      { threadTs: "1700.5" },
+      { "x-agent-capability": await cap() },
+    );
+    assert.equal(channelless.status, 400);
+    assert.match(((await channelless.json()) as any).message, /named channel/);
+
+    const pending = await (await signedGet(pendingPath())).json();
+    assert.deepEqual((pending as any).requests, [], "nothing was parked");
+  });
+
   it("passes a raw channel id straight to the plugin (a public channel the actor can see), skipping the (possibly stale) directory", async () => {
     const asking = post("/v1/surface-context", { channel: "CPUBLIC01" }, { "x-agent-capability": await cap() });
     const query = await fulfillNext(() => ({ messages: [] }));

--- a/test/surface-context.test.ts
+++ b/test/surface-context.test.ts
@@ -134,6 +134,18 @@ describe("surface-context pulls", async () => {
     assert.equal(((await res.json()) as any).channel, "#eng");
   });
 
+  it("passes a requested threadTs through to the surface", async () => {
+    const asking = post(
+      "/v1/surface-context",
+      { channel: "#eng", threadTs: "1700.5" },
+      { "x-agent-capability": await cap() },
+    );
+    const query = await fulfillNext(() => ({ messages: [] }));
+    assert.equal(query.channelId, "C-ENG");
+    assert.equal(query.threadTs, "1700.5");
+    assert.equal((await asking).status, 200);
+  });
+
   it("passes a raw channel id straight to the plugin (a public channel the actor can see), skipping the (possibly stale) directory", async () => {
     const asking = post("/v1/surface-context", { channel: "CPUBLIC01" }, { "x-agent-capability": await cap() });
     const query = await fulfillNext(() => ({ messages: [] }));


### PR DESCRIPTION
## Problem

`conversations.history` returns only top-level messages, so any agent-initiated read of a named channel — the `surface` tool's `read_thread`/`whats_new`/`search` fallback, and `POST /v1/surface-context` — came back without thread replies. The agent could see thread parents but never the conversation inside them. The per-turn context builder already expands recent threads (`conversation-view.ts`); on-demand reads did not, and the query type had no way to name a thread in another channel at all.

## Change

- Extract the turn-context path's thread expansion into `expandThreadReplies` and apply it to `fetchContextHistory`: an unpaged channel read now expands the 10 most recent thread parents (`CONTEXT_EXPANDED_THREADS`; the turn-context path keeps its 5). Paged (`before`) scans skip expansion so the cursor remains a pure history walk and deep `match` scans don't multiply Tier-3 Slack calls. Expansion failures log via `swallow` instead of disappearing.
- Add optional `threadTs` to `SurfaceContextQuery`, plumbed through `/v1/surface-context`. It's validated at the route (`/^\d+\.\d+$/`) and accepted only alongside a named `channel` (a plain read already follows the current conversation's thread). A `threadTs` read fetches exactly that thread — it doesn't compete with 200 newer channel messages for the window, so old threads come back whole — and an unknown `threadTs` produces an error naming it rather than failing the read.
- `buildContextWindow` now backfills a kept reply's missing parent into the window, via the same helper `recentWindow` already used for that invariant, so replies never arrive orphaned.

## Verification

- New fulfiller tests (`test/surface-context-read.test.ts`) drive `fulfillSurfaceContext` against a faked Slack client: expansion on unpaged reads, no expansion on paged reads, exact-thread fetch for `threadTs`, and the thread-not-found error path.
- Route tests cover `threadTs` pass-through and both 400 rejections.
- Verified end to end on a dev instance: a channel read through `/v1/surface-context` returned thread replies (with `threadTs` markers) that exist only inside a thread, where it previously returned only the two top-level messages.
- `npm run typecheck`, `npm run lint`, and the affected suites (`surface-context-read`, `surface-context`, `slack-conversation`, `group-dm-open`) pass.

https://claude.ai/code/session_01YbE1GGjhi6gMHEomrnUTsR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790532480&installation_model_id=19911&pr_number=715&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F715&signature=8345e821edd3fa9ce117f47582050bff7f46117a199dbc8cf9c59cbf917c8ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->