### PR TITLE
Fix immutable MicroVM GitHub CLI install

### DIFF
--- a/aws/microvm-agent/Dockerfile
+++ b/aws/microvm-agent/Dockerfile
@@ -12,10 +12,12 @@ RUN dnf install -y \
   && setsid --version \
   && seq 1 1
 
-RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
-       -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.97.0-1 \
-  && dnf clean all \
+RUN GH_VERSION=2.97.0 \
+  && GH_SHA256=73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5 \
+  && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_arm64.tar.gz" -o /tmp/gh.tgz \
+  && echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum -c - \
+  && tar -xzf /tmp/gh.tgz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_arm64/bin/gh" \
+  && rm /tmp/gh.tgz \
   && gh --version
 
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.36.5.zip" -o /tmp/awscliv2.zip \

--- a/cli/templates/aws/microvm-agent/Dockerfile
+++ b/cli/templates/aws/microvm-agent/Dockerfile
@@ -12,10 +12,12 @@ RUN dnf install -y \
   && setsid --version \
   && seq 1 1
 
-RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo \
-       -o /etc/yum.repos.d/gh-cli.repo \
-  && dnf install -y gh-2.97.0-1 \
-  && dnf clean all \
+RUN GH_VERSION=2.97.0 \
+  && GH_SHA256=73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5 \
+  && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_arm64.tar.gz" -o /tmp/gh.tgz \
+  && echo "${GH_SHA256}  /tmp/gh.tgz" | sha256sum -c - \
+  && tar -xzf /tmp/gh.tgz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_arm64/bin/gh" \
+  && rm /tmp/gh.tgz \
   && gh --version
 
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.36.5.zip" -o /tmp/awscliv2.zip \

--- a/cli/test/microvm-dockerfile.test.ts
+++ b/cli/test/microvm-dockerfile.test.ts
@@ -12,7 +12,15 @@ test("the canonical and packaged MicroVM Dockerfiles stay snapshot-safe and exec
   );
   assert.match(canonical, /^FROM public\.ecr\.aws\/lambda\/microvms:al2023-minimal@sha256:[a-f0-9]{64}$/m);
   assert.match(canonical, /dnf install -y[\s\\]+curl-minimal\b/);
-  assert.match(canonical, /dnf install -y gh-\d+\.\d+\.\d+-\d+/);
+  assert.doesNotMatch(canonical, /cli\.github\.com\/packages\/rpm/);
+  assert.doesNotMatch(canonical, /dnf install -y gh-/);
+  assert.match(canonical, /GH_VERSION=\d+\.\d+\.\d+/);
+  assert.match(canonical, /GH_SHA256=[a-f0-9]{64}/);
+  assert.match(
+    canonical,
+    /github\.com\/cli\/cli\/releases\/download\/v\$\{GH_VERSION\}\/gh_\$\{GH_VERSION\}_linux_arm64\.tar\.gz/,
+  );
+  assert.match(canonical, /\$\{GH_SHA256\} {2}\/tmp\/gh\.tgz" \| sha256sum -c -/);
   assert.match(canonical, /awscli-exe-linux-aarch64-\d+\.\d+\.\d+\.zip/);
   assert.match(canonical, /[a-f0-9]{64} {2}\/tmp\/awscliv2\.zip" \| sha256sum -c -/);
   assert.match(canonical, /rpm -q openssl-snapsafe-libs/);


### PR DESCRIPTION
Replaces the rolling RPM repository dependency with GitHub CLI’s immutable ARM64 v2.97.0 release artifact and verifies its pinned SHA-256 before installation. Implements #123.

- verification: MicroVM Dockerfile regression test
- verification: CLI typecheck
- verification: official artifact checksum, extraction, and tamper rejection

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790535680&installation_model_id=19911&pr_number=717&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F717&signature=06c301eda15bba66a63e41de8bb6fbb058f835e7bc12b4e8c7de697363d0103a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->