### PR TITLE
Extend portal session lifetime to 30 days

### DIFF
--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -26,7 +26,7 @@ surfaces, and it does **not** import the core.
    workspace pin) against the configured HTTPS JWKS, then reads
    the subject from userinfo. The verified `sub` **is** the core principal id. It mints a
    signed `portal_session` cookie (`{sub, org, auth, exp}`, HMAC, 8h sliding lifetime with a
-   24h absolute maximum by default).
+   30-day absolute maximum by default).
 3. **Proxy** — every other path requires a valid session. The portal picks the upstream by the
    **exact first path segment**, strips the prefix, and proxies to the private upstream,
    synthesizing the surface cookie for compatibility and attaching a short-lived signed portal
@@ -124,7 +124,7 @@ Non-secret (`[env]`): `PORT` (8097 local / 8080 image), `PORTAL_PUBLIC_URL`, `CO
 `CORE_ORG_ID`, `WEB_UI_UPSTREAM`, `ADMIN_UPSTREAM`,
 `OIDC_AUTH_ENDPOINT` / `OIDC_TOKEN_ENDPOINT` / `OIDC_USERINFO_ENDPOINT` / `OIDC_ISSUER` /
 `OIDC_JWKS_URI` / `OIDC_SCOPES` / `OIDC_CLIENT_ID`, `PORTAL_EXPECTED_TEAM_ID`,
-`PORTAL_SESSION_TTL_S`, `PORTAL_SESSION_MAX_TTL_S`. `PORTAL_SESSION_MAX_TTL_S` caps a session's total life from authentication; it defaults to the larger of one day and `PORTAL_SESSION_TTL_S`, and boot fails if it is set below the TTL.
+`PORTAL_SESSION_TTL_S`, `PORTAL_SESSION_MAX_TTL_S`. `PORTAL_SESSION_MAX_TTL_S` caps a session's total life from authentication; it defaults to the larger of 30 days and `PORTAL_SESSION_TTL_S`, and boot fails if it is set below the TTL.
 There is no `PORTAL_ADMIN_PRINCIPALS` — admin
 access is derived from the core (see the security model above).
 For local development only, `PORTAL_LOCAL_AUTH_BYPASS=1` mints a local session as

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -54,7 +54,10 @@ const PORT = portFromEnv(8097);
 const PUBLIC_URL = (process.env.PORTAL_PUBLIC_URL ?? `http://localhost:${PORT}`).replace(/\/$/, "");
 const SESSION_SECRET = process.env.PORTAL_SESSION_SECRET;
 const SESSION_TTL_S = Number(process.env.PORTAL_SESSION_TTL_S ?? 28800);
-const SESSION_MAX_TTL_S = Number(process.env.PORTAL_SESSION_MAX_TTL_S ?? Math.max(86400, SESSION_TTL_S));
+export const DEFAULT_SESSION_MAX_TTL_S = 30 * 24 * 60 * 60;
+const SESSION_MAX_TTL_S = Number(
+  process.env.PORTAL_SESSION_MAX_TTL_S ?? Math.max(DEFAULT_SESSION_MAX_TTL_S, SESSION_TTL_S),
+);
 const SESSION_RENEW_AFTER_S = Math.floor(SESSION_TTL_S / 2);
 const COOKIE_DOMAIN = process.env.PORTAL_COOKIE_DOMAIN || undefined;
 const APPS_DOMAIN = process.env.PORTAL_APPS_DOMAIN || undefined;

--- a/plugins/portal/test/entry.test.ts
+++ b/plugins/portal/test/entry.test.ts
@@ -104,6 +104,11 @@ test("production boot requires an explicit JWKS URI for custom issuers", () => {
   assert.equal(accepted.status, 0, accepted.stderr);
 });
 
+test("the default absolute session lifetime is 30 days", async () => {
+  const { DEFAULT_SESSION_MAX_TTL_S } = await import("../src/index.ts");
+  assert.equal(DEFAULT_SESSION_MAX_TTL_S, 30 * 24 * 60 * 60);
+});
+
 test("a session TTL above the default max ceiling still boots, but a contradictory pair does not", () => {
   const command = "import('./src/index.ts').then(m => m.bootChecks())";
   const baseEnv: NodeJS.ProcessEnv = {


### PR DESCRIPTION
Extends the default absolute portal session lifetime from one day to 30 days while preserving the eight-hour sliding inactivity window.

- verification: portal entry/session tests and typecheck pass
- verification: live 25-hour session remains authenticated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790541640&installation_model_id=19911&pr_number=720&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F720&signature=d0fca3abd0cbafddf7164b5a8da3e4b7d84be0dc301462697815ac4f632c03a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->