### PR TITLE
adrs: GCP/GKE Agent Sandbox runtime path

### DIFF
--- a/adrs/gcp-runtime.md
+++ b/adrs/gcp-runtime.md
@@ -1,0 +1,11 @@
+Following up on #367 / #735 in the format you asked for.
+
+We run SimpleLend entirely on GCP — Cloud Run, Cloud SQL, Secret Manager, Artifact Registry, GKE. When we picked qm as the agent runtime for our team, the only piece that didn't fit was the sandbox path, which assumes AWS.
+
+So we built a GCP path ourselves and have been running it in production since mid-August: GKE Autopilot with Google's Agent Sandbox for the isolated computers, GCS for durable files, Workload Identity instead of long-lived keys. Six agents on it behind a portal, used by actual staff. The isolation model lines up well — Agent Sandbox is gVisor, so it's the same shape as what you already do on AWS rather than a different concept bolted on.
+
+The reason I'd rather this lived upstream than in our fork: today every qm release means re-applying our adapter by hand. That's survivable for us, but we drift a little further each time, and more to the point any team already on GCP has to do that same work before they can even try qm. That's the actual argument, more than wanting our patch merged.
+
+If you do build it, I'm happy to be a tester. We have a real cluster under real load and can tell you quickly whether it holds up outside our own setup.
+
+Not attached to any of the implementation choices in #367 — that was just what we needed to ship.


### PR DESCRIPTION
Per CONTRIBUTING.md — re-submitting #367 as a short human-written note instead of code.

Adds one file, `adrs/gcp-runtime.md`. No implementation.

Tracked on your side as #735.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790546519&installation_model_id=19911&pr_number=842&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F842&signature=832b99ccd3f5ba19e08b0dc928b75042c59e2e83553eae953fa3ce50e15751b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->