### PR TITLE
docs: propose OrcaRouter as a first-class model provider

### DIFF
--- a/adrs/orcarouter-provider.md
+++ b/adrs/orcarouter-provider.md
@@ -1,0 +1,36 @@
+# Add OrcaRouter as a first-class model provider
+
+## Proposal
+
+Add OrcaRouter as a named model provider, mirroring how OpenRouter is wired today. A deployment would set `modelProvider: "orcarouter"` with an `ORCAROUTER_API_KEY`, and the base model and web picker would resolve through OrcaRouter's OpenAI-compatible endpoint — without treating it as an anonymous custom base URL.
+
+## Why
+
+QM already carries one gateway-as-provider in OpenRouter: a single key, many models, resolved through a dynamic catalog. [OrcaRouter](https://www.orcarouter.ai) is the same shape. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.
+
+It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Because QM's provider surface is deliberately a short list (anthropic, openai, openrouter), a named orcarouter entry keeps the mental model intact: one key, many models, a single `*_BASE_URL` override, admin key rotation, and catalog-driven picker entries — all mirroring the OpenRouter path exactly.
+
+## Shape
+
+The OpenRouter wiring is seven concrete touchpoints; orcarouter would be a sibling at each:
+
+- `src/model/provider-endpoints.ts` — `PROVIDER_IDS` and the `ORCAROUTER_BASE_URL` override
+- `src/model/pi-models.ts` — `MODEL_PROVIDERS`, availability gating, and an `orcarouter/auto` base model
+- `src/model/model-catalog.ts` — a catalog fetch against `https://api.orcarouter.ai/v1/models`, merged into the selectable picker only when OrcaRouter is configured
+- `src/model/model-credential-store.ts`, `src/wiring.ts`, `src/config.ts`, `src/deployment/secret-schema.ts` — key resolution and secret gating
+- `src/api/routes/admin/model-providers.ts` — admin key validation (OrcaRouter has no `/key` endpoint, so validation hits `/v1/models` instead)
+- `cli/` — `MODEL_PROVIDERS`/`MODEL_PROVIDER_KEYS`/`MODEL_PROVIDER_HARNESSES`, the secret spec, the doctor probe, and the setup prompts
+
+One deviation from OpenRouter: OrcaRouter is not a pi-ai built-in provider, so the pi harness registers an `orcarouter` provider at runtime, and the catalog parser maps OrcaRouter's OpenAI-style model list onto the existing runtime shape. Everything downstream (web picker, admin panel, `qm setup`/`qm doctor`, secret rotation) then behaves identically.
+
+## Out of scope
+
+This proposal only adds the provider slot and its wiring. No default changes, no model curation beyond the catalog pass-through, and no change to how the security posture or screening proxy are configured.
+
+---
+
+Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
+
+I'm an engineer on the OrcaRouter team.


### PR DESCRIPTION
This ADR proposes adding OrcaRouter as a first-class model provider in QM, mirroring the way OpenRouter is wired in today.

## The problem from a QM user's seat

QM's "multiplayer agent harness for work" lets each org pick its own model provider, and one of the cleanest options is a gateway: one `OPENROUTER_API_KEY`, one base URL, and a whole catalog of models behind it. OpenRouter is wired that way. But if you want OrcaRouter's stack — adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance on the same endpoint — there is currently no way to select it. You would have to register it as an anonymous custom base URL, which means no catalog in the picker, no admin key rotation, and no `qm setup`/`qm doctor` support. That's a worse experience than every named provider gets.

Adding `orcarouter` as a named provider closes that gap. A deployment sets `modelProvider: "orcarouter"` with an `ORCAROUTER_API_KEY`, and the base model, the web picker, and the admin panel all treat it exactly like OpenRouter today.

## What this means

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The ADR lists the concrete touchpoints, which are exactly the seven places OpenRouter already appears: `provider-endpoints.ts`, `pi-models.ts`, `model-catalog.ts`, the credential store, `wiring.ts`/`config.ts`/`secret-schema.ts`, the admin model-providers route, and the CLI. One deviation is called out honestly: OrcaRouter is not a pi-ai built-in provider, so the pi harness registers it at runtime and the catalog parser maps OrcaRouter's OpenAI-style model list onto the existing runtime shape.

## Verification

The ADR's Shape section was validated against the live OrcaRouter API:

- `GET https://api.orcarouter.ai/v1/models` returns `{ data: [...] }` (200 with a valid key, 401 without)
- `POST https://api.orcarouter.ai/v1/chat/completions` streams a completion (200) using a provider-prefixed model id such as `deepseek/deepseek-v4-flash-0731`

## Out of scope

No default changes, no model curation beyond a catalog pass-through, and no change to the security posture or screening proxy. If this direction is welcome, the code implementation can follow the ADR's shape.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790585665&installation_model_id=19911&pr_number=846&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F846&signature=aba88626d7ebaadfefe858b39fb8c0f9fb2bc51180cac2afdb4f70ff8a278b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->