### PR TITLE
local sandbox: recreate a parked container whose docker network is gone

### DIFF
--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -146,6 +146,21 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     return { running: running === "true", imageId };
   }
 
+  async function networksIntact(name: string): Promise<boolean> {
+    const r = await dexec(["inspect", "-f", "{{json .NetworkSettings.Networks}}", name]);
+    if (r.code !== 0) return false;
+    let endpoints: Record<string, { NetworkID?: string }>;
+    try {
+      endpoints = JSON.parse(r.stdout.trim() || "{}");
+    } catch {
+      return false;
+    }
+    for (const endpoint of Object.values(endpoints ?? {})) {
+      if (endpoint.NetworkID && (await dexec(["network", "inspect", endpoint.NetworkID])).code !== 0) return false;
+    }
+    return true;
+  }
+
   async function resolvePort(name: string): Promise<number> {
     const cached = portByName.get(name);
     if (cached) return cached;
@@ -293,7 +308,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localContainerName(scope);
       scopeByContainer.set(name, scope);
       const state = await containerState(name);
-      if (state && state.imageId === imageId) {
+      if (state && state.imageId === imageId && (state.running || (await networksIntact(name)))) {
         if (!state.running) await startContainer(name);
         else await connectCore(await ensureNetwork(name));
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
@@ -318,12 +333,13 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const name = localScratchName(key);
       scratchByKey.set(key, name);
       const state = await containerState(name);
-      if (state) {
+      if (state && (state.running || (await networksIntact(name)))) {
         if (!state.running) await startContainer(name);
         else await connectCore(await ensureNetwork(name));
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
       }
+      if (state) await dexec(["rm", "-f", name]);
       await runContainer(name, undefined, false);
       activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
       return { name, coldStart: true };

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -314,3 +314,38 @@ test("containerized core joins each sandbox network and reaches the daemon by co
   await sb.teardown(h, { destroy: true });
   assert.equal(fake.connections.has(`${localNetworkName(h.id)}|qm-test-core`), false);
 });
+
+test("a parked container whose network was pruned is recreated with its home volume", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake);
+  const layers = rw(scopeId("personal", "U41"));
+  const h1 = await sb.provision(layers);
+  await sb.teardown(h1);
+  assert.equal(fake.containers.get(h1.id)!.running, false);
+  const volume = fake.containers.get(h1.id)!.volume!;
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await makeSandbox(fake).provision(layers);
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "container recreated after its network vanished");
+  assert.equal(fake.containers.get(h2.id)!.running, true);
+  assert.equal(fake.volumes.has(volume), true, "volume survived the recreate");
+  assert.equal(fake.containers.get(h2.id)!.volume, volume, "recreate remounted the same volume");
+  assert.equal(fake.networks.has(localNetworkName(h1.id)), true, "network recreated");
+  assert.equal(h2.coldStart, false, "existing volume means a warm home");
+});
+
+test("a parked scratch box whose network was pruned is recreated", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake);
+  const layers = rw(scopeId("personal", "U42"));
+  const h1 = await sb.provision(layers, { scratch: { key: "pruned" } });
+  fake.containers.get(h1.id)!.running = false;
+  fake.networks.delete(localNetworkName(h1.id));
+
+  const h2 = await sb.provision(layers, { scratch: { key: "pruned" } });
+  assert.equal(h2.id, h1.id);
+  assert.equal(fake.runCount, 2, "scratch container recreated");
+  assert.equal(fake.containers.get(h2.id)!.running, true);
+  assert.equal(fake.networks.has(localNetworkName(h1.id)), true, "network recreated");
+});

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -6,6 +6,7 @@ export interface FakeContainer {
   running: boolean;
   labels: Record<string, string>;
   volume?: string;
+  network?: string;
   args: string[];
 }
 
@@ -54,6 +55,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const [k = "", v = ""] = args[++i]!.split("=");
         c.labels[k] = v;
       } else if (a === "-v") c.volume = args[++i]!.split(":")[0]!;
+      else if (a === "--network") c.network = args[++i]!;
       else if (a === "-p" || a === "--cpus" || a === "--memory") i++;
     }
     return c;
@@ -75,6 +77,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const name = rest[rest.length - 1]!;
         const c = containers.get(name);
         if (!c) return fail(`Error: No such object: ${name}`);
+        if (rest.includes("{{json .NetworkSettings.Networks}}"))
+          return ok(JSON.stringify(c.network ? { [c.network]: { NetworkID: c.network } } : {}));
         return ok(`${c.running} ${c.imageId}`);
       }
       case "network": {
@@ -122,6 +126,8 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
       case "start": {
         const c = containers.get(rest[0]!);
         if (!c) return fail("Error: No such container");
+        if (c.network && !networks.has(c.network))
+          return fail(`Error response from daemon: failed to set up container networking: network ${c.network} not found`);
         c.running = true;
         return ok(rest[0]!);
       }


### PR DESCRIPTION
## Problem

Each local-sandbox container runs on its own docker network and is parked (`docker stop`) between turns. Docker records that network in the container's endpoint config **by ID**. If the network is removed out-of-band while the container is parked — a manual `docker network prune`, a daemon restart that loses networks — the container can never start again:

```
Error response from daemon: failed to set up container networking: network <id> not found
```

`ensureContainer`/`ensureScratch` saw a stopped container with a matching image and went straight to `docker start`, which throws that error verbatim on every subsequent session. The only recovery was removing the container by hand. Recreating the network under the same name does not help, because the stored endpoint references the old network ID.

## Fix

Before reusing a **stopped** container, verify the networks it still references exist (`networksIntact`: inspect the endpoint map, check each `NetworkID`). When one is gone, fall through to the existing recreate path — `rm -f` + `docker run` on a freshly created network. That path remounts the per-scope named volume, so home-directory data survives. Running containers short-circuit past the check (their networks cannot be pruned out from under them).

The scratch path gets the same guard, plus the `rm -f` its fall-through previously never needed (reaching it used to imply the container did not exist).

Deliberately unchanged: `ensureRunning` (restart under a live handle) still surfaces the raw `docker start` error. That scenario implies the daemon died mid-session — execs fail regardless — and every new session enters through `provision`, where the guard now breaks the wedge permanently.

## Tests

Two new cases (scoped + scratch): park a container, delete its network, provision again → container recreated on a fresh network, same volume remounted, warm home (`coldStart: false`). The fake docker now models the failure mode itself — `start` fails with the "network not found" daemon error when the endpoint's network is missing — so both tests fail on the base commit with exactly the user-facing error this PR fixes, and pass with it. Full `test/local-sandbox.test.ts` suite passes (20/20), tsc and oxlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790608835&installation_model_id=19911&pr_number=848&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F848&signature=b47c2d638b169cff80532176c5e5e2556172fd3555a451565c7737e35105bb0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->