### PR TITLE
core: skip the model for human-directed web project mentions

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -137,6 +137,7 @@ import { resolveModel, CODEX_SUBSCRIPTION_PROVIDER } from "../model/pi-models.ts
 import type { ProviderKeys } from "../harness/pi-harness.ts";
 import type { CodexTurnAuth } from "../harness/harness.ts";
 import { resolveIndividualAuthRouting } from "./individual-auth-routing.ts";
+import { mentionsOtherMember } from "./orchestrator/human-mention.ts";
 import {
   MAX_AUTO_ATTACHMENT_SCREEN_BYTES,
   approvalGrantId,
@@ -844,6 +845,15 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       const branding = await resolveBranding(deps.config, resolution.orgScopeId, deps.brandingDefault);
       const botName = branding.selfLabel ?? "QM";
       const orgName = branding.orgName ?? "this organization";
+      const humanText =
+        typeof input.displayText === "string" && input.displayText ? input.displayText : input.text;
+      const humanDirected =
+        isWeb &&
+        conversation.kind === "group" &&
+        input.origin.kind === "human" &&
+        !input.approval &&
+        !input.attachments?.length &&
+        mentionsOtherMember(humanText, conversation.audience, actor.id, botName);
       const rawHandle = cleanBrandingLabel(input.gatewayContext?.botHandle?.replace(/^@/, ""), 40);
       const botHandle = rawHandle && rawHandle.toLowerCase() !== botName.toLowerCase() ? rawHandle : undefined;
       let modeName = "mode-fallback";
@@ -1415,6 +1425,20 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           await Promise.all(pendingScreenRequests.splice(0).map((rec) => recordScreenRequest(rec)));
           return true;
         });
+        if (humanDirected) {
+          await withManagedRosterVersion(async () => {
+            await deps.sessions.append(lease, {
+              type: "user",
+              payload: {
+                text: humanText,
+                ...(actor.displayName?.trim() ? { name: actor.displayName.trim() } : {}),
+              },
+              scopeLabel: scopeId,
+            });
+            return true;
+          });
+          return { status: "silent", sessionId: session.id };
+        }
         if (input.approval) {
           const p = await pending.get(input.approval.requestId);
           if (!input.approval.approved) {

--- a/src/core/orchestrator/human-mention.ts
+++ b/src/core/orchestrator/human-mention.ts
@@ -1,0 +1,34 @@
+import type { Principal } from "../../types.ts";
+
+const MENTION_BODY = /^[\p{L}\p{N}_.·-]+/u;
+
+export function mentionsOtherMember(
+  text: string,
+  audience: readonly Principal[],
+  selfId: string,
+  botName: string,
+): boolean {
+  if (!text.includes("@")) return false;
+  const bot = botName.trim().toLowerCase();
+  if (bot && text.toLowerCase().includes(bot)) return false;
+  const names = audience
+    .filter((p) => p.id !== selfId && p.displayName?.trim())
+    .map((p) => p.displayName!.trim().toLowerCase());
+  if (!names.length) return false;
+  const tokens = new Set<string>();
+  let i = text.indexOf("@");
+  while (i !== -1) {
+    const prev = i > 0 ? text[i - 1]! : "";
+    const m = text.slice(i + 1).match(MENTION_BODY);
+    if (m && m[0] && !/[A-Za-z0-9]/.test(prev)) tokens.add(m[0].toLowerCase());
+    i = text.indexOf("@", i + 1);
+  }
+  return [...tokens].some((t) =>
+    names.some((n) => {
+      if (n === t) return true;
+      if (t.length < 2 || n.length < 2) return false;
+      if (n.startsWith(t)) return true;
+      return t.startsWith(n) && /[^\x00-\x7F]/.test(t.slice(n.length));
+    }),
+  );
+}

--- a/test/turn-human-directed.test.ts
+++ b/test/turn-human-directed.test.ts
@@ -1,0 +1,143 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import "./support/auto-fake-sprites.ts";
+import { buildApp } from "../src/wiring.ts";
+import type { TurnRequest } from "../src/types.ts";
+import { testConfig } from "./support/test-config.ts";
+import { mentionsOtherMember } from "../src/core/orchestrator/human-mention.ts";
+import type { Principal } from "../src/types.ts";
+
+const p = (id: string, displayName: string): Principal => ({ id, displayName, type: "internal" });
+const audience: Principal[] = [
+  p("zhangsan@example.com", "张三"),
+  p("lisi@example.com", "李四"),
+  p("wangwu@example.com", "王五"),
+];
+
+describe("mentionsOtherMember", () => {
+  it("detects a full-name mention mid-sentence without spaces", () => {
+    assert.equal(mentionsOtherMember("帮我看下@李四这个方案", audience, "zhangsan@example.com", "QM"), true);
+  });
+
+  it("treats an ambiguous single-char surname prefix as not human-directed", () => {
+    assert.equal(mentionsOtherMember("@李 你看下", audience, "zhangsan@example.com", "QM"), false);
+    assert.equal(mentionsOtherMember("@李四的方案 我看看", audience, "zhangsan@example.com", "QM"), true);
+  });
+
+  it("ignores a self-mention", () => {
+    assert.equal(mentionsOtherMember("@张三 记一下", audience, "zhangsan@example.com", "QM"), false);
+  });
+
+  it("ignores unknown tokens and emails", () => {
+    assert.equal(mentionsOtherMember("发给 a@b.com 了", audience, "zhangsan@example.com", "QM"), false);
+    assert.equal(mentionsOtherMember("@赵六 在吗", audience, "zhangsan@example.com", "QM"), false);
+  });
+
+  it("ignores text without any at-sign", () => {
+    assert.equal(mentionsOtherMember("李四 看一下", audience, "zhangsan@example.com", "QM"), false);
+  });
+
+  it("returns false when the audience has no other named members", () => {
+    assert.equal(mentionsOtherMember("@李四 看", [p("x", "张三")], "x", "QM"), false);
+  });
+
+  it("does not treat a message naming the bot as human-directed", () => {
+    assert.equal(mentionsOtherMember("@李四 和 QM 一起看看", audience, "zhangsan@example.com", "QM"), false);
+  });
+
+  it("does not match a longer ascii word that merely starts with a member name", () => {
+    const asciiAudience = [
+      p("sam@example.com", "Sam"),
+      p("al@example.com", "Al"),
+      p("ann@example.com", "Ann"),
+    ];
+    assert.equal(
+      mentionsOtherMember("@sample the new endpoint and post the results", asciiAudience, "x@example.com", "QM"),
+      false,
+    );
+    assert.equal(mentionsOtherMember("@all hands", asciiAudience, "x@example.com", "QM"), false);
+    assert.equal(mentionsOtherMember("@announce it", asciiAudience, "x@example.com", "QM"), false);
+  });
+
+  it("still matches a name extended by CJK suffixes", () => {
+    const mixed = [p("amy@example.com", "Amy"), ...audience];
+    assert.equal(mentionsOtherMember("@amy看看这个", mixed, "zhangsan@example.com", "QM"), true);
+  });
+});
+
+describe("web group human-directed turns", () => {
+  function freshApp() {
+    return buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "hm-")) }));
+  }
+
+  async function projectFixture(
+    ownerId: string,
+    ownerName: string,
+    memberId: string,
+    memberName: string,
+  ): Promise<{ app: ReturnType<typeof buildApp>["app"]; groupRef: string }> {
+    const built = freshApp();
+    await built.app.upsertDirectory([
+      { principalId: ownerId, displayName: ownerName, type: "internal" },
+      { principalId: memberId, displayName: memberName, type: "internal" },
+    ]);
+    const project = await built.projects.create({ name: "Launch", ownerId });
+    await built.projects.addMember(project.id, ownerId, memberId);
+    return { app: built.app, groupRef: `web-project-${project.id}` };
+  }
+
+  function groupTurn(
+    actor: { externalId: string; displayName?: string },
+    groupRef: string,
+    text: string,
+    extra: Partial<TurnRequest> = {},
+  ): TurnRequest {
+    return {
+      surface: "web",
+      actor,
+      origin: { kind: "human" },
+      conversation: { kind: "group", channelRef: groupRef, threadRef: `${groupRef}:t1`, audience: [actor] },
+      text,
+      ...extra,
+    };
+  }
+
+  it("appends the typed message and stays silent", async () => {
+    const { app, groupRef } = await projectFixture("U1", "张三", "U2", "李四");
+    const res = await app.turn(groupTurn({ externalId: "U1" }, groupRef, "@李四 看下这个方案"));
+    assert.equal(res.status, "silent", res.reason);
+    const found = await app.getSession(res.sessionId!);
+    assert.deepEqual(found!.entries.map((e) => e.type), ["user"]);
+    assert.equal((found!.entries[0]!.payload as { text: string }).text, "@李四 看下这个方案");
+  });
+
+  it("matches the typed message, not spine-envelope metadata that happens to contain the bot label", async () => {
+    const { app, groupRef } = await projectFixture("qiming@acme.com", "Qiming", "U2", "李四");
+    const res = await app.turn(
+      groupTurn({ externalId: "qiming@acme.com" }, groupRef, "@李四 看下这个方案"),
+    );
+    assert.equal(res.status, "silent", "a sender whose id contains the bot label must not be vetoed");
+  });
+
+  it("a mention carrying attachments still reaches the model", async () => {
+    const { app, groupRef } = await projectFixture("U1", "张三", "U2", "李四");
+    const res = await app.turn(
+      groupTurn({ externalId: "U1" }, groupRef, "@李四 看这张图", {
+        attachments: [{ name: "shot.png", mimetype: "image/png", sizeBytes: 3, blobId: "b1" }],
+      }),
+    );
+    assert.notEqual(res.status, "silent");
+  });
+
+  it("slack-originated group mentions still reach the model", async () => {
+    const { app, groupRef } = await projectFixture("U1", "张三", "U2", "李四");
+    const res = await app.turn({
+      ...groupTurn({ externalId: "U1" }, groupRef, "@李四 看下这个方案"),
+      surface: "slack",
+    });
+    assert.equal(res.status, "ok");
+  });
+});


### PR DESCRIPTION
## Problem

In web project chats, a message from a human that @-mentions another human member is person-to-person communication routed through the bot. Running it through the model costs a turn, adds latency, and can make the model interject where nobody asked it to.

## Change

Append the message to the session transcript and end the turn silently (`{status: "silent"}`) when the incoming web group turn:

- is human-originated (`origin.kind === "human"`),
- carries no approval and no attachments,
- mentions another named member of the conversation audience.

Details worth review attention:

- **Matching runs on the display text**, not `input.text`. For web group human turns the spine rewrite substitutes a wake envelope for `input.text` and moves the typed message to `displayText`; the envelope's metadata carries the sender's identity, so matching (and the bot-name veto) must read the display form — otherwise any sender whose id contains the bot label is silently excluded.
- **CJK-aware matching** (new `src/core/orchestrator/human-mention.ts`): no-space boundaries; single-character surname prefixes stay ambiguous (not human-directed); an ASCII token that merely *starts with* a member name (`@sample` vs a member named Sam) does not match; CJK-suffixed extensions (`@李四这个方案`) do; self- and bot-mentions are ignored; email addresses do not count.
- **Attachments opt out**: turns with attachments keep the model path, because the silent path would persist raw blob references that are never materialized and cannot be fetched by any viewer.

Slack-originated turns are untouched (web-surface only).

## Tests

Unit tests for the matcher plus app-level integration tests through `app.turn` with a real project fixture: silent append of the typed message; the envelope-metadata veto case (sender id containing the bot label stays silent); mention-with-attachment still reaches the model; slack-originated mention still reaches the model. Full orchestrator suite passes (132 tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790656664&installation_model_id=19911&pr_number=854&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F854&signature=634522ac71a92bd737627e1ce609d7cfd266d564215063a5a5f0821af3128ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->