### PR TITLE
web-ui: @mentions for project chats (completion, chips, member realtime)

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -315,8 +315,95 @@ interface PendingWebDelivery {
   id: string;
   idempotencyKey: string;
   createdAt: number;
-  destination?: { target?: string };
+  destination?: { target?: string; audienceScopeId?: string };
 }
+
+const MENTION_TOKEN_BODY = /^[\p{L}\p{N}_.·-]+/u;
+
+function mentionTokensOf(text: string): string[] {
+  const tokens = new Set<string>();
+  let i = text.indexOf("@");
+  while (i !== -1) {
+    const prev = i > 0 ? text[i - 1]! : "";
+    const m = text.slice(i + 1).match(MENTION_TOKEN_BODY);
+    if (m && m[0] && !/[A-Za-z0-9]/.test(prev)) tokens.add(m[0]);
+    i = text.indexOf("@", i + 1);
+  }
+  return [...tokens].slice(0, 5);
+}
+
+function pushThreadEvent(user: string, threadRef: string): void {
+  const conns = deliveryClients.get(user);
+  if (!conns || !conns.size) return;
+  for (const res of conns) sseEvent(res, "delivery", { threadRef });
+}
+
+async function projectMembers(
+  projectId: string,
+  owner: string,
+): Promise<Array<{ principalId: string; displayName?: string }>> {
+  try {
+    const r = await coreFetch(
+      "GET",
+      `/v1/projects?principalId=${encodeURIComponent(owner)}`,
+    );
+    if (r.status !== 200) return [];
+    const parsed = JSON.parse(r.text) as {
+      projects?: Array<{
+        id?: string;
+        memberIds?: string[];
+        members?: Array<{ principalId: string; displayName?: string }>;
+      }>;
+    };
+    const project = (parsed.projects ?? []).find((p) => p.id === projectId);
+    if (project?.members?.length) return project.members;
+    return (project?.memberIds ?? []).map((principalId) => ({ principalId }));
+  } catch {
+    return [];
+  }
+}
+
+async function broadcastProjectThread(projectId: string, owner: string, threadRef: string): Promise<void> {
+  for (const member of await projectMembers(projectId, owner)) {
+    if (member.principalId !== owner) pushThreadEvent(member.principalId, threadRef);
+  }
+}
+
+export function matchMentionMembers(
+  tokens: readonly string[],
+  members: ReadonlyArray<{ principalId: string; displayName?: string }>,
+  senderId: string,
+): string[] {
+  const named = members
+    .filter((m) => m.principalId !== senderId && m.displayName?.trim())
+    .map((m) => ({ principalId: m.principalId, name: m.displayName!.trim().toLowerCase() }));
+  const hits: string[] = [];
+  for (const raw of tokens) {
+    const token = raw.replace(/[._·-]+$/, "").toLowerCase();
+    if (!token) continue;
+    const hit =
+      named.find((n) => n.name === token) ??
+      named.find(
+        (n) =>
+          token.length >= 2 &&
+          token.startsWith(n.name) &&
+          /[^\x00-\x7F]/.test(token.slice(n.name.length)),
+      );
+    if (hit && !hits.includes(hit.principalId)) hits.push(hit.principalId);
+  }
+  return hits;
+}
+
+async function notifyMentions(text: string, threadRef: string, senderId: string, scope: string): Promise<void> {
+  if (!scope.startsWith("group:web-project-")) return;
+  const owner = ownerOfWebThread(threadRef) ?? "";
+  const members = await projectMembers(scope.slice("group:web-project-".length), owner);
+  for (const principalId of matchMentionMembers(mentionTokensOf(text), members, senderId)) {
+    pushThreadEvent(principalId, threadRef);
+  }
+}
+
+const broadcastDeliveries = new Map<string, number>();
 
 async function drainWebDeliveries(): Promise<void> {
   if (deliveriesPollInFlight) return;
@@ -334,6 +421,18 @@ async function drainWebDeliveries(): Promise<void> {
     for (const d of pending) {
       const target = d.destination?.target ?? "";
       const isRecovery = d.idempotencyKey.startsWith("run:");
+      const audienceScopeId = !isRecovery ? (d.destination?.audienceScopeId ?? "") : "";
+      if (audienceScopeId.startsWith("group:web-project-")) {
+        for (const [id, at] of broadcastDeliveries) {
+          if (now - at > WEB_DELIVERY_GIVEUP_MS) broadcastDeliveries.delete(id);
+        }
+        if (!broadcastDeliveries.has(d.id)) {
+          broadcastDeliveries.set(d.id, now);
+          const owner = ownerOfWebThread(target) ?? "";
+          const projectId = audienceScopeId.slice("group:web-project-".length);
+          void broadcastProjectThread(projectId, owner, target);
+        }
+      }
       const conns = !isRecovery ? deliveryClients.get(ownerOfWebThread(target) ?? "") : undefined;
       if (conns && conns.size) {
         for (const res of conns) sseEvent(res, "delivery", { threadRef: target });
@@ -506,7 +605,7 @@ async function readJson<T extends object>(
   }
 }
 
-async function postTurnAndMint(res: ServerResponse, turn: unknown, user: string, threadRef: string): Promise<void> {
+async function postTurnAndMint(res: ServerResponse, turn: unknown, user: string, threadRef: string): Promise<boolean> {
   const r = await coreFetch("POST", `/v1/turns?async=1`, JSON.stringify(turn));
   if (r.status >= 200 && r.status < 300) {
     try {
@@ -514,13 +613,15 @@ async function postTurnAndMint(res: ServerResponse, turn: unknown, user: string,
       const runId = parsed.runId;
       if (runId) {
         rememberRun(runId, user, threadRef);
-        return json(res, r.status, parsed);
+        json(res, r.status, parsed);
+        return true;
       }
     } catch {
       void 0;
     }
   }
   relay(res, r);
+  return false;
 }
 
 async function userPermissions(): Promise<string[]> {
@@ -1794,7 +1895,18 @@ const apiRoutes: readonly WebRoute[] = [
         ...(proactiveOpener ? { proactiveOpener: true } : {}),
         ...(clientTurnId ? { idempotencyKey: `web:${user}:${clientTurnId}` } : {}),
       };
-      return postTurnAndMint(res, turn, user, threadRef);
+      const sent = await postTurnAndMint(res, turn, user, threadRef);
+      if (
+        sent &&
+        typeof scope === "string" &&
+        scope &&
+        !scope.startsWith("personal:") &&
+        typeof text === "string" &&
+        text.includes("@")
+      ) {
+        void notifyMentions(text, threadRef, user, scope);
+      }
+      return;
     },
   },
   {

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -75,6 +75,7 @@ import { errMessage, swallow } from "../../chassis/src/errors";
 import { showStateError } from "./error-banner";
 import { escapeLoneDollars } from "./markdown-dollars";
 import { splitStreamingMarkdown } from "./streaming-markdown";
+import { splitMentions } from "./mention";
 import { installMarkdownSanitizer } from "./markdown-sanitize";
 import {
   transcriptModel,
@@ -1281,7 +1282,7 @@ export function createChatSurface(
         <article class="message-row user-row ${steered ? "steered-row" : ""}" data-index=${index}>
           ${steered ? html`<div class="steer-label">↪ steered the running task</div>` : nothing}
           <div class="message-bubble user-bubble">
-            ${markdown(messageText(message))}
+            ${userTextWithMentions(messageText(message))}
             ${attachments.length ? html`<div class="message-files">${attachments.map(userAttachmentBadge)}</div>` : nothing}
           </div>
           ${
@@ -1498,6 +1499,21 @@ export function createChatSurface(
 
   function markdown(text: string): TemplateResult {
     return html`<markdown-block .content=${escapeLoneDollars(text)}></markdown-block>`;
+  }
+
+  function scopeMentionNames(): string[] {
+    const context = contextsState.list.find((c) => c.scopeId === chatState.scopeId);
+    return (context?.project?.members ?? []).map((m) => m.displayName).filter(Boolean);
+  }
+
+  function userTextWithMentions(text: string): TemplateResult {
+    const names = scopeMentionNames();
+    const segments =
+      names.length && !text.includes("```") ? splitMentions(text, names) : [{ text, mention: false }];
+    if (!segments.some((s) => s.mention)) return markdown(segments[0]!.text);
+    return html`${segments.map((s) =>
+      s.mention ? html`<span class="mention-chip">${s.text}</span>` : markdown(s.text),
+    )}`;
   }
 
   let escapedSegs: string[] = [];

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -54,6 +54,8 @@ import { bumpSessionActivity, dropPendingSession, renderList } from "./sessions"
 import { appState } from "./shell";
 import { base64ToText, bytesToBase64, insertIntoDraft, pasteChipLabel } from "./paste-text";
 import { clearDraft, newChatDraftKey, saveDraft } from "./drafts";
+import { contextsState } from "./contexts";
+import { mentionQuery, replaceMentionToken } from "./mention";
 
 export type ComposerMenu = "effort" | "harness" | "model" | "settings";
 
@@ -272,6 +274,8 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   let dragDepth = 0;
   let skillsLoading = false;
   let slashActiveIndex = 0;
+  let mentionActiveIndex = 0;
+  let mentionDismissed = false;
   let fastModeCharging = false;
   let orgFastModeDefault = false;
   let fastModeChargeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -411,7 +415,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     }
     return html`
       <form class="composer-wrap" @submit=${(e: Event) => submitComposer(e, agent)}>
-        ${slashMenu(agent)}
+        ${slashMenu(agent)} ${mentionMenu(agent)}
         ${
           activeRuntimeConfig?.upgradeAvailable
             ? html`<div class="runtime-upgrade">
@@ -483,6 +487,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                   ?disabled=${inputBlocked}
                   .value=${live(composerState.draft)}
                   @input=${(e: InputEvent) => onDraftInput(e, agent)}
+                  @compositionend=${(e: CompositionEvent) => onDraftCompositionEnd(e, agent)}
                   @keydown=${(e: KeyboardEvent) => onComposerKeydown(e, agent)}
                   @paste=${(e: ClipboardEvent) => void onComposerPaste(e, agent)}
                 ></textarea>
@@ -1098,6 +1103,70 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     focusComposerEnd();
   }
 
+  interface DirectoryPick {
+    principalId: string;
+    displayName: string;
+  }
+
+  function clampedMention(count: number): number {
+    return Math.max(0, Math.min(mentionActiveIndex, count - 1));
+  }
+
+  function scopeMembers(): DirectoryPick[] {
+    const context = contextsState.list.find((c) => c.scopeId === ctx.chat.state.scopeId);
+    return (context?.project?.members ?? [])
+      .filter((m) => m.principalId !== appState.me?.user && m.displayName)
+      .map((m) => ({ principalId: m.principalId, displayName: m.displayName }));
+  }
+
+  function currentMentionMenu(): { open: boolean; matches: DirectoryPick[] } {
+    const query = mentionQuery(composerState.draft);
+    if (query === null || mentionDismissed) return { open: false, matches: [] };
+    if (!ctx.chat.state.scopeId || ctx.chat.state.scopeId.startsWith("personal:")) {
+      return { open: false, matches: [] };
+    }
+    const members = scopeMembers();
+    if (!members.length) return { open: false, matches: [] };
+    const q = query.toLowerCase();
+    const matches = q ? members.filter((m) => m.displayName.toLowerCase().includes(q)) : members;
+    return { open: matches.length > 0, matches };
+  }
+
+  function acceptMention(match: DirectoryPick, agent: Agent): void {
+    composerState.draft = replaceMentionToken(composerState.draft, `@${match.displayName} `);
+    persistDraft();
+    mentionActiveIndex = 0;
+    mentionDismissed = false;
+    ctx.chat.drawActiveChat(agent);
+    focusComposerEnd();
+  }
+
+  function mentionMenu(agent: Agent): TemplateResult | typeof nothing {
+    const menu = currentMentionMenu();
+    if (!menu.open) return nothing;
+    const active = clampedMention(menu.matches.length);
+    return html`
+      <div class="slash-popover mention-popover" role="listbox" aria-label="Mention members">
+        <div class="menu-title">Mention members</div>
+        ${menu.matches.map((m, i) => {
+          return html`
+            <button
+              type="button"
+              role="option"
+              aria-selected=${i === active ? "true" : "false"}
+              class="slash-option ${i === active ? "active" : ""}"
+              @mousedown=${(e: Event) => e.preventDefault()}
+              @click=${() => acceptMention(m, agent)}
+            >
+              <span class="slash-name">${m.displayName}</span>
+              <span class="slash-desc">${m.principalId}</span>
+            </button>
+          `;
+        })}
+      </div>
+    `;
+  }
+
   let pendingComposerFocus = false;
 
   function focusComposerEnd(): void {
@@ -1171,22 +1240,48 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     void sendPrompt(agent);
   }
 
-  function onDraftInput(e: InputEvent, agent: Agent): void {
-    composerState.draft = (e.currentTarget as HTMLTextAreaElement).value;
-    persistDraft();
-    const hadError = Boolean(composerState.error);
-    composerState.error = "";
-    composerState.slashDismissed = false;
-    slashActiveIndex = 0;
+  function refreshComposerMenus(agent: Agent): void {
     const armed = slashQuery(composerState.draft) !== null;
     if (armed && skillsCache === null && !skillsLoading) void loadSkills(agent);
-    const popoverShown = Boolean(ctx.chat.state.host?.querySelector(".slash-popover"));
-    if (armed || popoverShown || hadError) {
+    const mentionArmed = mentionQuery(composerState.draft) !== null;
+    const popoverShown = Boolean(
+      ctx.chat.state.host?.querySelector(".slash-popover, .mention-popover"),
+    );
+    if (armed || mentionArmed || popoverShown) {
       ctx.chat.drawActiveChat(agent);
       return;
     }
     syncComposerControls(agent);
     resizeComposer();
+  }
+
+  function onDraftInput(e: InputEvent, agent: Agent): void {
+    composerState.draft = (e.currentTarget as HTMLTextAreaElement).value;
+    persistDraft();
+    if (e.isComposing) {
+      syncComposerControls(agent);
+      resizeComposer();
+      return;
+    }
+    const hadError = Boolean(composerState.error);
+    composerState.error = "";
+    composerState.slashDismissed = false;
+    slashActiveIndex = 0;
+    mentionDismissed = false;
+    mentionActiveIndex = 0;
+    if (hadError) {
+      ctx.chat.drawActiveChat(agent);
+      return;
+    }
+    refreshComposerMenus(agent);
+  }
+
+  function onDraftCompositionEnd(e: CompositionEvent, agent: Agent): void {
+    composerState.draft = (e.currentTarget as HTMLTextAreaElement).value;
+    persistDraft();
+    mentionDismissed = false;
+    mentionActiveIndex = 0;
+    refreshComposerMenus(agent);
   }
 
   function composerCanSend(): boolean {
@@ -1248,6 +1343,31 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       } else if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         return;
+      }
+    }
+    const mention = currentMentionMenu();
+    if (mention.open) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        mentionDismissed = true;
+        return ctx.chat.drawActiveChat(agent);
+      }
+      const count = mention.matches.length;
+      if (count) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          mentionActiveIndex = (clampedMention(count) + 1) % count;
+          return ctx.chat.drawActiveChat(agent);
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          mentionActiveIndex = (clampedMention(count) - 1 + count) % count;
+          return ctx.chat.drawActiveChat(agent);
+        }
+        if (!e.shiftKey && (e.key === "Enter" || e.key === "Tab")) {
+          e.preventDefault();
+          return acceptMention(mention.matches[clampedMention(count)]!, agent);
+        }
       }
     }
     if (e.key !== "Enter" || e.shiftKey) return;

--- a/plugins/web-ui/src/conversations.ts
+++ b/plugins/web-ui/src/conversations.ts
@@ -10,6 +10,28 @@ import type { Conversation, ConvCtx, ConvHost } from "./conv-types";
 const live = new Set<Conversation>();
 let main: Conversation | null = null;
 
+let mentionToastTimer: ReturnType<typeof setTimeout> | undefined;
+
+function notifyAwayThread(threadRef: string): void {
+  const openViewing = [...live].some((conv) => conv.state.threadRef === threadRef);
+  if (openViewing) return;
+  const session = sessionsState.list.find((s) => s.threadRef === threadRef);
+  const title = session?.title || session?.channelName || "New message";
+  let el = document.querySelector<HTMLDivElement>(".mention-toast");
+  if (!el) {
+    el = document.createElement("div");
+    el.className = "mention-toast";
+    document.body.appendChild(el);
+  }
+  el.textContent = `💬 New message: ${title}`;
+  el.classList.add("show");
+  if (mentionToastTimer !== undefined) clearTimeout(mentionToastTimer);
+  mentionToastTimer = setTimeout(() => {
+    el?.classList.remove("show");
+    mentionToastTimer = undefined;
+  }, 4500);
+}
+
 export function createConversation(host: ConvHost): Conversation {
   const ctx = { ...host } as ConvCtx;
   ctx.chat = createChatSurface(ctx);
@@ -69,6 +91,7 @@ export function ensureDeliveryStream(): void {
   subscribeDeliveries(
     (threadRef) => {
       void refreshSessions({ silent: true });
+      notifyAwayThread(threadRef);
       for (const conv of live) conv.onDelivery(threadRef);
     },
     (event) => {

--- a/plugins/web-ui/src/mention.ts
+++ b/plugins/web-ui/src/mention.ts
@@ -1,0 +1,58 @@
+const TOKEN_BODY = /^[\p{L}\p{N}_.·-]+/u;
+const ASCII_NAME = /^[A-Za-z0-9_.-]+$/;
+const MENTION_TOKEN = /(^|[^A-Za-z0-9@])@([^\s@]{0,40})$/;
+
+export function mentionQuery(draft: string): string | null {
+  const m = draft.match(MENTION_TOKEN);
+  return m ? (m[2] ?? "") : null;
+}
+
+export function replaceMentionToken(draft: string, insert: string): string {
+  return draft.replace(MENTION_TOKEN, (_all, pre: string) => `${pre}${insert}`);
+}
+
+export interface MentionSegment {
+  text: string;
+  mention: boolean;
+}
+
+export function splitMentions(text: string, knownNames: readonly string[]): MentionSegment[] {
+  if (!text.includes("@")) return [{ text, mention: false }];
+  const trimmed = [...new Set(knownNames.map((n) => n.trim()).filter(Boolean))].sort((a, b) => b.length - a.length);
+  if (!trimmed.length) return [{ text, mention: false }];
+  const segments: MentionSegment[] = [];
+  let last = 0;
+  let i = text.indexOf("@");
+  while (i !== -1) {
+    const rest = text.slice(i + 1);
+    const prev = i > 0 ? text[i - 1]! : "";
+    const hit = /[A-Za-z0-9]/.test(prev)
+      ? undefined
+      : trimmed.find((name) => {
+          if (rest.slice(0, name.length).toLowerCase() !== name.toLowerCase()) return false;
+          return !(ASCII_NAME.test(name) && /^[A-Za-z0-9_.-]/.test(rest.slice(name.length)));
+        });
+    if (hit) {
+      if (i > last) segments.push({ text: text.slice(last, i), mention: false });
+      segments.push({ text: `@${rest.slice(0, hit.length)}`, mention: true });
+      last = i + 1 + hit.length;
+      i = text.indexOf("@", last);
+    } else {
+      i = text.indexOf("@", i + 1);
+    }
+  }
+  if (last < text.length) segments.push({ text: text.slice(last), mention: false });
+  return segments.length ? segments : [{ text, mention: false }];
+}
+
+export function mentionTokens(text: string): string[] {
+  const tokens = new Set<string>();
+  let i = text.indexOf("@");
+  while (i !== -1) {
+    const prev = i > 0 ? text[i - 1]! : "";
+    const m = text.slice(i + 1).match(TOKEN_BODY);
+    if (m && m[0] && !/[A-Za-z0-9]/.test(prev)) tokens.add(m[0]);
+    i = text.indexOf("@", i + 1);
+  }
+  return [...tokens].slice(0, 5);
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1505,6 +1505,37 @@ a.chat-row-open {
   background: color-mix(in srgb, var(--secondary) 76%, var(--background));
   color: var(--foreground);
 }
+.mention-chip {
+  display: inline;
+  padding: 0 4px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--brand-accent) 12%, transparent);
+  color: var(--brand-accent);
+  font-weight: 600;
+}
+.mention-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 24px;
+  z-index: 60;
+  max-width: 320px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #f8fafc;
+  font-size: 13px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+.mention-toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
 .message-files,
 .attachment-strip {
   display: flex;

--- a/plugins/web-ui/test/mention-notify-server.test.ts
+++ b/plugins/web-ui/test/mention-notify-server.test.ts
@@ -1,0 +1,50 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const core = createServer((req: IncomingMessage, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ projects: [] }));
+});
+await new Promise<void>((resolve) => core.listen(0, resolve));
+after(() => new Promise<void>((resolve) => core.close(() => resolve())));
+
+process.env.CORE_API_URL = `http://localhost:${(core.address() as AddressInfo).port}`;
+process.env.CORE_SIGNING_SECRET = "mention-notify-test";
+process.env.WEB_UI_PRINCIPALS = "alice";
+
+const { matchMentionMembers } = await import("../server/index.ts");
+
+const members = [
+  { principalId: "alice", displayName: "Alice" },
+  { principalId: "dan", displayName: "Dan" },
+  { principalId: "daniel", displayName: "Daniel" },
+  { principalId: "lisi", displayName: "李四" },
+  { principalId: "amy", displayName: "Amy" },
+];
+
+test("matchMentionMembers resolves an exact display name", () => {
+  assert.deepEqual(matchMentionMembers(["daniel"], members, "alice"), ["daniel"]);
+});
+
+test("a trailing sentence period is stripped before matching", () => {
+  assert.deepEqual(matchMentionMembers(["alice."], members, "dan"), ["alice"]);
+});
+
+test("a longer ascii name does not notify its shorter prefix namesake", () => {
+  assert.deepEqual(matchMentionMembers(["daniel"], members, "dan"), ["daniel"]);
+  assert.deepEqual(matchMentionMembers(["daniela"], [{ principalId: "x", displayName: "Dan" }, ...members.slice(1)], "alice"), []);
+});
+
+test("a CJK run-on token still notifies the embedded name", () => {
+  assert.deepEqual(matchMentionMembers(["李四看一下"], members, "alice"), ["lisi"]);
+});
+
+test("the sender is never notified by their own mention", () => {
+  assert.deepEqual(matchMentionMembers(["alice"], members, "alice"), []);
+});
+
+test("duplicate tokens notify a member once", () => {
+  assert.deepEqual(matchMentionMembers(["amy", "amy."], members, "alice"), ["amy"]);
+});

--- a/plugins/web-ui/test/mention.test.ts
+++ b/plugins/web-ui/test/mention.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { splitMentions, mentionTokens, mentionQuery, replaceMentionToken } from "../src/mention.ts";
+
+describe("splitMentions", () => {
+  it("returns plain text untouched when no @ present", () => {
+    assert.deepEqual(splitMentions("今天开会", ["李四"]), [{ text: "今天开会", mention: false }]);
+  });
+
+  it("returns plain text when no known names are supplied", () => {
+    assert.deepEqual(splitMentions("@李四 看一下", []), [{ text: "@李四 看一下", mention: false }]);
+  });
+
+  it("chips a known member mention", () => {
+    assert.deepEqual(splitMentions("请@李四复核", ["李四", "王五"]), [
+      { text: "请", mention: false },
+      { text: "@李四", mention: true },
+      { text: "复核", mention: false },
+    ]);
+  });
+
+  it("chips multiple mentions and matches case-insensitively", () => {
+    assert.deepEqual(splitMentions("@Amy和@李四对齐", ["amy", "李四"]), [
+      { text: "@Amy", mention: true },
+      { text: "和", mention: false },
+      { text: "@李四", mention: true },
+      { text: "对齐", mention: false },
+    ]);
+  });
+
+  it("leaves unknown mentions as plain text", () => {
+    assert.deepEqual(splitMentions("@路人甲 你好", ["李四"]), [{ text: "@路人甲 你好", mention: false }]);
+  });
+
+  it("keeps adjacent CJK punctuation out of the mention token", () => {
+    assert.deepEqual(splitMentions("@李四，收到", ["李四"]), [
+      { text: "@李四", mention: true },
+      { text: "，收到", mention: false },
+    ]);
+  });
+
+  it("does not chip an at-sign embedded in an ascii word", () => {
+    assert.deepEqual(splitMentions("mail user@bob about it", ["bob"]), [
+      { text: "mail user@bob about it", mention: false },
+    ]);
+  });
+});
+
+describe("mentionTokens", () => {
+  it("extracts unique tokens capped at five", () => {
+    assert.deepEqual(mentionTokens("@a @b @a @c @d @e @f @g"), ["a", "b", "c", "d", "e"]);
+  });
+
+  it("skips email-interior at-signs", () => {
+    assert.deepEqual(mentionTokens("普通文本 邮箱是a@b.c"), []);
+  });
+});
+
+describe("mentionQuery", () => {
+  it("arms at message start", () => {
+    assert.equal(mentionQuery("@李"), "李");
+    assert.equal(mentionQuery("@"), "");
+  });
+
+  it("arms after CJK text without a space", () => {
+    assert.equal(mentionQuery("帮我看下@李四"), "李四");
+    assert.equal(mentionQuery("请@amy复"), "amy复");
+  });
+
+  it("arms after whitespace", () => {
+    assert.equal(mentionQuery("hello @zh"), "zh");
+  });
+
+  it("does not arm inside ascii words or emails", () => {
+    assert.equal(mentionQuery("a@b"), null);
+    assert.equal(mentionQuery("mail me tony@ex"), null);
+    assert.equal(mentionQuery("没有at符号"), null);
+  });
+
+  it("does not arm when the cursor text after @ contains a space", () => {
+    assert.equal(mentionQuery("@李 你好"), null);
+  });
+});
+
+describe("replaceMentionToken", () => {
+  it("keeps the preceding CJK text when inserting", () => {
+    assert.equal(replaceMentionToken("帮我看下@李四", "@李四 "), "帮我看下@李四 ");
+  });
+
+  it("keeps a leading space when inserting", () => {
+    assert.equal(replaceMentionToken("hello @zh", "@Amy "), "hello @Amy ");
+  });
+
+  it("inserts at message start", () => {
+    assert.equal(replaceMentionToken("@李", "@李四 "), "@李四 ");
+  });
+});


### PR DESCRIPTION
## Problem

Project chats are where members talk to each other through the bot, but the web-ui had no mention affordances: typing a member's name gave no completion, @names rendered as plain text, and members other than the thread owner only learned about new messages by refreshing.

## Change

- **Composer**: @-mention popup for project members — tab/enter accepts, arrows navigate, escape dismisses. Arms after CJK text without a leading space (the dominant Chinese typing pattern) and after whitespace; never inside ascii words or emails. IME composition events update the draft but re-arm the menus on `compositionend` (Chrome fires the committing input with `isComposing: true` and no trailing non-composing input).
- **Transcript**: user messages chip @name tokens of known project members; non-mention segments keep their markdown rendering.
- **Realtime**: when the delivery poll first sees a delivery for a `group:web-project-*` thread, an SSE event is pushed to every project member. Broadcast is deduplicated per delivery id for the giveup window — an absent thread owner leaves the delivery un-acked for up to 60s, and without the dedup the poll would re-broadcast every 2.5s for the whole window (event storm, pinned toast, one core roundtrip per re-broadcast). Turns containing @tokens additionally notify mentioned members, matched against the project roster: trailing sentence punctuation is stripped from the token, a longer ascii name never notifies its shorter namesake (`@daniel` with a member "Dan" notifies nobody unless "Daniel" is also a member), CJK run-on tokens match the embedded name, and the sender is never notified.
- A toast surfaces new activity in threads the user is not currently viewing.

Pairs naturally with a core-side change that ends human-directed mention turns silently instead of running the model, but stands alone.

## Tests

23 new: pure-module coverage for tokenizing, chip segmentation, arming, and replacement (including the ascii-word and CJK-punctuation boundaries), plus server-side roster-matching cases (exact name, stripped punctuation, prefix-truncation safety, run-on CJK, sender exclusion, dedupe). Full web-ui suite: 412 passing; the 23 failures present are identical on a clean upstream checkout (environment-gated, untouched by this change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790658930&installation_model_id=19911&pr_number=855&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F855&signature=90fcfbad770c9aef8c79e58b8d9dc5e0d8a8210b9de1f6c63b3b5d4660598f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->