### PR TITLE
fix(taste-skill): narrow routing to supported web pages

### DIFF
--- a/skills-seed/taste-skill/SKILL.md
+++ b/skills-seed/taste-skill/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: taste-skill
-description: Design taste and process for anything a person will look at in a browser — landing page, dashboard, prototype, deck. The default design driver for a browsable artifact, with an anti-slop playbook for the visual language.
+description: >-
+  Design process and anti-slop visual guidance for landing pages, portfolios, marketing or editorial pages, and
+  eligible visual redesigns. For dense product UI, including dashboards and data tables, use only when explicitly
+  asked for a visual audit. Do not use for decks, generic prototypes, or multi-step product UI builds.
 ---
 
-# Taste skill (design process for a browsable artifact)
+# Taste skill (design process for expressive web pages)
 
-Use this whenever you are about to build something a person will _look at_ — a published
-app or dashboard, a landing or status page, a prototype or deck. It carries the design
-process; the anti-slop playbook in `references/tasteskill.md` carries the visual taste.
+Use this to build or visually redesign landing pages, portfolios, and marketing or
+editorial web pages. It carries the design process; the anti-slop playbook in
+`references/tasteskill.md` carries the visual taste.
+
+Do not use this as the design driver for decks, generic prototypes, dashboards, data
+tables, or multi-step product UI. For dense product UI, admin panels, dashboards, or data
+tables, use this skill only when the user explicitly asks for a visual audit. In that
+branch, read only the relevant accessibility guidance in Section 6 and anti-tell guidance
+in Section 9, return audit findings, and do not run the landing-page workflow, build an
+artifact, default to HTML, or publish. The remaining workflow applies only to the
+full-scope page work above.
 
 ## House style comes first
 
@@ -24,13 +35,12 @@ the process.
 
 `references/tasteskill.md` is the full anti-slop playbook: read the brief before picking
 an aesthetic, set the variance/motion/density dials, pick a real design system, and run
-the pre-flight check before you call it done. Read it before you write markup for
-anything externally facing or high-fidelity. Two adjustments for this runtime:
+the pre-flight check before you call it done. For full-scope page work, read it before
+you write markup for anything externally facing or high-fidelity. One adjustment for
+this runtime:
 
 - The block library it describes (its Section 12) is a schema, not shipped files. There is
   no `blocks/` directory here — build the block and keep it in your workspace.
-- It targets landing pages, portfolios, and redesigns. For dense product UI, admin panels,
-  and data tables, take its accessibility and anti-tell sections and leave the rest.
 
 ## Runtime
 


### PR DESCRIPTION
## Summary

- Narrow `taste-skill` discovery to expressive web pages and eligible visual redesigns.
- Exclude decks, generic prototypes, dashboards, data tables, and multi-step product UI from the full landing-page workflow.
- Keep an explicit findings-only path for requested dense-product-UI visual audits using the playbook accessibility and anti-tell sections.

## Why

The skill advertised itself as the default design driver for dashboards, prototypes, and decks even though its vendored playbook explicitly excludes dashboards, data tables, and multi-step product UI, and its runtime defaults to an HTML artifact. That mismatch could route unsupported work into the landing-page workflow.

## Implementation

The change is limited to `skills-seed/taste-skill/SKILL.md`. It aligns the discovery description and opening scope with the playbook, and makes the dense-product-UI branch explicit: visual audit findings only, with no artifact build, HTML default, or publication. The vendored playbook and package topology are unchanged.

## Verification

- `node --test test/frontmatter.test.ts test/skill-conformance.test.ts` - passed, 10/10, on host Node 24.11.1.
- `git diff --check` - passed.
- Three paired fresh-context Codex CLI / gpt-5.4-mini cases - deck overreach fixed; landing-page full workflow preserved; dense-table visual audit preserved as findings-only.
- Fresh independent package review - PASS with no actionable findings.
- Not run on the pinned Node 24.18.0 / npm >=11.10 toolchain - the host has Node 24.11.1 / npm 11.6.2.
- Not run: `test/skills-seed.test.ts` - `pg-boss` is absent because dependencies are not installed.
- Not run: Prettier - `node_modules` is absent.
- Not run: live QM discovery/activation - no live instance was used for this narrow skill-instruction change.

## Review focus

- Confirm that the discovery boundary excludes unsupported artifact types without weakening landing-page, portfolio, marketing/editorial, or eligible visual-redesign routing.
- Confirm that explicit dense-product-UI visual audits remain useful without claiming build or publication authority.

## Risks / limitations

Live QM routing and harness/model combinations other than Codex CLI with gpt-5.4-mini remain unvalidated. The PR is draft until CI or a pinned-toolchain run supplies the missing repository validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790712249&installation_model_id=19911&pr_number=860&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F860&signature=04577f27be6501841ca05ce258ac455f94e4600d221adb9f1f5ad5338942046e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->