### PR TITLE
fix: terminate orphaned microVM when hydrate fails during provision

### DIFF
--- a/src/sandbox/aws-sandbox.ts
+++ b/src/sandbox/aws-sandbox.ts
@@ -266,20 +266,29 @@ export function createAwsSandbox(workspace: WorkspaceStore, opts: AwsSandboxOpti
               reportError("sandbox_snapshot", "rotate_snapshot_failed", errMessage(e), scope),
             );
             await api.terminate(stored.microvmId).catch(() => {});
+            client.evict(stored.microvmId);
           }
         }
         const body = await launchBody(scope);
         scopeByMicrovm.set(body.id, scope);
-        const hydrated = await hydrateHome(scope, body.id);
-        await store.put(scope, {
-          microvmId: body.id,
-          endpoint: body.endpoint,
-          ...(opts.imageVersion ? { imageVersion: opts.imageVersion } : {}),
-          createdAtMs: Date.now(),
-          ...(hydrated ? { lastSnapshotMs: Date.now() } : {}),
-          orgId: configOrgId(),
-        });
-        return { id: body.id, endpoint: body.endpoint, coldStart: !hydrated };
+        try {
+          const hydrated = await hydrateHome(scope, body.id);
+          await store.put(scope, {
+            microvmId: body.id,
+            endpoint: body.endpoint,
+            ...(opts.imageVersion ? { imageVersion: opts.imageVersion } : {}),
+            createdAtMs: Date.now(),
+            ...(hydrated ? { lastSnapshotMs: Date.now() } : {}),
+            orgId: configOrgId(),
+          });
+          return { id: body.id, endpoint: body.endpoint, coldStart: !hydrated };
+        } catch (e) {
+          scopeByMicrovm.delete(body.id);
+          endpointById.delete(body.id);
+          client.evict(body.id);
+          await api.terminate(body.id).catch(() => {});
+          throw e;
+        }
       }),
     );
   }
@@ -503,6 +512,7 @@ export function createAwsSandbox(workspace: WorkspaceStore, opts: AwsSandboxOpti
             await snapshotHome(scope, rec.microvmId);
           }
           await api.terminate(rec.microvmId);
+          client.evict(rec.microvmId);
           await store.delete(scope);
           reaped++;
         } catch (e) {

--- a/test/aws-sandbox.test.ts
+++ b/test/aws-sandbox.test.ts
@@ -151,3 +151,56 @@ test("concurrent provisions for one scope launch a single body", async () => {
   assert.equal(a.id, b.id);
   assert.equal(fake.runCount, 1);
 });
+
+test("a hydrate failure right after launch does not orphan the freshly launched microVM", async () => {
+  const fake = installFakeMicrovm();
+
+  let failNextHomeTarWrite = false;
+  const baseFetch = fake.fetchImpl;
+  const flakyFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = new URL(String(url));
+    if (u.pathname === "/write" && failNextHomeTarWrite) {
+      const payload = init?.body ? (JSON.parse(String(init.body)) as { path?: string }) : {};
+      if (payload.path === "/tmp/agent-home.tar") {
+        failNextHomeTarWrite = false;
+        return new Response(JSON.stringify({ error: "Bad Gateway" }), {
+          status: 502,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    }
+    return baseFetch(url, init);
+  }) as unknown as typeof fetch;
+
+  const terminateCalls: string[] = [];
+  const api = {
+    ...fake.api,
+    async terminate(id: string) {
+      terminateCalls.push(id);
+      return fake.api.terminate(id);
+    },
+  };
+
+  const sb = makeSandbox(fake, { snapshotIntervalMs: 0, api, fetchImpl: flakyFetch });
+  const layers = rw(scopeId("personal", "U8"));
+
+  const h1 = await sb.provision(layers);
+  await sb.writeFile(h1, "keep.txt", "v1");
+  await sb.teardown(h1);
+  fake.killBody(h1.id);
+
+  const idsBefore = new Set(fake.bodies.keys());
+  failNextHomeTarWrite = true;
+  await assert.rejects(() => sb.provision(layers));
+
+  const newIds = [...fake.bodies.keys()].filter((id) => !idsBefore.has(id));
+  assert.equal(newIds.length, 1);
+  const orphanId = newIds[0]!;
+
+  assert.ok(terminateCalls.includes(orphanId), "orphan terminated");
+  assert.equal(fake.bodies.get(orphanId)!.state, "TERMINATED");
+
+  const h3 = await sb.provision(layers);
+  assert.notEqual(h3.id, orphanId);
+  assert.equal(await sb.readFile(h3, "keep.txt"), "v1");
+});


### PR DESCRIPTION
## Summary

`ensureBody()` in `src/sandbox/aws-sandbox.ts` registers a freshly launched microVM in `endpointById`, `scopeByMicrovm`, and the client's `tokenById` *before* `store.put()` runs. If `hydrateHome()` throws (e.g. a transient 502 on the `agent-home.tar` write to the microVM), `store.put()` never executes.

That VM is then unreachable by every cleanup path:
- `teardown()` never runs — no `SandboxHandle` was ever returned.
- `reapDeepIdle()` can't find it — it only iterates `store`, which never got the entry.

The VM keeps running on AWS, permanently orphaned, and its in-process map entries leak for the life of the process. Worse, since `store` has nothing for that scope, the *next* provision attempt for the same scope calls `launchBody()` again — launching and leaking a fresh VM on every retry instead of reusing or cleaning up the failed one.

Also added the missing `client.evict()` call in the rotation branch and in `reapDeepIdle()`, which terminate the microVM via `api.terminate()` but never evicted its cached auth token, leaking a `tokenById` entry on every routine rotation/reap.

## Test plan

- Added a regression test in `test/aws-sandbox.test.ts`: simulates a transient 502 on the `agent-home.tar` write during a relaunch, and asserts the newly launched microVM is terminated (not orphaned) and a subsequent provision succeeds cleanly.
- Confirmed the new test fails on `main` (19 pass / 1 fail, failing on the terminate-not-called assertion) and passes after this fix (20/20).
- `node --experimental-test-module-mocks --test test/aws-sandbox.test.ts test/aws-microvm-api.test.ts` — 20/20 pass.
- `npx tsc --noEmit` — clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790747136&installation_model_id=19911&pr_number=871&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F871&signature=f30e64b6951e547ff12e76b2bb696c26ca9b2d87f09d7ac5e357430076209807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->