### PR TITLE
web-ui: surface mid-turn agent posts in the live dock and pre-refresh timeline

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -19,6 +19,7 @@ import {
   Files,
   GitFork,
   Maximize2,
+  MessageSquare,
   Paperclip,
   Pencil,
   Plug,
@@ -67,7 +68,7 @@ import {
   type WorkBlock,
   withBase,
 } from "./core-bridge";
-import { buildTimeline, toolRowKind, type TimelineItem, type ToolPayload, type ToolRowModel } from "./timeline";
+import { buildTimeline, postSpeechText, toolRowKind, type TimelineItem, type ToolPayload, type ToolRowModel } from "./timeline";
 import { CONNECTOR_NAMES, connectorLinksIn, stripConnectorLinks, type ConnectorLink } from "./connector-link";
 import { deepLinkPath, UI_BASE } from "./deep-link";
 import type { ChatSurface, ConvCtx } from "./conv-types";
@@ -1898,8 +1899,16 @@ export function createChatSurface(
     const call = (row.call?.payload ?? {}) as ToolPayload;
     const result = (row.result?.payload ?? {}) as ToolPayload;
     const tool = call.tool ?? result.tool ?? "unknown";
-    const meta = TOOL_META[tool] ?? UNKNOWN_TOOL;
     const secs = elapsedSeconds(row.call?.createdAt) || workSeconds(work);
+    const posting = postSpeechText(row, true);
+    if (posting) {
+      return {
+        icon: MessageSquare,
+        label: secs > 0 ? `Posting message for ${secs}s` : "Posting message",
+        detail: firstLine(posting, 60),
+      };
+    }
+    const meta = TOOL_META[tool] ?? UNKNOWN_TOOL;
     return {
       icon: meta.icon,
       label: secs > 0 ? `${meta.active} for ${secs}s` : meta.active,
@@ -1984,6 +1993,14 @@ export function createChatSurface(
         flushSeg();
         const text = ((it.activity.payload as { text?: string } | null)?.text ?? "").trim();
         if (text) parts.push(html`<div class="work-said">${markdown(text)}</div>`);
+      } else if (it.kind === "tool") {
+        const speech = postSpeechText(it.row);
+        if (speech) {
+          flushSeg();
+          parts.push(html`<div class="work-said">${markdown(speech)}</div>`);
+        } else {
+          seg.push(it);
+        }
       } else {
         seg.push(it);
       }
@@ -2063,6 +2080,8 @@ export function createChatSurface(
     if (item.kind === "thinking") return thinkingRow(item.activity);
     if (item.kind === "text") return messageRow(item.activity);
     if (item.kind === "approval") return approvalMarker(item.approval);
+    const speech = postSpeechText(item.row, work.status === "working" || work.status === "thinking");
+    if (speech) return messageRow({ ...item.row.call!, payload: { text: speech } });
     return toolRow(item.row, work, status, stale);
   }
 

--- a/plugins/web-ui/src/timeline.ts
+++ b/plugins/web-ui/src/timeline.ts
@@ -19,6 +19,7 @@ export interface ToolPayload {
   code?: number;
   timedOut?: boolean;
   action?: string;
+  text?: string;
   process_id?: string;
   monitor_id?: string;
   added?: number;
@@ -62,6 +63,17 @@ export function toolRowKind(row: ToolRowModel, status: WorkBlock["status"]): Too
 function callIdOf(a: ToolActivity): string | undefined {
   const id = (a.payload as { callId?: unknown } | null)?.callId;
   return typeof id === "string" && id ? id : undefined;
+}
+
+export function postSpeechText(row: ToolRowModel, allowInFlight = false): string | null {
+  const call = (row.call?.payload ?? {}) as ToolPayload;
+  if (call.action !== "post" || typeof call.text !== "string" || !call.text.trim()) return null;
+  if (row.result) {
+    const result = (row.result.payload ?? {}) as ToolPayload & { isError?: boolean; ok?: boolean };
+    if (result.isError === true || result.ok === false || result.error || result.denied === true) return null;
+    return call.text;
+  }
+  return allowInFlight ? call.text : null;
 }
 
 function orphanCallSignature(row: ToolRowModel): string | null {

--- a/plugins/web-ui/test/chat-post-speech.test.ts
+++ b/plugins/web-ui/test/chat-post-speech.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+
+test("a surface post renders as conversation speech on both render paths, never as a bare tool row", () => {
+  assert.match(
+    chat,
+    /const speech = postSpeechText\(item\.row, work\.status === "working" \|\| work\.status === "thinking"\);\s*if \(speech\) return messageRow\(\{ \.\.\.item\.row\.call!, payload: \{ text: speech \} \}\);/,
+    "live timeline rows must turn a post's text into a message row, gated on live work status so unconfirmed posts never render as speech inside settled folds",
+  );
+  assert.match(
+    chat,
+    /const speech = postSpeechText\(it\.row\);\s*if \(speech\) \{\s*flushSeg\(\);\s*parts\.push\(html`<div class="work-said">\$\{markdown\(speech\)\}<\/div>`\);\s*\} else \{\s*seg\.push\(it\);/,
+    "settled folds must flush the segment and render the confirmed post text as a work-said bubble instead of folding it away",
+  );
+});
+
+test("the live dock previews an in-flight post instead of showing a generic step", () => {
+  assert.match(
+    chat,
+    /const posting = postSpeechText\(row, true\);\s*if \(posting\) \{\s*return \{\s*icon: MessageSquare,\s*label: secs > 0 \? `Posting message for \$\{secs\}s` : "Posting message",\s*detail: firstLine\(posting, 60\),\s*\};\s*\}/,
+  );
+});

--- a/plugins/web-ui/test/timeline.test.ts
+++ b/plugins/web-ui/test/timeline.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { ToolActivity, WorkBlock } from "../src/core-bridge.ts";
-import { buildTimeline, toolRowKind, type ToolRowModel } from "../src/timeline.ts";
+import { buildTimeline, postSpeechText, toolRowKind, type ToolRowModel } from "../src/timeline.ts";
 
 function act(seq: number, type: ToolActivity["type"], payload: unknown): ToolActivity {
   return { seq, parentSeq: null, type, payload, createdAt: seq };
@@ -258,6 +258,40 @@ test("toolRowKind: no result yet — `running` mid-turn, `attempted`/`failed` on
     "failed",
     "turn itself failed, so the in-flight call counts as failed",
   );
+});
+
+test("postSpeechText: a delivered surface post is speech; failed or unconfirmed posts are not", () => {
+  const okRow: ToolRowModel = {
+    call: act(1, "tool_call", { tool: "web", action: "post", text: "Which plan should I use?", callId: "a" }),
+    result: act(2, "tool_result", { tool: "web", callId: "a", ok: true, deliveryId: "d" }),
+  };
+  assert.equal(postSpeechText(okRow), "Which plan should I use?");
+
+  const inFlight: ToolRowModel = {
+    call: act(1, "tool_call", { tool: "web", action: "post", text: "Still composing", callId: "b" }),
+    result: null,
+  };
+  assert.equal(postSpeechText(inFlight), null, "a post without a result never claims delivered speech");
+  assert.equal(postSpeechText(inFlight, true), "Still composing", "live contexts may preview the in-flight text");
+
+  const failed: ToolRowModel = {
+    call: act(1, "tool_call", { tool: "web", action: "post", text: "Never delivered", callId: "c" }),
+    result: act(2, "tool_result", { tool: "web", callId: "c", error: "channel unavailable" }),
+  };
+  assert.equal(postSpeechText(failed), null);
+  assert.equal(postSpeechText(failed, true), null);
+
+  const failedFlag: ToolRowModel = {
+    call: act(1, "tool_call", { tool: "web", action: "post", text: "Also never delivered", callId: "e" }),
+    result: act(2, "tool_result", { tool: "web", callId: "e", ok: false }),
+  };
+  assert.equal(postSpeechText(failedFlag), null);
+
+  const nonPost: ToolRowModel = {
+    call: act(1, "tool_call", { tool: "read", path: "/x", callId: "d" }),
+    result: act(2, "tool_result", { tool: "read", callId: "d" }),
+  };
+  assert.equal(postSpeechText(nonPost), null);
 });
 
 function workWith(activity: ToolActivity[], status: WorkBlock["status"] = "working"): WorkBlock {


### PR DESCRIPTION
## Problem

When the agent posts a message to the conversation mid-turn (the surface tool's `action: "post"`), that text is effectively invisible in the web UI at the moment it is sent:

- **While the turn streams**, run activity carries no text entries, and the live dock has no summary for the surface tool — it shows a generic "Working" line, so the posted text is nowhere in the transcript.
- **After the turn ends**, the post sits inside the collapsed `N tool calls` fold. Only the settled transcript rebuild (which lifts posts into assistant content bubbles) makes the text visible; until that rebuild lands, the only way to read it is to expand the fold. If the rebuild request fails (it is silently swallowed), the text stays buried.

This hurts most for skills/agents that ask the user a question mid-flow and end the turn waiting for the answer: the person staring at the chat sees "Working…" then a collapsed fold, and never learns they were asked anything.

## Fix

Treat a surface post as conversation speech as soon as the UI can responsibly show it:

- `postSpeechText(row, allowInFlight)` (timeline): a post's text is speech once its result confirms delivery; live contexts may preview the in-flight text; failed or unconfirmed posts stay plain tool rows (consistent with the existing contract that an interrupted post must not claim it was delivered).
- Live dock (chat): an in-flight post row renders as a message icon + "Posting message" + the first line of the text, instead of the generic step label.
- Settled-but-pre-refresh timeline (chat): once the turn reaches a terminal status, confirmed posts flush the fold segment and render as `work-said` bubbles, so the text is visible the moment the turn ends without waiting for the transcript rebuild. The in-flight preview is gated on live work status, so an unconfirmed post never renders as speech inside a settled fold.

Posts also stop inflating the "N tool calls" fold count, which now reflects only actual tool work.

## Testing

- New unit tests for `postSpeechText` (delivered / in-flight / failed / non-post shapes).
- Source-structure pins on both render sites and the dock branch, matching the repo's existing chat-source test idiom.
- `plugins/web-ui` suite: 597/597 green; tsc + oxlint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779275&installation_model_id=19911&pr_number=874&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F874&signature=20301f03251ff8685b383ff24b30c969bafaa83a449e3b67cbc3325dc0a5bed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->