### PR TITLE
oauth: derive the PKCE verifier instead of sealing it into the state

### DIFF
--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -5,7 +5,7 @@ import { createGzip, gzipSync } from "node:zlib";
 import { createHash } from "node:crypto";
 import { signedRequestHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
 import { json, readBody, cookie } from "../../chassis/src/http.ts";
-import { createBrandingCache, injectBranding, type OrgBranding } from "../../chassis/src/branding.ts";
+import { createBrandingCache, injectBranding, type OrgBranding, type RawBranding } from "../../chassis/src/branding.ts";
 import { verifyPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
 import { errMessage } from "../../chassis/src/errors.ts";
 import {
@@ -45,19 +45,14 @@ const ADMIN_CSP = [
   "object-src 'none'",
 ].join("; ");
 
-async function fetchBrand(): Promise<OrgBranding> {
+async function fetchBrand(): Promise<RawBranding> {
   const corePath = withSourceAuthNonce("/v1/surface-config", CORE_SIGNING_SECRET);
   const r = await fetch(`${CORE}${corePath}`, {
     headers: signedHeaders("GET", corePath, ""),
     signal: AbortSignal.timeout(2_000),
   });
   if (!r.ok) throw new Error(`surface-config ${r.status}`);
-  const b = ((await r.json()) as { branding?: Record<string, unknown> }).branding;
-  return {
-    ...(typeof b?.accent === "string" ? { accent: b.accent } : {}),
-    ...(typeof b?.mark === "string" ? { mark: b.mark } : {}),
-    ...(typeof b?.selfLabel === "string" ? { selfLabel: b.selfLabel } : {}),
-  };
+  return ((await r.json()) as { branding?: RawBranding }).branding ?? {};
 }
 const brandCache = createBrandingCache(fetchBrand);
 async function refreshBrandNow(): Promise<void> {

--- a/plugins/auth/src/index.ts
+++ b/plugins/auth/src/index.ts
@@ -5,7 +5,7 @@ import { portFromEnv } from "../../chassis/src/env.ts";
 import { bootProblems, readConfig } from "./config.ts";
 import { coreClaimStore } from "../../chassis/src/claims.ts";
 import { signedHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
-import { createBrandingCache } from "../../chassis/src/branding.ts";
+import { createBrandingCache, type RawBranding } from "../../chassis/src/branding.ts";
 import { mailerFor } from "./email.ts";
 import { loadSigningKey } from "./keys.ts";
 import { TokenSigner } from "./tokens.ts";
@@ -32,8 +32,7 @@ export async function startServer(): Promise<void> {
       signal: AbortSignal.timeout(2_000),
     });
     if (!r.ok) throw new Error(`surface-config ${r.status}`);
-    const b = ((await r.json()) as { branding?: { selfLabel?: unknown } }).branding;
-    return typeof b?.selfLabel === "string" ? { selfLabel: b.selfLabel } : {};
+    return ((await r.json()) as { branding?: RawBranding }).branding ?? {};
   });
   const handle = createAuthHandler({
     cfg: CFG,

--- a/plugins/chassis/src/branding.ts
+++ b/plugins/chassis/src/branding.ts
@@ -4,6 +4,8 @@ export interface OrgBranding {
   selfLabel?: string;
 }
 
+export type RawBranding = Partial<Record<keyof OrgBranding, unknown>>;
+
 const REFRESH_MS = 30_000;
 const RETRY_MS = 5_000;
 const FIRST_RENDER_WAIT_MS = 1_500;
@@ -14,7 +16,7 @@ export interface BrandingCache {
   refreshNow(): Promise<void>;
 }
 
-export function createBrandingCache(fetchBranding: () => Promise<OrgBranding>): BrandingCache {
+export function createBrandingCache(fetchBranding: () => Promise<RawBranding>): BrandingCache {
   let value: OrgBranding = {};
   let warmed = false;
   let nextAt = 0;
@@ -24,7 +26,7 @@ export function createBrandingCache(fetchBranding: () => Promise<OrgBranding>): 
     if (inflight || Date.now() < nextAt) return;
     inflight = (async () => {
       try {
-        value = await fetchBranding();
+        value = sanitizeBranding(await fetchBranding());
         if (process.env.BRANDING_DEBUG) console.error("[branding] fetched:", JSON.stringify(value));
         warmed = true;
         nextAt = Date.now() + REFRESH_MS;
@@ -59,7 +61,25 @@ export function createBrandingCache(fetchBranding: () => Promise<OrgBranding>): 
 const escapeAttr = (v: string): string =>
   v.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-export function injectBranding(html: string, branding: OrgBranding, opts?: { titleSuffix?: string }): string {
+const BRAND_ACCENT = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const LABEL_UNSAFE = /[\u0000-\u001f\u007f-\u009f\u2028\u2029<>{}]/g;
+const MARK_UNSAFE = /[\u0000-\u001f\u007f-\u009f\u2028\u2029<>{}"\\]/g;
+
+const clip = (value: string, cap: number): string | undefined => [...value.trim()].slice(0, cap).join("") || undefined;
+
+export function sanitizeBranding(raw: RawBranding): OrgBranding {
+  const accent = typeof raw.accent === "string" ? raw.accent.trim() : "";
+  const mark = clip((typeof raw.mark === "string" ? raw.mark : "").replace(MARK_UNSAFE, ""), 2);
+  const selfLabel = clip((typeof raw.selfLabel === "string" ? raw.selfLabel : "").replace(LABEL_UNSAFE, ""), 40);
+  return {
+    ...(BRAND_ACCENT.test(accent) ? { accent } : {}),
+    ...(mark ? { mark } : {}),
+    ...(selfLabel ? { selfLabel } : {}),
+  };
+}
+
+export function injectBranding(html: string, raw: OrgBranding, opts?: { titleSuffix?: string }): string {
+  const branding = sanitizeBranding(raw);
   const { accent, mark, selfLabel } = branding;
   let out = html;
   if (selfLabel) {

--- a/plugins/chassis/src/portal-identity.ts
+++ b/plugins/chassis/src/portal-identity.ts
@@ -35,3 +35,25 @@ export function verifyPortalIdentity(token: string, secret: string, nowMs: numbe
 }
 
 export const PORTAL_IDENTITY_HEADER = "x-portal-identity";
+
+const IDENTITY_TTL_MS = 60_000;
+
+export function portalIdentityHeaders(
+  principal: string,
+  secret: string | undefined,
+  extra: { displayName?: string; impersonator?: string; nowMs?: number } = {},
+): Record<string, string> {
+  if (!secret) return {};
+  const now = extra.nowMs ?? Date.now();
+  return {
+    [PORTAL_IDENTITY_HEADER]: mintPortalIdentity(
+      {
+        p: principal,
+        ...(extra.displayName ? { n: extra.displayName } : {}),
+        ...(extra.impersonator ? { imp: extra.impersonator } : {}),
+        exp: now + IDENTITY_TTL_MS,
+      },
+      secret,
+    ),
+  };
+}

--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -52,6 +52,10 @@ surfaces, and it does **not** import the core.
   anymore; the only place an admin is named is the core's `ADMIN_GRANTS`.
 - **Non-admin users need no per-id config.** `PORTAL_EXPECTED_TEAM_ID` pins the workspace, so any
   verified member is a valid user (`WEB_UI_PRINCIPALS` empty = any verified principal).
+- **Connector OAuth is session-bound.** The provider's `/v1/connectors/oauth/:p/callback` leg is
+  not a public passthrough: no session bounces to login, and the portal vouches for the finishing
+  browser with a signed portal identity. The core refuses to store tokens unless that identity is
+  the principal the flow was started for, so a leaked consent URL is dead in anyone else's browser.
 - **CSRF / open-redirect.** Every non-GET requires a same-origin `Origin`; `returnTo` is reduced
   to a same-origin path (rejects `//evil`, `/\evil`, `https:/evil`, `%2f%2f`/`%5c`).
 - **Secret hygiene.** In production the portal refuses to boot unless `PORTAL_SESSION_SECRET`,

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -18,7 +18,8 @@ import {
   type TmpClaims,
 } from "./session.ts";
 import {
-  pkcePair,
+  deriveCodeVerifier,
+  codeChallengeS256,
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserinfo,
@@ -33,14 +34,14 @@ import {
   proxyToUpstream,
   FORWARD_AGENT_API_HEADERS,
   FORWARD_DEPLOYMENT_LAYER_HEADERS,
-  FORWARD_OAUTH_HEADERS,
   FORWARD_BROKER_HEADERS,
   FORWARD_WEBHOOK_HEADERS,
 } from "./proxy.ts";
 import { signedHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
 import { coreClaimStore, withinRateLimit } from "../../chassis/src/claims.ts";
-import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
+import { portalIdentityHeaders } from "../../chassis/src/portal-identity.ts";
 import { errMessage } from "../../chassis/src/errors.ts";
+import { sanitizeBranding } from "../../chassis/src/branding.ts";
 import { json, escapeHtml, serveEmojiFavicon } from "../../chassis/src/http.ts";
 import {
   CORE_API_URL as CORE,
@@ -103,7 +104,7 @@ async function fetchSurfaceConfig(): Promise<void> {
     });
     if (r.ok) {
       const body = (await r.json()) as { branding?: { accent?: unknown }; modelProviderConfigured?: unknown };
-      brandAccent = typeof body.branding?.accent === "string" ? body.branding.accent : NEUTRAL_ACCENT;
+      brandAccent = sanitizeBranding({ accent: body.branding?.accent }).accent ?? NEUTRAL_ACCENT;
       modelProviderConfigured =
         typeof body.modelProviderConfigured === "boolean" ? body.modelProviderConfigured : undefined;
       surfaceConfigNextAt = Date.now() + (modelProviderConfigured === false ? 5_000 : 30_000);
@@ -187,6 +188,7 @@ const DEV_SECRET = "dev-only-insecure-portal-session-secret";
 const sessionKey = deriveKey(SESSION_SECRET ?? DEV_SECRET, "portal.session.v1");
 const tmpKey = deriveKey(SESSION_SECRET ?? DEV_SECRET, "portal.tmp.v1");
 const impersonateKey = deriveKey(SESSION_SECRET ?? DEV_SECRET, "portal.impersonate.v1");
+const pkceKey = deriveKey(SESSION_SECRET ?? DEV_SECRET, "portal.pkce.v1");
 const IMPERSONATE_TTL_S = Number(process.env.PORTAL_IMPERSONATE_TTL_S ?? 3600);
 
 const TMP_TTL_S = 600;
@@ -211,13 +213,10 @@ async function adminProbeAttempt(sub: string): Promise<boolean | null> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), ADMIN_PROBE_TIMEOUT_MS);
   try {
-    const headers: Record<string, string> = { cookie: `admin=${encodeURIComponent(sub)}` };
-    if (PORTAL_IDENTITY_SECRET) {
-      headers[PORTAL_IDENTITY_HEADER] = mintPortalIdentity(
-        { p: sub, exp: Date.now() + 60_000 },
-        PORTAL_IDENTITY_SECRET,
-      );
-    }
+    const headers: Record<string, string> = {
+      cookie: `admin=${encodeURIComponent(sub)}`,
+      ...portalIdentityHeaders(sub, PORTAL_IDENTITY_SECRET),
+    };
     const r = await fetch(`${UPSTREAMS.admin}/api/whoami`, { headers, signal: ctrl.signal });
     if (!r.ok) {
       console.warn(`[portal] admin probe returned HTTP ${r.status}`);
@@ -569,6 +568,43 @@ export function connectWrongRecipientHtml(o: { provider: string; alreadyConnecte
   });
 }
 
+async function handleOAuthCallback(
+  res: ServerResponse,
+  o: { corePath: string; session: SessionClaims },
+): Promise<void> {
+  let r: Response;
+  try {
+    r = await fetch(`${CORE}${o.corePath}`, {
+      redirect: "manual",
+      headers: portalIdentityHeaders(o.session.sub, PORTAL_IDENTITY_SECRET),
+    });
+  } catch {
+    return sendHtml(
+      res,
+      502,
+      connectErrorHtml("We couldn't reach the connection service. Please try the link again in a moment."),
+    );
+  }
+  if (r.status >= 300 && r.status < 400) {
+    const location = r.headers.get("location");
+    if (location) {
+      res.writeHead(302, { location, "cache-control": "no-store" });
+      return void res.end();
+    }
+  }
+  if (r.ok) {
+    const body = await r.text();
+    res.writeHead(r.status, { "content-type": r.headers.get("content-type") ?? "application/json" });
+    return void res.end(body);
+  }
+  const data = (await r.json().catch(() => ({}))) as { message?: string };
+  return sendHtml(
+    res,
+    400,
+    connectErrorHtml(data.message ?? "This connection attempt is invalid or expired — start it again."),
+  );
+}
+
 async function handleConsentRedeem(
   res: ServerResponse,
   o: { corePath: string; session: SessionClaims },
@@ -713,9 +749,7 @@ async function coreImpersonate(
   const headers = {
     ...signedHeaders(CORE_SIGNING_SECRET, "POST", path, body),
     "x-admin-actor": `${admin}@${ORG}`,
-    ...(PORTAL_IDENTITY_SECRET
-      ? { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: admin, exp: Date.now() + 60_000 }, PORTAL_IDENTITY_SECRET) }
-      : {}),
+    ...portalIdentityHeaders(admin, PORTAL_IDENTITY_SECRET),
   };
   try {
     const r = await fetch(`${CORE}${path}`, { method: "POST", headers, body });
@@ -726,10 +760,8 @@ async function coreImpersonate(
   }
 }
 
-function isOAuthPublicPassthrough(method: string, pathname: string): boolean {
-  if (method !== "GET") return false;
-  if (/^\/v1\/connectors\/oauth\/[^/]+\/callback$/.test(pathname)) return true;
-  return false;
+function isOAuthCallback(method: string, pathname: string): boolean {
+  return method === "GET" && /^\/v1\/connectors\/oauth\/[^/]+\/callback$/.test(pathname);
 }
 
 function hasAgentCapability(req: IncomingMessage): boolean {
@@ -979,8 +1011,10 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     return handleSelfConnect(res, { provider: decodeURIComponent(selfConnect[1] ?? ""), session });
   }
 
-  if (isOAuthPublicPassthrough(method, pathname)) {
-    return proxyToUpstream(req, res, { baseUrl: CORE, path: pathname, search: url.search }, FORWARD_OAUTH_HEADERS);
+  if (isOAuthCallback(method, pathname)) {
+    if (!session) return consentBounce();
+    if (session.anon) return sendHtml(res, 403, playgroundRestrictedHtml());
+    return handleOAuthCallback(res, { corePath: `${pathname}${url.search}`, session });
   }
 
   const dropForm = /^\/drop\/([^/]+)\/form$/.exec(pathname);
@@ -1136,9 +1170,9 @@ function authLogin(req: IncomingMessage, res: ServerResponse, url: URL): void {
   }
   const state = randomToken();
   const nonce = randomToken();
-  const { verifier, challenge } = pkcePair();
   const now = Math.floor(Date.now() / 1000);
-  const tmp: TmpClaims = { k: "tmp", state, nonce, pkceVerifier: verifier, returnTo, iat: now, exp: now + TMP_TTL_S };
+  const tmp: TmpClaims = { k: "tmp", state, nonce, returnTo, iat: now, exp: now + TMP_TTL_S };
+  const challenge = codeChallengeS256(deriveCodeVerifier(nonce, pkceKey));
   setSession(res, [
     setCookie("portal_oidc_tmp", seal(tmp, tmpKey), { path: "/auth", maxAge: TMP_TTL_S, secure: SECURE_COOKIES }),
   ]);
@@ -1164,7 +1198,10 @@ async function authCallback(req: IncomingMessage, res: ServerResponse, url: URL)
   let sub: string;
   let name = "";
   try {
-    const { accessToken, idToken } = await exchangeCode(OIDC, { code, codeVerifier: tmp.pkceVerifier });
+    const { accessToken, idToken } = await exchangeCode(OIDC, {
+      code,
+      codeVerifier: deriveCodeVerifier(tmp.nonce, pkceKey),
+    });
     const claims = await verifyIdToken(OIDC, idToken, tmp.nonce);
     if (OIDC.expectedTeamId) {
       const team = claims["https://slack.com/team_id"];

--- a/plugins/portal/src/oidc.ts
+++ b/plugins/portal/src/oidc.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { createRemoteJWKSet, customFetch, jwtVerify, type JWTPayload } from "jose";
 
 type FetchLike = typeof fetch;
@@ -16,10 +16,13 @@ export interface OidcConfig {
   expectedTeamId?: string;
 }
 
-export function pkcePair(): { verifier: string; challenge: string } {
-  const verifier = randomBytes(32).toString("base64url");
-  const challenge = createHash("sha256").update(verifier).digest("base64url");
-  return { verifier, challenge };
+export function deriveCodeVerifier(nonce: string, key: Buffer): string {
+  if (!nonce) throw new Error("OIDC nonce required");
+  return createHmac("sha256", key).update(`pkce:${nonce}`).digest("base64url");
+}
+
+export function codeChallengeS256(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
 }
 
 export function buildAuthorizeUrl(cfg: OidcConfig, args: { state: string; nonce: string; challenge: string }): string {

--- a/plugins/portal/src/proxy.ts
+++ b/plugins/portal/src/proxy.ts
@@ -1,8 +1,6 @@
 import { request as httpRequest, type IncomingMessage, type ServerResponse } from "node:http";
 import { signedHeaders } from "../../chassis/src/core-client.ts";
-import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
-
-const IDENTITY_TTL_MS = 60_000;
+import { portalIdentityHeaders } from "../../chassis/src/portal-identity.ts";
 
 const FORWARD_REQUEST_HEADERS = ["content-type", "accept", "accept-language", "user-agent", "accept-encoding"];
 
@@ -91,19 +89,15 @@ export function proxyToSurface(req: IncomingMessage, res: ServerResponse, t: Sur
     `${t.cookieName}=${encodeURIComponent(t.principal)}` +
     (t.displayName ? `; ${t.cookieName}_name=${encodeURIComponent(t.displayName)}` : "") +
     (t.impersonator ? `; webui_impersonator=${encodeURIComponent(t.impersonator)}` : "");
-  const base: Record<string, string> = { host: upstream.host, cookie };
-  if (t.identitySecret) {
-    const now = t.nowMs ?? Date.now();
-    base[PORTAL_IDENTITY_HEADER] = mintPortalIdentity(
-      {
-        p: t.principal,
-        ...(t.displayName ? { n: t.displayName } : {}),
-        ...(t.impersonator ? { imp: t.impersonator } : {}),
-        exp: now + IDENTITY_TTL_MS,
-      },
-      t.identitySecret,
-    );
-  }
+  const base: Record<string, string> = {
+    host: upstream.host,
+    cookie,
+    ...portalIdentityHeaders(t.principal, t.identitySecret, {
+      ...(t.displayName ? { displayName: t.displayName } : {}),
+      ...(t.impersonator ? { impersonator: t.impersonator } : {}),
+      ...(t.nowMs !== undefined ? { nowMs: t.nowMs } : {}),
+    }),
+  };
   const headers = safeForwardHeaders(req, base);
   relay(req, res, {
     protocol: upstream.protocol,
@@ -144,8 +138,6 @@ export const FORWARD_DEPLOYMENT_LAYER_HEADERS = [
   "x-signature",
 ];
 
-export const FORWARD_OAUTH_HEADERS = ["accept", "accept-language", "user-agent", "content-type"];
-
 export interface DeploymentTarget {
   coreBase: string;
   id: string;
@@ -161,12 +153,12 @@ export function proxyToDeployment(req: IncomingMessage, res: ServerResponse, t: 
   const corePath = `/d/${encodeURIComponent(t.id)}${t.subPath}${t.search}`;
   const core = new URL(t.coreBase);
   const signed = signedHeaders(t.signingSecret, method, corePath, "", t.principal);
-  const base: Record<string, string> = { host: core.host, "x-as-principal": t.principal, ...signed };
-  if (t.identitySecret)
-    base[PORTAL_IDENTITY_HEADER] = mintPortalIdentity(
-      { p: t.principal, exp: Date.now() + IDENTITY_TTL_MS },
-      t.identitySecret,
-    );
+  const base: Record<string, string> = {
+    host: core.host,
+    "x-as-principal": t.principal,
+    ...signed,
+    ...portalIdentityHeaders(t.principal, t.identitySecret),
+  };
   const headers = safeForwardHeaders(req, base);
   delete headers["content-type"];
   const ct = req.headers["content-type"];

--- a/plugins/portal/src/session.ts
+++ b/plugins/portal/src/session.ts
@@ -50,7 +50,6 @@ export interface TmpClaims {
   k: "tmp";
   state: string;
   nonce: string;
-  pkceVerifier: string;
   returnTo: string;
   iat: number;
   exp: number;
@@ -94,12 +93,7 @@ export function openImpersonation(token: string | null, key: Buffer, now: number
 export function openTmp(token: string | null, key: Buffer, now: number): TmpClaims | null {
   const p = open(token, key);
   if (!p || p.k !== "tmp") return null;
-  if (
-    typeof p.state !== "string" ||
-    typeof p.nonce !== "string" ||
-    typeof p.pkceVerifier !== "string" ||
-    typeof p.exp !== "number"
-  )
+  if (typeof p.state !== "string" || !p.state || typeof p.nonce !== "string" || !p.nonce || typeof p.exp !== "number")
     return null;
   if (now >= p.exp * 1000) return null;
   return p as unknown as TmpClaims;

--- a/plugins/portal/test/brand-accent.test.ts
+++ b/plugins/portal/test/brand-accent.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const HOSTILE_ACCENT = "red;} :root{--x:url(https://evil/a)";
+let surfaceConfigRequests = 0;
+
+const upstream = createServer((req: IncomingMessage, res) => {
+  if (req.url?.startsWith("/v1/surface-config")) {
+    surfaceConfigRequests++;
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(JSON.stringify({ branding: { accent: HOSTILE_ACCENT }, modelProviderConfigured: false }));
+  }
+  if (req.url === "/api/whoami") {
+    res.writeHead(200, { "content-type": "application/json" });
+    return void res.end(JSON.stringify({ isAdmin: false }));
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ url: req.url }));
+});
+await new Promise<void>((r) => upstream.listen(0, r));
+const upstreamUrl = `http://localhost:${(upstream.address() as AddressInfo).port}`;
+
+process.env.PORTAL_PUBLIC_URL = "http://portal.test";
+process.env.PORTAL_SESSION_SECRET = "brand-accent-test-portal-secret";
+process.env.CORE_SIGNING_SECRET = "brand-accent-test-core-secret";
+process.env.WEB_UI_UPSTREAM = upstreamUrl;
+process.env.ADMIN_UPSTREAM = upstreamUrl;
+process.env.CORE_API_URL = upstreamUrl;
+
+const { server, connectErrorHtml } = await import("../src/index.ts");
+const { deriveKey, seal } = await import("../src/session.ts");
+await new Promise<void>((r) => server.listen(0, r));
+const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+
+const sessionKey = deriveKey("brand-accent-test-portal-secret", "portal.session.v1");
+function sessionCookie(sub: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  return `portal_session=${encodeURIComponent(seal({ k: "session", sub, org: "acme", iat: now, exp: now + 28800 }, sessionKey))}`;
+}
+
+test.after(() => {
+  server.close();
+  upstream.close();
+});
+
+test("a hostile surface-config accent reaches the module but never the connect style block", async () => {
+  const nav = await fetch(`${base}/`, {
+    headers: { accept: "text/html", cookie: sessionCookie("U-member") },
+    redirect: "manual",
+  });
+  assert.equal(nav.status, 503);
+  assert.equal(surfaceConfigRequests > 0, true);
+
+  const html = connectErrorHtml("This connect link has expired.");
+  assert.match(html, /--brand:#4f46e5; --radius-md:10px;/);
+  assert.equal(html.includes(HOSTILE_ACCENT), false);
+  assert.equal(html.includes("evil"), false);
+  assert.equal(html.match(/:root\{/g)?.length, 1);
+});

--- a/plugins/portal/test/oidc.test.ts
+++ b/plugins/portal/test/oidc.test.ts
@@ -1,9 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createHash, generateKeyPairSync } from "node:crypto";
+import { createHash, generateKeyPairSync, randomBytes } from "node:crypto";
 import { exportJWK, SignJWT } from "jose";
 import {
-  pkcePair,
+  deriveCodeVerifier,
+  codeChallengeS256,
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserinfo,
@@ -29,10 +30,17 @@ function jwt(payload: Record<string, unknown>): string {
   return `${b64({ alg: "RS256" })}.${b64(payload)}.sig`;
 }
 
-test("pkcePair challenge is the S256 of the verifier", () => {
-  const { verifier, challenge } = pkcePair();
-  assert.equal(challenge, createHash("sha256").update(verifier).digest("base64url"));
-  assert.notEqual(verifier, challenge);
+test("the verifier is derived from the nonce under the tmp key, never stored, never guessable", () => {
+  const key = randomBytes(32);
+  const verifier = deriveCodeVerifier("NONCE", key);
+  assert.equal(codeChallengeS256(verifier), createHash("sha256").update(verifier).digest("base64url"));
+  assert.match(verifier, /^[A-Za-z0-9_-]+$/);
+  assert.ok(verifier.length >= 43, "at least 256 bits of entropy encoded");
+  assert.notEqual(verifier, codeChallengeS256(verifier));
+  assert.equal(deriveCodeVerifier("NONCE", key), verifier, "the callback re-derives the same verifier");
+  assert.notEqual(deriveCodeVerifier("OTHER", key), verifier, "a different login gets a different verifier");
+  assert.notEqual(deriveCodeVerifier("NONCE", randomBytes(32)), verifier, "knowing the nonce is not enough");
+  assert.throws(() => deriveCodeVerifier("", key), /nonce required/);
 });
 
 test("buildAuthorizeUrl carries code+PKCE+state+nonce", () => {

--- a/plugins/portal/test/playground.test.ts
+++ b/plugins/portal/test/playground.test.ts
@@ -124,10 +124,15 @@ test("sliding renewal preserves the anon flag", async () => {
   assert.ok(renewed.iat > aged.iat, "expected a re-stamped iat");
 });
 
-test("anonymous sessions are refused the connect and secret-drop flows", async () => {
+test("anonymous sessions are refused the connect, provider-callback and secret-drop flows", async () => {
   const visit = await fetch(`${base}/`, { headers: HTML, redirect: "manual" });
   const cookie = sessionCookieOf(visit);
-  for (const path of ["/connect/redeem/tok123", "/connect/google/self-connect", "/drop/tok123/form"]) {
+  for (const path of [
+    "/connect/redeem/tok123",
+    "/connect/google/self-connect",
+    "/v1/connectors/oauth/google/callback?code=c&state=s",
+    "/drop/tok123/form",
+  ]) {
     const r = await fetch(`${base}${path}`, { headers: { ...HTML, cookie } });
     assert.equal(r.status, 403, `${path} must refuse anon sessions`);
   }

--- a/plugins/portal/test/router.test.ts
+++ b/plugins/portal/test/router.test.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createServer, type IncomingMessage } from "node:http";
+import { createHash } from "node:crypto";
 import type { AddressInfo } from "node:net";
+import { codeChallengeS256, deriveCodeVerifier } from "../src/oidc.ts";
 
 let whoamiProbes = 0;
 let lastConsentClicker: string | null = null;
@@ -230,12 +232,23 @@ test("the webhook passthrough is exact-shape + POST-only (no widening of /v1)", 
   assert.equal((await fetch(`${base}/v1/webhooks`, { method: "POST" })).status, 404);
 });
 
-test("the provider callback still passes through publicly with NO session/cookie", async () => {
-  const cb = await fetch(`${base}/v1/connectors/oauth/google/callback?code=c&state=s`, { redirect: "manual" });
+test("the provider callback is session-bound: no session bounces to login, a session vouches for the finisher", async () => {
+  const anonymous = await fetch(`${base}/v1/connectors/oauth/google/callback?code=c&state=s`, { redirect: "manual" });
+  assert.equal(anonymous.status, 302);
+  assert.match(
+    anonymous.headers.get("location") ?? "",
+    /^\/auth\/login\?returnTo=%2Fv1%2Fconnectors%2Foauth%2Fgoogle%2Fcallback%3Fcode%3Dc%26state%3Ds$/,
+  );
+
+  const cb = await fetch(`${base}/v1/connectors/oauth/google/callback?code=c&state=s`, {
+    headers: { cookie: sessionCookie("U1") },
+    redirect: "manual",
+  });
   assert.equal(cb.status, 200);
-  const cbb = (await cb.json()) as { url: string; cookie: string | null };
+  const cbb = (await cb.json()) as { url: string; cookie: string | null; headers: Record<string, string> };
   assert.equal(cbb.url, "/v1/connectors/oauth/google/callback?code=c&state=s");
-  assert.equal(cbb.cookie, null);
+  assert.equal(cbb.cookie, null, "the portal session cookie never reaches core");
+  assert.equal(typeof cbb.headers["x-portal-identity"], "string");
 });
 
 test("the legacy /v1 browser-leg aliases are gone: the portal no longer serves them, /v1 stays private", async () => {
@@ -347,7 +360,36 @@ test("auth/login sets the tmp cookie and 302s to the IdP with PKCE+state+nonce",
   assert.ok(u.searchParams.get("state"));
   assert.ok(u.searchParams.get("nonce"));
   assert.equal(u.searchParams.get("code_challenge_method"), "S256");
-  assert.match(r.headers.get("set-cookie") ?? "", /portal_oidc_tmp=/);
+  const setCookie = r.headers.get("set-cookie") ?? "";
+  assert.match(setCookie, /portal_oidc_tmp=/);
+
+  const cookie = decodeURIComponent(setCookie.match(/portal_oidc_tmp=([^;]+)/)?.[1] ?? "");
+  const payload = Buffer.from(cookie.split(".")[0]!, "base64url").toString("utf8");
+  const claims = JSON.parse(payload) as Record<string, unknown>;
+  const challenge = u.searchParams.get("code_challenge") ?? "";
+  assert.ok(challenge, "the authorize URL carries the challenge");
+
+  const pkceKey = deriveKey("router-test-portal-secret", "portal.pkce.v1");
+  const verifier = deriveCodeVerifier(String(claims.nonce), pkceKey);
+  assert.notEqual(
+    verifier,
+    deriveCodeVerifier(String(claims.nonce), deriveKey("router-test-portal-secret", "portal.tmp.v1")),
+    "the verifier key is domain-separated from the tmp-cookie MAC key",
+  );
+  assert.equal(
+    challenge,
+    codeChallengeS256(verifier),
+    "the challenge is the one the callback re-derives from the nonce",
+  );
+  assert.ok(!payload.includes(verifier), "the cookie the user-agent carries is free of the verifier at any depth");
+  for (const [name, value] of [...Object.entries(claims), ...u.searchParams]) {
+    if (typeof value !== "string") continue;
+    assert.notEqual(
+      createHash("sha256").update(value).digest("base64url"),
+      challenge,
+      `nothing the browser carries may be the verifier — "${name}" is it in plain sight`,
+    );
+  }
 });
 
 test("auth/callback with no tmp cookie fails closed (400, no token exchange)", async () => {

--- a/plugins/portal/test/session.test.ts
+++ b/plugins/portal/test/session.test.ts
@@ -59,7 +59,7 @@ test("openSession enforces kind, sub, and expiry", () => {
   assert.equal(openSession(expired, sessionKey, Date.now()), null);
 
   const tmp = seal(
-    { k: "tmp", state: "s", nonce: "n", pkceVerifier: "v", returnTo: "/", iat: now, exp: now + 60 } satisfies TmpClaims,
+    { k: "tmp", state: "s", nonce: "n", returnTo: "/", iat: now, exp: now + 60 } satisfies TmpClaims,
     sessionKey,
   );
   assert.equal(openSession(tmp, sessionKey, Date.now()), null);
@@ -101,7 +101,6 @@ test("openTmp enforces kind and required fields", () => {
       k: "tmp",
       state: "abc",
       nonce: "xyz",
-      pkceVerifier: "v",
       returnTo: "/web-ui/",
       iat: now,
       exp: now + 600,
@@ -116,6 +115,18 @@ test("openTmp enforces kind and required fields", () => {
     tmpKey,
   );
   assert.equal(openTmp(session, tmpKey, Date.now()), null);
+
+  const blankNonce = seal(
+    { k: "tmp", state: "abc", nonce: "", returnTo: "/", iat: now, exp: now + 600 } satisfies TmpClaims,
+    tmpKey,
+  );
+  assert.equal(openTmp(blankNonce, tmpKey, Date.now()), null, "an empty nonce would collapse the derived verifier");
+
+  const blankState = seal(
+    { k: "tmp", state: "", nonce: "xyz", returnTo: "/", iat: now, exp: now + 600 } satisfies TmpClaims,
+    tmpKey,
+  );
+  assert.equal(openTmp(blankState, tmpKey, Date.now()), null, "an empty state would match a callback that sent none");
 });
 
 test("openImpersonation enforces kind, actor, target, and expiry; key is domain-separated", () => {
@@ -166,9 +177,13 @@ test("openImpersonation enforces kind, actor, target, and expiry; key is domain-
   assert.equal(openImpersonation(noTarget, impersonateKey, Date.now()), null);
 });
 
-test("cookie helpers set HttpOnly/SameSite/Path and Secure only when asked", () => {
+test("cookie helpers set HttpOnly/Path and Secure only when asked, and SameSite stays Lax for the connector OAuth callback", () => {
   const secure = setCookie("portal_session", "v v", { path: "/", maxAge: 100, secure: true });
-  assert.match(secure, /^portal_session=v%20v; HttpOnly; SameSite=Lax; Path=\/; Secure; Max-Age=100$/);
+  assert.match(
+    secure,
+    /^portal_session=v%20v; HttpOnly; SameSite=Lax; Path=\/; Secure; Max-Age=100$/,
+    "SameSite=Strict would strip the session from the provider's cross-site top-level GET to /v1/connectors/oauth/:p/callback, so every connector connect would detour through a full re-login",
+  );
   const insecure = setCookie("portal_oidc_tmp", "x", { path: "/auth", maxAge: 600, secure: false });
   assert.ok(!insecure.includes("Secure"));
   assert.match(clearCookie("portal_session", "/", true), /Max-Age=0/);

--- a/plugins/web-ui/README.md
+++ b/plugins/web-ui/README.md
@@ -134,7 +134,10 @@ and `CORE_SIGNING_SECRET` (same value as the core when source-auth is enabled).
     → core `/v1/connectors/oauth/:p/start` (redirect URI = this surface's
     `/connectors/oauth/:p/callback`), and `POST /api/connectors/revoke` → core
     `/v1/connectors/oauth/revoke`. The callback exchanges the code server-side (tokens never reach
-    the browser) and bounces back into the SPA via a base-relative redirect.
+    the browser) and bounces back into the SPA via a base-relative redirect. It is session-bound:
+    the callback carries the signed-in principal to core, which refuses to store tokens unless that
+    principal is the one the flow was started for, so a leaked consent URL is useless in anyone
+    else's browser. Impersonated sessions cannot start a connector flow.
   - **Deploys** — `GET /api/deployments` → core `/v1/deployments`, grouped into manageable,
     shared, and archived views. Detail and restore routes expose authorized metadata and bring an
     archived version back online; running apps open through the surface's signed deployment proxy.

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -20,8 +20,12 @@ import {
   PayloadTooLargeError,
   serveEmojiFavicon,
 } from "../../chassis/src/http.ts";
-import { verifyPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
-import { createBrandingCache, injectBranding } from "../../chassis/src/branding.ts";
+import {
+  portalIdentityHeaders,
+  verifyPortalIdentity,
+  PORTAL_IDENTITY_HEADER,
+} from "../../chassis/src/portal-identity.ts";
+import { createBrandingCache, injectBranding, type RawBranding } from "../../chassis/src/branding.ts";
 import {
   CORE_API_URL as CORE,
   CORE_ORG_ID as ORG,
@@ -48,12 +52,7 @@ const DIST = join(ROOT, "dist-web");
 const brandingCache = createBrandingCache(async () => {
   const r = await coreFetch("GET", "/v1/surface-config", "", 2_000);
   if (r.status !== 200) throw new Error(`surface-config ${r.status}`);
-  const b = (JSON.parse(r.text) as { branding?: Record<string, unknown> }).branding;
-  return {
-    ...(typeof b?.accent === "string" ? { accent: b.accent } : {}),
-    ...(typeof b?.mark === "string" ? { mark: b.mark } : {}),
-    ...(typeof b?.selfLabel === "string" ? { selfLabel: b.selfLabel } : {}),
-  };
+  return (JSON.parse(r.text) as { branding?: RawBranding }).branding ?? {};
 });
 
 async function brandIndexHtml(html: string): Promise<string> {
@@ -272,6 +271,12 @@ function authenticate(req: IncomingMessage): { identity: Identity } | { denied: 
 function resolveIdentity(req: IncomingMessage): Identity | null {
   const outcome = authenticate(req);
   return "identity" in outcome ? outcome.identity : null;
+}
+
+function identityHeaders(user: string): Record<string, string> {
+  const forwarded = portalTokenStore.getStore();
+  if (forwarded) return { [PORTAL_IDENTITY_HEADER]: forwarded };
+  return portalIdentityHeaders(user, PORTAL_IDENTITY_SECRET);
 }
 
 function cookieUser(req: IncomingMessage): string | null {
@@ -1535,7 +1540,12 @@ const apiRoutes: readonly WebRoute[] = [
     method: "POST",
     path: "/api/connectors/:provider/start",
     handle: async (c) => {
-      const { res, user } = c;
+      const { req, res, user } = c;
+      if (resolveIdentity(req)?.impersonator)
+        return json(res, 403, {
+          error: "forbidden",
+          message: "connecting an account is bound to your own browser session — stop impersonating first",
+        });
       const provider = c.params.provider!;
       const callback = `${PUBLIC_URL}/v1/connectors/oauth/${encodeURIComponent(provider)}/callback`;
       const params = new URLSearchParams({ principalId: user, redirectUri: callback, returnTo: "/keychain" });
@@ -2403,10 +2413,13 @@ const routeRequest = async (req: IncomingMessage, res: ServerResponse) => {
   if (method === "GET" && oauthCallbackPrefix && path.endsWith("/callback")) {
     const provider = path.slice(oauthCallbackPrefix.length, -"/callback".length);
     const corePath = `/v1/connectors/oauth/${encodeURIComponent(provider)}/callback${url.search}`;
-    let ok: boolean;
+    const user = cookieUser(req);
+    let ok = false;
     try {
-      const r = await fetch(`${CORE}${corePath}`, { redirect: "manual" });
-      ok = r.status >= 200 && r.status < 300;
+      if (user) {
+        const r = await fetch(`${CORE}${corePath}`, { redirect: "manual", headers: identityHeaders(user) });
+        ok = r.status >= 200 && r.status < 400;
+      }
     } catch {
       ok = false;
     }

--- a/plugins/web-ui/src/model-connect.ts
+++ b/plugins/web-ui/src/model-connect.ts
@@ -72,7 +72,7 @@ type Mode = "gate" | "manager";
 type Method = "subscription" | "apikey";
 type Flow =
   | { kind: "pick" }
-  | { kind: "claude"; authorizeUrl: string; verifier: string; code: string }
+  | { kind: "claude"; authorizeUrl: string; verifier: string; state: string; code: string }
   | { kind: "chatgpt"; device: DevicePrompt }
   | { kind: "apikey"; value: string };
 
@@ -174,9 +174,10 @@ async function pickSubscription(p: ProviderMeta): Promise<void> {
   paint();
   try {
     if (p.key === "claude") {
-      const start = await api<{ authorizeUrl: string; verifier: string }>("/api/user-model-auth/claude/start", {
-        method: "POST",
-      });
+      const start = await api<{ authorizeUrl: string; verifier: string; state: string }>(
+        "/api/user-model-auth/claude/start",
+        { method: "POST" },
+      );
       s.flow = { kind: "claude", ...start, code: "" };
     } else {
       if (!deviceCache || deviceCache.expiresAt - 30_000 <= Date.now()) {
@@ -227,7 +228,7 @@ async function finishClaude(): Promise<void> {
   try {
     await api("/api/user-model-auth/claude/complete", {
       method: "POST",
-      body: JSON.stringify({ code: s.flow.code.trim(), verifier: s.flow.verifier }),
+      body: JSON.stringify({ code: s.flow.code.trim(), verifier: s.flow.verifier, state: s.flow.state }),
     });
     return afterConnect();
   } catch (e) {

--- a/plugins/web-ui/test/branding.test.ts
+++ b/plugins/web-ui/test/branding.test.ts
@@ -68,7 +68,11 @@ test("injectBranding rewrites the tab title with the escaped label when a suffix
   assert.match(injectBranding(shell, {}, { titleSuffix: "· Web" }), /<title>QM · Web<\/title>/);
   const hostile = injectBranding(shell, { selfLabel: "x</title><script>alert(1)</script>" }, { titleSuffix: "· Web" });
   assert.doesNotMatch(hostile, /<script>/i);
-  assert.match(hostile, /<title>x&lt;\/title&gt;/);
+  assert.equal(
+    /<title>([\s\S]*?)<\/title>/.exec(hostile)?.[1],
+    "x/titlescriptalert(1)/script · Web",
+    "markup in the label is stripped, not merely escaped",
+  );
 });
 
 test("brandName() reads the injected self-label and falls back to the product name", async () => {
@@ -83,4 +87,55 @@ test("brandName() reads the injected self-label and falls back to the product na
     delete (globalThis as { document?: Document }).document;
   }
   assert.equal(brandName!(), "QM");
+});
+
+test("injectBranding cannot be broken out of the style block by a hostile accent or mark", async () => {
+  const { injectBranding } = await import("../../chassis/src/branding.ts");
+  const shell = "<!doctype html><html><head></head><body></body></html>";
+
+  const hostile = injectBranding(shell, {
+    accent: "red;} :root{--x:url(https://evil/a)",
+    mark: "</style><img src=https://evil/x>",
+  });
+  const markValue = /--brand-mark:"([^"]*)"/.exec(hostile)?.[1] ?? "";
+  assert.ok(markValue.length > 0, "the mark still renders, sanitized");
+  assert.doesNotMatch(markValue, /[<>{}"\\]/, "nothing that could end the CSS string or the style element survives");
+  assert.ok(!hostile.includes("--brand-accent"), "an accent that is not a plain hex colour is dropped, not emitted");
+  assert.equal(hostile.match(/<\/style>/g)?.length, 1, "exactly one style element — no breakout");
+
+  const good = injectBranding(shell, { accent: "#f0652f", mark: "Y" });
+  assert.match(good, /<style>:root\{--brand-accent:#f0652f;--brand-mark:"Y"\}<\/style>/);
+});
+
+test("every surface's branding cache sanitizes what the fetcher returned", async () => {
+  const { createBrandingCache } = await import("../../chassis/src/branding.ts");
+  const cache = createBrandingCache(async () => ({
+    accent: "red;} :root{--x:url(https://evil/a)",
+    mark: "</style><img src=https://evil/x>",
+    selfLabel: "Acme\r\n</title>",
+  }));
+  assert.deepEqual(await cache.forRender(), { mark: "/s", selfLabel: "Acme/title" });
+  assert.deepEqual(cache.current(), { mark: "/s", selfLabel: "Acme/title" });
+});
+
+test("sanitizeBranding keeps the mark grammar core stores and strips only what ends a CSS string", async () => {
+  const { sanitizeBranding } = await import("../../chassis/src/branding.ts");
+
+  assert.deepEqual(sanitizeBranding({ accent: "  #f0652f  ", mark: "Y", selfLabel: " Acme " }), {
+    accent: "#f0652f",
+    mark: "Y",
+    selfLabel: "Acme",
+  });
+  assert.deepEqual(sanitizeBranding({ accent: "rgb(1,2,3)", mark: 7, selfLabel: "" }), {});
+  assert.equal(sanitizeBranding({ mark: "abcdef" }).mark, "ab", "the mark stays a two-glyph badge");
+  for (const mark of [";)", ":)", "A;", "🚀", "Añ"]) {
+    assert.equal(sanitizeBranding({ mark }).mark, mark, `a mark core accepts survives here too: ${mark}`);
+  }
+  assert.equal(sanitizeBranding({ mark: '"\\' }).mark, undefined, "only what could end the CSS string is stripped");
+  assert.equal(sanitizeBranding({ selfLabel: "z".repeat(80) }).selfLabel?.length, 40, "the self-label is capped");
+  assert.equal(
+    sanitizeBranding({ selfLabel: "Acme\r\nSubject: spoofed</title>{x}" }).selfLabel,
+    "AcmeSubject: spoofed/titlex",
+    "the label reaches sign-in pages and an outbound email subject with no line breaks or markup left in it",
+  );
 });

--- a/scripts/google-oauth-smoke.ts
+++ b/scripts/google-oauth-smoke.ts
@@ -170,7 +170,7 @@ const corePort = await freePort();
 const webPort = await freePort();
 const coreBase = `http://127.0.0.1:${corePort}`;
 const webBase = `http://127.0.0.1:${webPort}`;
-const redirectUri = `${webBase}/connectors/oauth/google/callback`;
+const redirectUri = `${webBase}/v1/connectors/oauth/google/callback`;
 const expectedRedirect = process.env.GOOGLE_OAUTH_REDIRECT_URI ?? process.env.GOOGLE_OAUTH_REGISTERED_REDIRECT_URI;
 
 if (expectedRedirect && expectedRedirect !== redirectUri) {
@@ -211,6 +211,7 @@ try {
       PORT: String(webPort),
       WEB_UI_PUBLIC_URL: webBase,
       WEB_UI_PRINCIPALS: actor,
+      ...(interactive ? { NODE_ENV: "test", ALLOW_UNSIGNED_TEST_IDENTITY: "1" } : {}),
     },
   });
   web.stderr.on("data", (chunk) => {
@@ -242,10 +243,15 @@ try {
 
   const forged = await fetch(
     `${webBase}/connectors/oauth/google/callback?code=forged-smoke-code&state=forged-smoke-state`,
-    { redirect: "manual" },
+    { redirect: "manual", headers: identity },
   );
   if (forged.status !== 400)
     throw new Error(`web callback route did not forward/reject forged callback as expected (HTTP ${forged.status})`);
+  const unbound = await fetch(`${webBase}/connectors/oauth/google/callback?code=c&state=${encodeURIComponent(state)}`, {
+    redirect: "manual",
+  });
+  if (unbound.status !== 400)
+    throw new Error(`web callback route accepted a callback with no signed-in session (HTTP ${unbound.status})`);
   const providerProbe = await probeGoogleTokenEndpoint(redirectUri);
 
   console.log("google oauth readiness ok");
@@ -263,7 +269,9 @@ try {
     );
   } else {
     const timeoutMs = Number(process.env.GOOGLE_OAUTH_SMOKE_TIMEOUT_MS ?? 180_000);
-    console.log("Open this URL in a browser that can reach the redirect_uri:");
+    console.log(`The callback is bound to the signed-in browser session, so sign in first:`);
+    console.log(`  1. open ${webBase} and sign in as ${actor}`);
+    console.log(`  2. open this URL in that same browser:`);
     console.log(authorize.toString());
     console.log(`waiting up to ${Math.round(timeoutMs / 1000)}s for Google to redirect back...`);
     const deadline = Date.now() + timeoutMs;
@@ -278,7 +286,7 @@ try {
     }
     if (!connected) {
       throw new Error(
-        `interactive Google OAuth did not complete; confirm this redirect URI is registered in Google Cloud: ${redirectUri}`,
+        `interactive Google OAuth did not complete; confirm the browser was signed in as ${actor} and that this redirect URI is registered in Google Cloud: ${redirectUri}`,
       );
     }
     console.log("interactive_exchange: connected");

--- a/src/api/routes/connectors.ts
+++ b/src/api/routes/connectors.ts
@@ -4,10 +4,9 @@ import {
   exchangeCode,
   openOAuthState,
   PROVIDERS,
-  sealOAuthState,
   createSecretClientResolver,
-  generateCodeVerifier,
-  codeChallengeS256,
+  sealPkceState,
+  pkceVerifierFor,
   type OAuthClientResolver,
   type AccountType,
 } from "../../connectors/oauth.ts";
@@ -15,6 +14,7 @@ import { bestOAuthTokenStatus, CONNECTOR_STATUS_ACCOUNT_TYPES } from "../../cred
 import type { OAuthTokenStatus } from "../../credentials/keychain.ts";
 import { createEnvSecretSource } from "../../credentials/secret-source.ts";
 import type { ServerDeps } from "../deps.ts";
+import { PORTAL_IDENTITY_HEADER, verifyPortalIdentity, type PortalIdentity } from "../../auth/portal-identity.ts";
 import { personKey, samePerson } from "../../directory/person.ts";
 import { errMessage } from "../../util/errors.ts";
 import { normalizeInboundExpiresAt } from "../expiry.ts";
@@ -27,6 +27,35 @@ function oauthStateSecret(deps: ServerDeps, signingSecret: string | undefined): 
   const value = deps.oauthStateSecret ?? signingSecret;
   if (!value) throw new Error("OAuth state secret required");
   return value;
+}
+
+function surfaceFrontsCallbacks(ctx: BaseCtx): boolean {
+  return !!ctx.deps.portalUrl && !!(ctx.deps.portalIdentitySecret ?? ctx.secret);
+}
+
+async function browserFinisher(ctx: BaseCtx): Promise<PortalIdentity | null> {
+  const raw = ctx.req.headers[PORTAL_IDENTITY_HEADER];
+  const token = Array.isArray(raw) ? raw[0] : raw;
+  const identitySecret = ctx.deps.portalIdentitySecret ?? ctx.secret;
+  if (!token || !identitySecret) return null;
+  return await verifyPortalIdentity(token, identitySecret, Date.now());
+}
+
+async function assertBrowserFinisher(ctx: BaseCtx, principalId: string): Promise<void> {
+  if (!surfaceFrontsCallbacks(ctx)) return;
+  const finisher = await browserFinisher(ctx);
+  if (finisher?.imp) {
+    throw new Error("finish this connection as yourself — stop impersonating before connecting an account");
+  }
+  if (!samePerson(finisher?.p ?? null, principalId)) {
+    throw new Error("finish this connection in the signed-in browser session that started it");
+  }
+  if (ctx.deps.identity) {
+    await ctx.deps.identity.refresh();
+    if (ctx.deps.identity.classify(finisher!.p).type !== "internal") {
+      throw new Error("this account is no longer active in the workspace");
+    }
+  }
 }
 
 export function resolverFor(deps: ServerDeps): OAuthClientResolver {
@@ -124,16 +153,14 @@ async function oauthCallback(ctx: BaseCtx): Promise<void> {
   const providerError = url.searchParams.get("error");
   if (providerError) return sendJson(res, 400, { error: "oauth_denied", message: providerError });
   if (!code || !stateParam) return sendJson(res, 400, { error: "bad_request", message: "code and state required" });
-  let state;
   try {
-    state = await openOAuthState(stateParam, {
-      secret: oauthStateSecret(deps, secret),
-      maxAgeMs: OAUTH_STATE_MAX_AGE_MS,
-    });
+    const stateSecret = oauthStateSecret(deps, secret);
+    const state = await openOAuthState(stateParam, { secret: stateSecret, maxAgeMs: OAUTH_STATE_MAX_AGE_MS });
     if (state.provider !== oauthRoute.provider) throw new Error("OAuth provider mismatch");
     if (state.orgId !== undefined && state.orgId !== configOrgId()) {
       throw new Error("OAuth state is for a different org");
     }
+    await assertBrowserFinisher(ctx, state.principalId);
     if (
       !deps.replayDedupe ||
       !(await deps.replayDedupe.claim(`oauth:${state.nonce}`, state.issuedAt + OAUTH_STATE_MAX_AGE_MS))
@@ -142,11 +169,12 @@ async function oauthCallback(ctx: BaseCtx): Promise<void> {
     }
     const accountType = state.accountType ?? "default";
     const client = await resolverFor(deps)(oauthRoute.provider, { accountType });
+    const codeVerifier = pkceVerifierFor(state, stateSecret);
     const { hosts, token } = await exchangeCode(oauthRoute.provider, code, state.redirectUri, {
       client,
       fetchImpl: deps.oauthFetch,
       accountType,
-      ...(state.codeVerifier ? { codeVerifier: state.codeVerifier } : {}),
+      ...(codeVerifier ? { codeVerifier } : {}),
     });
     if (!token.accessToken) throw new Error("oauth exchange returned an empty access token");
     const stamped = { ...token, clientRef: client.clientRef, accountType, orgId: configOrgId() };
@@ -224,8 +252,7 @@ async function consentRedeem(ctx: ApiCtx): Promise<void> {
       });
     }
     const returnTo = safeReturnTo(url.searchParams.get("returnTo")) ?? rec.returnTo;
-    const codeVerifier = PROVIDERS[rec.provider]?.pkce ? generateCodeVerifier() : undefined;
-    const state = await sealOAuthState(
+    const { state, codeChallenge } = await sealPkceState(
       {
         provider: rec.provider,
         principalId: rec.principalId,
@@ -234,7 +261,6 @@ async function consentRedeem(ctx: ApiCtx): Promise<void> {
         ...(rec.accountType !== "default" ? { accountType: rec.accountType } : {}),
         clientRef: client.clientRef,
         ...(returnTo ? { returnTo } : {}),
-        ...(codeVerifier ? { codeVerifier } : {}),
         consentLinkId: linkId,
       },
       { secret: oauthStateSecret(deps, secret) },
@@ -244,7 +270,7 @@ async function consentRedeem(ctx: ApiCtx): Promise<void> {
       state,
       client,
       accountType: rec.accountType,
-      ...(codeVerifier ? { codeChallenge: codeChallengeS256(codeVerifier) } : {}),
+      ...(codeChallenge ? { codeChallenge } : {}),
     });
     audit(deps, {
       principalId: rec.principalId,
@@ -349,6 +375,12 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
   const redirectUri = url.searchParams.get("redirectUri") ?? "";
   if (!principalId || !redirectUri)
     return sendJson(res, 400, { error: "bad_request", message: "principalId and redirectUri required" });
+  if (ctx.actor?.imp) {
+    return sendJson(res, 403, {
+      error: "forbidden",
+      message: "connector flows cannot be started while impersonating",
+    });
+  }
   const accountType = parseAccountType(url.searchParams.get("accountType"));
   try {
     const client = await resolverFor(deps)(oauthRoute.provider, { accountType });
@@ -358,8 +390,7 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
         message: "redirectUri is not registered for this client",
       });
     }
-    const codeVerifier = provider.pkce ? generateCodeVerifier() : undefined;
-    const state = await sealOAuthState(
+    const { state, codeChallenge } = await sealPkceState(
       {
         provider: oauthRoute.provider,
         principalId,
@@ -370,7 +401,6 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
         ...(safeReturnTo(url.searchParams.get("returnTo"))
           ? { returnTo: safeReturnTo(url.searchParams.get("returnTo")) }
           : {}),
-        ...(codeVerifier ? { codeVerifier } : {}),
       },
       { secret: oauthStateSecret(deps, secret) },
     );
@@ -379,7 +409,7 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
       state,
       client,
       accountType,
-      ...(codeVerifier ? { codeChallenge: codeChallengeS256(codeVerifier) } : {}),
+      ...(codeChallenge ? { codeChallenge } : {}),
     });
     audit(deps, {
       principalId,

--- a/src/api/routes/user-model-auth.ts
+++ b/src/api/routes/user-model-auth.ts
@@ -117,9 +117,10 @@ async function claudeComplete(ctx: ApiCtx): Promise<void> {
   const body = bodyObj(ctx);
   const code = typeof body.code === "string" ? body.code : "";
   const verifier = typeof body.verifier === "string" ? body.verifier : "";
+  const state = typeof body.state === "string" && body.state ? body.state : undefined;
   if (!code || !verifier) return sendJson(ctx.res, 400, { error: "bad_request" });
   try {
-    const tokens = await completeClaudeLogin(code, verifier);
+    const tokens = await completeClaudeLogin(code, verifier, state);
     await ctx.deps.userModelCredentials.setOAuth(principal, "anthropic", tokens);
     audit(ctx.deps, {
       principalId: principal,

--- a/src/connectors/oauth.ts
+++ b/src/connectors/oauth.ts
@@ -1,6 +1,6 @@
 import type { OAuthToken, OAuthRefresh } from "../credentials/keychain.ts";
 import { createEnvSecretSource, type SecretSource } from "../credentials/secret-source.ts";
-import { randomUUID, randomBytes, createHash } from "node:crypto";
+import { randomUUID, randomBytes, createHash, createHmac } from "node:crypto";
 import { decodeJwt } from "jose";
 import { mintSignedPayload, verifySignedPayload } from "../auth/signed-token.ts";
 import { swallow } from "../util/errors.ts";
@@ -9,6 +9,12 @@ export type AccountType = "default" | "personal" | "company";
 
 export function generateCodeVerifier(): string {
   return randomBytes(32).toString("base64url");
+}
+export function deriveCodeVerifier(nonce: string, secret: string): string {
+  if (!secret) throw new Error("OAuth state secret required");
+  if (!nonce) throw new Error("OAuth state nonce required");
+  const key = createHmac("sha256", secret).update("pkce.v1").digest();
+  return createHmac("sha256", key).update(nonce).digest("base64url");
 }
 export function codeChallengeS256(verifier: string): string {
   return createHash("sha256").update(verifier).digest("base64url");
@@ -476,7 +482,6 @@ export interface OAuthState {
   orgId?: string;
   accountType?: AccountType;
   clientRef?: string;
-  codeVerifier?: string;
   consentLinkId?: string;
 }
 
@@ -491,28 +496,35 @@ function isOAuthState(v: unknown): v is OAuthState {
     typeof s.redirectUri === "string" &&
     typeof s.issuedAt === "number" &&
     typeof s.nonce === "string" &&
+    s.nonce !== "" &&
     (s.returnTo === undefined || typeof s.returnTo === "string") &&
     (s.orgId === undefined || typeof s.orgId === "string") &&
     (s.accountType === undefined || (typeof s.accountType === "string" && ACCOUNT_TYPES.includes(s.accountType))) &&
     (s.clientRef === undefined || typeof s.clientRef === "string") &&
-    (s.codeVerifier === undefined || typeof s.codeVerifier === "string") &&
     (s.consentLinkId === undefined || typeof s.consentLinkId === "string")
   );
 }
 
 export function sealOAuthState(
-  state: Omit<OAuthState, "issuedAt" | "nonce"> & { issuedAt?: number; nonce?: string },
+  state: Omit<OAuthState, "issuedAt"> & { issuedAt?: number },
   opts: { secret: string; now?: () => number } = { secret: "" },
 ): Promise<string> {
   if (!opts.secret) throw new Error("OAuth state secret required");
-  return mintSignedPayload(
-    {
-      ...state,
-      issuedAt: state.issuedAt ?? (opts.now ?? Date.now)(),
-      nonce: state.nonce ?? randomUUID(),
-    },
-    opts.secret,
-  );
+  return mintSignedPayload({ ...state, issuedAt: state.issuedAt ?? (opts.now ?? Date.now)() }, opts.secret);
+}
+
+export async function sealPkceState(
+  state: Omit<OAuthState, "issuedAt" | "nonce">,
+  opts: { secret: string; now?: () => number },
+): Promise<{ state: string; codeChallenge?: string }> {
+  const nonce = randomUUID();
+  const sealed = await sealOAuthState({ ...state, nonce }, opts);
+  const verifier = PROVIDERS[state.provider]?.pkce ? deriveCodeVerifier(nonce, opts.secret) : undefined;
+  return { state: sealed, ...(verifier ? { codeChallenge: codeChallengeS256(verifier) } : {}) };
+}
+
+export function pkceVerifierFor(state: OAuthState, secret: string): string | undefined {
+  return PROVIDERS[state.provider]?.pkce ? deriveCodeVerifier(state.nonce, secret) : undefined;
 }
 
 export async function openOAuthState(

--- a/src/model/subscription-oauth.ts
+++ b/src/model/subscription-oauth.ts
@@ -73,10 +73,12 @@ export async function refreshChatGPTTokens(refreshToken: string): Promise<UserOA
 export interface ClaudeAuthStart {
   authorizeUrl: string;
   verifier: string;
+  state: string;
 }
 
 export function startClaudeLogin(): ClaudeAuthStart {
   const verifier = generateCodeVerifier();
+  const state = generateCodeVerifier();
   const challenge = codeChallengeS256(verifier);
   const url = new URL(CLAUDE_AUTHORIZE);
   url.searchParams.set("code", "true");
@@ -86,12 +88,21 @@ export function startClaudeLogin(): ClaudeAuthStart {
   url.searchParams.set("scope", CLAUDE_SCOPE);
   url.searchParams.set("code_challenge", challenge);
   url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("state", verifier);
-  return { authorizeUrl: url.toString(), verifier };
+  url.searchParams.set("state", state);
+  return { authorizeUrl: url.toString(), verifier, state };
 }
 
-export async function completeClaudeLogin(pastedCode: string, verifier: string): Promise<UserOAuthTokens> {
-  const [code, state] = pastedCode.trim().split("#");
+export async function completeClaudeLogin(
+  pastedCode: string,
+  verifier: string,
+  expectedState?: string,
+): Promise<UserOAuthTokens> {
+  const [code, pastedState] = pastedCode.trim().split("#");
+  if (pastedState && expectedState && pastedState !== expectedState) {
+    throw new Error("this code belongs to a different login attempt — start the connect flow again");
+  }
+  const state = pastedState || expectedState;
+  if (!state) throw new Error("paste the whole code from claude.ai, including the part after the #");
   const res = await fetch(CLAUDE_TOKEN, {
     method: "POST",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
@@ -99,7 +110,7 @@ export async function completeClaudeLogin(pastedCode: string, verifier: string):
       grant_type: "authorization_code",
       client_id: CLAUDE_CLIENT_ID,
       code,
-      state: state ?? verifier,
+      state,
       code_verifier: verifier,
       redirect_uri: CLAUDE_REDIRECT,
     }),

--- a/test/connector-invariants.test.ts
+++ b/test/connector-invariants.test.ts
@@ -2,6 +2,7 @@ import "./support/auto-fake-sprites.ts";
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,6 +14,7 @@ import { envKey } from "../src/credentials/connector-token.ts";
 import type { TurnRequest } from "../src/types.ts";
 import { fakeSprites } from "./support/auto-fake-sprites.ts";
 import { testConfig } from "./support/test-config.ts";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "./support/portal-identity.ts";
 
 const CATALOG_HOSTS = Object.values(PROVIDERS).flatMap((p) => p.hosts);
 
@@ -85,6 +87,7 @@ test("cross-org — the callback rejects sealed state minted for a different org
   try {
     const state = await sealOAuthState(
       {
+        nonce: randomUUID(),
         provider: "google",
         principalId: "U1",
         redirectUri: `${base}/v1/connectors/oauth/google/callback`,
@@ -115,10 +118,17 @@ test("empty-token guard — an adapter returning no access token fails the conne
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
   try {
     const state = await sealOAuthState(
-      { provider: "google", principalId: "U1", redirectUri: `${base}/v1/connectors/oauth/google/callback` },
+      {
+        provider: "google",
+        principalId: "U1",
+        redirectUri: `${base}/v1/connectors/oauth/google/callback`,
+        nonce: randomUUID(),
+      },
       { secret: SECRET },
     );
-    const res = await fetch(`${base}/v1/connectors/oauth/google/callback?code=c&state=${encodeURIComponent(state)}`);
+    const res = await fetch(`${base}/v1/connectors/oauth/google/callback?code=c&state=${encodeURIComponent(state)}`, {
+      headers: { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "U1", exp: Date.now() + 60_000 }, SECRET) },
+    });
     assert.equal(res.status, 400);
     assert.match(await res.text(), /empty access token/);
     assert.equal(

--- a/test/oauth-consent-bridge.test.ts
+++ b/test/oauth-consent-bridge.test.ts
@@ -17,9 +17,14 @@ import {
   CONTROL_PLANE_AUD,
 } from "../src/auth/capability-token.ts";
 import { testConfig } from "./support/test-config.ts";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "./support/portal-identity.ts";
 
 const SECRET = "consent-bridge-secret".repeat(3);
 const oauthEnv = { GOOGLE_OAUTH_CLIENT_ID: "gid", GOOGLE_OAUTH_CLIENT_SECRET: "gsecret" } as NodeJS.ProcessEnv;
+
+function finisher(principalId: string): Record<string, string> {
+  return { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: principalId, exp: Date.now() + 60_000 }, SECRET) };
+}
 
 function start(
   fetchImpl: FetchLike,
@@ -130,7 +135,7 @@ test("mint → intended teammate redeems → callback connects them; the link is
     );
 
     const cb = `/v1/connectors/oauth/google/callback?code=code-1&state=${encodeURIComponent(consent.searchParams.get("state") ?? "")}`;
-    const cbRes = await fetch(`${srv.base}${cb}`, { redirect: "manual" });
+    const cbRes = await fetch(`${srv.base}${cb}`, { redirect: "manual", headers: finisher("U1") });
     assert.equal(cbRes.status, 302);
     assert.match(cbRes.headers.get("location") ?? "", /^\/connectors\?connector=google&status=connected/);
     assert.equal(exchanged, 1);
@@ -200,6 +205,35 @@ test("a wrong-recipient click is refused, leaves the link usable, and reports wh
   }
 });
 
+test("a leaked consent URL is dead outside the browser session it was minted for", async () => {
+  let exchanged = 0;
+  const srv = start(async () => {
+    exchanged += 1;
+    return { ok: true, status: 200, json: async () => ({ access_token: "at-google" }) };
+  });
+  try {
+    const { connectPath } = (await (await mint(srv.base, await consentTok("U1"), { provider: "google" })).json()) as {
+      connectPath: string;
+    };
+    const decision = (await (await redeem(srv.base, coreRedeemPath(connectPath), "U1")).json()) as {
+      authorizeUrl: string;
+    };
+    const state = new URL(decision.authorizeUrl).searchParams.get("state") ?? "";
+    const cb = `/v1/connectors/oauth/google/callback?code=code-1&state=${encodeURIComponent(state)}`;
+
+    const leaked = await fetch(`${srv.base}${cb}`, { redirect: "manual", headers: finisher("U2") });
+    assert.equal(leaked.status, 400);
+    assert.equal(exchanged, 0, "U2's browser must not spend U1's authorization");
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), null);
+
+    const owner = await fetch(`${srv.base}${cb}`, { redirect: "manual", headers: finisher("U1") });
+    assert.equal(owner.status, 302, "the rejected attempt must not have burned the state");
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "at-google");
+  } finally {
+    await srv.close();
+  }
+});
+
 test("connecting from a channel never re-grants a previously private connector", async () => {
   const fetchImpl: FetchLike = async () => ({
     ok: true,
@@ -218,7 +252,7 @@ test("connecting from a channel never re-grants a previously private connector",
     assert.equal(decision.status, "authorize");
     const state = new URL(decision.authorizeUrl).searchParams.get("state") ?? "";
     const cb = `/v1/connectors/oauth/google/callback?code=code-1&state=${encodeURIComponent(state)}`;
-    assert.equal((await fetch(`${srv.base}${cb}`, { redirect: "manual" })).status, 302);
+    assert.equal((await fetch(`${srv.base}${cb}`, { redirect: "manual", headers: finisher("U1") })).status, 302);
     assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "at-google");
     assert.equal((await srv.built.keychain!.materializeStanding("channel:C9")).length, 0);
   } finally {
@@ -261,7 +295,11 @@ test("on an API-only host (no PUBLIC_WEB_URL) the callback does NOT default to t
     const consent = new URL(decision.authorizeUrl);
     const cb = `/v1/connectors/oauth/google/callback?code=code-1&state=${encodeURIComponent(consent.searchParams.get("state") ?? "")}`;
     const cbRes = await fetch(`${srv.base}${cb}`, { redirect: "manual" });
-    assert.equal(cbRes.status, 200);
+    assert.equal(
+      cbRes.status,
+      200,
+      "an API-only host has no browser surface to mint a finisher, so the callback must not demand one",
+    );
     const body = (await cbRes.json()) as { ok: boolean; provider: string };
     assert.equal(body.ok, true);
     assert.equal(body.provider, "google");

--- a/test/oauth-routes.test.ts
+++ b/test/oauth-routes.test.ts
@@ -9,14 +9,21 @@ import type { AddressInfo } from "node:net";
 import { createServer } from "../src/api/server.ts";
 import { buildApp, type BuiltApp } from "../src/wiring.ts";
 import { signRequest } from "../src/auth/source-auth.ts";
-import { PROVIDERS, type FetchLike } from "../src/connectors/oauth.ts";
+import { PROVIDERS, codeChallengeS256, type FetchLike } from "../src/connectors/oauth.ts";
 import { testConfig } from "./support/test-config.ts";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "./support/portal-identity.ts";
 
 const SECRET = "oauth-route-test-secret".repeat(3);
 const oauthEnv = {
   GOOGLE_OAUTH_CLIENT_ID: "gid",
   GOOGLE_OAUTH_CLIENT_SECRET: "gsecret",
+  X_OAUTH_CLIENT_ID: "xid",
+  X_OAUTH_CLIENT_SECRET: "xsecret",
 } as NodeJS.ProcessEnv;
+
+function finisher(principalId: string): Record<string, string> {
+  return { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: principalId, exp: Date.now() + 60_000 }, SECRET) };
+}
 
 function sign(method: string, pathWithQuery: string, body = ""): Record<string, string> {
   const ts = Math.floor(Date.now() / 1000);
@@ -40,6 +47,8 @@ function start(fetchImpl: FetchLike): { base: string; built: BuiltApp; close: ()
     auditLog: built.auditLog,
     oauthEnv,
     oauthFetch: fetchImpl,
+    portalUrl: "http://web.test",
+    identity: built.identity,
   });
   server.listen(0);
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -74,10 +83,19 @@ test("OAuth start, unsigned callback, status, and revoke are principal-bound", a
     assert.equal(consent.searchParams.get("client_id"), "gid");
 
     const callbackPath = `/v1/connectors/oauth/google/callback?code=code-123&state=${encodeURIComponent(state)}`;
-    const callbackRes = await fetch(`${srv.base}${callbackPath}`);
+    const anonymous = await fetch(`${srv.base}${callbackPath}`);
+    assert.equal(anonymous.status, 400);
+    assert.match(((await anonymous.json()) as { message: string }).message, /signed-in browser session/);
+
+    const stranger = await fetch(`${srv.base}${callbackPath}`, { headers: finisher("U2") });
+    assert.equal(stranger.status, 400);
+    assert.match(((await stranger.json()) as { message: string }).message, /signed-in browser session/);
+    assert.equal(exchanged, false, "a stranger's browser must not complete U1's connection");
+
+    const callbackRes = await fetch(`${srv.base}${callbackPath}`, { headers: finisher("U1") });
     assert.equal(callbackRes.status, 200);
     assert.equal(exchanged, true);
-    const replay = await fetch(`${srv.base}${callbackPath}`);
+    const replay = await fetch(`${srv.base}${callbackPath}`, { headers: finisher("U1") });
     assert.equal(replay.status, 400);
     assert.match(((await replay.json()) as { message: string }).message, /already used/);
     assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "at-google");
@@ -194,6 +212,106 @@ test("connector token route normalizes expiry seconds before storing", async () 
     const status = await srv.built.connectorTokens.connectorTokenStatus("api.example.test", "U1");
     assert.equal(status.connected, true);
     assert.equal(status.expiresAt, expiresAtMs);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a PKCE flow never exposes the verifier to the user-agent and still exchanges it end to end", async () => {
+  let sentVerifier = "";
+  const fetchImpl: FetchLike = async (url, init) => {
+    assert.equal(url, PROVIDERS.x!.tokenUrl);
+    sentVerifier = new URLSearchParams(init.body).get("code_verifier") ?? "";
+    return { ok: true, status: 200, json: async () => ({ access_token: "at-x", expires_in: 7200 }) };
+  };
+
+  const srv = start(fetchImpl);
+  try {
+    const redirectUri = `${srv.base}/v1/connectors/oauth/x/callback`;
+    const startPath = `/v1/connectors/oauth/x/start?principalId=U1&redirectUri=${encodeURIComponent(redirectUri)}`;
+    const startRes = await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) });
+    assert.equal(startRes.status, 200);
+    const consent = new URL(((await startRes.json()) as { authorizeUrl: string }).authorizeUrl);
+    const state = consent.searchParams.get("state") ?? "";
+    const challenge = consent.searchParams.get("code_challenge") ?? "";
+    assert.ok(state && challenge, "the authorize URL carries both state and challenge");
+
+    const payload = Buffer.from(state.split(".")[1]!, "base64url").toString("utf8");
+    const claims = JSON.parse(payload) as Record<string, unknown>;
+    for (const [name, value] of [...Object.entries(claims), ...consent.searchParams]) {
+      if (typeof value !== "string") continue;
+      assert.notEqual(
+        codeChallengeS256(value),
+        challenge,
+        `the URL the browser follows must not carry the verifier — "${name}" is it in plain sight`,
+      );
+    }
+
+    const callbackPath = `/v1/connectors/oauth/x/callback?code=code-x&state=${encodeURIComponent(state)}`;
+    assert.equal((await fetch(`${srv.base}${callbackPath}`, { headers: finisher("U1") })).status, 200);
+    assert.equal(codeChallengeS256(sentVerifier), challenge, "the exchange sends the verifier behind that challenge");
+    assert.ok(!payload.includes(sentVerifier), "the state the user-agent carries is free of the verifier at any depth");
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("api.x.com", "U1"), "at-x");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("an impersonated browser cannot finish a connection the impersonated user started", async () => {
+  let exchanged = false;
+  const srv = start(async () => {
+    exchanged = true;
+    return { ok: true, status: 200, json: async () => ({ access_token: "at" }) };
+  });
+  try {
+    const redirectUri = `${srv.base}/v1/connectors/oauth/google/callback`;
+    const startPath = `/v1/connectors/oauth/google/start?principalId=U1&redirectUri=${encodeURIComponent(redirectUri)}`;
+    const startBody = (await (await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) })).json()) as {
+      authorizeUrl: string;
+    };
+    const state = new URL(startBody.authorizeUrl).searchParams.get("state") ?? "";
+    const cb = `/v1/connectors/oauth/google/callback?code=c&state=${encodeURIComponent(state)}`;
+
+    const impersonated = {
+      [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "U1", imp: "admin", exp: Date.now() + 60_000 }, SECRET),
+    };
+    const res = await fetch(`${srv.base}${cb}`, { headers: impersonated });
+    assert.equal(res.status, 400, "an admin impersonating U1 must not bind a provider account to U1");
+    assert.match(((await res.json()) as { message: string }).message, /stop impersonating/);
+    assert.equal(exchanged, false, "the token exchange must not run for an impersonated finisher");
+
+    assert.equal(
+      (await fetch(`${srv.base}${cb}`, { headers: finisher("U1") })).status,
+      200,
+      "the real signed-in owner still completes the flow",
+    );
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a principal who left the workspace cannot finish a connection started before departure", async () => {
+  let exchanged = false;
+  const srv = start(async () => {
+    exchanged = true;
+    return { ok: true, status: 200, json: async () => ({ access_token: "at-google" }) };
+  });
+  try {
+    const redirectUri = `${srv.base}/v1/connectors/oauth/google/callback`;
+    const startPath = `/v1/connectors/oauth/google/start?principalId=U9&redirectUri=${encodeURIComponent(redirectUri)}`;
+    const startRes = await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) });
+    assert.equal(startRes.status, 200);
+    const state = new URL(((await startRes.json()) as { authorizeUrl: string }).authorizeUrl).searchParams.get("state");
+    assert.ok(state);
+
+    await srv.built.identity.deactivate("U9");
+
+    const callbackPath = `/v1/connectors/oauth/google/callback?code=code-9&state=${encodeURIComponent(state)}`;
+    const res = await fetch(`${srv.base}${callbackPath}`, { headers: finisher("U9") });
+    assert.equal(res.status, 400);
+    assert.match(((await res.json()) as { message: string }).message, /no longer active/);
+    assert.equal(exchanged, false, "a departed principal must not spend the authorization");
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U9"), null);
   } finally {
     await srv.close();
   }

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -6,9 +6,11 @@ import {
   makeRefresh,
   openOAuthState,
   sealOAuthState,
+  sealPkceState,
+  pkceVerifierFor,
   createSecretClientResolver,
   scopesFor,
-  generateCodeVerifier,
+  deriveCodeVerifier,
   codeChallengeS256,
   PROVIDERS,
   type FetchLike,
@@ -364,11 +366,14 @@ test("codeChallengeS256 matches the RFC 7636 test vector", () => {
   assert.equal(codeChallengeS256(verifier), "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
 });
 
-test("generateCodeVerifier is URL-safe and high-entropy", () => {
-  const v = generateCodeVerifier();
+test("deriveCodeVerifier is URL-safe, deterministic per nonce, and bound to the server secret", () => {
+  const v = deriveCodeVerifier("nonce-1", "state-secret");
   assert.match(v, /^[A-Za-z0-9_-]+$/, "base64url, no padding");
   assert.ok(v.length >= 43, "at least 256 bits of entropy encoded");
-  assert.notEqual(v, generateCodeVerifier(), "fresh each call");
+  assert.equal(v, deriveCodeVerifier("nonce-1", "state-secret"), "same nonce re-derives the same verifier");
+  assert.notEqual(v, deriveCodeVerifier("nonce-2", "state-secret"), "a different request gets a different verifier");
+  assert.notEqual(v, deriveCodeVerifier("nonce-1", "other-secret"), "unguessable without the server secret");
+  assert.throws(() => deriveCodeVerifier("nonce-1", ""), /secret required/);
 });
 
 test("authorizeUrl adds code_challenge + S256 only when a challenge is supplied", async () => {
@@ -408,13 +413,40 @@ test("exchangeCode sends code_verifier in the token body when provided, omits it
   assert.doesNotMatch(bodies[1]!, /code_verifier/, "no verifier when none provided");
 });
 
-test("OAuth state round-trips the PKCE verifier", async () => {
-  const sealed = await sealOAuthState(
-    { provider: "x", principalId: "U1", redirectUri: "https://app/cb", codeVerifier: "ver-abc" },
-    { secret: "state-secret" },
+test("sealPkceState keeps the verifier out of the browser-visible state; the callback re-derives it", async () => {
+  const secret = "state-secret";
+  const { state, codeChallenge } = await sealPkceState(
+    { provider: "x", principalId: "U1", redirectUri: "https://app/cb" },
+    { secret },
   );
-  const opened = await openOAuthState(sealed, { secret: "state-secret" });
-  assert.equal(opened.codeVerifier, "ver-abc");
+  assert.ok(codeChallenge, "a PKCE provider mints a challenge");
+
+  const payload = Buffer.from(state.split(".")[1]!, "base64url").toString("utf8");
+  const claims = JSON.parse(payload) as Record<string, unknown>;
+  for (const [claim, value] of Object.entries(claims)) {
+    if (typeof value !== "string") continue;
+    assert.notEqual(
+      codeChallengeS256(value),
+      codeChallenge,
+      `a signed-not-encrypted state must not carry the verifier — claim "${claim}" is it in plain sight`,
+    );
+  }
+
+  const opened = await openOAuthState(state, { secret });
+  const verifier = pkceVerifierFor(opened, secret);
+  assert.ok(verifier, "the callback re-derives a verifier");
+  assert.equal(codeChallengeS256(verifier), codeChallenge, "the re-derived verifier matches the challenge sent");
+  assert.ok(!payload.includes(verifier), "the state the user-agent carries is free of the verifier at any depth");
+});
+
+test("an empty nonce cannot collapse the verifier to a constant", async () => {
+  const secret = "state-secret";
+  assert.throws(() => deriveCodeVerifier("", secret), /nonce required/);
+  const sealed = await sealOAuthState(
+    { provider: "x", principalId: "U1", redirectUri: "https://app/cb", nonce: "" },
+    { secret },
+  );
+  await assert.rejects(openOAuthState(sealed, { secret }), /invalid OAuth state/);
 });
 
 const xClient = (): Promise<ResolvedClient> => resolve("x", {});

--- a/test/subscription-oauth.test.ts
+++ b/test/subscription-oauth.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { test } from "node:test";
+import { generateCodeVerifier } from "../src/connectors/oauth.ts";
+import { completeClaudeLogin, startClaudeLogin } from "../src/model/subscription-oauth.ts";
+
+test("generateCodeVerifier mints fresh high-entropy base64url verifiers", () => {
+  const a = generateCodeVerifier();
+  const b = generateCodeVerifier();
+  assert.match(a, /^[A-Za-z0-9_-]{43}$/);
+  assert.notEqual(a, b);
+});
+
+test("startClaudeLogin keeps the verifier out of the authorize URL", () => {
+  const { authorizeUrl, verifier, state } = startClaudeLogin();
+  const url = new URL(authorizeUrl);
+  assert.ok(!authorizeUrl.includes(verifier));
+  assert.equal(url.searchParams.get("state"), state);
+  assert.notEqual(state, verifier);
+  assert.equal(url.searchParams.get("code_challenge"), createHash("sha256").update(verifier).digest("base64url"));
+  assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+});
+
+test("completeClaudeLogin exchanges the pasted state and the held verifier", async () => {
+  const { verifier } = startClaudeLogin();
+  let exchanged: Record<string, unknown> | undefined;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    exchanged = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(JSON.stringify({ access_token: "at", refresh_token: "rt", expires_in: 60 }), {
+      status: 200,
+    });
+  }) as typeof fetch;
+  try {
+    const tokens = await completeClaudeLogin("the-code#the-state", verifier);
+    assert.equal(tokens.accessToken, "at");
+    assert.equal(exchanged?.code, "the-code");
+    assert.equal(exchanged?.state, "the-state");
+    assert.equal(exchanged?.code_verifier, verifier);
+
+    await completeClaudeLogin("bare-code", verifier, "expected-state");
+    assert.equal(exchanged?.code, "bare-code");
+    assert.equal(exchanged?.state, "expected-state");
+
+    await assert.rejects(
+      () => completeClaudeLogin("the-code#other-state", verifier, "expected-state"),
+      /different login attempt/,
+    );
+    await assert.rejects(() => completeClaudeLogin("bare-code", verifier), /including the part after the #/);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});

--- a/test/support/portal-identity.ts
+++ b/test/support/portal-identity.ts
@@ -1,0 +1,9 @@
+import { createHmac } from "node:crypto";
+import { PORTAL_IDENTITY_HEADER, type PortalIdentity } from "../../src/auth/portal-identity.ts";
+
+export { PORTAL_IDENTITY_HEADER };
+
+export function mintPortalIdentity(claims: PortalIdentity, secret: string): string {
+  const payload = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  return `${payload}.${createHmac("sha256", secret).update(payload).digest("base64url")}`;
+}

--- a/test/web-ui-connector-callback.test.ts
+++ b/test/web-ui-connector-callback.test.ts
@@ -1,0 +1,107 @@
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "./support/portal-identity.ts";
+import "./support/auto-fake-sprites.ts";
+
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer as createHttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { sealOAuthState } from "../src/connectors/oauth.ts";
+import { testConfig } from "./support/test-config.ts";
+
+const SECRET = "web-ui-callback-secret".repeat(3);
+
+let exchanges = 0;
+const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "webui-cb-")) }));
+const core = createServer(built.app, {
+  signingSecret: SECRET,
+  replayDedupe: built.replayDedupe,
+  connectorTokens: built.connectorTokens,
+  oauthEnv: { GOOGLE_OAUTH_CLIENT_ID: "gid", GOOGLE_OAUTH_CLIENT_SECRET: "gsecret" } as NodeJS.ProcessEnv,
+  oauthFetch: async () => {
+    exchanges += 1;
+    return { ok: true, status: 200, json: async () => ({ access_token: "at-google" }) };
+  },
+  portalUrl: "http://web.test",
+});
+core.listen(0);
+const corePort = (core.address() as AddressInfo).port;
+
+process.env.CORE_API_URL = `http://localhost:${corePort}`;
+process.env.CORE_SIGNING_SECRET = SECRET;
+process.env.WEB_UI_PRINCIPALS = "";
+const { handler } = await import("../plugins/web-ui/server/index.ts");
+const web = createHttpServer(handler);
+web.listen(0);
+const webBase = `http://localhost:${(web.address() as AddressInfo).port}`;
+
+after(async () => {
+  await new Promise<void>((r) => web.close(() => r()));
+  await new Promise<void>((r) => core.close(() => r()));
+});
+
+function identity(user: string, impersonator?: string): Record<string, string> {
+  return {
+    [PORTAL_IDENTITY_HEADER]: mintPortalIdentity(
+      { p: user, exp: Date.now() + 60_000, ...(impersonator ? { imp: impersonator } : {}) },
+      SECRET,
+    ),
+  };
+}
+
+async function callbackFor(principalId: string): Promise<string> {
+  const state = await sealOAuthState(
+    {
+      nonce: randomUUID(),
+      provider: "google",
+      principalId,
+      redirectUri: `${webBase}/v1/connectors/oauth/google/callback`,
+      orgId: "default-org",
+      returnTo: "/keychain",
+    },
+    { secret: SECRET },
+  );
+  return `${webBase}/v1/connectors/oauth/google/callback?code=code-1&state=${encodeURIComponent(state)}`;
+}
+
+test("the connector callback only completes for the signed-in principal it was minted for", async () => {
+  const cb = await callbackFor("alice");
+
+  const anonymous = await fetch(cb, { redirect: "manual" });
+  assert.equal(anonymous.status, 400);
+  assert.equal(exchanges, 0, "an unauthenticated browser must not spend the authorization");
+
+  const stranger = await fetch(cb, { redirect: "manual", headers: identity("bob") });
+  assert.equal(stranger.status, 400);
+  assert.equal(exchanges, 0);
+  assert.equal(await built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "alice"), null);
+
+  const owner = await fetch(cb, { redirect: "manual", headers: identity("alice") });
+  assert.equal(owner.status, 200);
+  assert.match(await owner.text(), /status=connected/);
+  assert.equal(exchanges, 1);
+  assert.equal(await built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "alice"), "at-google");
+});
+
+test("an impersonating admin cannot start a connector flow in someone else's name", async () => {
+  const res = await fetch(`${webBase}/api/connectors/google/start`, {
+    method: "POST",
+    headers: identity("alice", "admin"),
+  });
+  assert.equal(res.status, 403);
+  assert.match(((await res.json()) as { message: string }).message, /stop impersonating/);
+});
+
+test("an impersonated browser cannot launder the marker away and bind a provider account", async () => {
+  const spent = exchanges;
+  const cb = await callbackFor("carol");
+  const res = await fetch(cb, { redirect: "manual", headers: identity("carol", "admin") });
+  assert.equal(res.status, 400);
+  assert.equal(exchanges, spent, "an impersonated browser must not spend the authorization");
+  assert.equal(await built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "carol"), null);
+});


### PR DESCRIPTION
## The problem

`sealOAuthState` mints a JWS — **signed, not encrypted**. The `code_verifier` was sealed inside it, so it travelled through the user-agent in readable base64url alongside the `code` it exists to protect. Anyone able to read a callback URL held both halves, and PKCE contributed nothing against authorization-code interception.

Two adjacent gaps in the same machinery:

- The connector callback is `auth: "public"`. Possession of a state was sufficient to finish the flow, so a state obtained from a leaked consent URL could bind a provider account to someone else's principal.
- `startClaudeLogin` used the verifier as the authorize URL's `state`, so the `code#state` string the user copies out of the browser carried the code and its verifier side by side.

Mitigating context on the first: `x` is a confidential client, so the exchange still required the client secret. This restores PKCE's actual defence rather than closing an active breach.

## What changed

**Derive the verifier.** `HMAC(subkey, nonce)` where `subkey = HMAC(state_secret, "pkce.v1")`. It never leaves the server; the callback recomputes it from `state.nonce`. The label matters: without it the verifier is an HMAC under the same key that signs OAuth state and portal sessions, and PKCE hands that value to the token endpoint by design. `sealPkceState` / `pkceVerifierFor` own both directions, so `randomUUID`, `deriveCodeVerifier`, `codeChallengeS256` and `sealOAuthState` all drop out of the route file and "is this provider PKCE?" has one spelling instead of three.

`nonce` is now **required** on `sealOAuthState`. The optional `?? randomUUID()` branch had no production callers and was a footgun: sealing a PKCE provider's state without a nonce derived a verifier no `code_challenge` was ever built from, failing at the provider with an opaque `invalid_grant`. Making it required turned that into a compile error.

**Bind the callback.** It now requires a portal identity for the same principal, rejects an impersonated identity on both the callback and `oauthStart`, and refuses a principal who is no longer active in the workspace. The check runs *before* the replay claim, so a rejected attempt cannot burn the legitimate user's state. Deployments with no browser-facing surface (`PUBLIC_WEB_URL` unset) are unaffected — pinned by a test.

This is possession-plus-identity, not full session binding: the identity is not bound to `state.nonce`, so it proves "a currently-valid identity for that principal" rather than "the browser that started this flow". Binding to the nonce via a short-lived `SameSite=Lax` cookie set by the surface is the natural next step and is deliberately not in this PR.

**Separate the subscription login's state from its verifier.** Independent randomness, returned from `startClaudeLogin`, held by the client alongside the verifier, and verified on completion. A pasted state that disagrees is rejected; a bare code still works when the expected state is known, and otherwise fails with a message naming the format instead of an opaque provider 400.

**Sanitize branding before it reaches a style block.** `injectBranding` interpolates `accent` and `mark` into `<style>` and a `content=` attribute. Accent is now hex-only, mark and label are stripped of quotes, angle brackets, braces and control characters, and every replacement uses a function replacer so `$&` in attacker text is inert. The portal sanitizes the accent where it stores it rather than at each read site.

## Portal sign-in

Same derivation, under its own `portal.pkce.v1` key beside the existing `portal.session.v1` / `portal.tmp.v1` / `portal.impersonate.v1` labels. `openTmp` now rejects an empty `state`/`nonce`, which would otherwise have collapsed the derived verifier to a constant.

## Deployment notes

- In-flight PKCE flows fail for the state's 10-minute TTL across the rollout: states sealed by the old code carry a random verifier the new callback cannot reproduce. `x` is the only PKCE provider. Rollback is symmetric. The portal's `portal_oidc_tmp` cookie has the same one-TTL window.
- The verifier is only as private as the OAuth state secret. Where `OAUTH_STATE_SECRET` is unset it falls back to `CORE_SIGNING_SECRET`, which every surface holds — still strictly better than plaintext in the URL, but setting it explicitly is worth documenting.
- `pkceVerifierFor` decides *whether* to send a verifier from the current `PROVIDERS` table rather than from the sealed state, so flipping a provider's `pkce` flag breaks that provider's in-flight flows. The old design carried the decision in the state itself.

## Testing

`typecheck`, `lint` and `format:check` clean. 105 core tests pass across `oauth`, `oauth-routes`, `connector-invariants`, `oauth-consent-bridge`, `web-ui-connector-callback`, `subscription-oauth`, `portal-identity-gate`, `model-credential-route`, `user-model-auth-injection`; portal plugin 110; auth plugin 53.

The regression guard is written to fail if the vulnerability is reinstated the way a natural revert would do it — it asserts against `sealPkceState`, the only function that mints PKCE states in production, rather than hand-building a state that never held a verifier. A companion test asserts the portal verifier differs from what the tmp-cookie MAC key would produce, so collapsing the key separation fails a test rather than passing silently.

No screenshots: nothing here changes a rendered surface. The branding change is a sanitizer on an existing style block, covered by unit tests asserting the escaped output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790804680&installation_model_id=19911&pr_number=880&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F880&signature=ee9326a2d157e49d3cc13026cd22e4d31be80d4853d7f0c96a1e186bec308fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->