### PR TITLE
web: align runtime controls with available credentials

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -2916,6 +2916,9 @@
         border-radius: 10px;
         background: color-mix(in srgb, var(--warn) 8%, var(--surface));
       }
+      .environment-notice.hidden {
+        display: none;
+      }
       .environment-notice strong,
       .environment-notice p {
         display: block;

--- a/plugins/admin/test/environments.test.ts
+++ b/plugins/admin/test/environments.test.ts
@@ -10,4 +10,5 @@ test("the admin UI lists named environments and links attachment warnings", () =
   assert.match(html, /id="environment-notice"/);
   assert.match(html, /Uses named environment/);
   assert.match(html, /scope: attachment\.environmentId/);
+  assert.match(html, /\.environment-notice\.hidden\s*\{\s*display:\s*none;/);
 });

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -344,7 +344,7 @@ export function createChatSurface(
     agent.streamFn = normalStreamFn;
     chatState.normalStreamFn = normalStreamFn;
     chatState.onWork = onWork;
-    void ctx.composer.refreshRuntimeSelection(scopeId, agent);
+    const runtimeReady = ctx.composer.refreshRuntimeSelection(scopeId, agent);
 
     let listedWorking = false;
     let titlePollStarted = false;
@@ -390,11 +390,15 @@ export function createChatSurface(
 
     stickToBottom = true;
     container.replaceChildren(chatState.host);
-    const opening = startProactiveOpenerIfNew(agent, threadRef, normalStreamFn, onWork, sessionId, scopeId, messages);
     drawActiveChat(agent, { forceScroll: true });
     ctx.composer.focusComposerEnd();
     ctx.ensureDeliveryStream();
-    if (!opening) void resumeTrackedRun(agent, threadRef, normalStreamFn, onWork);
+    void resumeTrackedRun(agent, threadRef, normalStreamFn, onWork);
+    void runtimeReady.then((runtimeAvailable) => {
+      if (agent !== chatState.agent) return;
+      if (runtimeAvailable)
+        startProactiveOpenerIfNew(agent, threadRef, normalStreamFn, onWork, sessionId, scopeId, messages);
+    });
     consumeBackgroundPanelRequest();
   }
 

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -301,30 +301,33 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     return modelOptionFor(picked ?? defaultModelValue(scopeKey()), scopeKey());
   }
 
-  async function refreshRuntimeSelection(scopeId: string | null, agent?: Agent): Promise<void> {
+  async function refreshRuntimeSelection(scopeId: string | null, agent?: Agent): Promise<boolean> {
     const request = ++runtimeRequest;
     const scopeKey = runtimeScopeKey(scopeId);
     const seeded = scopeKey !== null && seededRuntime?.scopeId === scopeKey ? seededRuntime.config : null;
-    if (seeded) {
-      applySelectedRuntime(seeded, agent);
-      return;
-    }
+    if (seeded) return applySelectedRuntime(seeded, agent);
     activeRuntimeConfig = null;
     composerState.error = "";
     ctx.chat.drawActiveChat(agent);
     const config = await fetchRuntimeConfig(scopeId);
-    if (request !== runtimeRequest) return;
+    if (request !== runtimeRequest) return false;
     if (!config) {
       composerState.error = "Could not load runtime settings.";
       ctx.chat.drawActiveChat(agent);
-      return;
+      return false;
     }
-    applySelectedRuntime(config, agent);
+    return applySelectedRuntime(config, agent);
   }
 
-  function applySelectedRuntime(config: RuntimeConfig, agent?: Agent): void {
+  function applySelectedRuntime(config: RuntimeConfig, agent?: Agent): boolean {
     activeRuntimeConfig = config;
     composerState.error = "";
+    if (!config.approvedHarnesses.length) {
+      composerState.error = "No approved harness has an available model.";
+      ctx.chat.drawActiveChat(agent);
+      if (pendingComposerFocus) focusComposerEnd();
+      return false;
+    }
     setFastModeModelIds(scopeKey(), config.fastModeModelIds);
     orgFastModeDefault = config.interactiveFastMode === true;
     applyRuntimeOptions(
@@ -342,6 +345,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       agent.state.model = currentModelOption().model;
     ctx.chat.drawActiveChat(agent);
     if (pendingComposerFocus) focusComposerEnd();
+    return true;
   }
 
   async function changeScopeRuntime(
@@ -380,6 +384,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     if (fastAvailable) fastTitle = fastOn ? "Fast mode active" : "Fast mode";
     const approvalPauses = ctx.chat.activePendingApprovals();
     const runtimePending = activeRuntimeConfig === null;
+    const runtimeUnavailable = activeRuntimeConfig?.approvedHarnesses.length === 0;
     const effectiveEffort =
       (activeRuntimeConfig?.effective.effortLevel as EffortLevel | undefined) ??
       defaultEffortForModel(selectedModel.model);
@@ -389,10 +394,13 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       (selectedModel.value !== defaultModelValue(scopeKey()) ||
         composerState.effortLevel !== effectiveEffort ||
         fastOn !== effectiveFast);
-    const inputBlocked = runtimePending || ctx.chat.state.resolvingApprovals.size > 0 || approvalPauses.length > 0;
+    const inputBlocked =
+      runtimePending || runtimeUnavailable || ctx.chat.state.resolvingApprovals.size > 0 || approvalPauses.length > 0;
     const attachingDisabled = inputBlocked;
     let placeholder = "Ask anything";
-    if (inputBlocked) placeholder = runtimePending ? "Loading runtime…" : "Approve or deny to continue";
+    if (runtimePending) placeholder = "Loading runtime…";
+    else if (runtimeUnavailable) placeholder = "No compatible runtime available";
+    else if (inputBlocked) placeholder = "Approve or deny to continue";
     else if (agent.state.isStreaming) placeholder = "Queue a message for after this turn…";
     let composerNotice: TemplateResult | typeof nothing = nothing;
     if (composerState.processingFiles) {
@@ -410,7 +418,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       composerNotice = html`<div class="composer-error">${composerState.error}</div>`;
     }
     let runtimeControls: TemplateResult | typeof nothing = nothing;
-    if (!appState.me?.individualModelAuth) {
+    if (!runtimeUnavailable) {
       runtimeControls = ctx.pane
         ? settingsControl(agent, selectedModel, inputBlocked)
         : html`
@@ -696,7 +704,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
         ${icon(ArrowUp, 17)}
       </button>`;
     }
-    const canQueue = Boolean(composerState.draft.trim());
+    const canQueue = Boolean(composerState.draft.trim()) && Boolean(activeRuntimeConfig?.approvedHarnesses.length);
     return html`
       <button class="stop-btn" type="button" title="Stop" aria-label="Stop" @click=${() => stopStreaming(agent)}>
         ${icon(Square, 16)}
@@ -1193,6 +1201,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       Boolean(composerState.draft.trim() || composerState.attachments.length) &&
       !composerState.processingFiles &&
       activeRuntimeConfig !== null &&
+      activeRuntimeConfig.approvedHarnesses.length > 0 &&
       ctx.chat.state.resolvingApprovals.size === 0 &&
       !ctx.chat.hasUnresolvedApproval()
     );
@@ -1260,6 +1269,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   }
 
   async function queueDraft(agent: Agent): Promise<void> {
+    if (!activeRuntimeConfig?.approvedHarnesses.length) return;
     const threadRef = ctx.chat.state.threadRef;
     const text = composerState.draft.trim();
     if (!text || !threadRef) return;
@@ -1390,7 +1400,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
 
   async function sendPrompt(agent: Agent): Promise<void> {
     if (composerState.processingFiles) return;
-    if (!activeRuntimeConfig && !agent.state.isStreaming) return;
+    if (!activeRuntimeConfig?.approvedHarnesses.length) return;
     if (composerState.pasteView) closePasteView(agent);
     if (ctx.chat.state.resolvingApprovals.size > 0) return;
     if (ctx.chat.hasUnresolvedApproval()) return;

--- a/plugins/web-ui/src/context-model.ts
+++ b/plugins/web-ui/src/context-model.ts
@@ -144,6 +144,11 @@ export function contextModelSection(scopeId: string): TemplateResult | typeof no
       <h2 class="context-panel-title" id="context-model-title">Model</h2>
       <span class="context-model-status error" aria-live="polite">${contextModelState.notice}</span>
     </section>`;
+  if (!config.approvedHarnesses.length)
+    return html`<section class="context-panel context-model" aria-labelledby="context-model-title">
+      <h2 class="context-panel-title" id="context-model-title">Model</h2>
+      <span class="context-model-status error" aria-live="polite"> No approved harness has an available model. </span>
+    </section>`;
   const options = optionsFor(config);
   const multiHarness = new Set(options.map((o) => o.harnessId)).size > 1;
   const selected = contextModelState.pending ?? selectedValue(config);

--- a/plugins/web-ui/src/conv-types.ts
+++ b/plugins/web-ui/src/conv-types.ts
@@ -122,7 +122,7 @@ export interface ComposerSurface {
   resizeComposer(): void;
   currentModelOption(): ModelOption;
   carryModelPick(fromThreadRef: string | null, toThreadRef: string): void;
-  refreshRuntimeSelection(scopeId: string | null, agent?: Agent): Promise<void>;
+  refreshRuntimeSelection(scopeId: string | null, agent?: Agent): Promise<boolean>;
   onDragEnter(e: DragEvent): void;
   onDragOver(e: DragEvent): void;
   onDragLeave(e: DragEvent): void;

--- a/plugins/web-ui/test/composer-source.test.ts
+++ b/plugins/web-ui/test/composer-source.test.ts
@@ -38,6 +38,27 @@ test("composer-right keeps its control order: make default, use org default, mod
   assert.ok(controlsAt < rendered.indexOf("sendControls(agent)"), "runtime controls render before send controls");
 });
 
+test("full chat and pane chat both render runtime controls for individual model auth", () => {
+  const controls = composer.slice(
+    composer.indexOf("let runtimeControls"),
+    composer.indexOf("return html`", composer.indexOf("let runtimeControls")),
+  );
+  assert.match(controls, /ctx\.pane\s*\? settingsControl/);
+  assert.doesNotMatch(controls, /individualModelAuth/);
+});
+
+test("the composer blocks clearly when no approved runtime matches the connected AI account", () => {
+  assert.match(composer, /if \(!config\.approvedHarnesses\.length\)/);
+  assert.match(composer, /No approved harness has an available model\./);
+  assert.match(composer, /activeRuntimeConfig\.approvedHarnesses\.length > 0/);
+  assert.match(composer, /No compatible runtime available/);
+  assert.match(composer, /const canQueue =[^;]+activeRuntimeConfig\?\.approvedHarnesses\.length/);
+  assert.match(
+    composer,
+    /async function sendPrompt[\s\S]+if \(!activeRuntimeConfig\?\.approvedHarnesses\.length\) return;/,
+  );
+});
+
 test("attaching files is allowed while a turn is streaming", () => {
   // The attach button and drop/paste paths must not gate on isStreaming —
   // only on runtime readiness and pending approvals.

--- a/plugins/web-ui/test/context-model-source.test.ts
+++ b/plugins/web-ui/test/context-model-source.test.ts
@@ -28,6 +28,11 @@ test("the panel is labelled, focus-keyed, and disabled while saving", () => {
   assert.match(panel, /aria-live="polite"/);
 });
 
+test("the panel reports when the connected AI account has no approved runtime", () => {
+  assert.match(panel, /if \(!config\.approvedHarnesses\.length\)/);
+  assert.match(panel, /No approved harness has an available model\./);
+});
+
 test("every context loads and resets its model setting with the page", () => {
   assert.match(contexts, /loadContextModel\(contextsState\.selected, drawContexts\)/);
   assert.match(contexts, /resetContextModel\(\)/);

--- a/plugins/web-ui/test/runtime-config-handoff.test.ts
+++ b/plugins/web-ui/test/runtime-config-handoff.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 
 test("boot hands its runtime config to the composer instead of dropping it", () => {
   assert.match(shell, /const personalScope = `personal:\$\{appState\.me\.user\}`;/);
@@ -26,7 +27,7 @@ test("the first mount in the seeded scope renders from it — no blanking, no se
   assert.ok(seedRead > 0, "the seeded config must be consulted");
   assert.ok(seedRead < blank, "consult the seed BEFORE blanking the composer");
   assert.ok(seedRead < fetchCall, "consult the seed BEFORE refetching");
-  assert.match(fn, /if \(seeded\) \{\s*applySelectedRuntime\(seeded, agent\);\s*return;\s*\}/);
+  assert.match(fn, /if \(seeded\) return applySelectedRuntime\(seeded, agent\);/);
   assert.match(fn, /seededRuntime\?\.scopeId === scopeKey \? seededRuntime\.config : null/);
   assert.match(fn, /const scopeKey = runtimeScopeKey\(scopeId\);/);
   assert.doesNotMatch(fn, /seededRuntime = null;/, "every pane booting on the seeded scope may read the seed");
@@ -36,6 +37,19 @@ test("the first mount in the seeded scope renders from it — no blanking, no se
     /seededRuntime = null;/,
     "changing the scope default is what retires the boot seed",
   );
+});
+
+test("a proactive opener waits for a usable runtime", () => {
+  assert.match(chat, /const runtimeReady = ctx\.composer\.refreshRuntimeSelection\(scopeId, agent\);/);
+  assert.match(chat, /runtimeReady\.then\(\(runtimeAvailable\) =>/);
+  assert.match(chat, /if \(runtimeAvailable\)\s*startProactiveOpenerIfNew/);
+});
+
+test("an existing run resumes without waiting for runtime settings", () => {
+  const resumeAt = chat.indexOf("void resumeTrackedRun(agent, threadRef, normalStreamFn, onWork);");
+  const runtimeWaitAt = chat.indexOf("void runtimeReady.then((runtimeAvailable) =>");
+  assert.ok(resumeAt > 0 && resumeAt < runtimeWaitAt);
+  assert.doesNotMatch(chat.slice(runtimeWaitAt, chat.indexOf("consumeBackgroundPanelRequest();")), /resumeTrackedRun/);
 });
 
 test("a still-loading composer is not painted as a failure", () => {

--- a/src/api/app-turn.ts
+++ b/src/api/app-turn.ts
@@ -17,6 +17,7 @@ import {
 import { selectableCatalogForHarness, selectableModelCatalog } from "../model/model-catalog.ts";
 import { resolveRuntimeChoiceDurable } from "../harness/harness-router.ts";
 import { errMessage } from "../util/errors.ts";
+import { individualAuthModelServiceable, individualAuthProviderAvailability } from "../core/individual-auth-routing.ts";
 
 import type { App, AppDeps } from "./app-types.ts";
 import { STALE_LEASE_GRACE_MS } from "./app-types.ts";
@@ -124,6 +125,7 @@ export function createTurnMethods(
       }
 
       const individualAuth = !!deps.userModelCredentials && (await deps.config.getIndividualModelAuthDurable());
+      let resolvedWebRuntime: { harnessId: string; modelId: string } | null = null;
       if (req.surface === "web") {
         const threadRef = req.conversation.threadRef;
         const existing = await deps.sessions.getByThread(threadRef);
@@ -148,64 +150,71 @@ export function createTurnMethods(
           harnessId: fallbackHarness,
           modelId: defaultModelForHarness(fallbackHarness),
         };
-        if (!individualAuth) {
-          const configuredKeys = deps.providerKeys ??
-            deps.modelProviders ?? { anthropic: false, openai: false, openrouter: false };
-          const managedKeys = deps.modelCredentials ? await deps.modelCredentials.availability() : configuredKeys;
-          let orgRuntime;
-          let configuredRuntime;
-          let runtime;
-          try {
-            orgRuntime = await resolveRuntimeChoiceDurable(deps.config, org, org, runtimeFallback);
-            configuredRuntime =
-              targetScope === org
-                ? orgRuntime
-                : await resolveRuntimeChoiceDurable(deps.config, org, targetScope, runtimeFallback);
-            runtime =
-              req.harness || req.model
-                ? await resolveRuntimeChoiceDurable(deps.config, org, targetScope, runtimeFallback, {
-                    ...(req.harness && isHarnessId(req.harness) ? { harnessId: req.harness } : {}),
-                    ...(req.model ? { modelId: req.model } : {}),
-                  })
-                : configuredRuntime;
-          } catch (error) {
-            return { status: "refused", reason: errMessage(error) };
-          }
-          if (req.harness && !isHarnessId(req.harness)) {
-            return { status: "refused", reason: `runtime ${req.harness} is not approved` };
-          }
-          let providers = deps.modelProviders;
-          if (deps.modelCredentials) {
-            providers = modelProviderAvailabilityFor(runtime.harnessId, configuredKeys, managedKeys);
-          } else if (deps.providerKeys) {
-            providers = modelProviderAvailabilityFor(runtime.harnessId, configuredKeys);
-          }
-          if (providers && !modelServiceable(runtime.modelId, providers)) {
-            return {
-              status: "refused",
-              reason: "that model isn't available on this deployment (its provider isn't configured)",
-            };
-          }
-          const configuredWebuiModels = await deps.config.getWebuiModelsDurable(org);
-          let enabledWebuiModels: string[] | null = null;
-          if (configuredWebuiModels?.length) {
-            enabledWebuiModels = [...new Set([...configuredWebuiModels, orgRuntime.modelId])];
-          } else if (providers?.openrouter) {
-            enabledWebuiModels = [
-              ...new Set([
-                ...selectableCatalogForHarness(
-                  await selectableModelCatalog(deps.modelCredentialFetch),
-                  runtime.harnessId,
-                ).map((model) => model.id),
-                ...(orgRuntime.harnessId === runtime.harnessId ? [orgRuntime.modelId] : []),
-              ]),
-            ];
-          }
-          const invalidModelOption =
-            validateWebTurnModelOptions(req, enabledWebuiModels, providers) ??
-            webTurnRuntimeModelRefusal(runtime.modelId, orgRuntime.modelId, configuredWebuiModels);
-          if (invalidModelOption) return { status: "refused", reason: invalidModelOption };
+        const configuredKeys = deps.providerKeys ??
+          deps.modelProviders ?? { anthropic: false, openai: false, openrouter: false };
+        const managedKeys = deps.modelCredentials ? await deps.modelCredentials.availability() : configuredKeys;
+        let orgRuntime;
+        let configuredRuntime;
+        let runtime;
+        try {
+          orgRuntime = await resolveRuntimeChoiceDurable(deps.config, org, org, runtimeFallback);
+          configuredRuntime =
+            targetScope === org
+              ? orgRuntime
+              : await resolveRuntimeChoiceDurable(deps.config, org, targetScope, runtimeFallback);
+          runtime =
+            req.harness || req.model
+              ? await resolveRuntimeChoiceDurable(deps.config, org, targetScope, runtimeFallback, {
+                  ...(req.harness && isHarnessId(req.harness) ? { harnessId: req.harness } : {}),
+                  ...(req.model ? { modelId: req.model } : {}),
+                })
+              : configuredRuntime;
+        } catch (error) {
+          return { status: "refused", reason: errMessage(error) };
         }
+        if (req.harness && !isHarnessId(req.harness)) {
+          return { status: "refused", reason: `runtime ${req.harness} is not approved` };
+        }
+        const individualConnections = individualAuth ? await deps.userModelCredentials!.connections(actor.id) : null;
+        let providers = deps.modelProviders;
+        if (individualConnections) {
+          providers = individualAuthProviderAvailability(runtime.harnessId, individualConnections);
+        } else if (deps.modelCredentials) {
+          providers = modelProviderAvailabilityFor(runtime.harnessId, configuredKeys, managedKeys);
+        } else if (deps.providerKeys) {
+          providers = modelProviderAvailabilityFor(runtime.harnessId, configuredKeys);
+        }
+        const runtimeModelServiceable = individualConnections
+          ? individualAuthModelServiceable(runtime.modelId, runtime.harnessId, individualConnections)
+          : !providers || modelServiceable(runtime.modelId, providers);
+        if (!runtimeModelServiceable) {
+          return {
+            status: "refused",
+            reason: individualAuth
+              ? "that model and harness aren't available with your connected AI account"
+              : "that model isn't available on this deployment (its provider isn't configured)",
+          };
+        }
+        const configuredWebuiModels = await deps.config.getWebuiModelsDurable(org);
+        let enabledWebuiModels: string[] | null = null;
+        if (configuredWebuiModels?.length) {
+          enabledWebuiModels = [...new Set([...configuredWebuiModels, orgRuntime.modelId])];
+        } else if (providers?.openrouter) {
+          enabledWebuiModels = [
+            ...new Set([
+              ...selectableCatalogForHarness(
+                await selectableModelCatalog(deps.modelCredentialFetch),
+                runtime.harnessId,
+              ).map((model) => model.id),
+              ...(orgRuntime.harnessId === runtime.harnessId ? [orgRuntime.modelId] : []),
+            ]),
+          ];
+        }
+        const invalidModelOption =
+          validateWebTurnModelOptions(req, enabledWebuiModels, providers) ??
+          webTurnRuntimeModelRefusal(runtime.modelId, orgRuntime.modelId, configuredWebuiModels);
+        if (invalidModelOption) return { status: "refused", reason: invalidModelOption };
+        resolvedWebRuntime = runtime;
       }
 
       const rawAudience = req.conversation.audience ?? [req.actor];
@@ -237,6 +246,8 @@ export function createTurnMethods(
 
       const origin = resolveTurnOrigin(req);
 
+      const selectedHarness = resolvedWebRuntime?.harnessId ?? req.harness;
+      const selectedModel = resolvedWebRuntime?.modelId ?? req.model;
       const input = {
         surface: req.surface,
         ...(req.deliveryTarget ? { deliveryTarget: req.deliveryTarget } : {}),
@@ -254,8 +265,8 @@ export function createTurnMethods(
         ...(req.detectOpener ? { detectOpener: req.detectOpener } : {}),
         ...(req.attachments?.length ? { attachments: req.attachments } : {}),
         ...(req.inboundNotes?.length ? { inboundNotes: req.inboundNotes } : {}),
-        ...(!individualAuth && req.harness ? { harness: req.harness } : {}),
-        ...(!individualAuth && req.model ? { model: req.model } : {}),
+        ...(selectedHarness ? { harness: selectedHarness } : {}),
+        ...(selectedModel ? { model: selectedModel } : {}),
         ...turnModelOptions(req),
         ...(req.readOnly ? { readOnly: true } : {}),
         ...(req.skipMemory ? { skipMemory: true } : {}),

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -17,6 +17,10 @@ import {
 import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../../model/model-catalog.ts";
 import { errMessage } from "../../util/errors.ts";
 import { renderAgentApis } from "../agent-api-catalog.ts";
+import {
+  individualAuthModelServiceable,
+  individualAuthProviderAvailability,
+} from "../../core/individual-auth-routing.ts";
 import { mintCapabilityToken, CAPABILITY_TTL_MS } from "../../auth/capability-token.ts";
 import { contentTypeWithUtf8Charset, pipeToResponse, sendJson } from "../http.ts";
 import { resolveBranding } from "../../resolution/branding.ts";
@@ -1112,7 +1116,7 @@ async function runtimeTarget(ctx: ApiCtx): Promise<{ actorId: string; scope: Sco
   return null;
 }
 
-async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<string, unknown>> {
+async function runtimeConfigBody(ctx: ApiCtx, actorId: string, scope: ScopeId): Promise<Record<string, unknown>> {
   const config = ctx.deps.config!;
   const fallback = runtimeFallback(ctx);
   const org = orgScope(ctx.deps);
@@ -1124,9 +1128,15 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
       : { harnessId: firstApproved, modelId: defaultModelForHarness(firstApproved, fallback.modelId) };
   const configuredKeys = ctx.deps.providerKeys ?? ALL_PROVIDERS_AVAILABLE;
   const managedKeys = ctx.deps.modelCredentials ? await ctx.deps.modelCredentials.availability() : configuredKeys;
-  const providersFor = (harnessId: string) => modelProviderAvailabilityFor(harnessId, configuredKeys, managedKeys);
+  const individualConnections =
+    ctx.deps.userModelCredentials && (await config.getIndividualModelAuthDurable())
+      ? await ctx.deps.userModelCredentials.connections(actorId)
+      : null;
+  const providersFor = individualConnections
+    ? (harnessId: string) => individualAuthProviderAvailability(harnessId, individualConnections)
+    : (harnessId: string) => modelProviderAvailabilityFor(harnessId, configuredKeys, managedKeys);
   const catalog =
-    ctx.deps.modelCredentials && managedKeys.openrouter
+    !individualConnections && ctx.deps.modelCredentials && managedKeys.openrouter
       ? await selectableModelCatalog(ctx.deps.modelCredentialFetch)
       : builtInModelCatalog();
   const orgStored = await config.getRuntimeSelectionDurable(org);
@@ -1187,23 +1197,25 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
   ) {
     scopeOverride = { harnessId: fallback.harnessId, modelId: legacyModel, orgRevision: 0 };
   }
-  const effective = scopeOverride ?? orgDefault;
-  const selected = [orgDefault, scopeOverride, effective].filter((choice) => choice !== null);
+  let effective = scopeOverride ?? orgDefault;
   const allowlist = await config.getWebuiModelsDurable(org);
   const modelsByHarness = Object.fromEntries(
     approvedHarnesses.map((harnessId) => {
       const ids = allowlist?.length
         ? allowlist.filter((id) => modelSupportedByHarness(id, harnessId))
         : selectableCatalogForHarness(catalog, harnessId).map((model) => model.id);
-      for (const choice of selected) {
-        if (
-          choice.harnessId === harnessId &&
-          modelSupportedByHarness(choice.modelId, harnessId) &&
-          !ids.includes(choice.modelId)
-        )
-          ids.push(choice.modelId);
-      }
-      return [harnessId, serviceableModelIds(ids, providersFor(harnessId))];
+      if (
+        orgDefault.harnessId === harnessId &&
+        modelSupportedByHarness(orgDefault.modelId, harnessId) &&
+        !ids.includes(orgDefault.modelId)
+      )
+        ids.push(orgDefault.modelId);
+      return [
+        harnessId,
+        individualConnections
+          ? ids.filter((id) => individualAuthModelServiceable(id, harnessId, individualConnections))
+          : serviceableModelIds(ids, providersFor(harnessId)),
+      ];
     }),
   );
   const advertisedModelIds = new Set(Object.values(modelsByHarness).flat());
@@ -1215,9 +1227,21 @@ async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<st
       return resolved ? [[id, { name: resolved.name, provider: resolved.provider }]] : [];
     }),
   );
+  const selectableHarnesses = approvedHarnesses.filter((harnessId) => modelsByHarness[harnessId]?.length);
+  const firstSelectable = selectableHarnesses.flatMap((harnessId) => {
+    const modelId = modelsByHarness[harnessId]?.[0];
+    return modelId ? [{ harnessId, modelId }] : [];
+  })[0];
+  if (individualConnections && firstSelectable) {
+    const selectable = (choice: { harnessId: HarnessId; modelId: string }) =>
+      selectableHarnesses.includes(choice.harnessId) && modelsByHarness[choice.harnessId]?.includes(choice.modelId);
+    if (!selectable(orgDefault)) orgDefault = { ...firstSelectable, revision: orgDefault.revision };
+    if (scopeOverride && !selectable(scopeOverride)) scopeOverride = null;
+    effective = scopeOverride ?? orgDefault;
+  }
   return {
     scopeId: scope,
-    approvedHarnesses,
+    approvedHarnesses: selectableHarnesses,
     modelsByHarness,
     modelCatalog,
     orgDefault,
@@ -1238,7 +1262,7 @@ async function getRuntimeConfig(ctx: ApiCtx): Promise<void> {
   if (!ctx.deps.config) return sendJson(ctx.res, 404, { error: "not_found" });
   const target = await runtimeTarget(ctx);
   if (!target) return sendJson(ctx.res, 403, { error: "forbidden" });
-  return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.scope));
+  return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.actorId, target.scope));
 }
 
 async function webuiModelEnabled(ctx: ApiCtx, modelId: string): Promise<boolean> {
@@ -1258,6 +1282,10 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
   const target = await runtimeTarget(ctx);
   if (!target) return sendJson(ctx.res, 403, { error: "forbidden" });
   const config = ctx.deps.config;
+  const individualConnections =
+    ctx.deps.userModelCredentials && (await config.getIndividualModelAuthDurable())
+      ? await ctx.deps.userModelCredentials.connections(target.actorId)
+      : null;
   if (ctx.body.inherit === true) await config.setRuntimeSelectionLatest(target.scope, null);
   else if (ctx.body.keep === true) {
     const runtime = await config.getRuntimeSelectionDurable(target.scope);
@@ -1270,6 +1298,8 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
         legacyModel &&
         approved.includes(fallback.harnessId) &&
         modelSupportedByHarness(legacyModel, fallback.harnessId) &&
+        (!individualConnections ||
+          individualAuthModelServiceable(legacyModel, fallback.harnessId, individualConnections)) &&
         (await webuiModelEnabled(ctx, legacyModel))
       ) {
         await config.setRuntimeSelectionLatest(target.scope, { harnessId: fallback.harnessId, modelId: legacyModel });
@@ -1284,6 +1314,8 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "harness_not_approved" });
     if (typeof modelId !== "string" || !modelSupportedByHarness(modelId, harnessId))
       return sendJson(ctx.res, 400, { error: "model_not_supported" });
+    if (individualConnections && !individualAuthModelServiceable(modelId, harnessId, individualConnections))
+      return sendJson(ctx.res, 400, { error: "model_not_available" });
     if (!(await webuiModelEnabled(ctx, modelId))) return sendJson(ctx.res, 400, { error: "model_not_enabled" });
     const effortLevel = ctx.body.effortLevel ?? "auto";
     if (typeof effortLevel !== "string" || !(THINKING_LEVELS as readonly string[]).includes(effortLevel))
@@ -1303,7 +1335,7 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
     resource: "runtime-config",
     scopeLabel: target.scope,
   });
-  return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.scope));
+  return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.actorId, target.scope));
 }
 
 async function getChannelHeaderPin(ctx: ApiCtx): Promise<void> {

--- a/src/core/individual-auth-routing.ts
+++ b/src/core/individual-auth-routing.ts
@@ -4,10 +4,12 @@ import {
   DEFAULT_CODEX_MODEL_ID,
   defaultModelForHarness,
   defaultModelForProvider,
+  modelSupportedByHarness,
+  type ModelProviderAvailability,
   resolveModel,
   type ModelProvider,
 } from "../model/pi-models.ts";
-import type { UserModelCredential } from "../model/user-model-credential-store.ts";
+import type { UserCredentialConnection, UserModelCredential } from "../model/user-model-credential-store.ts";
 
 export type IndividualAuthRouting =
   | { kind: "apikey"; provider: ModelProvider; harness: "pi"; model: string | undefined; apiKey: string }
@@ -16,6 +18,32 @@ export type IndividualAuthRouting =
   | { kind: "oauth"; provider: "openai"; harness: "pi"; model: string }
   | null;
 
+export function individualAuthProviderAvailability(
+  harness: string,
+  connections: readonly UserCredentialConnection[],
+): ModelProviderAvailability {
+  const anthropic = connections.find((connection) => connection.provider === "anthropic");
+  const openai = connections.find((connection) => connection.provider === "openai");
+  return {
+    anthropic:
+      (harness === "pi" && anthropic?.kind === "apikey") || (harness === "claude" && anthropic?.kind === "oauth"),
+    openai: (harness === "pi" && Boolean(openai)) || (harness === "codex" && openai?.kind === "oauth"),
+    openrouter: false,
+  };
+}
+
+export function individualAuthModelServiceable(
+  modelId: string,
+  harness: string,
+  connections: readonly UserCredentialConnection[],
+): boolean {
+  const provider = resolveModel(modelId)?.provider;
+  if (provider !== "anthropic" && provider !== "openai") return false;
+  return (
+    modelSupportedByHarness(modelId, harness) && individualAuthProviderAvailability(harness, connections)[provider]
+  );
+}
+
 export function resolveIndividualAuthRouting(
   anthCred: UserModelCredential | null,
   oaiCred: UserModelCredential | null,
@@ -23,6 +51,9 @@ export function resolveIndividualAuthRouting(
   preferredHarness?: string,
 ): IndividualAuthRouting {
   const requestedProvider = requestedModel ? resolveModel(requestedModel)?.provider : undefined;
+  if (requestedModel && requestedProvider !== "anthropic" && requestedProvider !== "openai") return null;
+  if (requestedProvider === "anthropic" && !anthCred) return null;
+  if (requestedProvider === "openai" && !oaiCred) return null;
   const pick = ((): { provider: "anthropic" | "openai"; cred: UserModelCredential } | null => {
     if (requestedProvider === "anthropic" && anthCred) return { provider: "anthropic", cred: anthCred };
     if (requestedProvider === "openai" && oaiCred) return { provider: "openai", cred: oaiCred };
@@ -49,7 +80,10 @@ export function resolveIndividualAuthRouting(
         kind: "oauth",
         provider: "anthropic",
         harness: "claude",
-        model: defaultModelForHarness("claude", DEFAULT_AGENT_MODEL_ID),
+        model:
+          requestedModel && requestedProvider === "anthropic"
+            ? requestedModel
+            : defaultModelForHarness("claude", DEFAULT_AGENT_MODEL_ID),
       };
     }
     if (preferredHarness === "pi") {
@@ -69,7 +103,10 @@ export function resolveIndividualAuthRouting(
       kind: "oauth",
       provider: "openai",
       harness: "codex",
-      model: defaultModelForHarness("codex", DEFAULT_CODEX_MODEL_ID),
+      model:
+        requestedModel && requestedProvider === "openai"
+          ? requestedModel
+          : defaultModelForHarness("codex", DEFAULT_CODEX_MODEL_ID),
     };
   }
   return null;

--- a/src/model/user-model-credential-store.ts
+++ b/src/model/user-model-credential-store.ts
@@ -20,7 +20,7 @@ export interface UserModelCredential {
   updatedAt: number;
 }
 
-interface UserCredentialConnection {
+export interface UserCredentialConnection {
   provider: ModelProvider;
   kind: UserCredentialKind;
 }

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -13,6 +13,7 @@ import { testConfig } from "./support/test-config.ts";
 import { createModelCredentialStore, type StoredModelCredential } from "../src/model/model-credential-store.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 import { getRequiredModel } from "../src/model/pi-models.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
 
 const ADMIN = { "content-type": "application/json", "x-admin-actor": "admin-alice@default-org" };
 
@@ -32,6 +33,7 @@ function start(
   const server = createInsecureTestServer(built.app, {
     config: built.config,
     modelCredentials: built.modelCredentials,
+    userModelCredentials: built.userModelCredentials,
     modelCredentialFetch,
     harnessId: config.harness ?? "pi",
     ...(harnessCarriedModelAuth(appConfig) ? { harnessCarriedModelAuth: harnessCarriedModelAuth(appConfig) } : {}),
@@ -335,6 +337,199 @@ test("managed Pi keys do not advertise unsupported OpenCode or browser credentia
     assert.ok(!data.modelsByHarness.opencode!.some((model) => model.id === "gpt-5.6-sol"));
   } finally {
     await srv.close();
+  }
+});
+
+test("individual model auth exposes and carries only compatible runtime choices", async () => {
+  const srv = start();
+  try {
+    srv.built.config.setApprovedHarnesses(["pi", "opencode", "codex", "claude"]);
+    srv.built.config.setWebuiModels("org:default-org", ["claude-sonnet-5", "gpt-5.6-terra"]);
+    srv.built.config.setIndividualModelAuth(true);
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.userModelCredentials.setOAuth("alice", "anthropic", { accessToken: "anthropic-access" });
+    await srv.built.userModelCredentials.setOAuth("alice", "openai", { accessToken: "openai-access" });
+
+    const response = await fetch(`${srv.base}/v1/runtime-config?principalId=alice&scopeId=personal%3Aalice`);
+    assert.equal(response.status, 200);
+    const runtime = (await response.json()) as {
+      approvedHarnesses: string[];
+      modelsByHarness: Record<string, string[]>;
+    };
+    assert.deepEqual(runtime.approvedHarnesses, ["pi", "codex", "claude"]);
+    assert.deepEqual(runtime.modelsByHarness.pi, ["gpt-5.6-terra"]);
+    assert.deepEqual(runtime.modelsByHarness.opencode, []);
+    assert.deepEqual(runtime.modelsByHarness.codex, ["gpt-5.6-terra"]);
+    assert.deepEqual(runtime.modelsByHarness.claude, ["claude-sonnet-5"]);
+
+    const accepted = await srv.built.app.turn({
+      surface: "web",
+      actor: { externalId: "alice" },
+      conversation: { kind: "dm", threadRef: "web:alice:individual-runtime" },
+      text: "hello",
+      harness: "codex",
+      model: "gpt-5.6-terra",
+      async: true,
+    });
+    assert.equal(accepted.status, "queued");
+    const run = accepted.runId ? await srv.built.runs.get(accepted.runId) : null;
+    assert.equal(run?.request.harness, "codex");
+    assert.equal(run?.request.model, "gpt-5.6-terra");
+
+    const refused = await srv.built.app.turn({
+      surface: "web",
+      actor: { externalId: "alice" },
+      conversation: { kind: "dm", threadRef: "web:alice:individual-opencode" },
+      text: "hello",
+      harness: "opencode",
+      model: "gpt-5.6-terra",
+      async: true,
+    });
+    assert.equal(refused.status, "refused");
+    assert.match(refused.reason ?? "", /connected AI account/);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("individual model auth resolves incompatible defaults and reports when no approved runtime is available", async () => {
+  const srv = start();
+  try {
+    srv.built.config.setApprovedHarnesses(["pi", "claude", "codex"]);
+    srv.built.config.setWebuiModels("org:default-org", ["claude-sonnet-5", "gpt-5.6-terra"]);
+    srv.built.config.setRuntimeSelection("org:default-org", { harnessId: "pi", modelId: "claude-sonnet-5" });
+    srv.built.config.setRuntimeSelection("personal:alice", { harnessId: "claude", modelId: "claude-sonnet-5" });
+    srv.built.config.setIndividualModelAuth(true);
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.config.flushScope("personal:alice");
+    await srv.built.userModelCredentials.setOAuth("alice", "openai", { accessToken: "openai-access" });
+
+    const url = `${srv.base}/v1/runtime-config?principalId=alice&scopeId=personal%3Aalice`;
+    const runtime = (await fetch(url).then((response) => response.json())) as {
+      approvedHarnesses: string[];
+      orgDefault: { harnessId: string; modelId: string };
+      scopeOverride: unknown;
+      effective: { harnessId: string; modelId: string };
+    };
+    assert.deepEqual(runtime.approvedHarnesses, ["pi", "codex"]);
+    assert.deepEqual(runtime.orgDefault, { harnessId: "pi", modelId: "gpt-5.6-terra", revision: 1 });
+    assert.equal(runtime.scopeOverride, null);
+    assert.deepEqual(runtime.effective, { harnessId: "pi", modelId: "gpt-5.6-terra" });
+
+    const unavailable = await fetch(`${srv.base}/v1/runtime-config`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        principalId: "alice",
+        scopeId: "personal:alice",
+        harnessId: "claude",
+        modelId: "claude-sonnet-5",
+      }),
+    });
+    assert.equal(unavailable.status, 400);
+    assert.equal(((await unavailable.json()) as { error: string }).error, "model_not_available");
+
+    srv.built.config.setWebuiModels("org:default-org", ["gpt-5.6-sol"]);
+    srv.built.config.setRuntimeSelection("personal:alice", { harnessId: "codex", modelId: "gpt-5.6-terra" });
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.config.flushScope("personal:alice");
+    const retired = (await fetch(url).then((response) => response.json())) as {
+      scopeOverride: unknown;
+      effective: { harnessId: string; modelId: string };
+    };
+    assert.equal(retired.scopeOverride, null);
+    assert.deepEqual(retired.effective, { harnessId: "pi", modelId: "gpt-5.6-sol" });
+
+    srv.built.config.setApprovedHarnesses(["claude"]);
+    await srv.built.config.flushScope("org:default-org");
+    const blocked = (await fetch(url).then((response) => response.json())) as { approvedHarnesses: string[] };
+    assert.deepEqual(blocked.approvedHarnesses, []);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("web turns carry the complete resolved scoped runtime when overrides are partial or omitted", async () => {
+  const srv = start();
+  try {
+    srv.built.config.setApprovedHarnesses(["pi", "codex"]);
+    srv.built.config.setWebuiModels("org:default-org", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+    srv.built.config.setRuntimeSelection("org:default-org", { harnessId: "codex", modelId: "gpt-5.6-sol" });
+    srv.built.config.setRuntimeSelection("personal:alice", { harnessId: "pi", modelId: "gpt-5.6-terra" });
+    srv.built.config.setIndividualModelAuth(true);
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.config.flushScope("personal:alice");
+    await srv.built.userModelCredentials.setOAuth("alice", "openai", { accessToken: "openai-access" });
+
+    const turn = (threadRef: string, overrides: { model?: string } = {}) =>
+      srv.built.app.turn({
+        surface: "web",
+        actor: { externalId: "alice" },
+        conversation: { kind: "dm", threadRef },
+        text: "hello",
+        async: true,
+        ...overrides,
+      });
+    const resolved = await turn("web:alice:resolved-runtime");
+    assert.equal(resolved.status, "queued");
+    const resolvedRun = resolved.runId ? await srv.built.runs.get(resolved.runId) : null;
+    assert.equal(resolvedRun?.request.harness, "pi");
+    assert.equal(resolvedRun?.request.model, "gpt-5.6-terra");
+
+    const partial = await turn("web:alice:partial-runtime", { model: "gpt-5.6-luna" });
+    assert.equal(partial.status, "queued");
+    const partialRun = partial.runId ? await srv.built.runs.get(partial.runId) : null;
+    assert.equal(partialRun?.request.harness, "pi");
+    assert.equal(partialRun?.request.model, "gpt-5.6-luna");
+  } finally {
+    await srv.close();
+  }
+});
+
+test("individual model auth excludes custom-provider models", async () => {
+  const srv = start();
+  const providers: Parameters<typeof setCustomProviders>[0] = [
+    {
+      id: "acme-gateway",
+      name: "Acme Gateway",
+      protocol: "openai",
+      baseUrl: "https://llm.acme.test/v1",
+      models: [{ id: "acme-large" }],
+    },
+  ];
+  setCustomProviders(providers);
+  try {
+    srv.built.config.setApprovedHarnesses(["pi", "opencode"]);
+    srv.built.config.setWebuiModels("org:default-org", ["acme-large"]);
+    srv.built.config.setIndividualModelAuth(true);
+    await srv.built.config.flushScope("org:default-org");
+    await srv.built.userModelCredentials.setOAuth("alice", "openai", { accessToken: "openai-access" });
+
+    const runtime = (await fetch(`${srv.base}/v1/runtime-config?principalId=alice&scopeId=personal%3Aalice`).then(
+      (response) => response.json(),
+    )) as {
+      approvedHarnesses: string[];
+      modelsByHarness: Record<string, string[]>;
+    };
+    assert.deepEqual(runtime.approvedHarnesses, []);
+    assert.deepEqual(runtime.modelsByHarness.pi, []);
+    assert.deepEqual(runtime.modelsByHarness.opencode, []);
+
+    setCustomProviders(providers);
+    const turn = await srv.built.app.turn({
+      surface: "web",
+      actor: { externalId: "alice" },
+      conversation: { kind: "dm", threadRef: "web:alice:individual-custom" },
+      text: "hello",
+      harness: "pi",
+      model: "acme-large",
+      async: true,
+    });
+    assert.equal(turn.status, "refused");
+    assert.match(turn.reason ?? "", /connected AI account/);
+  } finally {
+    await srv.close();
+    setCustomProviders([]);
   }
 });
 

--- a/test/user-model-auth-injection.test.ts
+++ b/test/user-model-auth-injection.test.ts
@@ -10,9 +10,14 @@ import { createUserModelCredentialStore } from "../src/model/user-model-credenti
 import { readFileSync } from "node:fs";
 import { prepareCodexHome } from "../src/harness/codex-harness.ts";
 import { codexOAuthAuthFromValue } from "../src/harness/codex-auth-store.ts";
-import { resolveIndividualAuthRouting } from "../src/core/individual-auth-routing.ts";
+import {
+  individualAuthModelServiceable,
+  individualAuthProviderAvailability,
+  resolveIndividualAuthRouting,
+} from "../src/core/individual-auth-routing.ts";
 import { resolveModel } from "../src/model/pi-models.ts";
 import type { UserModelCredential } from "../src/model/user-model-credential-store.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
 
 const apikey = (provider: "anthropic" | "openai", apiKey: string): UserModelCredential => ({
   provider,
@@ -170,6 +175,59 @@ test("routing: openai OAuth login -> codex harness (not pi)", () => {
 test("routing: requested model provider wins when that provider is connected", () => {
   const r = resolveIndividualAuthRouting(oauth("anthropic"), oauth("openai"), "gpt-5.6-sol");
   assert.equal(r?.harness, "codex");
+});
+
+test("routing: subscription logins preserve requested models", () => {
+  assert.equal(resolveIndividualAuthRouting(oauth("anthropic"), null, "claude-sonnet-5")?.model, "claude-sonnet-5");
+  assert.equal(resolveIndividualAuthRouting(null, oauth("openai"), "gpt-5.6-terra", "codex")?.model, "gpt-5.6-terra");
+});
+
+test("individual auth availability follows credential and harness compatibility", () => {
+  const connections = [
+    { provider: "anthropic" as const, kind: "apikey" as const },
+    { provider: "openai" as const, kind: "oauth" as const },
+  ];
+  assert.deepEqual(individualAuthProviderAvailability("pi", connections), {
+    anthropic: true,
+    openai: true,
+    openrouter: false,
+  });
+  assert.deepEqual(individualAuthProviderAvailability("claude", connections), {
+    anthropic: false,
+    openai: false,
+    openrouter: false,
+  });
+  assert.deepEqual(individualAuthProviderAvailability("codex", connections), {
+    anthropic: false,
+    openai: true,
+    openrouter: false,
+  });
+  assert.deepEqual(individualAuthProviderAvailability("opencode", connections), {
+    anthropic: false,
+    openai: false,
+    openrouter: false,
+  });
+});
+
+test("individual auth rejects unavailable requested providers instead of silently changing models", () => {
+  const connections = [{ provider: "openai" as const, kind: "oauth" as const }];
+  setCustomProviders([
+    {
+      id: "acme-gateway",
+      name: "Acme Gateway",
+      protocol: "openai",
+      baseUrl: "https://llm.acme.test/v1",
+      models: [{ id: "acme-large" }],
+    },
+  ]);
+  try {
+    assert.equal(individualAuthModelServiceable("acme-large", "pi", connections), false);
+    assert.equal(individualAuthModelServiceable("acme-large", "opencode", connections), false);
+    assert.equal(resolveIndividualAuthRouting(null, oauth("openai"), "acme-large"), null);
+    assert.equal(resolveIndividualAuthRouting(oauth("anthropic"), null, "gpt-5.6-sol"), null);
+  } finally {
+    setCustomProviders([]);
+  }
 });
 
 test("routing: openai OAuth + pi org -> pi harness on the Codex subscription provider", () => {


### PR DESCRIPTION
## Problem

Individual model authentication and the web runtime picker disagreed about what a user could actually run. Runtime config advertised organization-approved harnesses and models even when the user's connected account could not serve them, and web turns could silently fall back to a different harness or model. The pane composer also hid runtime controls that were available in the full composer, while proactive and queued sends could bypass an unavailable runtime.

Separately, an empty Admin environment notice retained its flex layout and rendered as a blank warning bar.

## Change

- derive the runtime catalog from the user's credential kind, provider, and harness compatibility when individual authentication is enabled
- reject unavailable requested choices, discard retired scope overrides, normalize incompatible personal defaults, and carry the complete resolved harness/model pair into web runs
- expose model, harness, effort, and fast-mode controls in both composer layouts, while preserving the compact settings menu in panes
- block normal, queued, and proactive sends when no approved runtime is available; existing active runs still reconnect immediately
- make the existing hidden state actually remove an empty Admin environment notice from layout

## Rendered behavior

Verified in a production-shaped local instance through the browser:

| Surface | Result |
| --- | --- |
| Full composer | Inline model, harness, effort, and fast-mode controls |
| Pane composer | Compact session-settings menu with the same controls and available choices |
| No compatible connected account | Clear unavailable state; normal, queued, and proactive sends remain blocked |
| Admin governance without an environment message | No warning bar or layout gap |

The browser preview's screenshot and recording capture both failed after interactive and computed-style verification, so there is no synthetic screenshot artifact attached.

## Verification

- independent fresh-context review, including follow-up reviews of every finding: no remaining findings
- credential/runtime, billing-default, and auth-routing tests: 40 passed
- focused web composer/runtime tests: 26 passed
- Admin notice test passed
- root, web UI, and Admin typechecks
- ESLint, Prettier, and `git diff --check`
- live browser QA of both composer layouts, unavailable-runtime behavior, the Admin notice, and existing-run reconnection ordering

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790805193&installation_model_id=19911&pr_number=881&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F881&signature=09d762968f33692a79b17eed2ed9ef9edc11226f47872e222c34f996936c99ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->