### PR TITLE
Suggestion: swappable memory provider

### DIFF
--- a/adrs/swappable-memory-provider.md
+++ b/adrs/swappable-memory-provider.md
@@ -1,0 +1,5 @@
+Suggestion: make the memory provider swappable.
+
+I'd like to be able to swap out the memory provider — for example, use claude-mem
+(https://github.com/thedotmack/claude-mem) as the primary memory for the entire
+organization.


### PR DESCRIPTION
Short feature suggestion in `adrs/`, per the contributing guidelines:

I'd like to be able to swap out the memory provider — for example, use [claude-mem](https://github.com/thedotmack/claude-mem) as the primary memory for the entire organization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790816651&installation_model_id=19911&pr_number=882&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F882&signature=39ef7427ff1642b83a23e467068580569a8f17d30b13cd881b630eabedd3eee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->