### PR TITLE
Suggestion: mermaid diagram rendering in chat

### DIFF
--- a/adrs/mermaid-rendering.md
+++ b/adrs/mermaid-rendering.md
@@ -1,0 +1,7 @@
+# Suggestion
+Add rendering of mermaid diagrams within the chat view. This would bring it inline with other chat UIs like Claude
+
+## Impl Proposal
+Hook into the web-ui plugin using the same mechanism as hljs currently does. In fact, mermaid md fences are currently rendered as code blocks (with language=mermaid) this way, it can just be intercept here.
+
+


### PR DESCRIPTION
Short feature suggestion in `adrs/`, per the contributing guidelines:

Render `mermaid` fences in the web chat view as actual diagrams instead of highlighted code blocks, bringing it in line with other chat UIs. They already flow through the web-ui plugin's hljs code-block path with `language=mermaid`, so they can be intercepted there and lazy-loaded the same way highlight.js is.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790863967&installation_model_id=19911&pr_number=884&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F884&signature=bdfe375b10ac669da043762fb206cc746718d2eb4694c3d57dbf3fbeb8c55d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->