### PR TITLE
Reconcile bootstrap administrator grants at startup

### DIFF
--- a/plugins/admin/README.md
+++ b/plugins/admin/README.md
@@ -46,9 +46,9 @@ Env: `CORE_API_URL` (default `http://localhost:8080`), `CORE_ORG_ID` (default `a
 portal also supplies a short-lived `x-portal-identity` token, which this surface forwards to core.
 There is **no** `ADMIN_PRINCIPALS` — admin identity + role + scope live solely in the core's
 durable, mutable `admin_grants` store, and this surface derives admin status from it via
-`/api/whoami`. `ADMIN_GRANTS` (env) is now only the **one-time seed** for an empty store; after
-that, admins are promoted/revoked at runtime through the Users tab (a redeploy never clobbers
-runtime grants).
+`/api/whoami`. `ADMIN_GRANTS` (env) is the declarative bootstrap set reconciled before core becomes
+ready. A redeploy adds configured bootstrap admins and removes stale bootstrap-owned rows, while
+admins promoted through the Users tab remain durable and are never removed by bootstrap changes.
 
 ## How it stays safe
 

--- a/scripts/dev/supervisor/main.ts
+++ b/scripts/dev/supervisor/main.ts
@@ -342,7 +342,7 @@ async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
 
   phase("durability", "start");
   let databaseUrl = assembled.env.DATABASE_URL || envFileGet(join(worktree, ".env"), "DATABASE_URL");
-  let adminGrantsSeed = assembled.env.ADMIN_GRANTS || envFileGet(join(worktree, ".env"), "ADMIN_GRANTS");
+  let adminGrantsBootstrap = assembled.env.ADMIN_GRANTS || envFileGet(join(worktree, ".env"), "ADMIN_GRANTS");
   let sessionStore = "memory";
   let runStore = "memory";
   let localPg = false;
@@ -370,14 +370,14 @@ async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
       throw new Error(`could not connect to DATABASE_URL: ${errMessage(err)}`, { cause: err });
     });
     const grants = await adminGrantCount(worktree, databaseUrl);
-    if (grants === 0 && !adminGrantsSeed) {
+    if (!adminGrantsBootstrap) {
       if (localPg) {
         const principal = assembled.env.DEV_INSTANCE_ADMIN_PRINCIPAL || assembled.env.USER || "dev-admin";
-        adminGrantsSeed = `${principal}:org_admin`;
-        log(`admin grants: local Postgres will seed ${principal}:org_admin if the store is empty`);
-      } else {
+        adminGrantsBootstrap = `${principal}:org_admin`;
+        log(`admin grants: local Postgres will reconcile ${principal}:org_admin as the bootstrap grant`);
+      } else if (grants === 0) {
         throw new Error(
-          "Postgres has no existing admin grants and ADMIN_GRANTS is unset. Set ADMIN_GRANTS=<principal>:org_admin for the first boot of this dev DB, or point DATABASE_URL at a DB that already has admin_grants.",
+          "Postgres has no existing admin grants and ADMIN_GRANTS is unset. Set ADMIN_GRANTS=<principal>:org_admin or point DATABASE_URL at a DB with an operator-created admin grant.",
         );
       }
     }
@@ -391,7 +391,7 @@ async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
   completeDevSecuritySecrets(assembled.env, databaseUrl || worktree);
   const portalSessionSecret = assembled.env.PORTAL_SESSION_SECRET!;
   let portalDevPrincipal = assembled.env.DEV_INSTANCE_ADMIN_PRINCIPAL || "";
-  if (!portalDevPrincipal && adminGrantsSeed) portalDevPrincipal = adminGrantsSeed.split(":")[0] ?? "";
+  if (!portalDevPrincipal && adminGrantsBootstrap) portalDevPrincipal = adminGrantsBootstrap.split(":")[0] ?? "";
   if (!portalDevPrincipal && durableAdminPrincipal) portalDevPrincipal = durableAdminPrincipal;
   if (!portalDevPrincipal) portalDevPrincipal = assembled.env.USER || "dev-admin";
   log(`portal auth: localhost bypass signs in as ${portalDevPrincipal}`);
@@ -408,7 +408,7 @@ async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
     sessionStore,
     runStore,
     databaseUrl,
-    adminGrantsSeed,
+    adminGrantsBootstrap,
     coreSigningSecret: assembled.env.CORE_SIGNING_SECRET || "",
     portalSessionSecret,
     portalDevPrincipal,

--- a/scripts/dev/supervisor/specs.ts
+++ b/scripts/dev/supervisor/specs.ts
@@ -11,7 +11,7 @@ export interface SpecInputs {
   sessionStore: string;
   runStore: string;
   databaseUrl: string;
-  adminGrantsSeed: string;
+  adminGrantsBootstrap: string;
   coreSigningSecret: string;
   portalSessionSecret: string;
   portalDevPrincipal: string;
@@ -39,7 +39,7 @@ export function buildChildSpecs(i: SpecInputs): ChildSpec[] {
         RUN_STORE: i.runStore,
         PORT: String(i.ports.core),
         ...(i.databaseUrl ? { DATABASE_URL: i.databaseUrl } : {}),
-        ...(i.adminGrantsSeed ? { ADMIN_GRANTS: i.adminGrantsSeed } : {}),
+        ...(i.adminGrantsBootstrap ? { ADMIN_GRANTS: i.adminGrantsBootstrap } : {}),
         PUBLIC_WEB_URL: `http://localhost:${i.ports.portal}`,
         ...(i.slack
           ? {

--- a/src/admin/admin-grant-store.ts
+++ b/src/admin/admin-grant-store.ts
@@ -1,8 +1,9 @@
 import type { ScopeId } from "../types.ts";
-import type { DurableMap } from "../persistence/durable-map.ts";
-import { createMemoryMap } from "../persistence/durable-map.ts";
 
 export type AdminRole = "org_admin";
+
+export const ADMIN_GRANT_BOOTSTRAP_ACTOR = "system";
+export const ADMIN_GRANT_BOOTSTRAP_TIME = 0;
 
 export interface AdminGrant {
   principalId: string;
@@ -16,70 +17,99 @@ export function grantKey(principalId: string, scopeId: ScopeId, role: AdminRole)
   return JSON.stringify([principalId, scopeId, role]);
 }
 
+export function isBootstrapAdminGrant(grant: AdminGrant): boolean {
+  return grant.grantedBy === ADMIN_GRANT_BOOTSTRAP_ACTOR && grant.createdAt === ADMIN_GRANT_BOOTSTRAP_TIME;
+}
+
+function bootstrapAdminGrant(grant: AdminGrant): AdminGrant {
+  return {
+    ...grant,
+    grantedBy: ADMIN_GRANT_BOOTSTRAP_ACTOR,
+    createdAt: ADMIN_GRANT_BOOTSTRAP_TIME,
+  };
+}
+
 export interface AdminGrantPersistence {
   all(): Promise<AdminGrant[]>;
   put(g: AdminGrant): Promise<void>;
   remove(principalId: string, scopeId: ScopeId, role: AdminRole): Promise<void>;
+  reconcileBootstrap(grants: readonly AdminGrant[]): Promise<void>;
 }
 
-export function createMapAdminGrantPersistence(
-  map: DurableMap<AdminGrant> = createMemoryMap<AdminGrant>(),
-): AdminGrantPersistence {
+export function createMemoryAdminGrantPersistence(): AdminGrantPersistence {
+  let rows = new Map<string, AdminGrant>();
+  const all = () =>
+    [...rows.entries()]
+      .sort(([a], [b]) => {
+        if (a < b) return -1;
+        if (a > b) return 1;
+        return 0;
+      })
+      .map(([, grant]) => grant);
   return {
     async all() {
-      return map.all();
+      return all();
     },
     async put(g) {
-      await map.put(grantKey(g.principalId, g.scopeId, g.role), g);
+      rows.set(grantKey(g.principalId, g.scopeId, g.role), g);
     },
     async remove(principalId, scopeId, role) {
-      await map.delete(grantKey(principalId, scopeId, role));
+      rows.delete(grantKey(principalId, scopeId, role));
+    },
+    async reconcileBootstrap(grants) {
+      const desired = new Map(
+        grants.map((grant) => [grantKey(grant.principalId, grant.scopeId, grant.role), bootstrapAdminGrant(grant)]),
+      );
+      const next = new Map(rows);
+      for (const [key, grant] of desired) {
+        if (!next.has(key)) next.set(key, grant);
+      }
+      for (const [key, grant] of next) {
+        if (isBootstrapAdminGrant(grant) && !desired.has(key)) next.delete(key);
+      }
+      rows = next;
     },
   };
 }
 
-export const createMemoryAdminGrantPersistence = (): AdminGrantPersistence => createMapAdminGrantPersistence();
-
 export interface AdminGrantStore {
+  ready(): Promise<void>;
   list(): Promise<AdminGrant[]>;
   add(g: AdminGrant): Promise<void>;
   revoke(principalId: string, scopeId: ScopeId, role: AdminRole): Promise<void>;
 }
 
 export interface AdminGrantStoreOptions {
-  seed?: AdminGrant[];
+  bootstrap?: AdminGrant[];
 }
 
 export function createAdminGrantStore(
   persist: AdminGrantPersistence = createMemoryAdminGrantPersistence(),
   opts: AdminGrantStoreOptions = {},
 ): AdminGrantStore {
-  const seeds = opts.seed ?? [];
-  let seededP: Promise<void> | null = null;
-  function ensureSeeded(): Promise<void> {
-    if (!seededP) {
-      seededP = (async () => {
-        if (!seeds.length) return;
-        if ((await persist.all()).length > 0) return;
-        for (const g of seeds) await persist.put({ grantedBy: "system", createdAt: 0, ...g });
-      })().catch((e) => {
-        seededP = null;
+  const bootstrap = opts.bootstrap ?? [];
+  let readyP: Promise<void> | null = null;
+  function ready(): Promise<void> {
+    if (!readyP) {
+      readyP = persist.reconcileBootstrap(bootstrap).catch((e) => {
+        readyP = null;
         throw e;
       });
     }
-    return seededP;
+    return readyP;
   }
   return {
+    ready,
     async list() {
-      await ensureSeeded();
+      await ready();
       return persist.all();
     },
     async add(g) {
-      await ensureSeeded();
+      await ready();
       await persist.put(g);
     },
     async revoke(principalId, scopeId, role) {
-      await ensureSeeded();
+      await ready();
       await persist.remove(principalId, scopeId, role);
     },
   };

--- a/src/admin/admin-service.ts
+++ b/src/admin/admin-service.ts
@@ -31,6 +31,7 @@ export function adminStatusFromGrants(grants: readonly AdminGrant[], principalId
 }
 
 export interface AdminService {
+  ready(): Promise<void>;
   resolveActor(header: string | undefined): Principal | null;
   canAdminister(principal: Principal, target: ScopeId): Promise<boolean>;
   adminStatusOf(principal: Principal): Promise<AdminStatus>;
@@ -62,7 +63,7 @@ function defaultAdminGrants(orgId: string): AdminGrant[] {
   ];
 }
 
-export function bootAdminGrantSeed(rawAdminGrants: string | undefined, orgId: string, durable: boolean): AdminGrant[] {
+export function bootAdminGrants(rawAdminGrants: string | undefined, orgId: string, durable: boolean): AdminGrant[] {
   return parseAdminGrants(rawAdminGrants, orgId) ?? (durable ? [] : defaultAdminGrants(orgId));
 }
 
@@ -73,7 +74,7 @@ export interface AdminServiceOptions {
 export function createAdminService(store?: AdminGrantStore, opts: AdminServiceOptions = {}): AdminService {
   const orgId = configOrgId();
   const grants: AdminGrantStore =
-    store ?? createAdminGrantStore(createMemoryAdminGrantPersistence(), { seed: defaultAdminGrants(orgId) });
+    store ?? createAdminGrantStore(createMemoryAdminGrantPersistence(), { bootstrap: defaultAdminGrants(orgId) });
   const now = opts.now ?? (() => Date.now());
 
   async function isOrgAdmin(actor: Principal): Promise<boolean> {
@@ -81,6 +82,9 @@ export function createAdminService(store?: AdminGrantStore, opts: AdminServiceOp
   }
 
   return {
+    ready() {
+      return grants.ready();
+    },
     resolveActor(header) {
       if (!header) return null;
       const at = header.lastIndexOf("@");

--- a/src/admin/postgres-admin-grant-store.ts
+++ b/src/admin/postgres-admin-grant-store.ts
@@ -1,6 +1,12 @@
-import { createPgPool } from "../persistence/pg-pool.ts";
+import { createPgPool, withPgTransaction } from "../persistence/pg-pool.ts";
 import type { ScopeId } from "../types.ts";
-import type { AdminGrant, AdminGrantPersistence, AdminRole } from "./admin-grant-store.ts";
+import {
+  ADMIN_GRANT_BOOTSTRAP_ACTOR,
+  ADMIN_GRANT_BOOTSTRAP_TIME,
+  type AdminGrant,
+  type AdminGrantPersistence,
+  type AdminRole,
+} from "./admin-grant-store.ts";
 
 function rowToGrant(r: Record<string, unknown>): AdminGrant {
   return {
@@ -46,6 +52,34 @@ export function createPostgresAdminGrantStore(connectionString: string): AdminGr
         scopeId,
         role,
       ]);
+    },
+    async reconcileBootstrap(grants) {
+      const principalIds = grants.map((grant) => grant.principalId);
+      const scopeIds = grants.map((grant) => grant.scopeId);
+      const roles = grants.map((grant) => grant.role);
+      await withPgTransaction(await pg.pool(), async (client) => {
+        await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", ["admin-grants-bootstrap"]);
+        await client.query(
+          `INSERT INTO admin_grants (principal_id, scope_id, role, granted_by, created_at)
+           SELECT principal_id, scope_id, role, $4, $5
+           FROM unnest($1::text[], $2::text[], $3::text[]) AS desired(principal_id, scope_id, role)
+           ON CONFLICT (principal_id, scope_id, role) DO NOTHING`,
+          [principalIds, scopeIds, roles, ADMIN_GRANT_BOOTSTRAP_ACTOR, ADMIN_GRANT_BOOTSTRAP_TIME],
+        );
+        await client.query(
+          `DELETE FROM admin_grants AS stored
+           WHERE stored.granted_by = $4
+             AND stored.created_at = $5
+             AND NOT EXISTS (
+               SELECT 1
+               FROM unnest($1::text[], $2::text[], $3::text[]) AS desired(principal_id, scope_id, role)
+               WHERE desired.principal_id = stored.principal_id
+                 AND desired.scope_id = stored.scope_id
+                 AND desired.role = stored.role
+             )`,
+          [principalIds, scopeIds, roles, ADMIN_GRANT_BOOTSTRAP_ACTOR, ADMIN_GRANT_BOOTSTRAP_TIME],
+        );
+      });
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { createSlackRuntimeReconciler } from "./surfaces/slack-runtime.ts";
 const config = loadConfig();
 
 const built = buildApp(config);
+await built.admin.ready();
 const envSlackConfig = slackPluginConfigFromEnv(process.env);
 const slackConfig = envSlackConfig;
 const envSlackAttempted = Boolean(process.env.SLACK_BOT_TOKEN || process.env.SLACK_APP_TOKEN);

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -267,8 +267,8 @@ import {
   modelProviderAvailabilityFor,
   type HarnessId,
 } from "./model/pi-models.ts";
-import { createAdminService, bootAdminGrantSeed, type AdminService } from "./admin/admin-service.ts";
-import { createAdminGrantStore, createMapAdminGrantPersistence, type AdminGrant } from "./admin/admin-grant-store.ts";
+import { createAdminService, bootAdminGrants, type AdminService } from "./admin/admin-service.ts";
+import { createAdminGrantStore, createMemoryAdminGrantPersistence } from "./admin/admin-grant-store.ts";
 import { createPostgresAdminGrantStore } from "./admin/postgres-admin-grant-store.ts";
 import { createProjectStore, type Project, type ProjectStore } from "./projects/project-store.ts";
 import { createErrorLog, type ErrorLog } from "./admin/error-log.ts";
@@ -986,9 +986,9 @@ export function buildApp(
   const approvals = artifactMap<PendingApprovalRecord>("approvals");
   const adminGrantPersist = config.databaseUrl
     ? createPostgresAdminGrantStore(config.databaseUrl)
-    : createMapAdminGrantPersistence(createMemoryMap<AdminGrant>());
+    : createMemoryAdminGrantPersistence();
   const adminGrantStore = createAdminGrantStore(adminGrantPersist, {
-    seed: bootAdminGrantSeed(config.adminGrants, config.orgId, !!config.databaseUrl),
+    bootstrap: bootAdminGrants(config.adminGrants, config.orgId, !!config.databaseUrl),
   });
   const admin = createAdminService(adminGrantStore);
   const { strategy: memoryStrategy, memory } = createMemoryStrategy(config.memoryStrategy, {

--- a/test/admin-bootstrap-startup.test.ts
+++ b/test/admin-bootstrap-startup.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+let serverCreated = 0;
+
+mock.module("../src/config.ts", {
+  namedExports: {
+    loadConfig: () => ({}),
+  },
+});
+
+mock.module("../src/wiring.ts", {
+  namedExports: {
+    buildApp: () => ({
+      admin: {
+        ready: async () => {
+          throw new Error("admin bootstrap unavailable");
+        },
+      },
+    }),
+    serverDeps: () => ({}),
+    stopWithBackstop: () => undefined,
+  },
+});
+
+mock.module("../src/api/server.ts", {
+  namedExports: {
+    createServer: () => {
+      serverCreated++;
+      return {};
+    },
+  },
+});
+
+test("admin bootstrap failure prevents the health server from being created", async () => {
+  await assert.rejects(import("../src/index.ts"), /admin bootstrap unavailable/);
+  assert.equal(serverCreated, 0);
+});

--- a/test/admin-grant-store.test.ts
+++ b/test/admin-grant-store.test.ts
@@ -18,24 +18,82 @@ test("grant store: add / list / revoke round-trip on (principal, scope, role)", 
   assert.ok(!list.some((g) => g.principalId === "U1"));
 });
 
-test("grant store: seed applies only when empty and never undoes a revoke", async () => {
+test("grant store: configured bootstrap grants apply at each boot", async () => {
   const persist = createMemoryAdminGrantPersistence();
-  const seed = [{ principalId: "A", scopeId: "org:default-org", role: "org_admin" as const }];
-  const store = createAdminGrantStore(persist, { seed });
+  const bootstrap = [{ principalId: "A", scopeId: "org:default-org", role: "org_admin" as const }];
+  const store = createAdminGrantStore(persist, { bootstrap });
   assert.equal((await store.list()).length, 1);
   await store.revoke("A", "org:default-org", "org_admin");
   assert.equal((await store.list()).length, 0);
 
-  await persist.put({ principalId: "B", scopeId: "org:default-org", role: "org_admin" });
-  const store2 = createAdminGrantStore(persist, { seed });
+  const store2 = createAdminGrantStore(persist, { bootstrap });
   assert.deepEqual(
     (await store2.list()).map((g) => g.principalId),
-    ["B"],
+    ["A"],
   );
 });
 
-test("grant store: an empty seed grants no admins (deliberate lock-out)", async () => {
-  const store = createAdminGrantStore(createMemoryAdminGrantPersistence(), { seed: [] });
+test("grant store: changed bootstrap grants replace stale bootstrap rows without touching durable grants", async () => {
+  const persist = createMemoryAdminGrantPersistence();
+  const oldBootstrap = [{ principalId: "old-admin@example.test", scopeId: "org:acme", role: "org_admin" as const }];
+  const firstBoot = createAdminGrantStore(persist, { bootstrap: oldBootstrap });
+  await firstBoot.list();
+  await firstBoot.add({
+    principalId: "operator-admin@example.test",
+    scopeId: "org:acme",
+    role: "org_admin",
+    grantedBy: "owner@example.test",
+    createdAt: 1,
+  });
+  await persist.put({ principalId: "legacy-admin@example.test", scopeId: "org:acme", role: "org_admin" });
+
+  const secondBoot = createAdminGrantStore(persist, {
+    bootstrap: [{ principalId: "new-admin@example.test", scopeId: "org:acme", role: "org_admin" }],
+  });
+
+  assert.deepEqual((await secondBoot.list()).map((g) => g.principalId).sort(), [
+    "legacy-admin@example.test",
+    "new-admin@example.test",
+    "operator-admin@example.test",
+  ]);
+  assert.deepEqual(
+    (await secondBoot.list()).find((g) => g.principalId === "new-admin@example.test"),
+    {
+      principalId: "new-admin@example.test",
+      scopeId: "org:acme",
+      role: "org_admin",
+      grantedBy: "system",
+      createdAt: 0,
+    },
+  );
+
+  const unchangedBoot = createAdminGrantStore(persist, {
+    bootstrap: [{ principalId: "new-admin@example.test", scopeId: "org:acme", role: "org_admin" }],
+  });
+  assert.deepEqual(await unchangedBoot.list(), await secondBoot.list());
+
+  const removedConfigBoot = createAdminGrantStore(persist, { bootstrap: [] });
+  assert.deepEqual((await removedConfigBoot.list()).map((g) => g.principalId).sort(), [
+    "legacy-admin@example.test",
+    "operator-admin@example.test",
+  ]);
+});
+
+test("grant store: an operator-owned replacement of a bootstrap row survives config removal", async () => {
+  const persist = createMemoryAdminGrantPersistence();
+  const bootstrap = [{ principalId: "admin@example.test", scopeId: "org:acme", role: "org_admin" as const }];
+  const firstBoot = createAdminGrantStore(persist, { bootstrap });
+  await firstBoot.list();
+  await firstBoot.add({ ...bootstrap[0]!, grantedBy: "owner@example.test", createdAt: 10 });
+
+  const removedConfigBoot = createAdminGrantStore(persist, { bootstrap: [] });
+  assert.deepEqual(await removedConfigBoot.list(), [
+    { ...bootstrap[0]!, grantedBy: "owner@example.test", createdAt: 10 },
+  ]);
+});
+
+test("grant store: an empty bootstrap grants no admins (deliberate lock-out)", async () => {
+  const store = createAdminGrantStore(createMemoryAdminGrantPersistence(), { bootstrap: [] });
   assert.deepEqual(await store.list(), []);
 });
 

--- a/test/admin-grants.test.ts
+++ b/test/admin-grants.test.ts
@@ -213,7 +213,7 @@ test("the last org admin cannot be revoked (400 lock-out guard)", async () => {
   }
 });
 
-test("without DATABASE_URL grants are in-memory: the seed re-applies each boot; a runtime promotion is NOT durable", async () => {
+test("without DATABASE_URL grants are in-memory: bootstrap reapplies each boot; a runtime promotion is NOT durable", async () => {
   const dataDir = mkdtempSync(join(tmpdir(), "admin-grants-mem-"));
   const boot = () => {
     const built = buildApp(testConfig({ dataDir }));
@@ -255,21 +255,21 @@ test("without DATABASE_URL grants are in-memory: the seed re-applies each boot; 
   }
 });
 
-test("boot seed: durable mode never seeds the fictional admin-alice/admin-bob defaults", async () => {
-  const { bootAdminGrantSeed } = await import("../src/admin/admin-service.ts");
-  assert.deepEqual(bootAdminGrantSeed(undefined, "acme", true), [], "durable + no ADMIN_GRANTS → no fictional admins");
+test("boot grants: durable mode never adds the fictional admin-alice/admin-bob defaults", async () => {
+  const { bootAdminGrants } = await import("../src/admin/admin-service.ts");
+  assert.deepEqual(bootAdminGrants(undefined, "acme", true), [], "durable + no ADMIN_GRANTS → no fictional admins");
   assert.deepEqual(
-    bootAdminGrantSeed(undefined, "acme", false).map((g) => g.principalId),
+    bootAdminGrants(undefined, "acme", false).map((g) => g.principalId),
     ["admin-alice", "admin-bob"],
     "memory mode keeps the dev/test convenience defaults",
   );
   assert.deepEqual(
-    bootAdminGrantSeed("alice:org_admin", "acme", true).map((g) => g.principalId),
+    bootAdminGrants("alice:org_admin", "acme", true).map((g) => g.principalId),
     ["alice"],
     "ADMIN_GRANTS names the real admins in either mode",
   );
   assert.deepEqual(
-    bootAdminGrantSeed("slack:U123:org_admin", "acme", true).map((g) => g.principalId),
+    bootAdminGrants("slack:U123:org_admin", "acme", true).map((g) => g.principalId),
     ["slack:U123"],
     "principal ids may contain colons",
   );

--- a/test/dev-cli-lib.test.ts
+++ b/test/dev-cli-lib.test.ts
@@ -423,7 +423,7 @@ test("supervised children share the selected dev org", () => {
     sessionStore: "memory",
     runStore: "memory",
     databaseUrl: "",
-    adminGrantsSeed: "",
+    adminGrantsBootstrap: "admin@example.test:org_admin",
     coreSigningSecret: "",
     portalSessionSecret: "secret",
     portalDevPrincipal: "U1",
@@ -432,6 +432,7 @@ test("supervised children share the selected dev org", () => {
   const specs = buildChildSpecs(inputs);
   assert.equal(specs.find((spec) => spec.name === "core")!.env.ORG_ID, "beta");
   assert.equal(specs.find((spec) => spec.name === "core")!.env.CODEX_AUTH_FILE, "/tmp/codex-auth.json");
+  assert.equal(specs.find((spec) => spec.name === "core")!.env.ADMIN_GRANTS, "admin@example.test:org_admin");
   for (const spec of specs.filter((spec) => spec.name !== "core")) {
     assert.equal(spec.env.CODEX_AUTH_FILE, "");
     assert.equal(spec.env.HOME, undefined);
@@ -452,7 +453,7 @@ test("child specs omit Slack env when no Slack tokens are supplied", () => {
     sessionStore: "memory",
     runStore: "memory",
     databaseUrl: "",
-    adminGrantsSeed: "",
+    adminGrantsBootstrap: "",
     coreSigningSecret: "",
     portalSessionSecret: "secret",
     portalDevPrincipal: "U1",

--- a/test/persistence-init-retry.test.ts
+++ b/test/persistence-init-retry.test.ts
@@ -31,16 +31,19 @@ test("pg map: a failed table-create is retried on the next call (rejection not c
   assert.deepEqual(await m.all(), [{ n: 1 }], "second call re-runs the table create and proceeds to the query");
 });
 
-test("admin grants: a failed seed is retried on the next call (rejection not cached)", async () => {
+test("admin grants: a failed bootstrap reconciliation is retried on the next call", async () => {
   let failures = 1;
   const rows: AdminGrant[] = [];
   const persist: AdminGrantPersistence = {
     async all() {
+      return [...rows];
+    },
+    async reconcileBootstrap(grants) {
       if (failures > 0) {
         failures--;
         throw new Error("transient pg failure");
       }
-      return [...rows];
+      rows.push(...grants);
     },
     async put(g) {
       rows.push(g);
@@ -48,7 +51,7 @@ test("admin grants: a failed seed is retried on the next call (rejection not cac
     async remove() {},
   };
   const store = createAdminGrantStore(persist, {
-    seed: [{ principalId: "p", scopeId: scopeId("personal", "p"), role: "org_admin" }],
+    bootstrap: [{ principalId: "p", scopeId: scopeId("personal", "p"), role: "org_admin" }],
   });
   await assert.rejects(() => store.list(), /transient pg failure/);
   const listed = await store.list();

--- a/test/portal-plugin.test.ts
+++ b/test/portal-plugin.test.ts
@@ -39,9 +39,9 @@ test("parseAdminGrants: parses org_admin grants and skips malformed / removed-ro
   assert.deepEqual(parseAdminGrants("", "default-org"), []);
 });
 
-test("ADMIN_GRANTS-seeded admins resolve and authorize org-wide; non-admins do not", async () => {
+test("ADMIN_GRANTS bootstrap admins resolve and authorize org-wide; non-admins do not", async () => {
   const store = createAdminGrantStore(createMemoryAdminGrantPersistence(), {
-    seed: parseAdminGrants("U1:org_admin", "default-org"),
+    bootstrap: parseAdminGrants("U1:org_admin", "default-org"),
   });
   const svc = createAdminService(store);
   const u1 = svc.resolveActor("U1@default-org");

--- a/test/postgres-admin-grants.test.ts
+++ b/test/postgres-admin-grants.test.ts
@@ -1,7 +1,7 @@
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { createPostgresAdminGrantStore } from "../src/admin/postgres-admin-grant-store.ts";
-import { createAdminGrantStore, type AdminGrant } from "../src/admin/admin-grant-store.ts";
+import { createAdminGrantStore, isBootstrapAdminGrant, type AdminGrant } from "../src/admin/admin-grant-store.ts";
 import { scopeId } from "../src/types.ts";
 
 const URL = process.env.DATABASE_URL;
@@ -60,20 +60,163 @@ test("pg admin grants survive a restart: a promotion is read back through a SEPA
 });
 
 test(
-  "pg-backed AdminGrantStore: seed applies once, then a redeploy never clobbers runtime grants",
+  "pg-backed AdminGrantStore reconciles changed and removed bootstrap config without clobbering grants",
   { skip },
   async () => {
-    const seed = [grant({ principalId: "seed-admin" })];
-    const s1 = createAdminGrantStore(createPostgresAdminGrantStore(URL!), { seed });
-    assert.equal(
-      (await s1.list()).some((g) => g.principalId === "seed-admin"),
-      true,
-      "seed applied to the empty store",
-    );
-    await s1.add(grant({ principalId: "promoted-at-runtime" }));
+    const persist = createPostgresAdminGrantStore(URL!);
+    const firstBoot = createAdminGrantStore(persist, { bootstrap: [grant({ principalId: "old-bootstrap" })] });
+    await firstBoot.list();
+    await firstBoot.add(grant({ principalId: "operator-admin", grantedBy: "owner", createdAt: 10 }));
+    await persist.put(grant({ principalId: "legacy-admin", grantedBy: undefined, createdAt: undefined }));
 
-    const s2 = createAdminGrantStore(createPostgresAdminGrantStore(URL!), { seed });
-    const ids = (await s2.list()).map((g) => g.principalId).sort();
-    assert.deepEqual(ids, ["promoted-at-runtime", "seed-admin"], "redeploy preserves both seed + runtime grants");
+    const changedBoot = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+      bootstrap: [grant({ principalId: "new-bootstrap" })],
+    });
+    assert.deepEqual((await changedBoot.list()).map((g) => g.principalId).sort(), [
+      "legacy-admin",
+      "new-bootstrap",
+      "operator-admin",
+    ]);
+
+    const unchangedBoot = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+      bootstrap: [grant({ principalId: "new-bootstrap" })],
+    });
+    assert.deepEqual(await unchangedBoot.list(), await changedBoot.list());
+
+    const removedConfigBoot = createAdminGrantStore(createPostgresAdminGrantStore(URL!), { bootstrap: [] });
+    assert.deepEqual((await removedConfigBoot.list()).map((g) => g.principalId).sort(), [
+      "legacy-admin",
+      "operator-admin",
+    ]);
   },
 );
+
+test("concurrent Postgres boots leave one complete bootstrap configuration", { skip }, async () => {
+  const persist = createPostgresAdminGrantStore(URL!);
+  const initial = createAdminGrantStore(persist, { bootstrap: [grant({ principalId: "old-bootstrap" })] });
+  await initial.list();
+  await initial.add(grant({ principalId: "operator-admin", grantedBy: "owner", createdAt: 10 }));
+
+  const leftIds = ["left-a", "left-b"];
+  const rightIds = ["right-a", "right-b"];
+  const left = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: leftIds.map((principalId) => grant({ principalId })),
+  });
+  const right = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: rightIds.map((principalId) => grant({ principalId })),
+  });
+  await Promise.all([left.list(), right.list()]);
+
+  const rows = await persist.all();
+  const bootstrapIds = rows
+    .filter(isBootstrapAdminGrant)
+    .map((row) => row.principalId)
+    .sort();
+  assert.ok(
+    [leftIds, rightIds].some(
+      (desired) => desired.length === bootstrapIds.length && desired.every((id, index) => id === bootstrapIds[index]),
+    ),
+    `expected one complete configuration, got ${bootstrapIds.join(",")}`,
+  );
+  assert.equal(
+    rows.some((row) => row.principalId === "operator-admin" && row.grantedBy === "owner"),
+    true,
+  );
+});
+
+test("Postgres readers observe the bootstrap swap atomically", { skip }, async () => {
+  const initial = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: [grant({ principalId: "old-bootstrap" })],
+  });
+  await initial.ready();
+
+  const pg = (await import("pg")).default;
+  const observer = new pg.Pool({ connectionString: URL! });
+  await observer.query(`
+    CREATE OR REPLACE FUNCTION delay_admin_grant_delete() RETURNS trigger LANGUAGE plpgsql AS $fn$
+    BEGIN
+      PERFORM pg_sleep(0.5);
+      RETURN NULL;
+    END
+    $fn$;
+    CREATE TRIGGER delay_admin_grant_delete
+    BEFORE DELETE ON admin_grants
+    FOR EACH STATEMENT EXECUTE FUNCTION delay_admin_grant_delete()
+  `);
+
+  const changed = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: [grant({ principalId: "new-bootstrap" })],
+  });
+  const reconciling = changed.ready();
+  try {
+    const deadline = Date.now() + 2_000;
+    let deleting = false;
+    while (!deleting && Date.now() < deadline) {
+      const active = await observer.query(
+        "SELECT 1 FROM pg_stat_activity WHERE datname = current_database() AND state = 'active' AND query LIKE '%DELETE FROM admin_grants AS stored%'",
+      );
+      deleting = (active.rowCount ?? 0) > 0;
+      if (!deleting) await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(deleting, true);
+    const during = await observer.query("SELECT principal_id FROM admin_grants ORDER BY principal_id");
+    assert.deepEqual(
+      during.rows.map((row) => row.principal_id),
+      ["old-bootstrap"],
+    );
+    await reconciling;
+    const after = await observer.query("SELECT principal_id FROM admin_grants ORDER BY principal_id");
+    assert.deepEqual(
+      after.rows.map((row) => row.principal_id),
+      ["new-bootstrap"],
+    );
+  } finally {
+    await reconciling.catch(() => undefined);
+    await observer.query("DROP TRIGGER IF EXISTS delay_admin_grant_delete ON admin_grants");
+    await observer.query("DROP FUNCTION IF EXISTS delay_admin_grant_delete() ");
+    await observer.end();
+  }
+});
+
+test("failed Postgres reconciliation rolls back and can be retried", { skip }, async () => {
+  const initial = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: [grant({ principalId: "old-bootstrap" })],
+  });
+  await initial.ready();
+
+  const pg = (await import("pg")).default;
+  const observer = new pg.Pool({ connectionString: URL! });
+  await observer.query(`
+    CREATE OR REPLACE FUNCTION reject_admin_grant_delete() RETURNS trigger LANGUAGE plpgsql AS $fn$
+    BEGIN
+      RAISE EXCEPTION 'bootstrap delete failed';
+    END
+    $fn$;
+    CREATE TRIGGER reject_admin_grant_delete
+    BEFORE DELETE ON admin_grants
+    FOR EACH STATEMENT EXECUTE FUNCTION reject_admin_grant_delete()
+  `);
+
+  const changed = createAdminGrantStore(createPostgresAdminGrantStore(URL!), {
+    bootstrap: [grant({ principalId: "new-bootstrap" })],
+  });
+  try {
+    await assert.rejects(changed.ready(), /bootstrap delete failed/);
+    const afterFailure = await observer.query("SELECT principal_id FROM admin_grants ORDER BY principal_id");
+    assert.deepEqual(
+      afterFailure.rows.map((row) => row.principal_id),
+      ["old-bootstrap"],
+    );
+    await observer.query("DROP TRIGGER reject_admin_grant_delete ON admin_grants");
+    await changed.ready();
+    const afterRetry = await observer.query("SELECT principal_id FROM admin_grants ORDER BY principal_id");
+    assert.deepEqual(
+      afterRetry.rows.map((row) => row.principal_id),
+      ["new-bootstrap"],
+    );
+  } finally {
+    await observer.query("DROP TRIGGER IF EXISTS reject_admin_grant_delete ON admin_grants");
+    await observer.query("DROP FUNCTION IF EXISTS reject_admin_grant_delete()");
+    await observer.end();
+  }
+});


### PR DESCRIPTION
## Summary

- reconcile configured bootstrap administrator grants on every startup instead of only when the durable store is empty
- replace only marker-owned bootstrap rows while preserving operator-created and ambiguous legacy grants
- make PostgreSQL reconciliation atomic under an advisory transaction lock and fail closed before the HTTP server listens
- clear failed readiness promises so a later startup attempt can retry cleanly

## Verification

- affected administrator, startup, supervisor, persistence-retry, and portal tests: 44 passed, 2 live-pool skips
- PostgreSQL 16 reconciliation suite: 6 passed, covering restart, changed and removed config, concurrent boots, reader atomicity, rollback, and retry
- adversarial PostgreSQL checks covered duplicate desired rows, same-key operator ownership, ambiguous legacy metadata, twenty concurrent boots, and an operator replacement racing stale-row deletion
- `npm run typecheck`
- `npm run typecheck:contract`
- targeted ESLint, oxlint, Prettier, and `git diff --check`

## Behavior

Startup now waits for one complete reconciliation transaction. An explicit empty bootstrap configuration deliberately removes bootstrap-owned grants, while grants without the complete bootstrap marker remain untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790866328&installation_model_id=19911&pr_number=885&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F885&signature=9a98e94d26d78c0992450f23d73950f8821f435a2f44de9450540ebd73665e27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->