### PR TITLE
web-ui: arm the slash skill menu after CJK text

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -198,7 +198,7 @@ export function clearSkillsCache(): void {
   skillsCache = null;
 }
 
-const SLASH_TOKEN = /(^|\s)\/([a-zA-Z0-9_-]*)$/;
+const SLASH_TOKEN = /(^|[\s\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff00-\uffef\uac00-\ud7af])\/([a-zA-Z0-9_-]*)$/;
 
 export function slashQuery(draft: string): string | null {
   const m = SLASH_TOKEN.exec(draft);

--- a/plugins/web-ui/test/slash-cjk-boundary.test.ts
+++ b/plugins/web-ui/test/slash-cjk-boundary.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+
+const tokenBody = composer.match(/const SLASH_TOKEN = \/(.*)\/;/)?.[1];
+const groupIndex = Number(composer.match(/return m \? \(m\[(\d)\] \?\? ""\) : null;/)?.[1]);
+
+test("SLASH_TOKEN and slashQuery stay adjacent and one capture group", () => {
+  assert.ok(tokenBody, "SLASH_TOKEN regex literal must exist");
+  assert.ok(Number.isInteger(groupIndex) && groupIndex >= 1, "slashQuery must read a capture group");
+});
+
+const SLASH_TOKEN = new RegExp(tokenBody!);
+const slashQuery = (draft: string): string | null => {
+  const m = draft.match(SLASH_TOKEN);
+  return m ? (m[groupIndex] ?? "") : null;
+};
+
+test("a slash after CJK text arms the skill menu — CJK characters are word boundaries", () => {
+  assert.equal(slashQuery("你好/"), "");
+  assert.equal(slashQuery("帮我写周报/"), "");
+  assert.equal(slashQuery("你好/office"), "office");
+  assert.equal(slashQuery("周报。/发"), null, "non-ASCII typed after the slash ends the token");
+});
+
+test("Japanese kana and Korean Hangul are boundaries too", () => {
+  assert.equal(slashQuery("こんにちは/"), "");
+  assert.equal(slashQuery("レポート/off"), "off");
+  assert.equal(slashQuery("보고서/"), "");
+  assert.equal(slashQuery("보고서/office"), "office");
+});
+
+test("a slash after latin text still requires a word boundary", () => {
+  assert.equal(slashQuery("hello/"), null, "mid-word slash stays inert (paths, URLs)");
+  assert.equal(slashQuery("see /office"), "office");
+  assert.equal(slashQuery("/office"), "office");
+  assert.equal(slashQuery("draft 2026/09"), null, "dates stay inert — no skill matches numeric queries");
+});
+
+test("the boundary class covers CJK punctuation and fullwidth forms", () => {
+  assert.equal(slashQuery("清单，/"), "");
+  assert.equal(slashQuery("报表、/"), "");
+  assert.equal(slashQuery("你好，/off"), "off");
+});
+
+test("acceptSkill keeps replacing the trailing token with the boundary prefix intact", () => {
+  assert.match(composer, /\.replace\(SLASH_TOKEN, \(_m, pre: string\) => `\$\{pre\}\/\$\{skill\.name\} `\)/);
+  const replace = (draft: string): string => draft.replace(SLASH_TOKEN, (_m, pre) => `${pre}/office-docs `);
+  assert.equal(replace("你好/"), "你好/office-docs ");
+  assert.equal(replace("see /"), "see /office-docs ");
+  assert.equal(replace("/off"), "/office-docs ");
+});


### PR DESCRIPTION
## Summary

Typing `/` after CJK text never opens the slash skill menu. `SLASH_TOKEN` requires the slash to sit at start-of-draft or after whitespace — a word-boundary assumption that holds for space-separated writing but not for Chinese, Japanese, or Korean input, which has no inter-word spaces. So `帮我写周报/` (or `こんにちは/`, `보고서/`) never arms the menu, while `see /office` does.

## Change

One line: widen the boundary class so CJK ideographs (incl. Ext A and compatibility), CJK punctuation, kana, Hangul syllables, and fullwidth forms also count as token boundaries:

```diff
-const SLASH_TOKEN = /(^|\s)\/([a-zA-Z0-9_-]*)$/;
+const SLASH_TOKEN = /(^|[\s\u3000-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff00-\uffef\uac00-\ud7af])\/([a-zA-Z0-9_-]*)$/;
```

Capture-group numbering is unchanged, so `slashQuery` and `acceptSkill`'s prefix-preserving replacement behave exactly as before. Mid-word ASCII slashes stay inert: `hello/`, URLs, and dates like `2026/09` still do not open the menu (and numeric queries never match a skill name, so dates stay quiet even when they arm).

## Tests

New `slash-cjk-boundary.test.ts` extracts the shipped regex from source and asserts: arming after Chinese / kana / Hangul text, CJK punctuation and fullwidth forms as boundaries, non-ASCII after the slash ends the token, mid-word and date cases stay inert, and `acceptSkill` keeps the prefix on replacement. Full web-ui suite green (600/600) plus typecheck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790867618&installation_model_id=19911&pr_number=887&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F887&signature=cae417836539da800ee5688771b7cf956e01b1968e461c9542b9ae46a900271a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->