### PR TITLE
admin: paginate the skills table and add a source filter

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -4993,6 +4993,7 @@
       const HISTORY_PAGE_SIZE = 50;
 
       const TRANSCRIPT_PAGE_SIZE = 500;
+      const SKILLS_PAGE_SIZE = 20;
       const DEFAULT_VIEW = "history";
       let scope = "org:acme";
       let view = DEFAULT_VIEW;
@@ -5620,7 +5621,7 @@
         if (st.view === "history" && st.session && st.turn != null) p.set("turn", String(st.turn));
         if (st.view === "history" && !st.session && st.historyKind && st.historyKind !== "conversation")
           p.set("kind", st.historyKind);
-        if (st.view === "history" && !st.session && st.page > 1) p.set("page", st.page);
+        if (((st.view === "history" && !st.session) || st.view === "skills") && st.page > 1) p.set("page", st.page);
         if (st.view === "slack" && st.container) p.set("container", st.container);
         if (st.view === "slack" && st.container && st.ts) p.set("ts", st.ts);
         if (st.view === "judgments" && st.container) p.set("container", st.container);
@@ -6122,7 +6123,19 @@
       }
 
       const scopeSearchState = {};
-      function wireScopeSearch({ key, indexWrap, listWrap, rows, names, noMatch, total, shell, placeholder }) {
+      function wireScopeSearch({
+        key,
+        indexWrap,
+        listWrap,
+        rows,
+        names,
+        noMatch,
+        total,
+        shell,
+        placeholder,
+        include,
+        afterFilter,
+      }) {
         const own = orgOwnView();
         const prev = scopeSearchState[key];
         const st =
@@ -6136,11 +6149,12 @@
           }
           let hits = 0;
           rows.forEach((row, i) => {
-            const hit = !q || names[i].includes(q);
+            const hit = (!q || names[i].includes(q)) && (!include || include(i));
             row.classList.toggle("hidden", !hit);
             if (hit) hits += 1;
           });
           noMatch.classList.toggle("hidden", !total || hits > 0);
+          if (afterFilter) afterFilter(hits);
         };
         const active = document.activeElement;
         const hadFocus = !!(active && active.closest(".shell-search"));
@@ -9530,6 +9544,11 @@
         };
         return rm;
       }
+      let skillsSourceFilter = "all";
+      function skillSourceOf(s) {
+        if (s.pack) return "pack";
+        return (s.createdBy || "").indexOf("system:") === 0 ? "builtin" : "own";
+      }
       function renderSkills(root, d) {
         const index = orgWideView() && !orgOwnView();
 
@@ -9590,13 +9609,59 @@
         const noMatch = document.createElement("p");
         noMatch.className = "empty hidden";
         noMatch.textContent = "No skills match.";
+
+        const tableRows = [...t.querySelectorAll("tbody tr")];
+        const sourceCounts = { pack: 0, builtin: 0, own: 0 };
+        skills.forEach((s) => {
+          sourceCounts[skillSourceOf(s)] += 1;
+        });
+        if (skillsSourceFilter !== "all" && !sourceCounts[skillsSourceFilter]) skillsSourceFilter = "all";
+        const sourceSeg = document.createElement("div");
+        sourceSeg.className = "segmented";
+        const sourceOpt = (value, label) => {
+          const b = document.createElement("button");
+          b.type = "button";
+          b.className = "seg" + (skillsSourceFilter === value ? " active" : "");
+          b.textContent = label;
+          b.onclick = () => {
+            if (skillsSourceFilter === value) return;
+            skillsSourceFilter = value;
+            renderData();
+          };
+          sourceSeg.appendChild(b);
+        };
+        sourceOpt("all", "All (" + skills.length + ")");
+        if (sourceCounts.pack) sourceOpt("pack", "Packs (" + sourceCounts.pack + ")");
+        if (sourceCounts.builtin) sourceOpt("builtin", "Built-in (" + sourceCounts.builtin + ")");
+        if (sourceCounts.own) sourceOpt("own", "Own (" + sourceCounts.own + ")");
+
+        const pagerWrap = document.createElement("div");
+        const applyPage = (hits) => {
+          const pages = Math.max(1, Math.ceil(hits / SKILLS_PAGE_SIZE));
+          const cur = Math.min(page, pages);
+          const start = (cur - 1) * SKILLS_PAGE_SIZE;
+          let shown = -1;
+          tableRows.forEach((row) => {
+            if (row.classList.contains("hidden")) return;
+            shown += 1;
+            row.classList.toggle("hidden", shown < start || shown >= start + SKILLS_PAGE_SIZE);
+          });
+          pagerWrap.textContent = "";
+          if (hits > SKILLS_PAGE_SIZE)
+            pagerWrap.appendChild(
+              pager(hits, SKILLS_PAGE_SIZE, start, (n) =>
+                go({ view, scope, own: urlToState().own || null, session: null, page: n }),
+              ),
+            );
+        };
+
         const tableWrap = document.createElement("div");
-        tableWrap.append(t, noMatch);
+        tableWrap.append(t, noMatch, pagerWrap);
         wireScopeSearch({
           key: "skills",
           indexWrap: scopeWrap,
           listWrap: tableWrap,
-          rows: [...t.querySelectorAll("tbody tr")],
+          rows: tableRows,
           names,
           noMatch,
           total: skills.length,
@@ -9611,8 +9676,11 @@
                 }),
             title: index ? VIEW_TITLE.skills : shortName(scope),
             count,
+            actions: [sourceSeg],
           },
           placeholder: index ? "Search all skills…" : "Search skills…",
+          include: (i) => skillsSourceFilter === "all" || skillSourceOf(skills[i]) === skillsSourceFilter,
+          afterFilter: applyPage,
         });
         const card = bareDataCard(tableWrap);
         if (scopeWrap) card.querySelector(".body").prepend(scopeWrap);


### PR DESCRIPTION
## Summary

The admin Skills table renders every skill in one long list. Orgs that import skill packs quickly end up with dozens-to-hundreds of rows, with no way to slice them.

## Change

- **Pagination**: the same pager the history view uses — 20 rows per page (`SKILLS_PAGE_SIZE`), page number persisted in the URL state only when > 1.
- **Source filter**: a segmented control next to the count — **All / Packs / Built-in / Own** with live counts. Pack skills are identified by their `pack` field, built-ins by a `system:` creator prefix, everything else counts as own.
- **Composability**: `wireScopeSearch` gains two optional hooks — `include` (a per-row predicate composed with the search query) and `afterFilter` (called with the hit count) — so search × filter × pagination compose in one pass instead of duplicating the search wiring. All other call sites pass neither hook and are unchanged.

Filter state is kept for the session (module-level), and switching segments re-renders through `renderData()` while preserving the active search text.

## Tests

Existing admin suite stays green (82/82); no existing test pins the old `wireScopeSearch` signature or the skills table markup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790867621&installation_model_id=19911&pr_number=888&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F888&signature=0d565bc9084e30de85bc1d899dc901ba1c11b516c49dd9756d86e19807f44b8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->