### PR TITLE
Defer deployment-layer sync while tenant runtime is suspended

### DIFF
--- a/cli/src/deployment-layer.ts
+++ b/cli/src/deployment-layer.ts
@@ -308,6 +308,10 @@ export async function syncDeploymentLayerBody(
     }
     throw new CliError(`could not sync deployment layer: ${errMessage(error)}`);
   }
+  if (opts.allowUnavailable && response.status === 503 && response.body === '{"error":"tenant_suspended"}') {
+    step(`deployment layer: core is suspended; deployment succeeded and sync is deferred until the next up`);
+    return;
+  }
   if (response.status < 200 || response.status >= 300)
     throw new CliError(`deployment layer sync failed (${response.status}): ${response.body}`);
   let parsed: unknown;

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -582,6 +582,41 @@ test("allowUnavailable swallows an unreachable core but NOT a local config error
   }
 });
 
+test("allowUnavailable defers an intentionally suspended core but no other HTTP failure", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-layer-sync-"));
+  let response = { status: 503, body: '{"error":"tenant_suspended"}' };
+  const { server, port } = await startCoreStub(() => response, []);
+  try {
+    writeLayer(dir);
+    await withEnv({ CORE_SIGNING_SECRET: SECRET, QM_BASE_PORT: String(port) }, () =>
+      syncDeploymentLayer({
+        config: makeConfig("http://example.invalid"),
+        transport: dockerDeploymentLayerTransport,
+        configDir: dir,
+        sandboxDir: join(dir, "sandbox"),
+        allowUnavailable: true,
+      }),
+    );
+    response = { status: 503, body: '{"error":"billing_unavailable"}' };
+    await withEnv({ CORE_SIGNING_SECRET: SECRET, QM_BASE_PORT: String(port) }, () =>
+      assert.rejects(
+        () =>
+          syncDeploymentLayer({
+            config: makeConfig("http://example.invalid"),
+            transport: dockerDeploymentLayerTransport,
+            configDir: dir,
+            sandboxDir: join(dir, "sandbox"),
+            allowUnavailable: true,
+          }),
+        /deployment layer sync failed \(503\): {"error":"billing_unavailable"}/,
+      ),
+    );
+  } finally {
+    await new Promise<void>((resolve) => server.close(resolve));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function fakeFly(dir: string, body: string): string {
   const bin = join(dir, "fake-fly.cjs");
   writeFileSync(bin, `#!/usr/bin/env node\nconst fs = require("node:fs");\n${body}\n`);


### PR DESCRIPTION
## Summary

- treat the exact suspended-tenant response as temporarily unavailable during deployment-layer sync
- defer only when unavailable deployments are explicitly allowed
- keep other HTTP 503 failures strict

## Verification

- `node --test cli/test/deployment-layer.test.ts`
- `npm run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790882809&installation_model_id=19911&pr_number=890&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F890&signature=545885d07d4414ccffcc7ff8ab0349505d84e5d1c2f2c1a3d6f6cd67db476e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->