### PR TITLE
Harden local setup and deployment branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ data/
 *.env
 .env.local
 *.env.local
+*.local
+secrets/
+*.pem
+*.key
+id_rsa*
 *.tfstate
 *.tfstate.*
 .terraform/

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -46,6 +46,13 @@ const ORG_LABEL_KEY = "qm.org";
 const orgLabelArgs = (ctx: DockerCtx): string[] => ["--label", `${ORG_LABEL_KEY}=${ctx.config.orgId}`];
 const baseHostPort = (ctx: DockerCtx): number => dockerBasePort(ctx.config);
 
+export function dockerPublishedPort(config: QmConfig, service: ServiceName): string | undefined {
+  const def = serviceDef(service);
+  if (def.docker.hostPortOffset === undefined) return undefined;
+  if (config.services.includes("portal") && service !== "core" && service !== "portal") return undefined;
+  return `127.0.0.1:${dockerBasePort(config) + def.docker.hostPortOffset}:${def.docker.internalPort}`;
+}
+
 interface DockerCtx {
   config: QmConfig;
   configDir: string;
@@ -466,7 +473,6 @@ function pushEnvArgs(args: string[], env: Record<string, string>, secretKeys: Se
 }
 
 function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: string[]; cleanup: () => void } {
-  const def = serviceDef(service);
   const args = [
     "run",
     "-d",
@@ -493,9 +499,8 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
       if (socket.gid) args.push("--group-add", socket.gid);
     }
   }
-  if (def.docker.hostPortOffset !== undefined) {
-    args.push("-p", `${baseHostPort(ctx) + def.docker.hostPortOffset}:${def.docker.internalPort}`);
-  }
+  const publishedPort = dockerPublishedPort(ctx.config, service);
+  if (publishedPort) args.push("-p", publishedPort);
   args.push(image);
   return { args, cleanup };
 }
@@ -641,8 +646,8 @@ export async function dockerUp(
     step(`network: ${ctx.network}`);
     if (resolvedLocalImage) step(`sandbox: local image ${resolvedLocalImage}`);
     for (const def of ordered(runnableServices(config.services))) {
-      const ports =
-        def.docker.hostPortOffset !== undefined ? ` (host :${baseHostPort(ctx) + def.docker.hostPortOffset})` : "";
+      const publishedPort = dockerPublishedPort(config, def.name);
+      const ports = publishedPort ? ` (publish ${publishedPort})` : "";
       step(
         `${def.name}: image ${ctx.buildFrom ? `build deploy/${def.name}/Dockerfile` : imageRef(ctx, def.name)}${ports}`,
       );
@@ -742,8 +747,8 @@ function printUrls(ctx: DockerCtx): void {
   if (has("portal")) note(`   portal : ${url("portal")}  (public front door)`);
   if (has("auth"))
     note(`   auth   : ${url("portal")}/idp/authorize  (sign-in broker, published only through the portal)`);
-  if (has("web-ui")) note(`   web-ui : ${url("web-ui")}`);
-  if (has("admin")) note(`   admin  : ${url("admin")}/admin`);
+  if (has("web-ui") && !has("portal")) note(`   web-ui : ${url("web-ui")}`);
+  if (has("admin")) note(`   admin  : ${has("portal") ? `${url("portal")}/admin` : `${url("admin")}/admin`}`);
   note(`   core   : ${url("core")}`);
   note(`   status : qm status   ·   logs: qm logs core   ·   stop: qm down`);
 }

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -121,19 +121,64 @@ function ensureLocalSandboxImage(config: QmConfig): string {
   return image;
 }
 
-function hostDockerSocket(): { path: string; gid?: string } {
-  const configured = process.env.DOCKER_HOST?.trim();
+export function dockerSocketCandidates(
+  dockerHost: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const configured = dockerHost?.trim();
   if (configured && !configured.startsWith("unix://")) {
     throw new CliError('sandbox.backend "local" requires a Unix Docker socket');
   }
-  const path = configured?.slice("unix://".length) || "/var/run/docker.sock";
-  let gid: string | undefined;
-  try {
-    gid = capture("stat", ["-c", "%g", path]).trim() || undefined;
-  } catch {
-    throw new CliError(`sandbox.backend "local" cannot read the Docker socket at ${path}`);
+  const path = configured?.slice("unix://".length);
+  if (configured && !path) throw new CliError('sandbox.backend "local" requires a Unix Docker socket path');
+  if (path?.includes(",")) throw new CliError(`Docker socket path cannot contain a comma: ${path}`);
+  if (!path) return ["/var/run/docker.sock"];
+  if (platform === "darwin" || /[/\\]\.docker[/\\]desktop[/\\]docker\.sock$/.test(path)) {
+    return [...new Set(["/var/run/docker.sock", path])];
   }
-  return { path, ...(gid ? { gid } : {}) };
+  return [path];
+}
+
+export function dockerSocketProbeArgs(path: string, image: string): string[] {
+  if (path.includes(",")) throw new CliError(`Docker socket path cannot contain a comma: ${path}`);
+  return [
+    "run",
+    "--rm",
+    "--entrypoint",
+    "/bin/stat",
+    "--mount",
+    `type=bind,source=${path},target=/var/run/docker.sock,readonly`,
+    image,
+    "-c",
+    "%g",
+    "/var/run/docker.sock",
+  ];
+}
+
+export function dockerSocketMountArgs(socket: { path: string; gid: string }): string[] {
+  if (socket.path.includes(",")) throw new CliError(`Docker socket path cannot contain a comma: ${socket.path}`);
+  return ["--mount", `type=bind,source=${socket.path},target=/var/run/docker.sock`, "--group-add", socket.gid];
+}
+
+export function resolveDockerSocket(
+  image: string,
+  dockerHost: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  probe: (args: string[]) => string = (args) => docker(args, undefined, 5_000),
+): { path: string; gid: string } {
+  for (const path of dockerSocketCandidates(dockerHost, platform)) {
+    try {
+      const gid = probe(dockerSocketProbeArgs(path, image)).trim();
+      if (/^\d+$/.test(gid)) return { path, gid };
+    } catch {
+      continue;
+    }
+  }
+  throw new CliError(`sandbox.backend "local" cannot mount the Docker daemon socket`);
+}
+
+function hostDockerSocket(image: string): { path: string; gid: string } {
+  return resolveDockerSocket(image, process.env.DOCKER_HOST);
 }
 
 function requireDocker(): void {
@@ -145,9 +190,9 @@ function requireDocker(): void {
   }
 }
 
-function docker(args: string[], allow?: RegExp): string {
+function docker(args: string[], allow?: RegExp, timeoutMs?: number): string {
   try {
-    return capture("docker", args, allow ? { allow } : {});
+    return capture("docker", args, { ...(allow ? { allow } : {}), ...(timeoutMs ? { timeoutMs } : {}) });
   } catch (e) {
     throw dockerError(args, errMessage(e));
   }
@@ -494,9 +539,8 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     for (const m of layerMounts(ctx)) args.push("-v", m);
     for (const m of skillMounts(ctx)) args.push("-v", m);
     if (localSandboxActive(ctx.config)) {
-      const socket = hostDockerSocket();
-      args.push("-v", `${socket.path}:/var/run/docker.sock`);
-      if (socket.gid) args.push("--group-add", socket.gid);
+      const socket = hostDockerSocket(image);
+      args.push(...dockerSocketMountArgs(socket));
     }
   }
   const publishedPort = dockerPublishedPort(ctx.config, service);

--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -250,10 +250,10 @@ async function modelProviderCheck(provider: ModelProvider, apiKey: string): Prom
   if (!res.ok) throw new CliError(`the ${provider} API returned HTTP ${res.status}; retry when it recovers`);
 }
 
-async function resendCheck(apiKey: string): Promise<void> {
+export async function resendCheck(apiKey: string, fetchImpl: typeof fetch = fetch): Promise<void> {
   let res: Response;
   try {
-    res = await fetch("https://api.resend.com/domains", {
+    res = await fetchImpl("https://api.resend.com/domains", {
       headers: { authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(10_000),
     });
@@ -261,6 +261,15 @@ async function resendCheck(apiKey: string): Promise<void> {
     throw new CliError(
       `could not reach the Resend API: ${errMessage(e)} — check network access (and any proxy) and retry`,
     );
+  }
+  if (res.status === 401) {
+    const body = (await res.json().catch(() => null)) as { message?: unknown } | null;
+    if (body?.message === "This API key is restricted to only send emails.") {
+      warn(
+        "Resend API key has sending-only access; the domains probe cannot validate it, so actual email delivery still must be verified",
+      );
+      return;
+    }
   }
   if (res.status === 401 || res.status === 403)
     throw new CliError("Resend rejected RESEND_API_KEY — mint a key with send access at https://resend.com/api-keys");

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -33,12 +33,13 @@ async function pollUntil(cond: () => boolean, tries: number): Promise<boolean> {
 export function capture(
   cmd: string,
   args: string[],
-  opts: { cwd?: string; env?: NodeJS.ProcessEnv; allow?: RegExp } = {},
+  opts: { cwd?: string; env?: NodeJS.ProcessEnv; allow?: RegExp; timeoutMs?: number } = {},
 ): string {
   try {
     return execFileSync(cmd, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
       ...procOpts(opts),
     });
   } catch (e: unknown) {

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { CONFIG_FILENAME, loadConfigAt, validatePortalTrust, type QmConfig } from "../src/config.ts";
 import { derivedTomlFor } from "../src/backends/fly.ts";
 import { serviceEnvironment } from "../src/backends/aws.ts";
-import { dockerServiceEnv } from "../src/backends/docker.ts";
+import { dockerPublishedPort, dockerServiceEnv } from "../src/backends/docker.ts";
 import { computedSecrets, runtimeSecretNames, secretsForService } from "../src/secrets.ts";
 import { stageFlyEmailAllowlist } from "../src/backends/fly.ts";
 import { isReservedContainerName, SERVICE_NAMES, serviceDef } from "../src/services.ts";
@@ -52,6 +52,19 @@ test("the auth service is a first-class, privately addressed service with its ow
     "the broker never gets a public IP",
   );
   assert.equal(def.fly?.flycast, true);
+});
+
+test("docker publishes only the loopback core and authenticated portal when the portal fronts surfaces", () => {
+  const config = configWith(configText());
+  assert.equal(dockerPublishedPort(config, "core"), "127.0.0.1:8080:8080");
+  assert.equal(dockerPublishedPort(config, "portal"), "127.0.0.1:8081:8080");
+  assert.equal(dockerPublishedPort(config, "web-ui"), undefined);
+  assert.equal(dockerPublishedPort(config, "admin"), undefined);
+  assert.equal(dockerPublishedPort(config, "auth"), undefined);
+
+  const direct = configWith(configText({ services: '["core", "web-ui"]', env: "{}" }));
+  assert.equal(dockerPublishedPort(direct, "core"), "127.0.0.1:8080:8080");
+  assert.equal(dockerPublishedPort(direct, "web-ui"), "127.0.0.1:8082:8080");
 });
 
 test("fly derives the portal's whole OIDC block from the broker, over the private network", () => {

--- a/cli/test/docker-socket.test.ts
+++ b/cli/test/docker-socket.test.ts
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  dockerSocketCandidates,
+  dockerSocketMountArgs,
+  dockerSocketProbeArgs,
+  resolveDockerSocket,
+} from "../src/backends/docker.ts";
+
+test("forwarded macOS Docker sockets prefer the daemon-side socket", () => {
+  for (const dockerHost of [
+    "unix:///Users/operator/.colima/default/docker.sock",
+    "unix:///Users/operator/.docker/run/docker.sock",
+    "unix:///Users/operator/.orbstack/run/docker.sock",
+  ]) {
+    assert.deepEqual(dockerSocketCandidates(dockerHost, "darwin"), [
+      "/var/run/docker.sock",
+      dockerHost.slice("unix://".length),
+    ]);
+  }
+});
+
+test("explicit native and rootless Linux sockets stay authoritative", () => {
+  assert.deepEqual(dockerSocketCandidates(undefined, "linux"), ["/var/run/docker.sock"]);
+  assert.deepEqual(dockerSocketCandidates("unix:///var/run/docker.sock", "linux"), ["/var/run/docker.sock"]);
+  assert.deepEqual(dockerSocketCandidates("unix:///run/user/1000/docker.sock", "linux"), [
+    "/run/user/1000/docker.sock",
+  ]);
+  assert.deepEqual(dockerSocketCandidates("unix:///home/operator/.docker/desktop/docker.sock", "linux"), [
+    "/var/run/docker.sock",
+    "/home/operator/.docker/desktop/docker.sock",
+  ]);
+});
+
+test("local sandboxes reject invalid Docker transports", () => {
+  assert.throws(
+    () => dockerSocketCandidates("tcp://docker.example.test:2376", "linux"),
+    /requires a Unix Docker socket/,
+  );
+  assert.throws(() => dockerSocketCandidates("unix://", "linux"), /requires a Unix Docker socket path/);
+  assert.throws(() => dockerSocketCandidates("unix:///tmp/a,b.sock", "linux"), /cannot contain a comma/);
+});
+
+test("socket probing bypasses image entrypoints and uses a read-only daemon-side mount", () => {
+  assert.deepEqual(dockerSocketProbeArgs("/var/run/docker.sock", "qm-core:local"), [
+    "run",
+    "--rm",
+    "--entrypoint",
+    "/bin/stat",
+    "--mount",
+    "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock,readonly",
+    "qm-core:local",
+    "-c",
+    "%g",
+    "/var/run/docker.sock",
+  ]);
+});
+
+test("socket resolution validates GIDs and falls back only for forwarded clients", () => {
+  const calls: string[][] = [];
+  const socket = resolveDockerSocket(
+    "qm-core:local",
+    "unix:///Users/operator/.colima/default/docker.sock",
+    "darwin",
+    (args) => {
+      calls.push(args);
+      if (args.some((arg) => arg.includes("source=/var/run/docker.sock"))) throw new Error("missing");
+      return "991\n";
+    },
+  );
+  assert.deepEqual(socket, { path: "/Users/operator/.colima/default/docker.sock", gid: "991" });
+  assert.equal(calls.length, 2);
+  assert.throws(
+    () => resolveDockerSocket("qm-core:local", undefined, "linux", () => "not-a-gid"),
+    /cannot mount the Docker daemon socket/,
+  );
+  assert.throws(
+    () =>
+      resolveDockerSocket("qm-core:local", undefined, "linux", () => {
+        throw new Error("probe failed");
+      }),
+    /cannot mount the Docker daemon socket/,
+  );
+});
+
+test("socket mount args preserve group access and reject mount delimiters", () => {
+  assert.deepEqual(dockerSocketMountArgs({ path: "/var/run/docker.sock", gid: "991" }), [
+    "--mount",
+    "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock",
+    "--group-add",
+    "991",
+  ]);
+  assert.throws(() => dockerSocketProbeArgs("/tmp/a,b.sock", "qm-core:local"), /cannot contain a comma/);
+  assert.throws(() => dockerSocketMountArgs({ path: "/tmp/a,b.sock", gid: "991" }), /cannot contain a comma/);
+});

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -7,6 +7,7 @@ import {
   doctorCommon,
   localDoctorSecrets,
   requiredSlackScopes,
+  resendCheck,
   slackManifestBotScopes,
 } from "../src/backends/doctor.ts";
 import { flyDoctor, verifyLocalFlyTokens } from "../src/backends/fly.ts";
@@ -24,6 +25,45 @@ const config: QmConfig = {
   imageOverrides: {},
   sandbox: { app: "acme-sandboxes" },
 };
+
+const resendResponse = (status: number, message?: string): Response =>
+  new Response(message === undefined ? undefined : JSON.stringify({ message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+test("Resend doctor accepts a full-access key", async () => {
+  const fetchImpl = (async () => resendResponse(200)) as typeof fetch;
+  await assert.doesNotReject(resendCheck("re_full", fetchImpl));
+});
+
+test("Resend doctor accepts the explicit sending-only restriction with an unverified-delivery warning", async () => {
+  const fetchImpl = (async () =>
+    resendResponse(401, "This API key is restricted to only send emails.")) as typeof fetch;
+  const priorWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...parts: unknown[]): void => void warnings.push(parts.join(" "));
+  try {
+    await assert.doesNotReject(resendCheck("re_sending", fetchImpl));
+    assert.deepEqual(warnings, [
+      "! Resend API key has sending-only access; the domains probe cannot validate it, so actual email delivery still must be verified",
+    ]);
+  } finally {
+    console.warn = priorWarn;
+  }
+});
+
+test("Resend doctor rejects an invalid key", async () => {
+  const fetchImpl = (async () => resendResponse(403, "API key is invalid.")) as typeof fetch;
+  await assert.rejects(resendCheck("re_invalid", fetchImpl), /Resend rejected RESEND_API_KEY/);
+});
+
+test("Resend doctor rejects other authorization and API errors", async () => {
+  const unauthorized = (async () => resendResponse(401, "Authentication required.")) as typeof fetch;
+  const unavailable = (async () => resendResponse(500, "Unavailable")) as typeof fetch;
+  await assert.rejects(resendCheck("re_other", unauthorized), /Resend rejected RESEND_API_KEY/);
+  await assert.rejects(resendCheck("re_other", unavailable), /Resend API returned HTTP 500/);
+});
 
 test("Docker doctor rejects missing and placeholder required secrets before external probes", async () => {
   const prior = process.env.ANTHROPIC_API_KEY;

--- a/cli/test/e2e/docker-lifecycle.e2e.test.ts
+++ b/cli/test/e2e/docker-lifecycle.e2e.test.ts
@@ -95,8 +95,18 @@ test(
         const coreInfo = inspect(core);
         assert.ok(coreInfo.Config.Env.includes("DOCKER_HOST=unix:///var/run/docker.sock"));
         assert.ok(coreInfo.Config.Env.includes(`QM_CORE_CONTAINER=${core}`));
-        assert.ok(coreInfo.Mounts.some((mount) => mount.Destination === "/var/run/docker.sock"));
+        assert.ok(
+          coreInfo.Mounts.some(
+            (mount) => mount.Source === "/var/run/docker.sock" && mount.Destination === "/var/run/docker.sock",
+          ),
+        );
         assert.ok(!inspect(portal).Mounts.some((mount) => mount.Destination === "/var/run/docker.sock"));
+        assert.match(
+          execFileSync("docker", ["exec", core, "docker", "version", "-f", "{{.Server.Version}}"], {
+            encoding: "utf8",
+          }).trim(),
+          /^\d+\.\d+/,
+        );
       });
 
       await t.test("services receive their private-network aliases", () => {

--- a/cli/test/e2e/plan.e2e.test.ts
+++ b/cli/test/e2e/plan.e2e.test.ts
@@ -128,7 +128,7 @@ test("plan honors a host port base from the config", () => {
     writeConfig(dir, { orgId: "acme", target: "docker", services: ["core"], basePort: 31080 });
     const r = runCli(["plan"], { cwd: dir, env: { QM_BASE_PORT: undefined } });
     assert.equal(r.code, 0, r.out);
-    assert.match(r.out, /core: image .*\(host :31080\)/);
+    assert.match(r.out, /core: image .*\(publish 127\.0\.0\.1:31080:8080\)/);
   } finally {
     rmDir(dir);
   }
@@ -140,7 +140,7 @@ test("plan honors QM_BASE_PORT over the config", () => {
     writeConfig(dir, { orgId: "acme", target: "docker", services: ["core"], basePort: 31080 });
     const r = runCli(["plan"], { cwd: dir, env: { QM_BASE_PORT: "32099" } });
     assert.equal(r.code, 0, r.out);
-    assert.match(r.out, /\(host :32099\)/);
+    assert.match(r.out, /\(publish 127\.0\.0\.1:32099:8080\)/);
   } finally {
     rmDir(dir);
   }

--- a/cli/test/layer-wiring.test.ts
+++ b/cli/test/layer-wiring.test.ts
@@ -149,15 +149,15 @@ test("a missing secretEnv value is warned, not invented", async () => {
   }
 });
 
-test("model → PI_MODEL and host ports follow the offset map (core+0, portal+1, web-ui+2, admin+3)", async () => {
+test("portal deployments publish only loopback core and portal ports", async () => {
   const dir = makeDeployment({ model: "claude-opus-4-8", services: ["core", "portal", "web-ui", "admin"] });
   try {
     const out = await plan(dir);
     assert.match(out, /PI_MODEL/);
-    assert.match(out, /host :8080/);
-    assert.match(out, /host :8081/);
-    assert.match(out, /host :8082/);
-    assert.match(out, /host :8083/);
+    assert.match(out, /core: .*publish 127\.0\.0\.1:8080:8080/);
+    assert.match(out, /portal: .*publish 127\.0\.0\.1:8081:8080/);
+    assert.doesNotMatch(out, /web-ui: .*publish/);
+    assert.doesNotMatch(out, /admin: .*publish/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -169,7 +169,7 @@ test("QM_BASE_PORT overrides the host port base for one run", async () => {
   process.env.QM_BASE_PORT = "9000";
   try {
     const out = await plan(dir);
-    assert.match(out, /host :9000/);
+    assert.match(out, /publish 127\.0\.0\.1:9000:8080/);
   } finally {
     if (prev === undefined) delete process.env.QM_BASE_PORT;
     else process.env.QM_BASE_PORT = prev;

--- a/plugins/auth/src/config.ts
+++ b/plugins/auth/src/config.ts
@@ -130,6 +130,13 @@ export function validEmail(value: string): boolean {
   return value.length <= 254 && /^[^@\s,;<>"]+@[^@\s,;<>"]+\.[^@\s,;<>"]+$/.test(value);
 }
 
+function isLoopbackHttpUrl(url: URL): boolean {
+  const host = url.hostname.toLowerCase();
+  return (
+    url.protocol === "http:" && (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]")
+  );
+}
+
 function httpsUrlProblem(label: string, value: string, requireHttps: boolean): string | null {
   if (isMissingOrPlaceholder(value)) return `${label} is required and may not be a placeholder`;
   let url: URL;
@@ -138,9 +145,28 @@ function httpsUrlProblem(label: string, value: string, requireHttps: boolean): s
   } catch {
     return `${label} must be an absolute URL`;
   }
-  if (requireHttps && url.protocol !== "https:") return `${label} must be https in production`;
+  if (requireHttps && url.protocol !== "https:" && !isLoopbackHttpUrl(url)) {
+    return `${label} must be https in production`;
+  }
   if (url.search || url.hash) return `${label} must not carry a query string or fragment`;
   return null;
+}
+
+function browserEndpointTopologyProblem(issuer: string, redirectUri: string, requireHttps: boolean): string | null {
+  if (!requireHttps) return null;
+  let issuerUrl: URL;
+  let redirectUrl: URL;
+  try {
+    issuerUrl = new URL(issuer);
+    redirectUrl = new URL(redirectUri);
+  } catch {
+    return null;
+  }
+  if (issuerUrl.protocol !== "http:" && redirectUrl.protocol !== "http:") return null;
+  if (isLoopbackHttpUrl(issuerUrl) && isLoopbackHttpUrl(redirectUrl) && issuerUrl.origin === redirectUrl.origin) {
+    return null;
+  }
+  return "AUTH_ISSUER and AUTH_REDIRECT_URI must both use loopback HTTP on the same origin when either uses HTTP";
 }
 
 export function bootProblems(cfg: AuthConfig, isProd: boolean): string[] {
@@ -151,6 +177,7 @@ export function bootProblems(cfg: AuthConfig, isProd: boolean): string[] {
 
   push(httpsUrlProblem("AUTH_ISSUER", cfg.issuer, isProd));
   push(httpsUrlProblem("AUTH_REDIRECT_URI", cfg.redirectUri, isProd));
+  push(browserEndpointTopologyProblem(cfg.issuer, cfg.redirectUri, isProd));
   if (isMissingOrPlaceholder(cfg.clientId)) problems.push("AUTH_CLIENT_ID is required and may not be a placeholder");
   if (isMissingOrPlaceholder(cfg.clientSecret))
     problems.push("AUTH_CLIENT_SECRET is required and may not be a placeholder");

--- a/plugins/auth/test/config.test.ts
+++ b/plugins/auth/test/config.test.ts
@@ -58,6 +58,49 @@ test("production refuses cleartext endpoints and cleartext SMTP", () => {
   assert.equal(bootProblems(readConfig(testEnv({ AUTH_ISSUER: "http://localhost:8099" })), false).join(" | "), "");
 });
 
+test("production permits cleartext only for true loopback browser endpoints", () => {
+  const signing = { CORE_SIGNING_SECRET: "a".repeat(48) };
+  for (const origin of ["http://localhost:8099", "http://127.0.0.1:8099", "http://[::1]:8099"]) {
+    assert.equal(
+      problemsFor({ ...signing, AUTH_ISSUER: `${origin}/idp`, AUTH_REDIRECT_URI: `${origin}/auth/callback` }),
+      "",
+    );
+  }
+  for (const origin of ["http://0.0.0.0:8099", "http://192.168.1.20:8099", "http://agent.local:8099"]) {
+    assert.match(
+      problemsFor({ ...signing, AUTH_ISSUER: `${origin}/idp`, AUTH_REDIRECT_URI: `${origin}/auth/callback` }),
+      /must be https in production/,
+    );
+  }
+});
+
+test("production rejects mixed cleartext browser endpoint topology", () => {
+  const signing = { CORE_SIGNING_SECRET: "a".repeat(48) };
+  for (const endpoints of [
+    {
+      AUTH_ISSUER: "http://127.0.0.1:8099/idp",
+      AUTH_REDIRECT_URI: "https://127.0.0.1:8099/auth/callback",
+    },
+    {
+      AUTH_ISSUER: "https://127.0.0.1:8099/idp",
+      AUTH_REDIRECT_URI: "http://127.0.0.1:8099/auth/callback",
+    },
+    {
+      AUTH_ISSUER: "http://localhost:8099/idp",
+      AUTH_REDIRECT_URI: "http://127.0.0.1:8099/auth/callback",
+    },
+    {
+      AUTH_ISSUER: "http://127.0.0.1:8099/idp",
+      AUTH_REDIRECT_URI: "http://127.0.0.1:8100/auth/callback",
+    },
+  ]) {
+    assert.match(
+      problemsFor({ ...signing, ...endpoints }),
+      /must both use loopback HTTP on the same origin when either uses HTTP/,
+    );
+  }
+});
+
 test("production requires the core signing secret that makes links single-use", () => {
   assert.match(problemsFor({}), /CORE_SIGNING_SECRET is required/);
   assert.equal(problemsFor({ CORE_SIGNING_SECRET: "a".repeat(48) }), "");

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -320,6 +320,19 @@ function isLocalPortalUrl(raw: string): boolean {
   }
 }
 
+function isLoopbackHttpUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    const hostname = url.hostname.toLowerCase();
+    return (
+      url.protocol === "http:" &&
+      (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
+}
+
 function originOf(raw: string): string {
   try {
     return new URL(raw).origin;
@@ -1302,8 +1315,13 @@ export function bootChecks(): void {
     if (SESSION_SECRET && CORE_SIGNING_SECRET && SESSION_SECRET === CORE_SIGNING_SECRET) {
       problems.push("PORTAL_SESSION_SECRET must differ from CORE_SIGNING_SECRET");
     }
-    if (!PUBLIC_URL.startsWith("https://")) problems.push("PORTAL_PUBLIC_URL must be https in production");
-    if (!OIDC.authEndpoint.startsWith("https://")) {
+    if (!PUBLIC_URL.startsWith("https://") && !isLoopbackHttpUrl(PUBLIC_URL)) {
+      problems.push("PORTAL_PUBLIC_URL must be https in production unless it is loopback-only");
+    }
+    if (
+      !OIDC.authEndpoint.startsWith("https://") &&
+      !(isLoopbackHttpUrl(OIDC.authEndpoint) && originOf(OIDC.authEndpoint) === originOf(PUBLIC_URL))
+    ) {
       problems.push(`OIDC_AUTH_ENDPOINT must be https — the browser is sent there: ${OIDC.authEndpoint}`);
     }
     const brokerOrigin =

--- a/plugins/portal/test/entry.test.ts
+++ b/plugins/portal/test/entry.test.ts
@@ -188,3 +188,41 @@ test("production accepts cleartext OIDC only on private-network hosts, and only 
   assert.notEqual(externalCleartext.status, 0, "the relaxation is for the built-in broker only");
   assert.match(externalCleartext.stderr, /OIDC endpoint must be https unless it is the built-in broker/);
 });
+
+test("production permits cleartext browser routes only on one true loopback origin", () => {
+  const command = "import('./src/index.ts').then(m => m.bootChecks())";
+  const boot = (publicUrl: string, authEndpoint = `${publicUrl}/idp/authorize`) =>
+    spawnSync(process.execPath, ["--input-type=module", "-e", command], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        PORTAL_PUBLIC_URL: publicUrl,
+        PORTAL_SESSION_SECRET: "portal-session-secret",
+        CORE_SIGNING_SECRET: "core-signing-secret",
+        OIDC_CLIENT_ID: "qm-portal",
+        OIDC_CLIENT_SECRET: "client-secret",
+        OIDC_ISSUER: `${publicUrl}/idp`,
+        OIDC_AUTH_ENDPOINT: authEndpoint,
+        OIDC_TOKEN_ENDPOINT: "http://auth.internal:8080/token",
+        OIDC_USERINFO_ENDPOINT: "http://auth.internal:8080/userinfo",
+        OIDC_JWKS_URI: "http://auth.internal:8080/.well-known/jwks.json",
+        OIDC_ALLOWED_EMAILS: "admin@example.com",
+        AUTH_BROKER_UPSTREAM: "http://auth.internal:8080",
+      },
+      encoding: "utf8",
+    });
+
+  for (const origin of ["http://localhost:8081", "http://127.0.0.1:8081", "http://[::1]:8081"]) {
+    const accepted = boot(origin);
+    assert.equal(accepted.status, 0, accepted.stderr);
+  }
+  for (const origin of ["http://0.0.0.0:8081", "http://192.168.1.20:8081", "http://agent.local:8081"]) {
+    const refused = boot(origin);
+    assert.notEqual(refused.status, 0, origin);
+    assert.match(refused.stderr, /PORTAL_PUBLIC_URL must be https in production unless it is loopback-only/);
+  }
+  const crossOrigin = boot("http://127.0.0.1:8081", "http://localhost:8081/idp/authorize");
+  assert.notEqual(crossOrigin.status, 0);
+  assert.match(crossOrigin.stderr, /OIDC_AUTH_ENDPOINT must be https/);
+});

--- a/plugins/web-ui/src/brand.ts
+++ b/plugins/web-ui/src/brand.ts
@@ -1,0 +1,4 @@
+export function brandName(): string {
+  if (typeof document === "undefined") return "QM";
+  return document.querySelector<HTMLMetaElement>('meta[name="brand-self-label"]')?.content || "QM";
+}

--- a/plugins/web-ui/src/document-title.ts
+++ b/plugins/web-ui/src/document-title.ts
@@ -1,4 +1,5 @@
 import type { View } from "./shell-state";
+import { brandName } from "./brand.ts";
 
 interface TitledSession {
   id: string;
@@ -13,6 +14,10 @@ interface ActiveConversation {
 
 export const PRODUCT_TITLE = "QM · Web";
 
+export function productTitle(): string {
+  return `${brandName()} · Web`;
+}
+
 const VIEW_TITLES: Record<View, string> = {
   chats: "Chats",
   contexts: "Projects",
@@ -26,9 +31,10 @@ const VIEW_TITLES: Record<View, string> = {
 };
 
 export function documentTitle(view?: View, conversationTitle?: string | null, conversationOpen = false): string {
+  const product = productTitle();
   const title =
     view === "chats" && conversationOpen ? conversationTitle?.trim() || "New chat" : view && VIEW_TITLES[view];
-  return title ? `${title} · ${PRODUCT_TITLE}` : PRODUCT_TITLE;
+  return title ? `${title} · ${product}` : product;
 }
 
 export function updateDocumentTitle(view?: View, conversationTitle?: string | null, conversationOpen = false): void {

--- a/plugins/web-ui/src/search.ts
+++ b/plugins/web-ui/src/search.ts
@@ -7,6 +7,7 @@
  */
 import { html, nothing, render, type TemplateResult } from "lit";
 import { CornerDownLeft, Search } from "lucide";
+import { brandName } from "./brand.ts";
 import { api, type CoreSession } from "./core-bridge";
 import { mainConversation } from "./conversations";
 import { recencyGroup } from "./session-list";
@@ -256,7 +257,7 @@ function resultRows(): TemplateResult[] {
         }}
       >
         <span class="chat-search-who ${hit.entryType === "user" ? "user" : "agent"}"
-          >${(hit.entryType === "user" ? (hit.author ?? "You") : "QM").slice(0, 1).toUpperCase()}</span
+          >${(hit.entryType === "user" ? (hit.author ?? "You") : brandName()).slice(0, 1).toUpperCase()}</span
         >
         <span class="chat-search-text">
           <span class="chat-search-snippet">${highlight(hit.snippet)}</span>
@@ -287,8 +288,10 @@ function askRow(): TemplateResult {
     >
       <span class="chat-search-who ask">+</span>
       <span class="chat-search-text">
-        <span class="chat-search-snippet">Ask QM to find it: <b>“${searchState.query.trim()}”</b></span>
-        <span class="chat-search-meta">starts a new chat where QM hunts down the matching session and links it</span>
+        <span class="chat-search-snippet">Ask ${brandName()} to find it: <b>“${searchState.query.trim()}”</b></span>
+        <span class="chat-search-meta"
+          >starts a new chat where ${brandName()} hunts down the matching session and links it</span
+        >
       </span>
       <span class="chat-search-kbd">${isMac ? "⌘" : "Ctrl"}${icon(CornerDownLeft, 11)}</span>
     </button>
@@ -337,7 +340,7 @@ function paletteTpl(): TemplateResult {
         <div class="chat-search-foot">
           <span><span class="chat-search-kbd">↑↓</span> navigate</span>
           <span><span class="chat-search-kbd">↵</span> open chat</span>
-          <span><span class="chat-search-kbd">${isMac ? "⌘↵" : "Ctrl+↵"}</span> ask QM in a new chat</span>
+          <span><span class="chat-search-kbd">${isMac ? "⌘↵" : "Ctrl+↵"}</span> ask ${brandName()} in a new chat</span>
         </div>
       </div>
     </div>

--- a/plugins/web-ui/src/ui.ts
+++ b/plugins/web-ui/src/ui.ts
@@ -1,11 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { live } from "lit/directives/live.js";
 import { Check, ChevronDown, createElement, type IconNode } from "lucide";
-
-export function brandName(): string {
-  if (typeof document === "undefined") return "QM";
-  return document.querySelector<HTMLMetaElement>('meta[name="brand-self-label"]')?.content || "QM";
-}
+export { brandName } from "./brand.ts";
 
 export function brandMark(): TemplateResult {
   return html`<span class="brand-mark" aria-hidden="true"></span>`;

--- a/plugins/web-ui/test/document-title.test.ts
+++ b/plugins/web-ui/test/document-title.test.ts
@@ -21,6 +21,21 @@ test("chat and non-chat views have useful fallbacks", () => {
   assert.equal(documentTitle("keychain"), `Keychain · ${PRODUCT_TITLE}`);
 });
 
+test("page titles follow the server-injected deployment label", () => {
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: new JSDOM('<meta name="brand-self-label" content="Acme">').window.document,
+  });
+  try {
+    assert.equal(documentTitle("chats", "Quarterly planning", true), "Quarterly planning · Acme · Web");
+    assert.equal(documentTitle("contexts"), "Projects · Acme · Web");
+  } finally {
+    if (documentDescriptor) Object.defineProperty(globalThis, "document", documentDescriptor);
+    else delete (globalThis as { document?: Document }).document;
+  }
+});
+
 test("active session selection follows conversation switches and title updates", () => {
   const sessions = [
     { id: "old", threadRef: "old-thread", title: "Old title" },

--- a/plugins/web-ui/test/search-branding.test.ts
+++ b/plugins/web-ui/test/search-branding.test.ts
@@ -1,0 +1,13 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../src/search.ts", import.meta.url), "utf8");
+
+test("every agent label in the search palette follows deployment branding", () => {
+  assert.match(source, /hit\.entryType === "user"[\s\S]*?: brandName\(\)/);
+  assert.match(source, /Ask \$\{brandName\(\)\} to find it/);
+  assert.match(source, /where \$\{brandName\(\)\} hunts down the matching session/);
+  assert.match(source, /ask \$\{brandName\(\)\} in a new chat/);
+  assert.doesNotMatch(source, /Ask QM|QM hunts|ask QM/);
+});

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -244,8 +244,39 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
 
   async function connectCore(net: string): Promise<void> {
     if (!opts.coreContainer) return;
-    const r = await dexec(["network", "connect", net, opts.coreContainer]);
-    if (r.code !== 0 && !/already (?:exists|connected)/i.test(r.stderr)) {
+    const inspectAliases = async (): Promise<string[] | null> => {
+      const result = await dexec([
+        "inspect",
+        "-f",
+        `{{json (index .NetworkSettings.Networks ${JSON.stringify(net)}).Aliases}}`,
+        opts.coreContainer!,
+      ]);
+      if (result.code !== 0) return null;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(result.stdout) as unknown;
+      } catch {
+        throw new Error(`docker inspect ${opts.coreContainer} returned invalid network aliases`);
+      }
+      if (parsed === null) return null;
+      if (!Array.isArray(parsed) || parsed.some((alias) => typeof alias !== "string")) {
+        throw new Error(`docker inspect ${opts.coreContainer} returned invalid network aliases`);
+      }
+      return parsed;
+    };
+    const aliases = await inspectAliases();
+    if (aliases?.includes("core")) return;
+    if (aliases) {
+      const disconnected = await dexec(["network", "disconnect", net, opts.coreContainer]);
+      if (disconnected.code !== 0) {
+        throw new Error(`docker network disconnect ${net} ${opts.coreContainer} failed: ${disconnected.stderr.trim()}`);
+      }
+    }
+    const r = await dexec(["network", "connect", "--alias", "core", net, opts.coreContainer]);
+    if (
+      r.code !== 0 &&
+      !(/already (?:exists|connected)/i.test(r.stderr) && (await inspectAliases())?.includes("core"))
+    ) {
       throw new Error(`docker network connect ${net} ${opts.coreContainer} failed: ${r.stderr.trim()}`);
     }
   }

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -289,6 +289,7 @@ test("a replacement core reattaches to an already-running sandbox", async () => 
   const connection = `${localNetworkName(first.id)}|qm-test-core`;
   assert.equal(fake.connections.has(connection), true);
   fake.connections.delete(connection);
+  fake.connectionAliases.delete(connection);
   const second = await sb.provision(layers);
   assert.equal(second.id, first.id);
   assert.equal(fake.connections.has(connection), true);
@@ -296,7 +297,7 @@ test("a replacement core reattaches to an already-running sandbox", async () => 
   await sb.teardown(second, { destroy: true });
 });
 
-test("containerized core joins each sandbox network and reaches the daemon by container name", async () => {
+test("containerized core joins each sandbox network as core and reaches the daemon by container name", async () => {
   const fake = installFakeDocker(daemonPort);
   const seen: string[] = [];
   const fetchImpl: typeof fetch = (input) => {
@@ -308,9 +309,64 @@ test("containerized core joins each sandbox network and reaches the daemon by co
   const sb = makeSandbox(fake, { coreContainer: "qm-test-core", fetchImpl });
   const h = await sb.provision(rw(scopeId("personal", "U40")));
   const args = fake.containers.get(h.id)!.args;
+  const network = localNetworkName(h.id);
   assert.equal(args.includes("-p"), false);
-  assert.equal(fake.connections.has(`${localNetworkName(h.id)}|qm-test-core`), true);
+  assert.equal(fake.connections.has(`${network}|qm-test-core`), true);
+  assert.deepEqual([...fake.connectionAliases.get(`${network}|qm-test-core`)!], ["core"]);
+  assert.deepEqual(
+    fake.calls.find((call) => call[0] === "network" && call[1] === "connect" && call.at(-2) === network),
+    ["network", "connect", "--alias", "core", network, "qm-test-core"],
+  );
   assert.ok(seen.includes(`http://${h.id}:8080/health`));
   await sb.teardown(h, { destroy: true });
-  assert.equal(fake.connections.has(`${localNetworkName(h.id)}|qm-test-core`), false);
+  assert.equal(fake.connections.has(`${network}|qm-test-core`), false);
+});
+
+test("an existing core connection without its callback alias is repaired", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, { coreContainer: "qm-test-core", fetchImpl });
+  const layers = rw(scopeId("personal", "U41"));
+  const first = await sb.provision(layers);
+  const network = localNetworkName(first.id);
+  const connection = `${network}|qm-test-core`;
+  fake.connectionAliases.set(connection, new Set());
+  fake.calls.length = 0;
+
+  const second = await sb.provision(layers);
+  assert.deepEqual(
+    fake.calls.filter((call) => call[0] === "network" && ["connect", "disconnect"].includes(call[1]!)),
+    [
+      ["network", "disconnect", network, "qm-test-core"],
+      ["network", "connect", "--alias", "core", network, "qm-test-core"],
+    ],
+  );
+  assert.deepEqual([...fake.connectionAliases.get(connection)!], ["core"]);
+  await sb.teardown(first);
+  await sb.teardown(second, { destroy: true });
+});
+
+test("an existing core connection with its callback alias is preserved", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, { coreContainer: "qm-test-core", fetchImpl });
+  const layers = rw(scopeId("personal", "U42"));
+  const first = await sb.provision(layers);
+  fake.calls.length = 0;
+
+  const second = await sb.provision(layers);
+  assert.equal(
+    fake.calls.some((call) => call[0] === "network" && ["connect", "disconnect"].includes(call[1]!)),
+    false,
+  );
+  await sb.teardown(first);
+  await sb.teardown(second, { destroy: true });
 });

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -15,6 +15,8 @@ export interface FakeDocker {
   volumes: Set<string>;
   networks: Set<string>;
   connections: Set<string>;
+  connectionAliases: Map<string, Set<string>>;
+  calls: string[][];
   runCount: number;
   daemonDown: boolean;
   imageMissing: boolean;
@@ -28,11 +30,15 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const volumes = new Set<string>();
   const networks = new Set<string>();
   const connections = new Set<string>();
+  const connectionAliases = new Map<string, Set<string>>();
+  const calls: string[][] = [];
   const self: FakeDocker = {
     containers,
     volumes,
     networks,
     connections,
+    connectionAliases,
+    calls,
     runCount: 0,
     daemonDown: false,
     imageMissing: false,
@@ -60,6 +66,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   }
 
   function exec(args: string[]): { code: number; stdout: string; stderr: string } {
+    calls.push([...args]);
     const [cmd, ...rest] = args;
     if (self.daemonDown) return fail("Cannot connect to the Docker daemon");
     switch (cmd) {
@@ -73,6 +80,12 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
       }
       case "inspect": {
         const name = rest[rest.length - 1]!;
+        const format = rest[rest.indexOf("-f") + 1];
+        if (format?.includes(".NetworkSettings.Networks")) {
+          const network = /Networks\s+"([^"]+)"/.exec(format)?.[1] ?? "";
+          const aliases = connectionAliases.get(`${network}|${name}`);
+          return ok(aliases ? JSON.stringify([...aliases]) : "null");
+        }
         const c = containers.get(name);
         if (!c) return fail(`Error: No such object: ${name}`);
         return ok(`${c.running} ${c.imageId}`);
@@ -87,12 +100,20 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         }
         if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
         if (sub === "connect" || sub === "disconnect") {
-          const container = rest[2]!;
-          const key = `${name}|${container}`;
+          const network = rest.at(-2)!;
+          const container = rest.at(-1)!;
+          const key = `${network}|${container}`;
           if (sub === "connect") {
             if (connections.has(key)) return fail("endpoint already exists");
             connections.add(key);
-          } else connections.delete(key);
+            connectionAliases.set(
+              key,
+              new Set(rest.flatMap((value, index) => (value === "--alias" ? [rest[index + 1]!] : []))),
+            );
+          } else {
+            connections.delete(key);
+            connectionAliases.delete(key);
+          }
           return ok(key);
         }
         return fail(`unknown network subcommand ${sub}`);


### PR DESCRIPTION
## Summary

- bind Docker-published service ports to IPv4 loopback
- keep portal-fronted web and admin services private to the Docker network
- permit production-mode HTTP authentication only when both browser endpoints share one true loopback origin
- reject mixed-scheme, cross-host, cross-port, LAN, and wildcard HTTP authentication configurations
- attach core to each local sandbox network with the stable `core` callback alias
- repair existing sandbox network attachments that lack the callback alias while preserving correct active attachments
- resolve the daemon-side Docker socket and GID for local sandboxes, including forwarded macOS clients, without crossing explicit native or rootless Linux daemon boundaries
- reject unsafe socket mount delimiters and bound socket probes to five seconds
- let document titles and search UI consistently use the deployment-provided brand label while preserving QM as the default
- recognize Resend sending-only API keys during doctor checks and warn that actual email delivery still requires verification
- ignore common local credential-file paths

## Verification

- Docker socket and secret tests: 10 passed
- web UI branding tests: 10 passed
- local sandbox networking tests cover alias repair, exact daemon-side socket mounts, and non-root Docker API access
- auth configuration, portal entry, and doctor tests cover loopback boundaries and Resend sending-only behavior
- root and plugin typechecks passed
- web UI production build passed
- root lint, formatting, diff checks, and gitleaks history scan passed
- both the Docker socket and generic branding changes passed independent review
