### PR TITLE
Support Slack HTTP mode in doctor

### DIFF
--- a/cli/src/backends/doctor.ts
+++ b/cli/src/backends/doctor.ts
@@ -84,8 +84,19 @@ async function slackApi(
   }
 }
 
-async function slackCheck(botToken: string, appToken: string, configDir?: string): Promise<void> {
-  const auth = await slackApi("https://slack.com/api/auth.test", { headers: { authorization: `Bearer ${botToken}` } });
+function slackApiBase(raw?: string): string {
+  const base = (raw?.trim() || "https://slack.com").replace(/\/+$/, "");
+  return base.endsWith("/api") ? `${base}/` : `${base}/api/`;
+}
+
+async function slackCheck(
+  botToken: string,
+  appToken: string | undefined,
+  configDir?: string,
+  apiUrl?: string,
+): Promise<void> {
+  const base = slackApiBase(apiUrl);
+  const auth = await slackApi(`${base}auth.test`, { headers: { authorization: `Bearer ${botToken}` } });
   if (!auth.res.ok || !auth.body.ok)
     throw new CliError(`Slack bot token rejected (${auth.body.error ?? auth.res.status})`);
   const granted = new Set(
@@ -99,7 +110,8 @@ async function slackCheck(botToken: string, appToken: string, configDir?: string
     throw new CliError(
       `Slack app is missing scopes: ${missing.join(", ")}; update from slack-app-manifest.yml and reinstall`,
     );
-  const socket = await slackApi("https://slack.com/api/apps.connections.open", {
+  if (!appToken) return;
+  const socket = await slackApi(`${base}apps.connections.open`, {
     method: "POST",
     headers: { authorization: `Bearer ${appToken}`, "content-type": "application/x-www-form-urlencoded" },
   });
@@ -165,13 +177,16 @@ export async function doctorCommon(
   if (config.services.includes("slack")) {
     const bot = deploymentSecretValue("SLACK_BOT_TOKEN", secrets.get("SLACK_BOT_TOKEN"));
     const app = deploymentSecretValue("SLACK_APP_TOKEN", secrets.get("SLACK_APP_TOKEN"));
-    if (Boolean(bot) !== Boolean(app)) {
+    const eventsMode = config.env.slack?.SLACK_EVENTS_MODE?.trim() === "http" ? "http" : "socket";
+    if ((!bot && app) || (eventsMode === "socket" && Boolean(bot) !== Boolean(app))) {
       throw new CliError(
-        "Slack setup needs both SLACK_BOT_TOKEN and SLACK_APP_TOKEN, or neither when setup is deferred",
+        eventsMode === "http"
+          ? "Slack HTTP setup needs SLACK_BOT_TOKEN without SLACK_APP_TOKEN, or neither when setup is deferred"
+          : "Slack setup needs both SLACK_BOT_TOKEN and SLACK_APP_TOKEN, or neither when setup is deferred",
       );
     }
-    if (bot && app) {
-      await slackCheck(bot, app, opts.configDir);
+    if (bot) {
+      await slackCheck(bot, eventsMode === "socket" ? app : undefined, opts.configDir, config.env.slack?.SLACK_API_URL);
       if (opts.requiredSecretValues) {
         step("Slack tokens and manifest scopes: ok");
       } else if (config.target === "aws") {

--- a/cli/test/doctor.test.ts
+++ b/cli/test/doctor.test.ts
@@ -370,6 +370,30 @@ test("slackCheck passes when granted scopes are a superset of the manifest's", a
   }
 });
 
+test("Slack doctor validates an HTTP events broker without a Socket Mode token", async () => {
+  const dir = manifestDir();
+  const priorFetch = globalThis.fetch;
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    seen.push(`${String(input)} ${new Headers(init?.headers).get("authorization")}`);
+    return authOk("chat:write, users:read");
+  }) as typeof fetch;
+  try {
+    const brokerConfig = slackConfig();
+    brokerConfig.env = {
+      slack: {
+        SLACK_EVENTS_MODE: "http",
+        SLACK_API_URL: "https://broker.example.test/slack",
+      },
+    };
+    await doctorCommon(brokerConfig, new Map([["SLACK_BOT_TOKEN", "broker-token"]]), { configDir: dir });
+    assert.deepEqual(seen, ["https://broker.example.test/slack/api/auth.test Bearer broker-token"]);
+  } finally {
+    globalThis.fetch = priorFetch;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("Slack doctor validates deployment-file tokens before conflicting ambient tokens", async () => {
   const dir = manifestDir();
   const priorFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary
- honor `SLACK_API_URL` when validating Slack credentials
- allow HTTP Events API deployments to omit the Socket Mode app token
- retain existing Socket Mode bot/app token validation

## Tests
- `node --test cli/test/doctor.test.ts`
- `npm run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790888168&installation_model_id=19911&pr_number=892&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F892&signature=2e205fdfc9dd00a1fe1a1b08a01c38ad46c89c3d1a1533e2de135f01048630a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->