### PR TITLE
Write the pane density attribute on every measurement

### DIFF
--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -857,8 +857,10 @@ class PaneContent implements IContentRenderer {
 
   private syncDensity(): void {
     const next = paneDensity(this.element);
-    if (!next || next === this.density) return;
+    if (!next) return;
+    const changed = next !== this.density;
     this.element.dataset.density = this.density = next;
+    if (!changed) return;
     for (const handler of this.redrawOnResize) handler();
   }
 

--- a/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
+++ b/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
@@ -20,7 +20,29 @@ test("responsive pane summaries do not replace the transcript scroller", () => {
   );
 });
 
-test("hidden panes retain their last meaningful density", () => {
+test("hidden panes retain their last meaningful density, and every measure writes the attribute", () => {
   const fn = split.match(/private syncDensity\(\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
-  assert.match(fn, /if \(!next\s*\|\|\s*next === this\.density\) return;/);
+  assert.match(fn, /if \(!next\) return;/, "an unmeasurable pane keeps its last density");
+  assert.doesNotMatch(
+    fn,
+    /next === this\.density\) return;/,
+    "the DOM write must not be skipped when the measured tier equals the starting one",
+  );
+  const write = fn.indexOf("this.element.dataset.density");
+  const gate = fn.indexOf("if (!changed) return;");
+  assert.ok(write >= 0, "the tier is published to the DOM");
+  assert.ok(
+    gate > write,
+    "only the redraw callbacks are gated on an actual change — a pane that mounts at its starting tier still gets the attribute",
+  );
+});
+
+test("pane composer sizing hangs off the density attribute, so writing it is load-bearing", () => {
+  const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+  const block = css.match(/\[data-density\] \.composer-input \{[^}]*\}/)?.[0] ?? "";
+  assert.match(
+    block,
+    /min-height: 0;/,
+    "without the attribute the pane composer falls back to the main-window min-height",
+  );
 });


### PR DESCRIPTION
Panes now publish their measured density tier to the DOM on every measurement, instead of skipping the write when the measured tier matched the pane's starting value — that skip left freshly mounted panes without the attribute their compact composer layout depends on, so their input box rendered at the taller main-window size until an unrelated resize.

- verification: `npm run typecheck` and `node --test "test/**/*.test.ts"` in `plugins/web-ui` (599 passing); new assertions fail on the previous code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790889825&installation_model_id=19911&pr_number=893&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F893&signature=00bba3011491607db57fb6c70c57bb78c048ae6ba82ca40fcf9a6f32450dacbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->