### PR TITLE
fix: email identity parity, clearer deactivated state, operator recovery

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -96,6 +96,8 @@ Auto uses its built-in model classifier unless `qm.config.jsonc` declares one
 init [dir] [--org id] [--target docker|fly|aws]
 check [--json] [--live]
 doctor
+principal status <id>
+principal reactivate <id> --yes
 infra render|build-image|delete-image|delete-task-definitions
 conformance [dir] [--static]
 plan

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yc-software/qm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "qm": "dist/bin/qm.js"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yc-software/qm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "description": "Control-plane CLI for portable QM deployments on Docker, Fly, and AWS.",
   "type": "module",

--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -253,6 +253,8 @@ export function serviceEnvironment(config: QmConfig, service: ServiceName): Reco
   };
   if (service === "core") {
     const sandboxBackend = config.env.core?.SANDBOX_BACKEND?.trim() || config.sandbox?.backend;
+    if (config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN)
+      env.AUTH_ALLOWED_EMAIL_DOMAIN = config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN;
     const stores = {
       DEPLOY_PROVIDER: "aws",
       AWS_DEPLOY_REGION: aws.region,

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -353,6 +353,9 @@ export function dockerServiceEnv(config: QmConfig, service: ServiceName): Record
     CORE_API_URL: "http://core:8080",
     ...orgEnv(service, config.orgId, config.publicUrl, config.services.includes("portal"), brandEnvOf(config)),
   };
+  if (service === "core" && config.env.auth?.AUTH_ALLOWED_EMAIL_DOMAIN) {
+    out.AUTH_ALLOWED_EMAIL_DOMAIN = config.env.auth.AUTH_ALLOWED_EMAIL_DOMAIN;
+  }
   if (service === "core" && localSandboxActive(config)) {
     out.DOCKER_HOST = "unix:///var/run/docker.sock";
     out.QM_CORE_CONTAINER = `${dockerPrefix(config)}-core`;

--- a/cli/src/backends/fly.ts
+++ b/cli/src/backends/fly.ts
@@ -64,9 +64,14 @@ const FLY_RESPONSE = "QM_LAYER_RESPONSE=";
 const FLY_REMOTE_ERROR = "QM_LAYER_ERROR=";
 const FLY_REQUEST_TIMEOUT_MS = 120_000;
 
-function flyRequest(config: QmConfig, method: "GET" | "PUT", body: string): { status: number; body: string } {
+function flyRequest(
+  config: QmConfig,
+  method: "GET" | "POST" | "PUT",
+  path: string,
+  body: string,
+): { status: number; body: string } {
   const app = `${appPrefixOf(config)}-core`;
-  const script = `const fs=require("node:fs"),{createHmac}=require("node:crypto");const fail=error=>{const code=error&&(error.cause&&error.cause.code||error.code);console.log(${JSON.stringify(FLY_REMOTE_ERROR)}+JSON.stringify({message:error&&error.message?error.message:String(error),...(typeof code==="string"?{code}:{})}))};try{const method=${JSON.stringify(method)},path="/v1/deployment-layer",body=fs.readFileSync(0,"utf8"),timestamp=Math.floor(Date.now()/1000),canonical=method+"\\n"+path+"\\n"+body,secret=process.env.CORE_SIGNING_SECRET;if(!secret)throw new Error("CORE_SIGNING_SECRET is not set on core");const signature=createHmac("sha256",secret).update("v0:"+timestamp+":"+canonical).digest("hex");fetch("http://127.0.0.1:"+(process.env.PORT||8080)+path,{method,headers:{"content-type":"application/json","x-timestamp":String(timestamp),"x-signature":"v0="+signature},...(method==="PUT"?{body}: {})}).then(async response=>console.log(${JSON.stringify(FLY_RESPONSE)}+JSON.stringify({status:response.status,body:await response.text()}))).catch(fail)}catch(error){fail(error)}`;
+  const script = `const fs=require("node:fs"),{createHmac}=require("node:crypto");const fail=error=>{const code=error&&(error.cause&&error.cause.code||error.code);console.log(${JSON.stringify(FLY_REMOTE_ERROR)}+JSON.stringify({message:error&&error.message?error.message:String(error),...(typeof code==="string"?{code}:{})}))};try{const method=${JSON.stringify(method)},path=${JSON.stringify(path)},body=fs.readFileSync(0,"utf8"),timestamp=Math.floor(Date.now()/1000),canonical=method+"\\n"+path+"\\n"+body,secret=process.env.CORE_SIGNING_SECRET;if(!secret)throw new Error("CORE_SIGNING_SECRET is not set on core");const signature=createHmac("sha256",secret).update("v0:"+timestamp+":"+canonical).digest("hex");fetch("http://127.0.0.1:"+(process.env.PORT||8080)+path,{method,headers:{"content-type":"application/json","x-timestamp":String(timestamp),"x-signature":"v0="+signature},...(body?{body}: {})}).then(async response=>console.log(${JSON.stringify(FLY_RESPONSE)}+JSON.stringify({status:response.status,body:await response.text()}))).catch(fail)}catch(error){fail(error)}`;
   const encoded = Buffer.from(script).toString("base64");
   const command = `node -e "eval(Buffer.from('${encoded}','base64').toString())"`;
   let output: string;
@@ -99,7 +104,7 @@ function flyRequest(config: QmConfig, method: "GET" | "PUT", body: string): { st
 
 /** Deployment-layer transport for Fly: a signed request executed on the core VM over fly ssh. */
 export const flyDeploymentLayerTransport: DeploymentLayerTransport = (opts) =>
-  Promise.resolve(flyRequest(opts.config, opts.method, opts.body));
+  Promise.resolve(flyRequest(opts.config, opts.method, opts.path ?? "/v1/deployment-layer", opts.body));
 
 import { doctorCommon, localDoctorSecrets, requireFlyAuth } from "./doctor.ts";
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -28,6 +28,7 @@ import { renderSlackFiles, runOutputs } from "./commands/outputs.ts";
 import { cliVersion } from "./manifest.ts";
 import { gitTopLevel, promptHidden, writeEnvValue } from "./util.ts";
 import { scopeStorageKey } from "./scope-storage-key.ts";
+import { principalStatus, reactivatePrincipal } from "./commands/principal.ts";
 
 interface Parsed {
   positionals: string[];
@@ -128,6 +129,8 @@ ${bold("DEPLOY (operator)")} ${dim("— runs in the deployment directory")}
     --json                                 machine-readable results keyed by contract clause
     --live                                 verify running identity, rendered config, and health
   doctor                                   verify deployment prerequisites read-only
+  principal status <id>                    report whether a principal is active
+  principal reactivate <id> --yes           restore a deactivated principal
   config get <dot.path>                    print one config value (raw scalar, JSON otherwise)
   slack render                             render the bot manifest (+ SSO manifest for Slack OIDC)
   outputs [--json]                         print the Web UI, health, and Slack app creation links
@@ -551,6 +554,24 @@ async function dispatch(argv: string[]): Promise<void> {
       runChecks(ctx.config, ctx.configDir, ctx.sandboxDir, { report: false });
       await deploymentBackend(ctx).doctor();
       note(`doctor: ${ctx.target} prerequisites are ready`);
+      return;
+    }
+
+    case "principal": {
+      const action = positionals[0];
+      if (action !== "status" && action !== "reactivate")
+        throw new CliError(`usage: ${CLI_NAME} principal status <id> | principal reactivate <id> --yes`);
+      rejectExtraPositionals(positionals, 2);
+      rejectUnknownFlags(flags, ["config", "env-file", "sandbox-dir", "target", "yes"]);
+      const id = positionals[1]?.trim();
+      if (!id)
+        throw new CliError(`usage: ${CLI_NAME} principal ${action} <id>${action === "reactivate" ? " --yes" : ""}`);
+      if (action === "reactivate" && !boolFlag(flags, "yes"))
+        throw new CliError(`principal reactivate changes access; pass --yes to confirm`);
+      const ctx = deployContext(flags);
+      const transport = hostingProvider(ctx.target).deploymentLayerTransport;
+      if (action === "status") await principalStatus(ctx.config, ctx.configDir, transport, id, ctx.envFile);
+      else await reactivatePrincipal(ctx.config, ctx.configDir, transport, id, ctx.envFile);
       return;
     }
 

--- a/cli/src/commands/principal.ts
+++ b/cli/src/commands/principal.ts
@@ -1,0 +1,69 @@
+import { CliError, note, ok } from "../log.ts";
+import type { QmConfig } from "../config.ts";
+import type { DeploymentLayerTransport } from "../deployment-layer.ts";
+
+export interface PrincipalStatus {
+  principalId: string;
+  active: boolean;
+  source?: "manual" | "directory-sync";
+}
+
+async function request(
+  config: QmConfig,
+  configDir: string,
+  transport: DeploymentLayerTransport,
+  id: string,
+  action: "status" | "reactivate",
+  envFile?: string,
+): Promise<PrincipalStatus> {
+  const response = await transport({
+    config,
+    configDir,
+    method: action === "status" ? "GET" : "POST",
+    path: `/v1/principals/${encodeURIComponent(id)}/${action}`,
+    body: "",
+    ...(envFile ? { envFile } : {}),
+  });
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.body);
+  } catch {
+    throw new CliError(`core returned an invalid principal ${action} response`);
+  }
+  if (response.status < 200 || response.status >= 300) {
+    const message =
+      parsed && typeof parsed === "object" && typeof (parsed as { message?: unknown }).message === "string"
+        ? (parsed as { message: string }).message
+        : `HTTP ${response.status}`;
+    throw new CliError(`principal ${action} failed: ${message}`);
+  }
+  return parsed as PrincipalStatus;
+}
+
+export async function principalStatus(
+  config: QmConfig,
+  configDir: string,
+  transport: DeploymentLayerTransport,
+  id: string,
+  envFile?: string,
+): Promise<PrincipalStatus> {
+  const status = await request(config, configDir, transport, id, "status", envFile);
+  note(
+    status.active
+      ? `${status.principalId}: active`
+      : `${status.principalId}: deactivated${status.source ? ` (${status.source})` : ""}`,
+  );
+  return status;
+}
+
+export async function reactivatePrincipal(
+  config: QmConfig,
+  configDir: string,
+  transport: DeploymentLayerTransport,
+  id: string,
+  envFile?: string,
+): Promise<PrincipalStatus> {
+  const status = await request(config, configDir, transport, id, "reactivate", envFile);
+  ok(`${status.principalId}: reactivated`);
+  return status;
+}

--- a/cli/src/deployment-layer.ts
+++ b/cli/src/deployment-layer.ts
@@ -169,9 +169,10 @@ function isCoreUnreachable(error: unknown): boolean {
 interface DeploymentLayerTransportOpts {
   config: QmConfig;
   configDir: string;
-  method: "GET" | "PUT";
+  method: "GET" | "POST" | "PUT";
   body: string;
   envFile?: string;
+  path?: string;
 }
 
 /**
@@ -197,10 +198,14 @@ export function httpDeploymentLayerTransport(
     if (!secret && o.secretFallback) secret = o.secretFallback(opts.config);
     if (!secret) throw new CliError(`CORE_SIGNING_SECRET is required locally to access the deployment layer`);
     const url = (o.urlOf ?? defaultCoreUrl)(opts.config);
+    if (opts.path) {
+      url.pathname = opts.path;
+      url.search = "";
+    }
     const response = await fetch(url, {
       method: opts.method,
       headers: signingHeaders(secret, opts.method, url.pathname + url.search, opts.body),
-      ...(opts.method === "PUT" ? { body: opts.body } : {}),
+      ...(opts.body ? { body: opts.body } : {}),
       ...(o.timeoutMs ? { signal: AbortSignal.timeout(o.timeoutMs) } : {}),
     });
     return { status: response.status, body: await response.text() };

--- a/cli/src/services.ts
+++ b/cli/src/services.ts
@@ -192,6 +192,7 @@ const CATALOG: Record<ServiceName, ServiceDef> = {
         ...orgEnv("core", s.orgId, s.publicUrl, s.hasPortal, s.brand),
         ...brokerEnv("core", s),
         FLY_DEPLOY_APP_PREFIX: s.deployAppPrefix,
+        ...(s.authAllowedEmailDomain ? { AUTH_ALLOWED_EMAIL_DOMAIN: s.authAllowedEmailDomain } : {}),
       }),
       stackKeys: [
         "SNAPSHOT_STORE",

--- a/cli/test/auth-broker.test.ts
+++ b/cli/test/auth-broker.test.ts
@@ -73,6 +73,7 @@ test("fly derives the portal's whole OIDC block from the broker, over the privat
   const auth = derivedTomlFor(brokerConfig(), "auth", repoRoot);
   assert.equal(auth, readFileSync(join(repoRoot, "deploy", "auth", "fly.toml"), "utf8"));
   assert.match(auth, /AUTH_ISSUER = "https:\/\/agent\.example\.com\/idp"/);
+  assert.match(derivedTomlFor(brokerConfig(), "core", repoRoot), /AUTH_ALLOWED_EMAIL_DOMAIN = "example.com"/);
   assert.match(auth, /AUTH_REDIRECT_URI = "https:\/\/agent\.example\.com\/auth\/callback"/);
 });
 
@@ -100,6 +101,7 @@ test("a configured botName brands the docker service env for core and auth", () 
 test("docker and AWS wire the broker with parity", () => {
   const docker = configWith(configText());
   const dockerPortal = dockerServiceEnv(docker, "portal");
+  assert.equal(dockerServiceEnv(docker, "core").AUTH_ALLOWED_EMAIL_DOMAIN, "example.com");
   assert.equal(dockerPortal.AUTH_BROKER_UPSTREAM, "http://qm-acme-auth.internal:8080");
   assert.equal(dockerPortal.OIDC_TOKEN_ENDPOINT, "http://qm-acme-auth.internal:8080/token");
   assert.equal(dockerPortal.OIDC_ISSUER, "https://agent.example.com/idp");
@@ -125,6 +127,7 @@ test("docker and AWS wire the broker with parity", () => {
     }
   }`);
   const awsPortal = serviceEnvironment(aws, "portal");
+  assert.equal(serviceEnvironment(aws, "core").AUTH_ALLOWED_EMAIL_DOMAIN, "example.com");
   assert.equal(awsPortal.AUTH_BROKER_UPSTREAM, "http://auth.acme.internal:8080");
   assert.equal(awsPortal.OIDC_JWKS_URI, "http://auth.acme.internal:8080/.well-known/jwks.json");
   assert.equal(awsPortal.OIDC_ALLOWED_EMAIL_DOMAIN, "example.com");

--- a/cli/test/principal.test.ts
+++ b/cli/test/principal.test.ts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { principalStatus, reactivatePrincipal } from "../src/commands/principal.ts";
+import type { QmConfig } from "../src/config.ts";
+import type { DeploymentLayerTransport } from "../src/deployment-layer.ts";
+const config = {
+  contract: 1,
+  orgId: "acme",
+  publicUrl: "https://example.com",
+  target: "docker",
+  services: ["core"],
+  plugins: [],
+  skills: [],
+  env: {},
+  imageOverrides: {},
+} as QmConfig;
+test("principal status and reactivation use the signed provider transport", async () => {
+  const calls: Array<{ method: string; path?: string }> = [];
+  const transport: DeploymentLayerTransport = async (opts) => {
+    calls.push({ method: opts.method, path: opts.path });
+    return opts.method === "GET"
+      ? { status: 200, body: JSON.stringify({ principalId: "person@example.com", active: false, source: "manual" }) }
+      : { status: 200, body: JSON.stringify({ principalId: "person@example.com", active: true }) };
+  };
+  assert.equal((await principalStatus(config, "/tmp", transport, "person@example.com")).active, false);
+  assert.equal((await reactivatePrincipal(config, "/tmp", transport, "person@example.com")).active, true);
+  assert.deepEqual(calls, [
+    { method: "GET", path: "/v1/principals/person%40example.com/status" },
+    { method: "POST", path: "/v1/principals/person%40example.com/reactivate" },
+  ]);
+});

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -468,7 +468,7 @@ export class ApiError extends Error {
 
 export interface SigninRequired {
   mode?: "portal" | "dev";
-  reason?: "unauthenticated" | "not_allowed";
+  reason?: "unauthenticated" | "not_allowed" | "deactivated";
 }
 
 let onSigninRequired: ((detail: SigninRequired) => void) | null = null;

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -322,6 +322,14 @@ function portalGate() {
   `);
 }
 
+function deactivatedGate() {
+  return gateShell(html`
+    <h1>Your account is deactivated</h1>
+    <p class="signin-body">Contact an administrator to restore access.</p>
+    <button class="btn" type="button" @click=${signOut}>Sign out</button>
+  `);
+}
+
 function deniedGate() {
   return gateShell(html`
     <h1>You don't have access</h1>
@@ -402,6 +410,7 @@ function devGate(gate: { value?: string; error?: string; pending?: boolean }) {
 export type AuthGate =
   | { kind: "portal" }
   | { kind: "denied" }
+  | { kind: "deactivated" }
   | { kind: "unreachable" }
   | { kind: "dev"; value?: string; error?: string; pending?: boolean };
 
@@ -413,6 +422,8 @@ export function renderAuthGate(gate: AuthGate): void {
         return portalGate();
       case "denied":
         return deniedGate();
+      case "deactivated":
+        return deactivatedGate();
       case "unreachable":
         return unreachableGate();
       default:
@@ -422,8 +433,9 @@ export function renderAuthGate(gate: AuthGate): void {
   render(body, appEl as HTMLElement);
 }
 
-function gateFor(mode: AuthMode, reason: "unauthenticated" | "not_allowed" | undefined): AuthGate {
+function gateFor(mode: AuthMode, reason: "unauthenticated" | "not_allowed" | "deactivated" | undefined): AuthGate {
   if (reason === "not_allowed") return { kind: "denied" };
+  if (reason === "deactivated") return { kind: "deactivated" };
   return mode === "dev" ? { kind: "dev" } : { kind: "portal" };
 }
 

--- a/plugins/web-ui/test/deactivated-gate-source.test.ts
+++ b/plugins/web-ui/test/deactivated-gate-source.test.ts
@@ -1,0 +1,10 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+const source = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+test("a deactivated identity renders an account-deactivated gate, not session expiry", () => {
+  assert.match(source, /reason === ["']deactivated["'].*kind: ["']deactivated["']/s);
+  const gate = source.slice(source.indexOf("function deactivatedGate"), source.indexOf("function deniedGate"));
+  assert.match(gate, /account is deactivated/i);
+  assert.doesNotMatch(gate, /session ended/i);
+});

--- a/src/api/app-messaging.ts
+++ b/src/api/app-messaging.ts
@@ -91,6 +91,14 @@ export function createMessagingMethods(
   const contextRequests = deps.contextRequests ?? createMemoryMap<SurfaceContextRequest>();
   const contextRequestListeners = new Set<(request: SurfaceContextRequest) => void>();
   const contextRequestTokens = new Map<string, string>();
+  const emailAuthDomain = deps.emailAuthDomain?.trim().toLowerCase();
+  const domainMember = (query: string) => {
+    const principalId = personKey(query);
+    const at = principalId.lastIndexOf("@");
+    return at > 0 && principalId.slice(at + 1) === emailAuthDomain
+      ? { principalId, displayName: principalId, type: "internal" as const }
+      : null;
+  };
   const emailMembers = async (): Promise<DirectoryMember[]> => {
     const externals = (await deps.identity.listExternalMembers()).filter((member) => externalMemberActive(member));
     return [
@@ -416,9 +424,10 @@ export function createMessagingMethods(
       const stored = await deps.directory.resolve(query);
       if (stored.kind !== "none") return stored;
       const key = personKey(query);
-      const member = (await emailMembers()).find(
-        (candidate) => personKey(candidate.principalId) === key || personKey(candidate.displayName) === key,
-      );
+      const member =
+        (await emailMembers()).find(
+          (candidate) => personKey(candidate.principalId) === key || personKey(candidate.displayName) === key,
+        ) ?? domainMember(query);
       return member ? { kind: "one", member } : { kind: "none" };
     },
     resolveChannel(query) {
@@ -434,7 +443,7 @@ export function createMessagingMethods(
       return (
         (await deps.directory.get(principalId)) ??
         (await emailMembers()).find((member) => personKey(member.principalId) === personKey(principalId)) ??
-        null
+        domainMember(principalId)
       );
     },
     samePerson(a, b) {

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -549,6 +549,7 @@ export interface AppDeps {
   deliveries: DeliveryStore;
   directory: DirectoryStore;
   emailAuthMembers?: DirectoryMember[];
+  emailAuthDomain?: string;
   projects?: ProjectStore;
   deploy: DeployService;
   deploymentLayer?: DeploymentLayerRuntime;

--- a/src/api/routes/directory.ts
+++ b/src/api/routes/directory.ts
@@ -6,6 +6,15 @@ import { type ApiCtx, type Route } from "./route.ts";
 
 const numOrUndef = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
 
+async function principalStatus(ctx: ApiCtx): Promise<void> {
+  const { res, deps } = ctx;
+  if (!deps.identity) return sendJson(res, 404, { error: "not_found" });
+  const id = ctx.params.id!;
+  if (!id) return sendJson(res, 404, { error: "not_found" });
+  await deps.identity.refresh();
+  return sendJson(res, 200, { principalId: id, ...deps.identity.status(id) });
+}
+
 async function deactivatePrincipal(ctx: ApiCtx): Promise<void> {
   const { res, deps } = ctx;
   if (!deps.identity) return sendJson(res, 404, { error: "not_found" });
@@ -145,6 +154,7 @@ async function resolveDirectory(ctx: ApiCtx): Promise<void> {
 }
 
 export const directoryRoutes: ReadonlyArray<Route<ApiCtx>> = [
+  { method: "GET", path: "/v1/principals/:id/status", auth: "source", handle: principalStatus },
   { method: "POST", path: "/v1/principals/:id/deactivate", auth: "source", handle: deactivatePrincipal },
   { method: "POST", path: "/v1/principals/:id/reactivate", auth: "source", handle: reactivatePrincipal },
   { method: "POST", path: "/v1/directory", auth: "source", handle: pushDirectory },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -269,9 +269,11 @@ async function gate(
     const rawToken = req.headers[PORTAL_IDENTITY_HEADER];
     const token = Array.isArray(rawToken) ? rawToken[0] : rawToken;
     actor = token && psecret ? await verifyPortalIdentity(token, psecret, Date.now()) : null;
+    let inactiveActor = false;
     if (actor && deps.identity) {
       await deps.identity.refresh();
-      if (deps.identity.classify(actor.p).type !== "internal") actor = null;
+      inactiveActor = deps.identity.classify(actor.p).type !== "internal";
+      if (inactiveActor) actor = null;
     }
     if (!isPublicRoute && requirePortalIdentity) {
       const webTurn =
@@ -287,6 +289,14 @@ async function gate(
         isUnclassifiedWrite(method, pathname);
       if (needsActor) {
         if (!psecret || !actor) {
+          if (inactiveActor) {
+            sendJson(res, 401, {
+              error: "account_deactivated",
+              message: "account is deactivated",
+              reason: "deactivated",
+            });
+            return null;
+          }
           sendJson(res, 401, { error: "unauthorized", message: "portal identity required" });
           return null;
         }

--- a/src/api/user-scoped-routes.ts
+++ b/src/api/user-scoped-routes.ts
@@ -92,6 +92,7 @@ const SYSTEM: Rule[] = [
   pat("POST", "/v1/deliveries/:id/ack"),
   pat("POST", "/v1/deliveries/ack-by-key"),
   pat("POST", "/v1/directory"),
+  pat("GET", "/v1/principals/:id/status"),
   pat("POST", "/v1/principals/:id/deactivate"),
   pat("POST", "/v1/principals/:id/reactivate"),
   pat("POST", "/v1/surface-cache/ingest"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1060,6 +1060,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     ...(modelProvider ? { modelProvider } : {}),
     providerBaseUrls,
     ...(env.ADMIN_GRANTS ? { adminGrants: env.ADMIN_GRANTS } : {}),
+    ...(env.AUTH_ALLOWED_EMAIL_DOMAIN?.trim()
+      ? { emailAuthDomain: env.AUTH_ALLOWED_EMAIL_DOMAIN.trim().toLowerCase() }
+      : {}),
     ...(env.AUTH_ALLOWED_EMAILS
       ? {
           emailAuthPrincipals: [
@@ -1070,9 +1073,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
             ),
           ],
         }
-      : {}),
-    ...(env.AUTH_ALLOWED_EMAIL_DOMAIN?.trim()
-      ? { emailAuthDomain: env.AUTH_ALLOWED_EMAIL_DOMAIN.trim().toLowerCase() }
       : {}),
     ...(env.RESEND_API_KEY?.trim() ? { resendApiKey: env.RESEND_API_KEY.trim() } : {}),
     ...(env.AUTH_EMAIL_FROM?.trim() ? { emailFrom: env.AUTH_EMAIL_FROM.trim() } : {}),

--- a/src/identity/identity-service.ts
+++ b/src/identity/identity-service.ts
@@ -8,7 +8,7 @@ interface IdentityProvider {
   classify(externalId: string, isExternalGuest?: boolean): Principal;
 }
 
-export type DeactivationSource = "manual" | "directory-sync";
+type DeactivationSource = "manual" | "directory-sync";
 
 export interface DeactivationRecord {
   principalId: string;

--- a/src/identity/identity-service.ts
+++ b/src/identity/identity-service.ts
@@ -8,7 +8,7 @@ interface IdentityProvider {
   classify(externalId: string, isExternalGuest?: boolean): Principal;
 }
 
-type DeactivationSource = "manual" | "directory-sync";
+export type DeactivationSource = "manual" | "directory-sync";
 
 export interface DeactivationRecord {
   principalId: string;
@@ -33,11 +33,16 @@ export interface IdentityService extends IdentityProvider {
   removeExternalMember(principalId: string): Promise<void>;
   hydrate(): Promise<void>;
   refresh(force?: boolean): Promise<void>;
+  status(externalId: string): { active: boolean; source?: DeactivationSource };
 }
 
 export function createIdentityService(
   backing?: DurableMap<DeactivationRecord>,
-  opts: { directorySyncProtected?: readonly string[]; externalMembers?: DurableMap<ExternalMember> } = {},
+  opts: {
+    directorySyncProtected?: readonly string[];
+    directorySyncProtectedDomain?: string;
+    externalMembers?: DurableMap<ExternalMember>;
+  } = {},
 ): IdentityService {
   const store = backing ?? createMemoryMap<DeactivationRecord>();
   const externalStore = opts.externalMembers ?? createMemoryMap<ExternalMember>();
@@ -49,7 +54,12 @@ export function createIdentityService(
   let refreshP: Promise<void> | null = null;
   let hydrateP: Promise<void> | null = null;
 
-  const keptByDirectorySync = (key: string): boolean => directorySyncProtected.has(key) || externals.has(key);
+  const directorySyncProtectedDomain = opts.directorySyncProtectedDomain?.trim().toLowerCase();
+  const keptByDirectorySync = (key: string): boolean => {
+    if (directorySyncProtected.has(key) || externals.has(key)) return true;
+    const at = key.lastIndexOf("@");
+    return at > 0 && key.slice(at + 1) === directorySyncProtectedDomain;
+  };
 
   async function load(overwrite: boolean): Promise<void> {
     const [deactivations, members] = await Promise.all([store.all(), externalStore.all()]);
@@ -110,6 +120,12 @@ export function createIdentityService(
 
   return {
     classify,
+    status(externalId) {
+      const key = personKey(externalId);
+      if (classify(externalId).type === "internal") return { active: true };
+      const source = deactivated.get(key)?.source;
+      return { active: false, ...(source ? { source } : {}) };
+    },
     deactivate,
     reactivate,
     async recordDirectorySync(removedIds: string[], presentIds: string[]): Promise<DirectorySyncOutcome> {

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -457,6 +457,7 @@ export function buildApp(
   const identity = createIdentityService(artifactMap<DeactivationRecord>("deactivated_principals"), {
     directorySyncProtected: config.emailAuthPrincipals,
     externalMembers: artifactMap<ExternalMember>("external_members"),
+    directorySyncProtectedDomain: config.emailAuthDomain,
   });
   void identity.hydrate();
   const leaderLease: LeaderLease = pgArtifactMap
@@ -1345,6 +1346,7 @@ export function buildApp(
     webhooks,
     deliveries,
     directory,
+    ...(config.emailAuthDomain ? { emailAuthDomain: config.emailAuthDomain } : {}),
     ...(config.emailAuthPrincipals?.length
       ? {
           emailAuthMembers: config.emailAuthPrincipals.map((principalId) => ({

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,6 +27,10 @@ test("ORG_BRAND_* parses into a validated branding default", () => {
   assert.deepEqual(loadConfig({ ORG_BRAND_SELF_LABEL: "{{straylight}}" }).brandingDefault, { selfLabel: "straylight" });
 });
 
+test("AUTH_ALLOWED_EMAIL_DOMAIN becomes a normalized core identity boundary", () => {
+  assert.equal(loadConfig({ AUTH_ALLOWED_EMAIL_DOMAIN: " Example.COM " }).emailAuthDomain, "example.com");
+});
+
 test("AUTH_ALLOWED_EMAILS becomes a normalized email-auth principal set", () => {
   assert.equal(loadConfig({}).emailAuthPrincipals, undefined);
   assert.deepEqual(

--- a/test/identity-offboarding.test.ts
+++ b/test/identity-offboarding.test.ts
@@ -39,6 +39,7 @@ describe("offboarding: directory sync and the /v1/principals routes drive deacti
         dataDir: mkdtempSync(join(tmpdir(), "offboarding-")),
         signingSecret: SECRET,
         emailAuthPrincipals: ["allowed@example.com"],
+        emailAuthDomain: "example.com",
       }),
     );
     await built.identity.hydrate();
@@ -87,11 +88,28 @@ describe("offboarding: directory sync and the /v1/principals routes drive deacti
     );
   });
 
+  it("a domain-authorized email remains active and exactly resolvable after Slack omission", async () => {
+    await built.app.upsertDirectory([member("U-stay"), member("domain@example.com")]);
+    await built.app.upsertDirectory([member("U-stay")]);
+    assert.equal(built.identity.classify("domain@example.com").type, "internal");
+    const resolved = await built.app.resolveRecipient("domain@example.com");
+    assert.equal(resolved.kind, "one");
+    if (resolved.kind === "one") assert.equal(resolved.member.principalId, "domain@example.com");
+  });
+
   it("the deactivate/reactivate routes flip classification and are audited", async () => {
     const off = await signedPost("/v1/principals/U-manual/deactivate");
     assert.equal(off.status, 200);
     assert.deepEqual(await off.json(), { ok: true, principalId: "U-manual", active: false });
     assert.equal(built.identity.classify("U-manual").type, "guest");
+
+    const path = "/v1/principals/U-manual/status";
+    const ts = Math.floor(Date.now() / 1000);
+    const status = await fetch(`${base}${path}`, {
+      headers: { "x-timestamp": String(ts), "x-signature": signRequest(SECRET, ts, `GET\n${path}\n`) },
+    });
+    assert.equal(status.status, 200);
+    assert.deepEqual(await status.json(), { principalId: "U-manual", active: false, source: "manual" });
 
     await built.app.upsertDirectory([member("U-manual")]);
     assert.equal(built.identity.classify("U-manual").type, "guest");

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -146,3 +146,12 @@ test("a manual deactivation survives roster churn — only reactivate() clears i
   await svc.reactivate("U-fired");
   assert.equal(svc.classify("U-fired").type, "internal");
 });
+
+test("directory sync cannot deactivate an email admitted by the configured domain", async () => {
+  const svc = createIdentityService(undefined, { directorySyncProtectedDomain: "Example.COM" });
+  await svc.recordDirectorySync(["Person@example.com", "outsider@other.com"], []);
+  assert.equal(svc.classify("person@example.com").type, "internal");
+  assert.equal(svc.classify("outsider@other.com").type, "guest");
+  await svc.deactivate("person@example.com");
+  assert.equal(svc.classify("person@example.com").type, "guest", "manual deactivation remains authoritative");
+});

--- a/test/portal-identity-gate.test.ts
+++ b/test/portal-identity-gate.test.ts
@@ -32,6 +32,7 @@ describe("user-scoped routes require a portal-verified actor when enforcement is
       portalIdentitySecret: PID,
       requireSignedPortalIdentity: true,
       scheduler: built.scheduler,
+      identity: built.identity,
     });
     await new Promise<void>((resolve) => server.listen(0, resolve));
     base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -53,6 +54,21 @@ describe("user-scoped routes require a portal-verified actor when enforcement is
 
   it("rejects (403) when the portal identity names a different user than the viewer", async () => {
     assert.equal((await get({ "x-portal-identity": await token("U2") })).status, 403);
+  });
+
+  it("distinguishes a verified inactive principal from a missing portal identity", async () => {
+    await built.identity.deactivate("U1");
+    try {
+      const r = await get({ "x-portal-identity": await token("U1") });
+      assert.equal(r.status, 401);
+      assert.deepEqual(await r.json(), {
+        error: "account_deactivated",
+        message: "account is deactivated",
+        reason: "deactivated",
+      });
+    } finally {
+      await built.identity.reactivate("U1");
+    }
   });
 
   it("rejects (401) a portal identity forged with the source-auth secret (what a surface holds)", async () => {


### PR DESCRIPTION
Aligns core identity with the deployment's configured email-auth boundary, keeps a verified-but-inactive session distinct from an expired one in the API and UI, and adds supported operator commands to inspect and restore a principal.

- verification: focused core, CLI, and Web UI regressions pass; typecheck, lint, and formatting clean
- verification: live before/after run against a development build reproduces the old behavior and confirms the fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790890076&installation_model_id=19911&pr_number=895&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F895&signature=b0f69db3047c828973a0a04bf149c5090b0ecf15f73dcff979a5d87888cf707a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->