### PR TITLE
refactor: drop the unused core-search backend injection point

### DIFF
--- a/src/api/app-search.ts
+++ b/src/api/app-search.ts
@@ -112,12 +112,9 @@ function slackBackend(deps: AppDeps, app: App): SearchBackend | null {
 }
 export function createSearchMethods(deps: AppDeps, app: App): Pick<App, "search"> {
   const slack = slackBackend(deps, app);
-  const core = createCoreSearch(
-    [conversationBackend(app), ...(slack ? [slack] : []), fileBackend(app), ...(deps.searchBackends ?? [])],
-    {
-      onBackendError: (backend, error) =>
-        console.error(`[search] backend ${backend} failed:`, error instanceof Error ? error.message : String(error)),
-    },
-  );
+  const core = createCoreSearch([conversationBackend(app), ...(slack ? [slack] : []), fileBackend(app)], {
+    onBackendError: (backend, error) =>
+      console.error(`[search] backend ${backend} failed:`, error instanceof Error ? error.message : String(error)),
+  });
   return { search: (query, principals, limit) => core.search({ query, principals, limit }) };
 }

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -97,7 +97,7 @@ import type { ModelProviderAvailability } from "../model/pi-models.ts";
 import type { RuntimeChoice } from "../harness/harness-router.ts";
 import { type ReachOpts, type ReachResolution, type ReachTarget } from "../reach/reach.ts";
 import { type Project, type ProjectStore } from "../projects/project-store.ts";
-import type { SearchBackend, SearchHit } from "../search/core-search.ts";
+import type { SearchHit } from "../search/core-search.ts";
 
 interface DeploymentVersionView {
   version: number;
@@ -571,7 +571,6 @@ export interface AppDeps {
   modelProviders?: ModelProviderAvailability;
   providerKeys?: ModelProviderAvailability;
   runtimeFallback?: RuntimeChoice;
-  searchBackends?: readonly SearchBackend[];
 }
 
 export interface ContextSummary {

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -294,7 +294,6 @@ import { createPostgresMetricsSink } from "./admin/postgres-metrics-sink.ts";
 import { errMessage, swallowAs } from "./util/errors.ts";
 import { sleep } from "./util/async.ts";
 import { createSlackInstallationStore, type SlackInstallationStore } from "./surfaces/slack-installation.ts";
-import type { SearchBackend } from "./search/core-search.ts";
 
 export interface Runtime {
   start(): void;
@@ -404,7 +403,6 @@ export function buildApp(
     securityScreener?: SecurityScreener;
     credentialBrokers?: Record<string, AwsRoleBroker>;
     modelCredentialFetch?: typeof fetch;
-    searchBackends?: readonly SearchBackend[];
   } = {},
 ): BuiltApp {
   if (config.databaseUrl && !config.connectorSecretKey) {
@@ -1316,7 +1314,6 @@ export function buildApp(
     providerKeys,
     modelProviders: modelProviderAvailabilityFor(config.harness, providerKeys),
     runWaitMs: config.runWaitMs,
-    ...(overrides.searchBackends ? { searchBackends: overrides.searchBackends } : {}),
   });
   const slackCore = createSlackCoreClient({
     app,

--- a/test/core-search.test.ts
+++ b/test/core-search.test.ts
@@ -56,22 +56,22 @@ test("intersection backend requires visibility to every principal", async () => 
   );
 });
 test("POST /v1/search derives principals from capability and shared scopes fail closed", async () => {
-  const seen: string[][] = [];
-  const external: SearchBackend = {
-    name: "external",
-    async search(r) {
-      seen.push(r.principals.map((p) => p.id));
-      return [];
-    },
-  };
   const secret = "search-route-secret".repeat(3);
-  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "search-")), signingSecret: secret }), {
-    searchBackends: [external],
-  });
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "search-")), signingSecret: secret }));
   await built.directory.replaceChannels(
-    [{ channelId: "C1", name: "private", isPrivate: true }],
-    principals.map((p) => ({ channelId: "C1", principalId: p.id })),
+    [
+      { channelId: "C1", name: "private", isPrivate: true },
+      { channelId: "C-ALICE", name: "alice-only", isPrivate: true },
+    ],
+    [
+      ...principals.map((p) => ({ channelId: "C1", principalId: p.id })),
+      { channelId: "C-ALICE", principalId: principals[0]!.id },
+    ],
   );
+  await built.app.ingestSurfaceEvents([
+    { container: "C1", ts: "1", text: "pelican launch shared", kind: "channel" },
+    { container: "C-ALICE", ts: "2", text: "pelican launch private", kind: "channel" },
+  ]);
   const server = createServer(built.app, { signingSecret: secret, auditLog: built.auditLog });
   await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
   const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
@@ -89,16 +89,26 @@ test("POST /v1/search derives principals from capability and shared scopes fail 
     fetch(`${base}/v1/search`, {
       method: "POST",
       headers: { "content-type": "application/json", "x-agent-capability": cap },
-      body: JSON.stringify({ query: "plan" }),
+      body: JSON.stringify({ query: "pelican" }),
     });
   try {
-    assert.equal((await post(await token(principals))).status, 200);
-    assert.deepEqual(seen, [["alice@example.com", "bob@example.com"]]);
-    assert.equal((await post(await token())).status, 409);
-    assert.equal(seen.length, 1);
-    const event = (await built.auditLog.events()).find((e) => e.action === "search.query");
-    assert.ok(event);
-    assert.doesNotMatch(event.detail ?? "", /plan/);
+    const ok = await post(await token(principals));
+    assert.equal(ok.status, 200);
+    const body = (await ok.json()) as { hits: Array<{ id: string; backend: string }> };
+    assert.deepEqual(
+      body.hits.filter((hit) => hit.backend === "slack").map((hit) => hit.id),
+      ["C1:1"],
+      "a message only one participant can see is never returned to the shared conversation",
+    );
+
+    const missing = await post(await token());
+    assert.equal(missing.status, 409);
+    assert.equal(((await missing.json()) as { error: string }).error, "principal_set_unavailable");
+
+    const events = (await built.auditLog.events()).filter((e) => e.action === "search.query");
+    assert.equal(events.length, 1, "a fail-closed request runs no search and records none");
+    assert.match(events[0]!.detail ?? "", /"principals":\["alice@example.com","bob@example.com"\]/);
+    assert.doesNotMatch(events[0]!.detail ?? "", /pelican/, "query text is not copied into the audit log");
   } finally {
     await new Promise<void>((r) => server.close(() => r()));
   }


### PR DESCRIPTION
Removes the optional search backend injection point, which has no production caller now that external search sources are out of scope for core search.

The route test no longer injects a stand-in backend; it exercises the real backends against seeded data instead, so a message visible to only one participant is proven absent from a shared conversation's results.

- verification: focused search tests pass, and the visibility assertion fails when the intersection is reverted
- verification: 71 adjacent API, routing, memory, and visibility tests pass
- verification: typecheck, ESLint, Oxlint, and Prettier pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790899224&installation_model_id=19911&pr_number=896&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F896&signature=6a156ce4818cd876c0582fd9b2a7685afed6b109c833c7c8c138f0734f8a7981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->