### PR TITLE
Warn at boot when the docker deploy provider has no daemon

### DIFF
--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -14,11 +14,19 @@ export interface DockerDeployProviderOptions {
   dockerExec?: DockerExec;
 }
 
-export async function dockerDaemonUnreachable(opts: DockerDeployProviderOptions = {}): Promise<string | null> {
+export interface DockerDaemonProbeOptions {
+  docker?: string;
+  dockerExec?: DockerExec;
+}
+
+export async function dockerDaemonFailure(opts: DockerDaemonProbeOptions = {}): Promise<string | null> {
   const dexec = opts.dockerExec ?? spawnDockerExec(opts.docker ?? "docker");
   try {
     const r = await dexec(["version", "-f", "{{.Server.Version}}"], DAEMON_PROBE_TIMEOUT_MS);
-    return r.code === 0 ? null : r.stderr.trim() || `exit ${r.code}`;
+    if (r.code === 0) return null;
+    const stderr = r.stderr.trim();
+    if (stderr) return stderr;
+    return r.code < 0 ? `no response within ${DAEMON_PROBE_TIMEOUT_MS / 1000}s` : `exit ${r.code}`;
   } catch (e) {
     return errMessage(e);
   }

--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -1,15 +1,27 @@
 import type { Deployment, DeploymentVersion } from "./deploy-store.ts";
 import type { DeployEndpoint, DeployProvider } from "./deploy-provider.ts";
 import { spawnDockerExec, type DockerExec } from "../sandbox/docker-exec.ts";
+import { errMessage } from "../util/errors.ts";
 
 const APP_PORT = 8080;
 const LEGACY_NETWORK = "agent-deploynet";
+const DAEMON_PROBE_TIMEOUT_MS = 10_000;
 
 export interface DockerDeployProviderOptions {
   image?: string;
   docker?: string;
   basePort?: number;
   dockerExec?: DockerExec;
+}
+
+export async function dockerDaemonUnreachable(opts: DockerDeployProviderOptions = {}): Promise<string | null> {
+  const dexec = opts.dockerExec ?? spawnDockerExec(opts.docker ?? "docker");
+  try {
+    const r = await dexec(["version", "-f", "{{.Server.Version}}"], DAEMON_PROBE_TIMEOUT_MS);
+    return r.code === 0 ? null : r.stderr.trim() || `exit ${r.code}`;
+  } catch (e) {
+    return errMessage(e);
+  }
 }
 
 export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {}): DeployProvider {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { loadConfig } from "./config.ts";
 import { buildApp, serverDeps, stopWithBackstop } from "./wiring.ts";
 import { createServer } from "./api/server.ts";
+import { dockerDaemonFailure } from "./deploy/docker-deploy-provider.ts";
 import { errMessage } from "./util/errors.ts";
 import { slackPluginConfigFromEnv, startSlackPlugin } from "./slack/index.ts";
 import { createSlackRuntimeReconciler } from "./surfaces/slack-runtime.ts";
@@ -29,6 +30,15 @@ server.listen(config.port, () => {
       `runStore=${config.runStore}, workers=${config.workers}, backgroundWork=${config.backgroundWorkEnabled})`,
   );
 });
+
+if (config.deployProvider === "docker") {
+  void dockerDaemonFailure().then((failure) => {
+    if (failure)
+      console.warn(
+        `[qm] publishing is unavailable: the docker deploy provider is selected but no Docker daemon is reachable from core (${failure}) — make a daemon reachable, or set DEPLOY_PROVIDER to fly or aws`,
+      );
+  });
+}
 
 if (config.backgroundWorkEnabled) {
   built.scheduler.start(1000);

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -82,7 +82,7 @@ import { createPgBossCronQueue } from "./cron/job-queue.ts";
 import { createWebhookStore, disableLegacyWebhookRows } from "./webhooks/webhook-store.ts";
 import { createWebhookReceiver, type WebhookReceiver } from "./webhooks/webhook-receiver.ts";
 import { createDeployStore, type Deployment } from "./deploy/deploy-store.ts";
-import { createDockerDeployProvider, dockerDaemonUnreachable } from "./deploy/docker-deploy-provider.ts";
+import { createDockerDeployProvider } from "./deploy/docker-deploy-provider.ts";
 import { createAwsDeployProvider, type StoredDeployBody } from "./deploy/aws-deploy-provider.ts";
 import { createFlyDeployProvider } from "./deploy/fly-deploy-provider.ts";
 import type { DeployProvider } from "./deploy/deploy-provider.ts";
@@ -983,14 +983,6 @@ export function buildApp(
     if (config.deployProvider === "fly") return createFlyDeployProvider(config.flyDeploy);
     return createDockerDeployProvider();
   })();
-  if (config.deployProvider === "docker") {
-    void dockerDaemonUnreachable().then((reason) => {
-      if (reason)
-        console.warn(
-          `[wiring] docker deploy: DEPLOY_PROVIDER is docker (the default when unset) but no Docker daemon is reachable from core (${reason}) — every publish will fail until a daemon is reachable or DEPLOY_PROVIDER selects fly or aws`,
-        );
-    });
-  }
   if (config.deployProvider === "aws" && !config.awsDeploy.dataBucket && !config.awsSandbox.s3Bucket) {
     console.warn(
       "[wiring] aws deploy: no data bucket resolved (AWS_DEPLOY_DATA_BUCKET unset, sandbox is not aws) — deployed apps have NO durable /data",

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -82,7 +82,7 @@ import { createPgBossCronQueue } from "./cron/job-queue.ts";
 import { createWebhookStore, disableLegacyWebhookRows } from "./webhooks/webhook-store.ts";
 import { createWebhookReceiver, type WebhookReceiver } from "./webhooks/webhook-receiver.ts";
 import { createDeployStore, type Deployment } from "./deploy/deploy-store.ts";
-import { createDockerDeployProvider } from "./deploy/docker-deploy-provider.ts";
+import { createDockerDeployProvider, dockerDaemonUnreachable } from "./deploy/docker-deploy-provider.ts";
 import { createAwsDeployProvider, type StoredDeployBody } from "./deploy/aws-deploy-provider.ts";
 import { createFlyDeployProvider } from "./deploy/fly-deploy-provider.ts";
 import type { DeployProvider } from "./deploy/deploy-provider.ts";
@@ -983,6 +983,14 @@ export function buildApp(
     if (config.deployProvider === "fly") return createFlyDeployProvider(config.flyDeploy);
     return createDockerDeployProvider();
   })();
+  if (config.deployProvider === "docker") {
+    void dockerDaemonUnreachable().then((reason) => {
+      if (reason)
+        console.warn(
+          `[wiring] docker deploy: DEPLOY_PROVIDER is docker (the default when unset) but no Docker daemon is reachable from core (${reason}) — every publish will fail until a daemon is reachable or DEPLOY_PROVIDER selects fly or aws`,
+        );
+    });
+  }
   if (config.deployProvider === "aws" && !config.awsDeploy.dataBucket && !config.awsSandbox.s3Bucket) {
     console.warn(
       "[wiring] aws deploy: no data bucket resolved (AWS_DEPLOY_DATA_BUCKET unset, sandbox is not aws) — deployed apps have NO durable /data",

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createDockerDeployProvider } from "../src/deploy/docker-deploy-provider.ts";
+import { createDockerDeployProvider, dockerDaemonUnreachable } from "../src/deploy/docker-deploy-provider.ts";
 import { createDeployStore } from "../src/deploy/deploy-store.ts";
 import type { DockerExec } from "../src/sandbox/docker-exec.ts";
 import { scopeId } from "../src/types.ts";
@@ -143,4 +143,42 @@ test("a transient target inspection failure does not report the deployment missi
   const provider = createDockerDeployProvider({ dockerExec });
 
   await assert.rejects(provider.resolveEndpoint!(running, running.versions[0]!), /daemon unavailable/);
+});
+
+test("the daemon probe reports nothing when Docker answers", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    return { code: 0, stdout: "29.1.3\n", stderr: "" };
+  };
+
+  assert.equal(await dockerDaemonUnreachable({ dockerExec }), null);
+  assert.deepEqual(calls, [["version", "-f", "{{.Server.Version}}"]]);
+});
+
+test("the daemon probe reports why Docker is unreachable", async () => {
+  const dockerExec: DockerExec = async () => ({
+    code: 1,
+    stdout: "",
+    stderr: "dial unix /var/run/docker.sock: connect: no such file or directory\n",
+  });
+
+  assert.equal(
+    await dockerDaemonUnreachable({ dockerExec }),
+    "dial unix /var/run/docker.sock: connect: no such file or directory",
+  );
+});
+
+test("the daemon probe reports a failed probe rather than throwing", async () => {
+  const dockerExec: DockerExec = async () => {
+    throw new Error("spawn docker ENOENT");
+  };
+
+  assert.equal(await dockerDaemonUnreachable({ dockerExec }), "spawn docker ENOENT");
+});
+
+test("the daemon probe reports the exit code when Docker is silent", async () => {
+  const dockerExec: DockerExec = async () => ({ code: 7, stdout: "", stderr: "" });
+
+  assert.equal(await dockerDaemonUnreachable({ dockerExec }), "exit 7");
 });

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createDockerDeployProvider, dockerDaemonUnreachable } from "../src/deploy/docker-deploy-provider.ts";
+import { createDockerDeployProvider, dockerDaemonFailure } from "../src/deploy/docker-deploy-provider.ts";
 import { createDeployStore } from "../src/deploy/deploy-store.ts";
 import type { DockerExec } from "../src/sandbox/docker-exec.ts";
 import { scopeId } from "../src/types.ts";
@@ -152,7 +152,7 @@ test("the daemon probe reports nothing when Docker answers", async () => {
     return { code: 0, stdout: "29.1.3\n", stderr: "" };
   };
 
-  assert.equal(await dockerDaemonUnreachable({ dockerExec }), null);
+  assert.equal(await dockerDaemonFailure({ dockerExec }), null);
   assert.deepEqual(calls, [["version", "-f", "{{.Server.Version}}"]]);
 });
 
@@ -164,7 +164,7 @@ test("the daemon probe reports why Docker is unreachable", async () => {
   });
 
   assert.equal(
-    await dockerDaemonUnreachable({ dockerExec }),
+    await dockerDaemonFailure({ dockerExec }),
     "dial unix /var/run/docker.sock: connect: no such file or directory",
   );
 });
@@ -174,11 +174,17 @@ test("the daemon probe reports a failed probe rather than throwing", async () =>
     throw new Error("spawn docker ENOENT");
   };
 
-  assert.equal(await dockerDaemonUnreachable({ dockerExec }), "spawn docker ENOENT");
+  assert.equal(await dockerDaemonFailure({ dockerExec }), "spawn docker ENOENT");
 });
 
 test("the daemon probe reports the exit code when Docker is silent", async () => {
   const dockerExec: DockerExec = async () => ({ code: 7, stdout: "", stderr: "" });
 
-  assert.equal(await dockerDaemonUnreachable({ dockerExec }), "exit 7");
+  assert.equal(await dockerDaemonFailure({ dockerExec }), "exit 7");
+});
+
+test("the daemon probe reports a hung daemon as a timeout", async () => {
+  const dockerExec: DockerExec = async () => ({ code: -1, stdout: "", stderr: "" });
+
+  assert.equal(await dockerDaemonFailure({ dockerExec }), "no response within 10s");
 });


### PR DESCRIPTION
Warn once at core startup when the deploy provider is docker but no Docker daemon is reachable, instead of surfacing a bare socket error at the first publish. The probe runs off the boot path and never blocks startup.

- verification: `npx tsx --test test/docker-deploy-provider.test.ts` (9/9), adjacent deploy tests pass
- verification: `npm run typecheck`, eslint, prettier clean
- verification: live core boot with the daemon stopped warns with the reason and starts normally; no warning when it is reachable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790900063&installation_model_id=19911&pr_number=897&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F897&signature=cf449fdee64ea75f346ae89931244bfee83bcce3b27e95b2855f73084b006706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->