### PR TITLE
fix: sanitize the failure text stored on a failed run

### DIFF
--- a/src/runs/worker.ts
+++ b/src/runs/worker.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { TurnResult } from "../types.ts";
 import type { Orchestrator } from "../core/orchestrator.ts";
-import { NonRetryableTurnError } from "../core/turn-error.ts";
+import { NonRetryableTurnError, turnFailureMessage } from "../core/turn-error.ts";
 import { resolveTurnOrigin } from "../core/turn-origin.ts";
 import { errorParks, type Run, type RunStore } from "./run-store.ts";
 import type { SessionStore } from "../sessions/session-store.ts";
@@ -74,7 +74,10 @@ export async function processRun(deps: ProcessDeps, run: Run, opts?: { backgroun
     return result;
   } catch (err) {
     stopBeat();
-    await deps.runs.fail(run.id, token, errMessage(err), {
+    // The stored reason is the run's user-facing failure text: it reaches the web
+    // thread, Slack, and trigger notices verbatim. Sanitize it exactly as the durable
+    // transcript does; the raw error still propagates to the caller and the error log.
+    await deps.runs.fail(run.id, token, turnFailureMessage(err), {
       retry: !(err instanceof NonRetryableTurnError),
     });
     throw err;

--- a/test/process-run.test.ts
+++ b/test/process-run.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createMemoryRunStore } from "../src/runs/memory-run-store.ts";
 import { processRun, LEASE_LOST_CONSECUTIVE } from "../src/runs/worker.ts";
-import { NonRetryableTurnError } from "../src/core/turn-error.ts";
+import { NonRetryableTurnError, turnFailureMessage } from "../src/core/turn-error.ts";
 import type { RunStore } from "../src/runs/run-store.ts";
 import type { Orchestrator, OrchestratorInput } from "../src/core/orchestrator.ts";
 import type { Principal, TurnResult } from "../src/types.ts";
@@ -376,6 +376,35 @@ test("the heartbeat stops before complete(), so a late tick cannot spuriously ab
     "no beat fires after the terminal write — the interval was stopped first",
   );
   assert.equal((await runs.get(run!.id))?.status, "done", "the run completed normally, not aborted");
+});
+
+test("a parked run stores the sanitized turn-failure text, not the raw error", async () => {
+  const { runs } = createMemoryRunStore();
+  const internal = new Error("remaining connection slots are reserved for non-replication superuser connections");
+  const orchestrator = fakeOrchestrator(async () => {
+    throw internal;
+  });
+
+  await runs.enqueue({ sessionId: "s1", request: turn, maxAttempts: 1 });
+  const run = await runs.claim("w1", 5_000);
+  await assert.rejects(
+    processRun({ runs, orchestrator, leaseTtlMs: 5_000 }, run!),
+    /connection slots/,
+    "the raw error still reaches the caller and the operator error log",
+  );
+
+  const parked = await runs.get(run!.id);
+  assert.equal(parked?.status, "failed");
+  assert.equal(
+    parked?.result?.reason,
+    turnFailureMessage(internal),
+    "the stored reason is the same text the durable transcript shows",
+  );
+  assert.doesNotMatch(
+    parked?.result?.reason ?? "",
+    /connection slots/,
+    "internal error detail never reaches a client surface",
+  );
 });
 
 test("a NonRetryableTurnError parks the run even with attempts remaining", async () => {

--- a/test/refusal-admin-link-integration.test.ts
+++ b/test/refusal-admin-link-integration.test.ts
@@ -121,4 +121,5 @@ test("a failed turn surfaces a refusal whose admin link points at the real sessi
   assert.match(note, new RegExp(`Full error: ${ADMIN}/admin/history\\?session=${session!.id}`));
   assert.doesNotMatch(note, /ch:C_UUID_FIXTURE/, "the link must not contain the threadRef");
   assert.doesNotMatch(note, /fully-internal/, "a turn failure is not a boundary refusal");
+  assert.doesNotMatch(note, /boom/, "the internal error text is not relayed to the channel");
 });


### PR DESCRIPTION
A failed run stored the raw thrown error as its user-facing reason, so clients rendered internal error text even though the durable transcript already replaces it with a generic message — the same failure changed wording on reload. The stored reason now goes through the existing `turnFailureMessage` helper: one conversion from internal error to user-facing text, shared by every surface. The raw error still reaches the caller and the operator error log.

- new regression test fails without the change
- verified over HTTP: `GET /v1/runs/:id` no longer carries internal error text
- `tsc`, `eslint`, `oxlint`, `prettier`, tests green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790909831&installation_model_id=19911&pr_number=898&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F898&signature=f697130dfa1658807ba167d42f8a4f3a2eb62f1922e996be5a81d4cf5ddf3cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->