### PR TITLE
feat: authorize MCP tools per turn

### DIFF
--- a/src/api/routes/admin/mcp-servers.ts
+++ b/src/api/routes/admin/mcp-servers.ts
@@ -37,7 +37,7 @@ export async function getMcpServers(ctx: ApiCtx): Promise<void> {
   const servers = await ctx.deps.mcpServers.list();
   return sendJson(ctx.res, 200, {
     servers: servers.map(redact),
-    tools: ctx.deps.mcpToolService?.toolDefs().map(({ name, serverId, description, readOnly }) => ({
+    tools: ctx.deps.mcpToolService?.allToolDefs().map(({ name, serverId, description, readOnly }) => ({
       name,
       serverId,
       description,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1833,6 +1833,24 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             `[orchestrator] trigger delivery has no surface tools (missing deliveries store?) — reply would be lost session=${session.id}`,
           );
 
+        const mcpContext = {
+          principalId: actor.id,
+          scopeId,
+          ...(input.runId ? { runId: input.runId } : {}),
+        };
+        const mcpToolDefs = deps.mcp
+          ? await deps.mcp.toolDefs(mcpContext).catch(() => {
+              deps.auditLog.record({
+                at: Date.now(),
+                principalId: actor.id,
+                action: "mcp.discover",
+                resource: "policy",
+                scopeLabel: scopeId,
+                status: "error",
+              });
+              return [];
+            })
+          : [];
         const tools = createToolContext({
           sandbox: deps.sandbox,
           provision,
@@ -2004,6 +2022,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           memoryScopeId,
           ...(memoryAccess ? { memoryAccess } : {}),
           ...(deps.mcp ? { mcp: deps.mcp } : {}),
+          ...(deps.mcp ? { mcpContext, mcpToolDefs } : {}),
           sessionHistory: {
             search: async (q: string, limit?: number) =>
               searchSessionEntries(
@@ -2548,6 +2567,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             systemCacheBoundary: stableSystemBytes,
             history: continuation?.history ?? history,
             tools,
+            mcpToolDefs,
             ...(tools.credentialExecServices ? { credentialExecServices: tools.credentialExecServices } : {}),
             ...(securityPolicy.inboundScreening === "external" &&
             (deps.securityScreener || deps.harness.models.screenSecurity)

--- a/src/deployment/load-layer.ts
+++ b/src/deployment/load-layer.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   compileApproval,
   parseToolDescriptor,
@@ -10,6 +11,12 @@ import {
 import { credentialServiceForPath } from "../credentials/resident-paths.ts";
 import type { ResidentAuthConnector } from "../credentials/resident-auth.ts";
 import type { CommandRule } from "../types.ts";
+import type {
+  McpAuthorization,
+  McpAuthorizationTarget,
+  McpAuthorizer,
+  McpCallContext,
+} from "../mcp/mcp-tool-service.ts";
 
 export interface DeploymentLayerRuntime {
   dir: string;
@@ -42,6 +49,52 @@ export function emptyDeploymentLayer(): DeploymentLayerRuntime {
     commandRules: [],
     brokeredTools: [],
   };
+}
+
+function authorizationResult(value: unknown): McpAuthorization {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    typeof (value as { allowed?: unknown }).allowed !== "boolean"
+  ) {
+    throw new Error("deployment layer MCP authorizer must return an object with boolean allowed");
+  }
+  const result = value as Record<string, unknown>;
+  if (result.authorization !== undefined && typeof result.authorization !== "string") {
+    throw new Error("deployment layer MCP authorizer authorization must be a string");
+  }
+  if (
+    result.headers !== undefined &&
+    (!result.headers ||
+      typeof result.headers !== "object" ||
+      Array.isArray(result.headers) ||
+      Object.values(result.headers).some((header) => typeof header !== "string"))
+  ) {
+    throw new Error("deployment layer MCP authorizer headers must be an object of string values");
+  }
+  return {
+    allowed: result.allowed as boolean,
+    ...(typeof result.authorization === "string" ? { authorization: result.authorization } : {}),
+    ...(result.headers ? { headers: result.headers as Record<string, string> } : {}),
+  };
+}
+
+export async function loadMcpLayerAuthorizer(dir: string): Promise<McpAuthorizer | undefined> {
+  const path = join(dir, "mcp-policy.mjs");
+  if (!existsSync(path)) return undefined;
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`${path} must be a regular file`);
+  const loaded = (await import(pathToFileURL(path).href)) as { authorizeMcp?: unknown };
+  if (typeof loaded.authorizeMcp !== "function") {
+    throw new Error(`${path} must export async function authorizeMcp(context, target)`);
+  }
+  const authorize = loaded.authorizeMcp as (
+    context: Readonly<McpCallContext>,
+    target: Readonly<McpAuthorizationTarget>,
+  ) => Promise<unknown>;
+  return async (context, target) =>
+    authorizationResult(await authorize(Object.freeze({ ...context }), Object.freeze({ ...target })));
 }
 
 function assertDisjointCredentialLinks(tools: ToolDescriptor[]): void {

--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -40,7 +40,7 @@ import {
   renderDetectPrompt,
 } from "./pi-harness.ts";
 import { coreToolOptions, createPiTools, type PiToolsOptions, type ToolContextRef } from "./pi-tools.ts";
-import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
+import { mcpToolsForTurn, type McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import { reconstructMessagesFromHistory, seedPriorTurns, type PiReplayMessage } from "./replay.ts";
 
 export interface ClaudeHarnessOptions {
@@ -207,11 +207,12 @@ class MessageQueue implements AsyncIterable<SDKUserMessage> {
 }
 
 function toolOptions(opts: ClaudeHarnessOptions, turn?: HarnessTurnInput): PiToolsOptions {
+  const mcpTools = mcpToolsForTurn(turn?.mcpToolDefs, opts.mcpTools);
   return {
     scratchExec: opts.scratchExec,
     ownerAuthExec: opts.ownerAuthExec,
     reachExec: opts.reachExec,
-    ...(opts.mcpTools ? { mcpTools: opts.mcpTools } : {}),
+    ...(mcpTools ? { mcpTools } : {}),
     controlTools: opts.controlTools,
     execTimeoutMs: opts.execTimeoutMs,
     execTimeoutCeilingMs: opts.execTimeoutCeilingMs,

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -23,7 +23,7 @@ import {
 } from "./codex-auth-store.ts";
 import { defineHarness, type Harness, type HarnessTurnInput, type HarnessTurnResult } from "./harness.ts";
 import { coreToolOptions, createPiTools, type PiToolsOptions, type ToolContextRef } from "./pi-tools.ts";
-import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
+import { mcpToolsForTurn, type McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import { reconstructMessagesFromHistory, seedPriorTurns, type PiReplayMessage } from "./replay.ts";
 
 export interface CodexHarnessOptions {
@@ -317,11 +317,12 @@ async function transitionTask(
 }
 
 function toolOptions(opts: CodexHarnessOptions, turn?: HarnessTurnInput): PiToolsOptions {
+  const mcpTools = mcpToolsForTurn(turn?.mcpToolDefs, opts.mcpTools);
   return {
     scratchExec: opts.scratchExec,
     ownerAuthExec: opts.ownerAuthExec,
     reachExec: opts.reachExec,
-    ...(opts.mcpTools ? { mcpTools: opts.mcpTools } : {}),
+    ...(mcpTools ? { mcpTools } : {}),
     controlTools: opts.controlTools,
     execTimeoutMs: opts.execTimeoutMs,
     execTimeoutCeilingMs: opts.execTimeoutCeilingMs,

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -12,6 +12,7 @@ export type { GapWork } from "../sessions/session-store.ts";
 import type { OverheardEntryPayload } from "./replay.ts";
 import type { ProviderKeys } from "./pi-harness.ts";
 import type { ToolContext } from "../tools/primitives.ts";
+import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import type { SecurityScreenVerdict } from "../security/security-posture.ts";
 
 interface HarnessImage {
@@ -83,6 +84,7 @@ export interface HarnessTurnInput {
   systemCacheBoundary?: number;
   history: SessionEntry[];
   tools: ToolContext;
+  mcpToolDefs?: readonly McpToolDescriptor[];
   credentialExecServices?: readonly { service: string; binary: string }[];
   screenExternalContent?(input: {
     content: string;

--- a/src/harness/opencode-harness.ts
+++ b/src/harness/opencode-harness.ts
@@ -26,7 +26,7 @@ import {
   type HarnessTurnResult,
 } from "./harness.ts";
 import { coreToolOptions, createPiTools, type PiToolsOptions, type ToolContextRef } from "./pi-tools.ts";
-import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
+import { mcpToolsForTurn, type McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import { reconstructMessagesFromHistory } from "./replay.ts";
 import { parseSecurityScreenVerdict, SECURITY_SCREEN_SYSTEM_PROMPT } from "../security/security-posture.ts";
 import { countTokens } from "../util/tokens.ts";
@@ -107,11 +107,12 @@ type Runtime = {
 };
 
 function toolOptions(opts: OpenCodeHarnessOptions, turn?: HarnessTurnInput): PiToolsOptions {
+  const mcpTools = mcpToolsForTurn(turn?.mcpToolDefs, opts.mcpTools);
   return {
     scratchExec: opts.scratchExec,
     ownerAuthExec: opts.ownerAuthExec,
     reachExec: opts.reachExec,
-    ...(opts.mcpTools ? { mcpTools: opts.mcpTools } : {}),
+    ...(mcpTools ? { mcpTools } : {}),
     controlTools: opts.controlTools,
     execTimeoutMs: opts.execTimeoutMs,
     execTimeoutCeilingMs: opts.execTimeoutCeilingMs,

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -62,7 +62,7 @@ import {
   type GapWork,
 } from "./harness.ts";
 import { coreToolOptions, createPiTools, pauseStampAfterToolCall, type ToolContextRef } from "./pi-tools.ts";
-import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
+import { mcpToolsForTurn, type McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import { startSignalPoll, type RunSignalStore } from "../runs/run-signal-store.ts";
 import {
   planColdStartSeed,
@@ -1286,6 +1286,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
     tapeFold?: unknown[],
     tape?: HarnessTurnInput["tape"],
     turnProviderKeys?: ProviderKeys,
+    turnMcpTools?: readonly McpToolDescriptor[],
   ): Promise<{ entry: TurnSession; compileMs: number; tapeWriteFailed: boolean }> {
     const compileStart = Date.now();
     const cacheBoundary =
@@ -1326,6 +1327,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
 
     const model = getRequiredModel(resolveModelId(turnScope));
     const modelRuntime = await buildModelRuntime(turnProviderKeys ?? (await resolveProviderKeys()));
+    const availableMcpTools = mcpToolsForTurn(turnMcpTools, mcpTools);
     const ref: ToolContextRef = { current: null };
     const { resourceLoader, cwd, agentDir } = await createIsolatedResources(tempDirPrefix, composedPrompt);
     const compileMs = Date.now() - compileStart;
@@ -1340,7 +1342,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           scratchExec,
           ownerAuthExec,
           reachExec,
-          ...(mcpTools ? { mcpTools } : {}),
+          ...(availableMcpTools ? { mcpTools: availableMcpTools } : {}),
           controlTools,
           ...(credentialExecServices?.length ? { credentialExecServices } : {}),
           ...(surfaceTools ? { surfaceTools: true } : {}),
@@ -1505,6 +1507,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
           turn.tapeFold,
           turn.tape,
           turn.providerKeys,
+          turn.mcpToolDefs,
         );
         try {
           const turnWallClockMs = turn.turnWallClockMs ?? defaultTurnWallClockMs;

--- a/src/harness/pi-tools.ts
+++ b/src/harness/pi-tools.ts
@@ -2820,11 +2820,11 @@ export function createPiTools(ref: ToolContextRef, opts?: PiToolsOptions): ToolD
               d.name,
               `mcp server ${d.serverId}`,
             );
-          } catch (error) {
+          } catch {
             return recordResult(
               callId,
               { tool: d.name, mcpServer: d.serverId, failed: true },
-              text(`[error] ${errMessage(error)}`),
+              text("[error] MCP tool call failed"),
               true,
             );
           }

--- a/src/mcp/mcp-client.ts
+++ b/src/mcp/mcp-client.ts
@@ -111,7 +111,7 @@ export interface McpClient {
   readonly base: string;
   readonly host: string;
   listTools(): Promise<McpRemoteTool[]>;
-  callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult>;
+  callTool(name: string, args: Record<string, unknown>, headers?: Record<string, string>): Promise<McpToolResult>;
 }
 
 interface CachedToken {
@@ -159,12 +159,17 @@ export function createMcpClient(opts: {
     return { authorization: `Bearer ${await mintToken(auth.clientId, auth.clientSecret)}` };
   }
 
-  async function rpc(method: string, params: Record<string, unknown>): Promise<unknown> {
+  async function rpc(
+    method: string,
+    params: Record<string, unknown>,
+    headers?: Record<string, string>,
+  ): Promise<unknown> {
     const id = ++rpcId;
     const res = await fetchImpl(`${base}/mcp`, {
       method: "POST",
       headers: {
         ...(await authHeaders()),
+        ...headers,
         "content-type": "application/json",
         accept: MCP_ACCEPT,
       },
@@ -198,8 +203,8 @@ export function createMcpClient(opts: {
       }
       return out;
     },
-    async callTool(name, args) {
-      const result = (await rpc("tools/call", { name, arguments: args })) as McpToolResult;
+    async callTool(name, args, headers) {
+      const result = (await rpc("tools/call", { name, arguments: args }, headers)) as McpToolResult;
       if (result.isError) throw new Error(`mcp tool ${name} error: ${mcpResultText(result) || "(no detail)"}`);
       return result;
     },

--- a/src/mcp/mcp-tool-service.ts
+++ b/src/mcp/mcp-tool-service.ts
@@ -7,7 +7,6 @@
 // other or with built-in tools.
 
 import type { AuditLog } from "../audit/audit-log.ts";
-import { errMessage } from "../util/errors.ts";
 import { createMcpClient, mcpResultText, type McpAuth, type McpClient, type McpFetch } from "./mcp-client.ts";
 import type { McpServer, McpServerStore } from "./mcp-server-store.ts";
 
@@ -25,17 +24,49 @@ export interface McpToolDescriptor {
   readOnly: boolean;
 }
 
+export function mcpToolsForTurn(
+  turnTools: readonly McpToolDescriptor[] | undefined,
+  fallback?: () => McpToolDescriptor[],
+): (() => McpToolDescriptor[]) | undefined {
+  return turnTools === undefined ? fallback : () => [...turnTools];
+}
+
 export interface McpToolService {
   /** Current snapshot of injectable tools across enabled servers. */
-  toolDefs(): McpToolDescriptor[];
+  toolDefs(context?: McpCallContext): Promise<McpToolDescriptor[]>;
+  /** Current unfiltered snapshot for privileged connector administration. */
+  allToolDefs(): McpToolDescriptor[];
   /** Call a namespaced tool. Returns the tool's text output (clamped). */
-  call(name: string, args: Record<string, unknown>, principalId?: string): Promise<string>;
+  call(name: string, args: Record<string, unknown>, context?: McpCallContext | string): Promise<string>;
   /** Force a registry re-read + tools/list refresh (admin save path, tests). */
   refresh(): Promise<void>;
   /** Probe a server config without persisting it. Returns its tool names. */
   probe(server: McpServer): Promise<string[]>;
   close(): void;
 }
+
+export interface McpCallContext {
+  principalId: string;
+  scopeId: string;
+  runId?: string;
+}
+
+export interface McpAuthorizationTarget {
+  action: "discover" | "call";
+  serverId: string;
+  toolName: string;
+}
+
+export interface McpAuthorization {
+  allowed: boolean;
+  authorization?: string;
+  headers?: Record<string, string>;
+}
+
+export type McpAuthorizer = (
+  context: Readonly<McpCallContext>,
+  target: Readonly<McpAuthorizationTarget>,
+) => Promise<McpAuthorization>;
 
 function authOf(server: McpServer): McpAuth {
   if (server.auth === "bearer") return { mode: "bearer", token: server.bearerToken ?? "" };
@@ -50,6 +81,7 @@ export function createMcpToolService(opts: {
   fetchImpl?: McpFetch;
   now?: () => number;
   refreshIntervalMs?: number;
+  authorize?: McpAuthorizer;
 }): McpToolService {
   const now = opts.now ?? (() => Date.now());
   const clients = new Map<string, { client: McpClient; server: McpServer }>();
@@ -80,6 +112,73 @@ export function createMcpToolService(opts: {
     return client;
   }
 
+  function contextFor(context: McpCallContext | string | undefined): McpCallContext | undefined {
+    if (!context || typeof context === "string") return undefined;
+    if (
+      typeof context.principalId !== "string" ||
+      !context.principalId.trim() ||
+      typeof context.scopeId !== "string" ||
+      !context.scopeId.trim() ||
+      (context.runId !== undefined && (typeof context.runId !== "string" || !context.runId.trim()))
+    ) {
+      return undefined;
+    }
+    return Object.freeze({
+      principalId: context.principalId,
+      scopeId: context.scopeId,
+      ...(context.runId ? { runId: context.runId } : {}),
+    });
+  }
+
+  async function authorize(
+    context: McpCallContext | undefined,
+    target: McpAuthorizationTarget,
+  ): Promise<McpAuthorization | null> {
+    if (!opts.authorize) return { allowed: true };
+    if (!context) return null;
+    let decision: McpAuthorization;
+    try {
+      decision = await opts.authorize(context, Object.freeze({ ...target }));
+    } catch {
+      throw new Error("MCP authorization failed");
+    }
+    return decision.allowed ? decision : null;
+  }
+
+  function callHeaders(server: McpServer, decision: McpAuthorization): Record<string, string> {
+    const headers: Record<string, string> = {};
+    for (const [name, value] of Object.entries(decision.headers ?? {})) {
+      const normalized = name.toLowerCase();
+      if (!/^[!#$%&'*+.^_`|~0-9a-z-]+$/.test(normalized) || /[\r\n]/.test(value)) {
+        throw new Error("MCP authorization returned an invalid header");
+      }
+      if (
+        [
+          "authorization",
+          "content-type",
+          "accept",
+          "host",
+          "content-length",
+          "connection",
+          "transfer-encoding",
+        ].includes(normalized)
+      ) {
+        throw new Error(`MCP authorization cannot set reserved header ${normalized}`);
+      }
+      headers[normalized] = value;
+    }
+    if (decision.authorization !== undefined) {
+      if (!decision.authorization || /[\r\n]/.test(decision.authorization)) {
+        throw new Error("MCP authorization returned an invalid authorization value");
+      }
+      if (server.auth !== "none") {
+        throw new Error("MCP authorization cannot add authorization to a statically authenticated MCP server");
+      }
+      headers.authorization = decision.authorization;
+    }
+    return headers;
+  }
+
   async function refresh(): Promise<void> {
     const servers = (await opts.servers.list()).filter((s) => s.enabled);
     const next: McpToolDescriptor[] = [];
@@ -97,8 +196,8 @@ export function createMcpToolService(opts: {
           });
         }
         record("list", server.id, `ok tools=${tools.length}`);
-      } catch (e) {
-        record("list", server.id, `error: ${errMessage(e)}`);
+      } catch {
+        record("list", server.id, "error");
       }
     }
     // De-duplicate on the namespaced name; first server wins deterministically.
@@ -116,19 +215,51 @@ export function createMcpToolService(opts: {
   void refresh();
 
   return {
-    toolDefs: () => snapshot,
-    async call(name, args, principalId) {
+    allToolDefs: () => snapshot,
+    async toolDefs(context) {
+      const callContext = contextFor(context);
+      if (opts.authorize && !callContext) return [];
+      const allowed = await Promise.all(
+        snapshot.map(async (def) => {
+          const decision = await authorize(callContext, {
+            action: "discover",
+            serverId: def.serverId,
+            toolName: def.remoteName,
+          });
+          return decision ? def : null;
+        }),
+      );
+      return allowed.filter((def): def is McpToolDescriptor => def !== null);
+    },
+    async call(name, args, context) {
+      const callContext = contextFor(context);
       const def = snapshot.find((t) => t.name === name);
       if (!def) throw new Error(`unknown MCP tool: ${name}`);
       const server = await opts.servers.get(def.serverId);
       if (!server || !server.enabled) throw new Error(`MCP server ${def.serverId} is not available`);
       try {
-        const result = await clientFor(server).callTool(def.remoteName, args);
-        record("call", `${def.serverId}/${def.remoteName}`, "ok", principalId);
+        const decision = await authorize(callContext, {
+          action: "call",
+          serverId: def.serverId,
+          toolName: def.remoteName,
+        });
+        if (!decision) throw new Error("MCP tool is not authorized for this context");
+        const result = await clientFor(server).callTool(def.remoteName, args, callHeaders(server, decision));
+        record(
+          "call",
+          `${def.serverId}/${def.remoteName}`,
+          "ok",
+          callContext?.principalId ?? (typeof context === "string" ? context : undefined),
+        );
         const text = mcpResultText(result) || JSON.stringify(result.structuredContent ?? "") || "";
         return text.length > MAX_RESULT_CHARS ? `${text.slice(0, MAX_RESULT_CHARS)}\n[truncated]` : text;
       } catch (e) {
-        record("call", `${def.serverId}/${def.remoteName}`, `error: ${errMessage(e)}`, principalId);
+        record(
+          "call",
+          `${def.serverId}/${def.remoteName}`,
+          "error",
+          callContext?.principalId ?? (typeof context === "string" ? context : undefined),
+        );
         throw e;
       }
     },

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -43,7 +43,7 @@ import { swallow } from "../util/errors.ts";
 import { fileArtifactId, isArtifactPath, type FileArtifactStore } from "../files/file-artifact-store.ts";
 import type { ScopedConfigStore } from "../resolution/config-store.ts";
 import { MEMORY_FILE, type MemoryService } from "../memory/memory-service.ts";
-import type { McpToolService, McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
+import type { McpCallContext, McpToolService, McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
 import type { ReachResolution } from "../resolution/scope-reach.ts";
 import type {
   ControlService,
@@ -411,6 +411,8 @@ export interface ToolContextDeps {
   memoryScopeId?: ScopeId;
   memoryAccess?: { write?: ScopeId; read: ScopeId[] };
   mcp?: McpToolService;
+  mcpContext?: McpCallContext;
+  mcpToolDefs?: readonly McpToolDescriptor[];
   sessionHistory?: { search(q: string, limit?: number): Promise<string[]> };
   actingSlackUserId?: string;
   layerAuth?: {
@@ -917,12 +919,12 @@ export function createToolContext(deps: ToolContextDeps): ToolContext {
     },
 
     mcpToolDefs(): McpToolDescriptor[] {
-      return deps.mcp?.toolDefs() ?? [];
+      return [...(deps.mcpToolDefs ?? [])];
     },
 
     async callMcpTool(name: string, args: Record<string, unknown>): Promise<string> {
       if (!deps.mcp) throw new Error("no MCP connectors are configured");
-      return deps.mcp.call(name, args, deps.createdBy);
+      return deps.mcp.call(name, args, deps.mcpContext ?? deps.createdBy);
     },
 
     async backgroundStart(command: string, opts?: { ttlSeconds?: number }): Promise<BackgroundStartResult> {

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -278,6 +278,7 @@ import { createAwsRoleBroker, type AwsRoleBroker } from "./auth/aws-role-broker.
 import {
   emptyDeploymentLayer,
   loadDeploymentLayer,
+  loadMcpLayerAuthorizer,
   type BrokeredLayerTool,
   type DeploymentLayerRuntime,
 } from "./deployment/load-layer.ts";
@@ -503,6 +504,7 @@ export function buildApp(
   const deploymentLayer = config.deploymentLayerDir
     ? loadDeploymentLayer(config.deploymentLayerDir)
     : emptyDeploymentLayer();
+  const mcpAuthorizer = config.deploymentLayerDir ? loadMcpLayerAuthorizer(config.deploymentLayerDir) : undefined;
   const layerSkillsDir = config.deploymentLayerDir ? resolve(deploymentLayer.dir, "skills") : undefined;
   const brokeredTools = deploymentLayer.brokeredTools;
   const orgScope = scopeId("org", config.orgId);
@@ -535,7 +537,7 @@ export function buildApp(
         }
       : {}),
   });
-  const deploymentLayerReady = deploymentLayerStore.hydrate();
+  const deploymentLayerReady = Promise.all([deploymentLayerStore.hydrate(), mcpAuthorizer]).then(() => undefined);
   const deploymentLayerRefresh = createSweeper(() => deploymentLayerStore.hydrate(), 30_000, {
     label: "deployment layer refresh",
   });
@@ -612,8 +614,18 @@ export function buildApp(
     },
   });
   const mcpServers = createMcpServerStore(artifactMap<McpServer>("mcp_servers"));
-  const mcpToolService = createMcpToolService({ servers: mcpServers, audit: auditLog });
-  const mcpTools = () => mcpToolService.toolDefs();
+  const mcpToolService = createMcpToolService({
+    servers: mcpServers,
+    audit: auditLog,
+    ...(mcpAuthorizer
+      ? {
+          authorize: async (context, target) => {
+            const authorize = await mcpAuthorizer;
+            return authorize ? authorize(context, target) : { allowed: true };
+          },
+        }
+      : {}),
+  });
   const errors = config.databaseUrl ? createPostgresErrorLog(config.databaseUrl) : createErrorLog();
   const sandboxOnError = (e: { category: string; code: string; message: string; scopeLabel?: string }) =>
     errors.record({
@@ -838,7 +850,6 @@ export function buildApp(
         resolveBaseModelId: orgBaseModelId,
         resolveProviderKeys: resolveModelProviderKeys,
         signals: runSignals,
-        mcpTools,
       }),
     ],
     [
@@ -847,7 +858,6 @@ export function buildApp(
         ...openCodeHarnessConfigOptions(config),
         signals: runSignals,
         tasks,
-        mcpTools,
         resolveCustomProviders: async () => {
           const enabled = await customProviders.enabled();
           return Promise.all(
@@ -880,7 +890,6 @@ export function buildApp(
           : {}),
         signals: runSignals,
         tasks,
-        mcpTools,
       }),
     ],
     [
@@ -897,7 +906,6 @@ export function buildApp(
           : {}),
         signals: runSignals,
         tasks,
-        mcpTools,
       }),
     ],
     ["mock", createMockHarness()],

--- a/test/deployment-layer-load.test.ts
+++ b/test/deployment-layer-load.test.ts
@@ -1,9 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { emptyDeploymentLayer, loadDeploymentLayer, replaceDeploymentLayer } from "../src/deployment/load-layer.ts";
+import {
+  emptyDeploymentLayer,
+  loadDeploymentLayer,
+  loadMcpLayerAuthorizer,
+  replaceDeploymentLayer,
+} from "../src/deployment/load-layer.ts";
 import { buildApp } from "../src/wiring.ts";
 import { testConfig } from "./support/test-config.ts";
 import { parseToolDescriptor } from "../src/deployment/deployment-layer.ts";
@@ -59,6 +65,87 @@ test("loadDeploymentLayer derives the runtime shapes from tool descriptors", () 
   assert.deepEqual(layer.splitEnvTemplates, [
     { ACMECLI_ACTING_SLACK_USER_ID: "{actingSlackUserId}", ACMECLI_PLATFORM: "slack" },
   ]);
+});
+
+test("a trusted deployment layer can supply a scoped MCP authorizer", async () => {
+  const dir = layerDir({ helper: { id: "helper" } });
+  writeFileSync(
+    join(dir, "mcp-policy.mjs"),
+    'export async function authorizeMcp(context, target) { return { allowed: context.scopeId === "project:west" && target.action === "discover" }; }',
+  );
+  const authorize = await loadMcpLayerAuthorizer(dir);
+  assert.ok(authorize);
+  assert.deepEqual(
+    await authorize!(
+      { principalId: "person-1", scopeId: "project:west", runId: "run-1" },
+      { action: "discover", serverId: "crm", toolName: "query" },
+    ),
+    { allowed: true },
+  );
+  assert.deepEqual(
+    await authorize!(
+      { principalId: "person-1", scopeId: "project:east", runId: "run-1" },
+      { action: "discover", serverId: "crm", toolName: "query" },
+    ),
+    { allowed: false },
+  );
+});
+
+test("a deployment layer MCP authorizer cannot be a symlink", async () => {
+  const dir = layerDir({ helper: { id: "helper" } });
+  const outside = join(dir, "outside.mjs");
+  writeFileSync(outside, "export async function authorizeMcp() { return { allowed: true }; }");
+  symlinkSync(outside, join(dir, "mcp-policy.mjs"));
+  await assert.rejects(() => loadMcpLayerAuthorizer(dir), /must be a regular file/);
+});
+
+test("buildApp applies the layer MCP authorizer before exposing tool schemas", async () => {
+  const dir = layerDir({ helper: { id: "helper" } });
+  writeFileSync(
+    join(dir, "mcp-policy.mjs"),
+    'export async function authorizeMcp(context) { return { allowed: context.scopeId === "project:west" }; }',
+  );
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      const message = JSON.parse(body) as { id: number; method: string };
+      const result =
+        message.method === "tools/list"
+          ? { tools: [{ name: "read", description: "read", inputSchema: { type: "object" } }] }
+          : { content: [{ type: "text", text: "ok" }] };
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const built = buildApp(testConfig({ deploymentLayerDir: dir }));
+    await built.deploymentLayerReady;
+    await built.mcpServers.put({
+      id: "records",
+      name: "Records",
+      url: `http://127.0.0.1:${address.port}/mcp`,
+      auth: "none",
+      readOnly: true,
+      enabled: true,
+      updatedAt: 0,
+      updatedBy: "internal:admin",
+    });
+    await built.mcpToolService.refresh();
+    assert.deepEqual(
+      (await built.mcpToolService.toolDefs({ principalId: "person-1", scopeId: "project:west" })).map(
+        (tool) => tool.name,
+      ),
+      ["records_read"],
+    );
+    assert.deepEqual(await built.mcpToolService.toolDefs({ principalId: "person-1", scopeId: "project:east" }), []);
+    built.mcpToolService.close();
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+  }
 });
 
 test("brokered tools resolve to service, binary, and quarantine roots", () => {

--- a/test/mcp-connectors.test.ts
+++ b/test/mcp-connectors.test.ts
@@ -2,8 +2,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createMcpClient, mcpResultText, type McpFetch } from "../src/mcp/mcp-client.ts";
 import { createMcpServerStore, isValidMcpServerId, type McpServer } from "../src/mcp/mcp-server-store.ts";
-import { createMcpToolService } from "../src/mcp/mcp-tool-service.ts";
+import { createMcpToolService, mcpToolsForTurn, type McpCallContext } from "../src/mcp/mcp-tool-service.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
+import { createAuditLog } from "../src/audit/audit-log.ts";
 
 function jsonResponse(body: unknown, status = 200, contentType = "application/json") {
   return {
@@ -97,11 +98,124 @@ test("tool service exposes namespaced tools and calls through", async () => {
   const service = createMcpToolService({ servers: store, fetchImpl: fetch, refreshIntervalMs: 3600_000 });
   await store.put(server());
   await service.refresh();
-  const defs = service.toolDefs();
+  const defs = await service.toolDefs();
   assert.deepEqual(defs.map((d) => d.name).sort(), ["crm_query", "crm_update"]);
   assert.ok(defs.every((d) => d.readOnly));
   const out = await service.call("crm_query", { q: "hello" }, "internal:U1");
   assert.equal(out, "ran query");
+  service.close();
+});
+
+test("tool discovery is limited by immutable principal and scope context", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  const contexts: McpCallContext[] = [];
+  const service = createMcpToolService({
+    servers: store,
+    fetchImpl: fakeServerFetch().fetch,
+    refreshIntervalMs: 3600_000,
+    authorize: async (context, target) => {
+      contexts.push(context);
+      return { allowed: context.scopeId === "project:west" && target.toolName === "query" };
+    },
+  });
+  await store.put(server());
+  await service.refresh();
+  const west = await service.toolDefs({ principalId: "person-1", scopeId: "project:west", runId: "run-1" });
+  const east = await service.toolDefs({ principalId: "person-1", scopeId: "project:east", runId: "run-1" });
+  assert.deepEqual(
+    west.map((tool) => tool.name),
+    ["crm_query"],
+  );
+  assert.deepEqual(east, []);
+  assert.deepEqual(contexts, [
+    { principalId: "person-1", scopeId: "project:west", runId: "run-1" },
+    { principalId: "person-1", scopeId: "project:west", runId: "run-1" },
+    { principalId: "person-1", scopeId: "project:east", runId: "run-1" },
+    { principalId: "person-1", scopeId: "project:east", runId: "run-1" },
+  ]);
+  service.close();
+});
+
+test("tool invocation is denied when the policy denies its immutable scope context", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  const service = createMcpToolService({
+    servers: store,
+    fetchImpl: fakeServerFetch().fetch,
+    refreshIntervalMs: 3600_000,
+    authorize: async (context) => ({ allowed: context.scopeId === "project:west" }),
+  });
+  await store.put(server());
+  await service.refresh();
+  await assert.rejects(
+    () => service.call("crm_query", {}, { principalId: "person-1", scopeId: "project:east", runId: "run-1" }),
+    /not authorized/,
+  );
+  service.close();
+});
+
+test("dynamic authorization cannot replace configured static MCP authentication", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  const service = createMcpToolService({
+    servers: store,
+    fetchImpl: fakeServerFetch().fetch,
+    refreshIntervalMs: 3600_000,
+    authorize: async () => ({ allowed: true, authorization: "Bearer dynamic" }),
+  });
+  await store.put(server({ auth: "bearer", bearerToken: "static-token" }));
+  await service.refresh();
+  await assert.rejects(
+    () => service.call("crm_query", {}, { principalId: "person-1", scopeId: "project:west", runId: "run-1" }),
+    /cannot add authorization to a statically authenticated MCP server/,
+  );
+  service.close();
+});
+
+test("an explicit empty per-turn MCP tool list masks legacy global tools", () => {
+  const global = () => [{ name: "global_tool" } as never];
+  assert.deepEqual(mcpToolsForTurn([], global)?.(), []);
+  assert.deepEqual(mcpToolsForTurn(undefined, global)?.(), global());
+});
+
+test("malformed MCP contexts fail closed before the authorizer is invoked", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  let authorizations = 0;
+  const service = createMcpToolService({
+    servers: store,
+    fetchImpl: fakeServerFetch().fetch,
+    refreshIntervalMs: 3600_000,
+    authorize: async () => {
+      authorizations += 1;
+      return { allowed: true };
+    },
+  });
+  await store.put(server());
+  await service.refresh();
+  const malformed = { principalId: "person-1" } as unknown as McpCallContext;
+  assert.deepEqual(await service.toolDefs(malformed), []);
+  await assert.rejects(() => service.call("crm_query", {}, malformed), /not authorized/);
+  assert.equal(authorizations, 0);
+  service.close();
+});
+
+test("MCP authorization failures do not disclose policy error text", async () => {
+  const store = createMcpServerStore(createMemoryMap<McpServer>());
+  const audit = createAuditLog();
+  const service = createMcpToolService({
+    servers: store,
+    audit,
+    fetchImpl: fakeServerFetch().fetch,
+    refreshIntervalMs: 3600_000,
+    authorize: async () => {
+      throw new Error("ephemeral-authorization-secret");
+    },
+  });
+  await store.put(server());
+  await service.refresh();
+  await assert.rejects(
+    () => service.call("crm_query", {}, { principalId: "person-1", scopeId: "project:west" }),
+    /MCP authorization failed/,
+  );
+  assert.ok((await audit.events()).every((event) => !JSON.stringify(event).includes("ephemeral-authorization-secret")));
   service.close();
 });
 
@@ -111,10 +225,10 @@ test("disabled server's tools disappear and calls fail", async () => {
   const service = createMcpToolService({ servers: store, fetchImpl: fetch, refreshIntervalMs: 3600_000 });
   await store.put(server());
   await service.refresh();
-  assert.equal(service.toolDefs().length, 2);
+  assert.equal((await service.toolDefs()).length, 2);
   await store.put(server({ enabled: false }));
   await service.refresh();
-  assert.equal(service.toolDefs().length, 0);
+  assert.equal((await service.toolDefs()).length, 0);
   service.close();
 });
 

--- a/test/pi-tools.test.ts
+++ b/test/pi-tools.test.ts
@@ -369,6 +369,33 @@ test("miniapp is offered only on the web surface", () => {
   );
 });
 
+test("MCP tool failures do not disclose their error text to the model", async () => {
+  const marker = "ephemeral-authorization-secret";
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      async callMcpTool() {
+        throw new Error(marker);
+      },
+    },
+  };
+  const tool = createPiTools(ref, {
+    mcpTools: () => [
+      {
+        name: "crm_query",
+        serverId: "crm",
+        remoteName: "query",
+        description: "Query records",
+        inputSchema: { type: "object" },
+        readOnly: true,
+      },
+    ],
+  }).find((candidate) => candidate.name === "crm_query");
+  const result = await call(tool, {});
+  assert.doesNotMatch(JSON.stringify(result), new RegExp(marker));
+  assert.match(JSON.stringify(result), /MCP tool call failed/);
+});
+
 test("each pi tool emits a tool_call then a tool_result", async () => {
   const emitted: Emitted[] = [];
   const ref: ToolContextRef = {

--- a/test/prompt-modes.test.ts
+++ b/test/prompt-modes.test.ts
@@ -25,6 +25,7 @@ import type { LivenessCache } from "../src/credentials/resident-auth.ts";
 import type { ConnectorStatusCache } from "../src/credentials/connector-status.ts";
 import type { ConnectorTokenStore } from "../src/credentials/keychain.ts";
 import type { SkillStore } from "../src/skills/skill-store.ts";
+import type { McpToolService } from "../src/mcp/mcp-tool-service.ts";
 import { scopeId, type Conversation, type Principal } from "../src/types.ts";
 
 const ORG = "default-org";
@@ -81,6 +82,8 @@ function buildOrchestrator(
     scopeSoulFor?: { conversation: Conversation; soul: string };
     branding?: OrgBranding;
     brandingDefault?: OrgBranding;
+    mcp?: McpToolService;
+    auditLog?: ReturnType<typeof createAuditLog>;
   } = {},
 ) {
   const config = createMemoryConfigStore(ORG);
@@ -88,7 +91,7 @@ function buildOrchestrator(
   if (opts.branding) config.setBranding(scopeId("org", ORG), opts.branding);
 
   const acl = createAclStore();
-  const auditLog = createAuditLog();
+  const auditLog = opts.auditLog ?? createAuditLog();
   const workspace = createLocalWorkspaceStore(mkdtempSync(join(tmpdir(), "pm-")));
   const memory = createMemoryService(workspace);
   const deploy = createDeployService({
@@ -120,6 +123,7 @@ function buildOrchestrator(
     deploy,
     acl,
     config,
+    ...(opts.mcp ? { mcp: opts.mcp } : {}),
     ...(opts.brandingDefault ? { brandingDefault: opts.brandingDefault } : {}),
     skills,
     livenessCache,
@@ -164,6 +168,20 @@ async function sysprompt(orch: ReturnType<typeof createOrchestrator>, input: Orc
   assert.notEqual(prompt, "", "expected !sysprompt to echo the assembled system prompt as the reply");
   return prompt;
 }
+
+test("MCP discovery policy errors are redacted from orchestration audit records", async () => {
+  const marker = "ephemeral-authorization-secret";
+  const auditLog = createAuditLog();
+  const mcp = {
+    async toolDefs() {
+      throw new Error(marker);
+    },
+  } as unknown as McpToolService;
+  const prompt = await sysprompt(buildOrchestrator({ auditLog, mcp }), slackDm(""));
+  assert.doesNotMatch(prompt, new RegExp(marker));
+  assert.ok((await auditLog.events()).every((event) => !JSON.stringify(event).includes(marker)));
+  assert.ok((await auditLog.events()).some((event) => event.action === "mcp.discover" && event.status === "error"));
+});
 
 function assertNoTemplateTokens(prompt: string, label: string) {
   assert.doesNotMatch(


### PR DESCRIPTION
Adds an optional deployment-layer MCP authorization boundary with immutable per-turn context. Tool discovery is filtered before schemas reach the harness, invocation is re-authorized, and dynamic call headers are validated and constrained. Includes regression coverage for static-auth precedence, malformed context denial, per-turn tool masking, and safe error handling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790937833&installation_model_id=19911&pr_number=900&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F900&signature=1e8c6b2fc0546a72eae4cb5433244cab0eb3a9efcbfd546b0af5128564c92f7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->