### PR TITLE
feat: isolate local Docker workloads behind control relays

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -154,6 +154,7 @@ export interface Config {
   eagerProvisionEnabled: boolean;
   awsSandbox: AwsSandboxEnv;
   localSandbox: LocalSandboxEnv;
+  dockerDeploy: DockerDeployEnv;
   spritesSandbox: SpritesSandboxEnv;
   smolmachinesSandbox: SmolmachinesSandboxEnv;
   awsDeploy: AwsDeployEnv;
@@ -274,11 +275,33 @@ interface LocalSandboxEnv {
   dockerBin?: string;
   cpus?: number;
   memoryMb?: number;
-  coreContainer?: string;
+  agentHost?: string;
+  networkInternal?: boolean;
+  controlNetwork?: string;
+  controlProxyImage?: string;
   defaultTimeoutSec?: number;
 }
 
 function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
+  const agentHost = env.LOCAL_SANDBOX_AGENT_HOST?.trim();
+  const controlNetwork = env.LOCAL_SANDBOX_CONTROL_NETWORK?.trim();
+  const controlProxyImage = env.LOCAL_SANDBOX_CONTROL_PROXY_IMAGE?.trim();
+  const networkInternal = boolEnvStrict("LOCAL_SANDBOX_NETWORK_INTERNAL", env.LOCAL_SANDBOX_NETWORK_INTERNAL);
+  if (agentHost && !/^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,251}[a-zA-Z0-9])?$/.test(agentHost)) {
+    throw new Error("LOCAL_SANDBOX_AGENT_HOST must be a hostname without a scheme, port, or path");
+  }
+  if (!!controlNetwork !== !!controlProxyImage) {
+    throw new Error("LOCAL_SANDBOX_CONTROL_NETWORK and LOCAL_SANDBOX_CONTROL_PROXY_IMAGE must be set together");
+  }
+  if (controlNetwork && networkInternal !== true) {
+    throw new Error("LOCAL_SANDBOX_CONTROL_NETWORK requires LOCAL_SANDBOX_NETWORK_INTERNAL=true");
+  }
+  if (controlNetwork && !/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$/.test(controlNetwork)) {
+    throw new Error("LOCAL_SANDBOX_CONTROL_NETWORK must be a Docker network name");
+  }
+  if (controlProxyImage && !/^[a-z0-9][a-z0-9./_-]*@sha256:[a-f0-9]{64}$/.test(controlProxyImage)) {
+    throw new Error("LOCAL_SANDBOX_CONTROL_PROXY_IMAGE must be an immutable image digest");
+  }
   return {
     ...(env.LOCAL_SANDBOX_IMAGE ? { image: env.LOCAL_SANDBOX_IMAGE } : {}),
     ...(env.LOCAL_SANDBOX_DOCKER_BIN ? { dockerBin: env.LOCAL_SANDBOX_DOCKER_BIN } : {}),
@@ -288,6 +311,10 @@ function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
     ...(numEnvStrict("LOCAL_SANDBOX_MEMORY_MB", env.LOCAL_SANDBOX_MEMORY_MB) !== undefined
       ? { memoryMb: numEnvStrict("LOCAL_SANDBOX_MEMORY_MB", env.LOCAL_SANDBOX_MEMORY_MB) }
       : {}),
+    ...(agentHost ? { agentHost } : {}),
+    ...(controlNetwork ? { controlNetwork } : {}),
+    ...(controlProxyImage ? { controlProxyImage } : {}),
+    ...(networkInternal !== undefined ? { networkInternal } : {}),
     ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
       ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }
       : {}),
@@ -300,6 +327,41 @@ interface SpritesSandboxEnv {
   namePrefix?: string;
   egressProxyUrl?: string;
   defaultTimeoutSec?: number;
+}
+
+interface DockerDeployEnv {
+  endpointHost?: string;
+  networkInternal?: boolean;
+  controlNetwork?: string;
+  controlProxyImage?: string;
+}
+
+function dockerDeployEnv(env: NodeJS.ProcessEnv): DockerDeployEnv {
+  const endpointHost = env.DOCKER_DEPLOY_ENDPOINT_HOST?.trim();
+  const controlNetwork = env.DOCKER_DEPLOY_CONTROL_NETWORK?.trim();
+  const controlProxyImage = env.DOCKER_DEPLOY_CONTROL_PROXY_IMAGE?.trim();
+  const networkInternal = boolEnvStrict("DOCKER_DEPLOY_NETWORK_INTERNAL", env.DOCKER_DEPLOY_NETWORK_INTERNAL);
+  if (endpointHost && !/^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,251}[a-zA-Z0-9])?$/.test(endpointHost)) {
+    throw new Error("DOCKER_DEPLOY_ENDPOINT_HOST must be a hostname without a scheme, port, or path");
+  }
+  if (!!controlNetwork !== !!controlProxyImage) {
+    throw new Error("DOCKER_DEPLOY_CONTROL_NETWORK and DOCKER_DEPLOY_CONTROL_PROXY_IMAGE must be set together");
+  }
+  if (controlNetwork && networkInternal !== true) {
+    throw new Error("DOCKER_DEPLOY_CONTROL_NETWORK requires DOCKER_DEPLOY_NETWORK_INTERNAL=true");
+  }
+  if (controlNetwork && !/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$/.test(controlNetwork)) {
+    throw new Error("DOCKER_DEPLOY_CONTROL_NETWORK must be a Docker network name");
+  }
+  if (controlProxyImage && !/^[a-z0-9][a-z0-9./_-]*@sha256:[a-f0-9]{64}$/.test(controlProxyImage)) {
+    throw new Error("DOCKER_DEPLOY_CONTROL_PROXY_IMAGE must be an immutable image digest");
+  }
+  return {
+    ...(endpointHost ? { endpointHost } : {}),
+    ...(controlNetwork ? { controlNetwork } : {}),
+    ...(controlProxyImage ? { controlProxyImage } : {}),
+    ...(networkInternal !== undefined ? { networkInternal } : {}),
+  };
 }
 
 function spritesSandboxEnv(env: NodeJS.ProcessEnv): SpritesSandboxEnv {
@@ -979,6 +1041,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     eagerProvisionEnabled: boolEnvStrict("EAGER_PROVISION", env.EAGER_PROVISION) ?? false,
     awsSandbox: awsSandboxEnv(env),
     localSandbox: localSandboxEnv(env),
+    dockerDeploy: dockerDeployEnv(env),
     spritesSandbox: spritesSandboxEnv(env),
     smolmachinesSandbox: smolmachinesSandboxEnv(env),
     awsDeploy: awsDeployEnv(env),

--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -11,6 +11,10 @@ export interface DockerDeployProviderOptions {
   image?: string;
   docker?: string;
   basePort?: number;
+  endpointHost?: string;
+  networkInternal?: boolean;
+  controlNetwork?: string;
+  controlProxyImage?: string;
   dockerExec?: DockerExec;
 }
 
@@ -33,8 +37,18 @@ export async function dockerDaemonFailure(opts: DockerDaemonProbeOptions = {}): 
 }
 
 export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {}): DeployProvider {
+  if (opts.controlNetwork && opts.networkInternal !== true) {
+    throw new Error("controlNetwork requires networkInternal=true");
+  }
+  if (!!opts.controlNetwork !== !!opts.controlProxyImage) {
+    throw new Error("controlNetwork requires controlProxyImage");
+  }
+  if (opts.controlProxyImage && !/^[a-z0-9][a-z0-9./_-]*@sha256:[a-f0-9]{64}$/.test(opts.controlProxyImage)) {
+    throw new Error("controlProxyImage requires an immutable digest");
+  }
   const docker = opts.docker ?? "docker";
   const image = opts.image ?? "node:24-alpine";
+  const endpointHost = opts.endpointHost ?? "127.0.0.1";
   let nextPort = opts.basePort ?? 9200;
   const ports = new Map<string, number>();
   const freed: number[] = [];
@@ -56,15 +70,169 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
   const dexec = opts.dockerExec ?? spawnDockerExec(docker);
 
   const name = (d: Deployment) => `agent-deploy-${d.id.slice(0, 12)}`;
+  const controlName = (d: Deployment) => `qm-control-${name(d)}`;
   const network = (d: Deployment) => `${name(d)}-net`;
   const ensureNetwork = async (net: string): Promise<string> => {
-    if ((await dexec(["network", "inspect", net])).code !== 0) {
-      const r = await dexec(["network", "create", net]);
+    const existing = await dexec(["network", "inspect", "-f", "{{.Internal}}", net]);
+    if (existing.code === 0) {
+      if (opts.networkInternal && existing.stdout.trim() !== "true") {
+        throw new Error(`docker network ${net} must be internal`);
+      }
+    } else {
+      if (!/no such network|network .* not found/i.test(existing.stderr)) {
+        throw new Error(`docker network inspect ${net} failed: ${existing.stderr.trim()}`);
+      }
+      const r = await dexec(["network", "create", ...(opts.networkInternal ? ["--internal"] : []), net]);
       if (r.code !== 0 && !/already exists/i.test(r.stderr)) {
         throw new Error(`docker network create ${net} failed: ${r.stderr.trim()}`);
       }
+      if (opts.controlNetwork) {
+        const created = await dexec(["network", "inspect", "-f", "{{.Internal}}", net]);
+        if (created.code !== 0) {
+          throw new Error(`docker network inspect ${net} failed: ${created.stderr.trim()}`);
+        }
+        if (created.stdout.trim() !== "true") throw new Error(`docker network ${net} must be internal`);
+      }
     }
     return net;
+  };
+  const ensureControlProxy = async (d: Deployment, net: string): Promise<void> => {
+    if (!opts.controlNetwork) return;
+    if (!opts.controlProxyImage) throw new Error("controlNetwork requires controlProxyImage");
+    const proxy = controlName(d);
+    const expected = await dexec(["image", "inspect", "-f", "{{.Id}}", opts.controlProxyImage]);
+    if (expected.code !== 0) throw new Error(`control proxy image ${opts.controlProxyImage} is unavailable`);
+    const inspected = await dexec(["inspect", "-f", "{{.State.Running}} {{.Image}}", proxy]);
+    let needsCreate = inspected.code !== 0;
+    if (inspected.code === 0) {
+      const [running, imageId] = inspected.stdout.trim().split(/\s+/);
+      if (!(await controlProxyMatches(proxy, d, net)) || imageId !== expected.stdout.trim()) {
+        const removed = await dexec(["rm", "-f", proxy]);
+        if (removed.code !== 0)
+          throw new Error(`deploy control proxy ${proxy} removal failed: ${removed.stderr.trim()}`);
+        needsCreate = true;
+      } else if (running !== "true") {
+        const started = await dexec(["start", proxy]);
+        if (started.code !== 0) throw new Error(`deploy control proxy ${proxy} start failed: ${started.stderr.trim()}`);
+      }
+    }
+    if (needsCreate) {
+      const r = await dexec([
+        "run",
+        "-d",
+        "--name",
+        proxy,
+        "--label",
+        "qm.deploy-control=1",
+        "--label",
+        `qm.control-target=${name(d)}:${APP_PORT}`,
+        "--read-only",
+        "--tmpfs",
+        "/tmp:rw,noexec,nosuid,size=16m",
+        "--user",
+        "65532:65532",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges:true",
+        "--pids-limit",
+        "64",
+        "--memory",
+        "64m",
+        "--cpus",
+        "0.25",
+        "--network",
+        net,
+        "--network-alias",
+        "control",
+        opts.controlProxyImage,
+        "socat",
+        `TCP-LISTEN:${APP_PORT},fork,reuseaddr`,
+        `TCP:${name(d)}:${APP_PORT}`,
+      ]);
+      if (r.code !== 0) {
+        throw new Error(`deploy control proxy ${proxy} failed: ${r.stderr.trim()}`);
+      }
+    }
+    const connected = await dexec(["network", "connect", opts.controlNetwork, proxy]);
+    if (connected.code !== 0 && !/already (?:exists|connected)/i.test(connected.stderr)) {
+      throw new Error(`docker network connect ${opts.controlNetwork} ${proxy} failed: ${connected.stderr.trim()}`);
+    }
+  };
+  const controlProxyMatches = async (proxy: string, d: Deployment, workloadNetwork: string): Promise<boolean> => {
+    const label = await dexec(["inspect", "-f", '{{index .Config.Labels "qm.deploy-control"}}', proxy]);
+    if (label.code !== 0 || label.stdout.trim() !== "1") return false;
+    const networks = await dexec(["inspect", "-f", "{{json .NetworkSettings.Networks}}", proxy]);
+    if (networks.code !== 0) return false;
+    try {
+      const attached = JSON.parse(networks.stdout) as Record<string, unknown>;
+      if (
+        JSON.stringify(Object.keys(attached).sort()) !== JSON.stringify([workloadNetwork, opts.controlNetwork!].sort())
+      )
+        return false;
+    } catch {
+      return false;
+    }
+    const command = await dexec(["inspect", "-f", "{{json .Config.Cmd}}", proxy]);
+    if (command.code !== 0) return false;
+    try {
+      if (
+        JSON.stringify(JSON.parse(command.stdout)) !==
+        JSON.stringify(["socat", `TCP-LISTEN:${APP_PORT},fork,reuseaddr`, `TCP:${name(d)}:${APP_PORT}`])
+      )
+        return false;
+    } catch {
+      return false;
+    }
+    const hardening = await dexec([
+      "inspect",
+      "-f",
+      "{{.Config.User}}|{{.HostConfig.ReadonlyRootfs}}|{{json .HostConfig.CapDrop}}|{{json .HostConfig.SecurityOpt}}|{{.HostConfig.PidsLimit}}|{{.HostConfig.Memory}}|{{.HostConfig.NanoCpus}}|{{json .HostConfig.Tmpfs}}",
+      proxy,
+    ]);
+    if (hardening.code !== 0) return false;
+    const [user, readOnly, capDrop, securityOpt, pids, memory, cpus, tmpfs] = hardening.stdout.trim().split("|");
+    try {
+      return (
+        user === "65532:65532" &&
+        readOnly === "true" &&
+        JSON.parse(capDrop ?? "[]").includes("ALL") &&
+        JSON.parse(securityOpt ?? "[]").includes("no-new-privileges:true") &&
+        pids === "64" &&
+        memory === "67108864" &&
+        cpus === "250000000" &&
+        JSON.parse(tmpfs ?? "{}")["/tmp"] === "rw,noexec,nosuid,size=16m"
+      );
+    } catch {
+      return false;
+    }
+  };
+  const destroyControlProxy = async (d: Deployment): Promise<void> => {
+    if (!opts.controlNetwork) return;
+    const proxy = controlName(d);
+    const r = await dexec(["rm", "-f", proxy]);
+    if (r.code !== 0 && !/no such (?:object|container)|not found/i.test(r.stderr)) {
+      throw new Error(`deploy control proxy ${proxy} removal failed: ${r.stderr.trim()}`);
+    }
+  };
+  const removeContainerIfPresent = async (container: string): Promise<void> => {
+    const r = await dexec(["rm", "-f", container]);
+    if (r.code !== 0 && !/no such (?:object|container)|not found/i.test(r.stderr)) {
+      throw new Error(`docker rm ${container} failed: ${r.stderr.trim()}`);
+    }
+  };
+  const hasPublishedPorts = async (container: string): Promise<boolean | null> => {
+    const inspected = await dexec(["inspect", "-f", "{{json .HostConfig.PortBindings}}", container]);
+    if (inspected.code !== 0) {
+      if (/no such (?:object|container)|not found/i.test(inspected.stderr)) return null;
+      throw new Error(`docker inspect ${container} failed: ${inspected.stderr.trim()}`);
+    }
+    try {
+      const bindings = JSON.parse(inspected.stdout) as Record<string, unknown> | null;
+      return bindings !== null && Object.keys(bindings).length > 0;
+    } catch {
+      throw new Error(`docker inspect ${container} returned invalid published-port state`);
+    }
   };
 
   const migrateContainer = async (container: string): Promise<boolean> => {
@@ -106,7 +274,7 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
     async apply(d: Deployment, version: DeploymentVersion): Promise<DeployEndpoint> {
       const net = await ensureNetwork(network(d));
       await dexec(["rm", "-f", name(d)]);
-      const hostPort = allocPort(name(d));
+      const hostPort = opts.controlNetwork ? undefined : allocPort(name(d));
       const envArgs = Object.entries(version.env ?? {}).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
       const r = await dexec([
         "run",
@@ -121,8 +289,7 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
         "1",
         "--pids-limit",
         "256",
-        "-p",
-        `127.0.0.1:${hostPort}:${APP_PORT}`,
+        ...(hostPort === undefined ? [] : ["-p", `127.0.0.1:${hostPort}:${APP_PORT}`]),
         "-v",
         `${version.snapshotDir}:/app:ro`,
         "-w",
@@ -141,7 +308,15 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
         freePort(name(d));
         throw new Error(`deploy run failed: ${r.stderr.trim()}`);
       }
-      return { host: "127.0.0.1", port: hostPort };
+      try {
+        await ensureControlProxy(d, net);
+      } catch (e) {
+        await dexec(["rm", "-f", name(d)]);
+        await dexec(["network", "rm", net]);
+        freePort(name(d));
+        throw e;
+      }
+      return opts.controlNetwork ? { host: controlName(d), port: APP_PORT } : { host: endpointHost, port: hostPort! };
     },
 
     async logs(d: Deployment, opts: { tailLines: number }): Promise<string | null> {
@@ -153,13 +328,37 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
     },
 
     async destroy(d: Deployment): Promise<void> {
-      await dexec(["rm", "-f", name(d)]);
-      await dexec(["network", "rm", network(d)]);
-      freePort(name(d));
+      let failure: unknown;
+      try {
+        await removeContainerIfPresent(name(d));
+      } catch (e) {
+        failure = e;
+      }
+      try {
+        await destroyControlProxy(d);
+      } catch (e) {
+        failure ??= e;
+      }
+      try {
+        const removed = await dexec(["network", "rm", network(d)]);
+        if (removed.code !== 0 && !/no such network|not found/i.test(removed.stderr)) {
+          failure ??= new Error(`docker network rm ${network(d)} failed: ${removed.stderr.trim()}`);
+        }
+      } finally {
+        freePort(name(d));
+      }
+      if (failure) throw failure;
     },
 
     async resolveEndpoint(d): Promise<DeployEndpoint | null> {
-      return (await migrateTarget(name(d))) ? d.endpoint : null;
+      if (opts.controlNetwork) {
+        if ((await hasPublishedPorts(name(d))) !== false) return null;
+        if (!(await migrateTarget(name(d)))) return null;
+        await ensureControlProxy(d, network(d));
+        return { host: controlName(d), port: APP_PORT };
+      }
+      if (!(await migrateTarget(name(d)))) return null;
+      return d.endpoint;
     },
   };
 }

--- a/src/sandbox/local-sandbox.ts
+++ b/src/sandbox/local-sandbox.ts
@@ -44,6 +44,11 @@ export interface LocalSandboxOptions {
   cpus?: number;
   memoryMb?: number;
   coreContainer?: string;
+  agentHost?: string;
+  networkInternal?: boolean;
+  controlNetwork?: string;
+  controlProxyImage?: string;
+  daemonReadyTimeoutMs?: number;
   defaultTimeoutSec?: number;
   homeDir?: string;
   repoRoot?: string;
@@ -80,6 +85,7 @@ export const localVolumeName = (scopeId: string): string => `qm-home-${localSlug
 export const localNetworkName = (containerName: string): string =>
   `qm-net-${containerName.replace(/^qm-(sbx|scratch)-/, "")}`;
 const localScratchName = (key: string): string => `qm-scratch-${localSlug(key)}`;
+const localControlName = (name: string): string => `qm-control-${name}`;
 
 function localSlug(id: string): string {
   const cleaned = id
@@ -90,7 +96,17 @@ function localSlug(id: string): string {
 }
 
 export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandboxOptions = {}): Sandbox {
+  if (opts.controlNetwork && opts.networkInternal !== true) {
+    throw new Error("controlNetwork requires networkInternal=true");
+  }
+  if (!!opts.controlNetwork !== !!opts.controlProxyImage) {
+    throw new Error("controlNetwork requires controlProxyImage");
+  }
+  if (opts.controlProxyImage && !/^[a-z0-9][a-z0-9./_-]*@sha256:[a-f0-9]{64}$/.test(opts.controlProxyImage)) {
+    throw new Error("controlProxyImage requires an immutable digest");
+  }
   const image = opts.image ?? DEFAULT_LOCAL_SANDBOX_IMAGE;
+  const controlProxyImage = opts.controlNetwork ? opts.controlProxyImage : undefined;
   const dexec = opts.dockerExec ?? spawnDockerExec(opts.dockerBin ?? "docker");
   const fetchImpl = opts.fetchImpl ?? fetch;
   const defaultTimeoutSec = opts.defaultTimeoutSec ?? 600;
@@ -168,9 +184,10 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     timeoutMs?: number,
     signal?: AbortSignal,
   ): Promise<{ status: number; text: string }> {
-    const base = opts.coreContainer
-      ? `http://${name}:${AGENT_PORT}${path}`
-      : `http://127.0.0.1:${await resolvePort(name)}${path}`;
+    let base: string;
+    if (opts.controlNetwork) base = `http://${localControlName(name)}:${AGENT_PORT}${path}`;
+    else if (opts.coreContainer) base = `http://${name}:${AGENT_PORT}${path}`;
+    else base = `http://${opts.agentHost ?? "127.0.0.1"}:${await resolvePort(name)}${path}`;
     const signals = [AbortSignal.timeout(timeoutMs ?? 30_000), ...(signal ? [signal] : [])];
     const res = await fetchImpl(base, {
       method: body === undefined ? "GET" : "POST",
@@ -181,7 +198,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
   }
 
   async function waitDaemon(name: string): Promise<void> {
-    const deadline = Date.now() + 30_000;
+    const deadline = Date.now() + (opts.daemonReadyTimeoutMs ?? 30_000);
     let lastErr = "";
     while (Date.now() < deadline) {
       try {
@@ -200,7 +217,9 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
     portByName.delete(name);
     const r = await dexec(["start", name]);
     if (r.code !== 0) throw new Error(`docker start ${name} failed: ${r.stderr.trim()}`);
-    await connectCore(await ensureNetwork(name));
+    const net = await ensureNetwork(name);
+    await connectCore(net);
+    await ensureControlProxy(name, net);
     await waitDaemon(name);
   }
 
@@ -233,20 +252,159 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
 
   async function ensureNetwork(name: string): Promise<string> {
     const net = localNetworkName(name);
-    if ((await dexec(["network", "inspect", net])).code !== 0) {
-      const r = await dexec(["network", "create", net]);
+    const existing = await dexec(["network", "inspect", "-f", "{{.Internal}}", net]);
+    if (existing.code === 0) {
+      if (opts.networkInternal && existing.stdout.trim() !== "true") {
+        throw new Error(`docker network ${net} must be internal`);
+      }
+    } else {
+      if (!/no such network|network .* not found/i.test(existing.stderr)) {
+        throw new Error(`docker network inspect ${net} failed: ${existing.stderr.trim()}`);
+      }
+      const r = await dexec(["network", "create", ...(opts.networkInternal ? ["--internal"] : []), net]);
       if (r.code !== 0 && !/already exists/i.test(r.stderr)) {
         throw new Error(`docker network create ${net} failed: ${r.stderr.trim()}`);
+      }
+      if (opts.controlNetwork) {
+        const created = await dexec(["network", "inspect", "-f", "{{.Internal}}", net]);
+        if (created.code !== 0) {
+          throw new Error(`docker network inspect ${net} failed: ${created.stderr.trim()}`);
+        }
+        if (created.stdout.trim() !== "true") throw new Error(`docker network ${net} must be internal`);
       }
     }
     return net;
   }
 
   async function connectCore(net: string): Promise<void> {
+    if (opts.controlNetwork) return;
     if (!opts.coreContainer) return;
     const r = await dexec(["network", "connect", net, opts.coreContainer]);
     if (r.code !== 0 && !/already (?:exists|connected)/i.test(r.stderr)) {
       throw new Error(`docker network connect ${net} ${opts.coreContainer} failed: ${r.stderr.trim()}`);
+    }
+  }
+
+  async function ensureControlProxy(name: string, net: string): Promise<void> {
+    if (!opts.controlNetwork) return;
+    if (!controlProxyImage) throw new Error("controlNetwork requires controlProxyImage");
+    const proxy = localControlName(name);
+    const expected = await dexec(["image", "inspect", "-f", "{{.Id}}", controlProxyImage]);
+    if (expected.code !== 0) throw new Error(`control proxy image ${controlProxyImage} is unavailable`);
+    const expectedImageId = expected.stdout.trim();
+    let state = await containerState(proxy);
+    if (state && (!(await controlProxyMatches(proxy, name, net)) || state.imageId !== expectedImageId)) {
+      const removed = await dexec(["rm", "-f", proxy]);
+      if (removed.code !== 0) throw new Error(`docker rm ${proxy} failed: ${removed.stderr.trim()}`);
+      state = null;
+    }
+    if (!state) {
+      const r = await dexec([
+        "run",
+        "-d",
+        "--name",
+        proxy,
+        "--label",
+        "qm.sandbox-control=1",
+        "--label",
+        `qm.control-target=${name}:${AGENT_PORT}`,
+        "--read-only",
+        "--tmpfs",
+        "/tmp:rw,noexec,nosuid,size=16m",
+        "--user",
+        "65532:65532",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges:true",
+        "--pids-limit",
+        "64",
+        "--memory",
+        "64m",
+        "--cpus",
+        "0.25",
+        "--network",
+        net,
+        "--network-alias",
+        "control",
+        controlProxyImage,
+        "socat",
+        `TCP-LISTEN:${AGENT_PORT},fork,reuseaddr`,
+        `TCP:${name}:${AGENT_PORT}`,
+      ]);
+      if (r.code !== 0) throw new Error(`docker run ${proxy} failed: ${r.stderr.trim()}`);
+    } else if (!state.running) {
+      const r = await dexec(["start", proxy]);
+      if (r.code !== 0) throw new Error(`docker start ${proxy} failed: ${r.stderr.trim()}`);
+    }
+    const connected = await dexec(["network", "connect", opts.controlNetwork, proxy]);
+    if (connected.code !== 0 && !/already (?:exists|connected)/i.test(connected.stderr)) {
+      throw new Error(`docker network connect ${opts.controlNetwork} ${proxy} failed: ${connected.stderr.trim()}`);
+    }
+  }
+
+  async function controlProxyMatches(proxy: string, target: string, workloadNetwork: string): Promise<boolean> {
+    const label = await dexec(["inspect", "-f", '{{index .Config.Labels "qm.sandbox-control"}}', proxy]);
+    if (label.code !== 0 || label.stdout.trim() !== "1") return false;
+    const networks = await dexec(["inspect", "-f", "{{json .NetworkSettings.Networks}}", proxy]);
+    if (networks.code !== 0) return false;
+    try {
+      const attached = JSON.parse(networks.stdout) as Record<string, unknown>;
+      if (
+        JSON.stringify(Object.keys(attached).sort()) !== JSON.stringify([workloadNetwork, opts.controlNetwork!].sort())
+      )
+        return false;
+    } catch {
+      return false;
+    }
+    const command = await dexec(["inspect", "-f", "{{json .Config.Cmd}}", proxy]);
+    if (command.code !== 0) return false;
+    try {
+      if (
+        JSON.stringify(JSON.parse(command.stdout)) !==
+        JSON.stringify(["socat", `TCP-LISTEN:${AGENT_PORT},fork,reuseaddr`, `TCP:${target}:${AGENT_PORT}`])
+      )
+        return false;
+    } catch {
+      return false;
+    }
+    const hardening = await dexec([
+      "inspect",
+      "-f",
+      "{{.Config.User}}|{{.HostConfig.ReadonlyRootfs}}|{{json .HostConfig.CapDrop}}|{{json .HostConfig.SecurityOpt}}|{{.HostConfig.PidsLimit}}|{{.HostConfig.Memory}}|{{.HostConfig.NanoCpus}}|{{json .HostConfig.Tmpfs}}",
+      proxy,
+    ]);
+    if (hardening.code !== 0) return false;
+    const [user, readOnly, capDrop, securityOpt, pids, memory, cpus, tmpfs] = hardening.stdout.trim().split("|");
+    try {
+      return (
+        user === "65532:65532" &&
+        readOnly === "true" &&
+        JSON.parse(capDrop ?? "[]").includes("ALL") &&
+        JSON.parse(securityOpt ?? "[]").includes("no-new-privileges:true") &&
+        pids === "64" &&
+        memory === "67108864" &&
+        cpus === "250000000" &&
+        JSON.parse(tmpfs ?? "{}")["/tmp"] === "rw,noexec,nosuid,size=16m"
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async function destroyControlProxy(name: string): Promise<void> {
+    if (!opts.controlNetwork) return;
+    const proxy = localControlName(name);
+    const r = await dexec(["rm", "-f", proxy]);
+    if (r.code !== 0 && !/no such (?:object|container)|not found/i.test(r.stderr)) {
+      throw new Error(`docker rm ${proxy} failed: ${r.stderr.trim()}`);
+    }
+  }
+
+  async function removeContainerIfPresent(name: string): Promise<void> {
+    const r = await dexec(["rm", "-f", name]);
+    if (r.code !== 0 && !/no such (?:object|container)|not found/i.test(r.stderr)) {
+      throw new Error(`docker rm ${name} failed: ${r.stderr.trim()}`);
     }
   }
 
@@ -274,17 +432,26 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       "--network",
       net,
       ...(withVolume && scope ? ["-v", `${localVolumeName(scope)}:${homeDir}`] : []),
-      ...(opts.coreContainer ? [] : ["-p", `127.0.0.1:0:${AGENT_PORT}`]),
-      "--add-host=host.docker.internal:host-gateway",
+      ...(opts.coreContainer || opts.controlNetwork ? [] : ["-p", `127.0.0.1:0:${AGENT_PORT}`]),
+      ...(opts.controlNetwork ? [] : ["--add-host=host.docker.internal:host-gateway"]),
       ...(opts.cpus ? ["--cpus", String(opts.cpus)] : []),
       ...(opts.memoryMb ? ["--memory", `${opts.memoryMb}m`] : []),
       image,
     ];
     const r = await dexec(args, 120_000);
     if (r.code !== 0) throw new Error(`docker run ${name} failed: ${r.stderr.trim()}`);
-    portByName.delete(name);
-    await connectCore(net);
-    await waitDaemon(name);
+    try {
+      portByName.delete(name);
+      await connectCore(net);
+      await ensureControlProxy(name, net);
+      await waitDaemon(name);
+    } catch (error) {
+      await destroyControlProxy(name).catch(swallowAs("local-sandbox: control proxy rollback", undefined));
+      await dexec(["rm", "-f", name]).catch(swallowAs("local-sandbox: workload rollback", undefined));
+      await dexec(["network", "rm", net]).catch(swallowAs("local-sandbox: network rollback", undefined));
+      portByName.delete(name);
+      throw error;
+    }
   }
 
   async function ensureContainer(scope: string): Promise<{ name: string; coldStart: boolean }> {
@@ -295,7 +462,11 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const state = await containerState(name);
       if (state && state.imageId === imageId) {
         if (!state.running) await startContainer(name);
-        else await connectCore(await ensureNetwork(name));
+        else {
+          const net = await ensureNetwork(name);
+          await connectCore(net);
+          await ensureControlProxy(name, net);
+        }
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
       }
@@ -320,7 +491,11 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
       const state = await containerState(name);
       if (state) {
         if (!state.running) await startContainer(name);
-        else await connectCore(await ensureNetwork(name));
+        else {
+          const net = await ensureNetwork(name);
+          await connectCore(net);
+          await ensureControlProxy(name, net);
+        }
         activeByContainer.set(name, (activeByContainer.get(name) ?? 0) + 1);
         return { name, coldStart: false };
       }
@@ -477,8 +652,9 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
 
         if (handle.scratch) {
           for (const [k, name] of scratchByKey) if (name === handle.id) scratchByKey.delete(k);
-          if (tdOpts?.destroy) await dexec(["rm", "-f", handle.id]);
+          if (tdOpts?.destroy) await removeContainerIfPresent(handle.id);
           else await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: scratch rm", undefined));
+          await destroyControlProxy(handle.id);
           await disconnectCore(localNetworkName(handle.id));
           await dexec(["network", "rm", localNetworkName(handle.id)]).catch(
             swallowAs("local-sandbox: scratch network rm", undefined),
@@ -490,6 +666,7 @@ export function createLocalSandbox(workspace: WorkspaceStore, opts: LocalSandbox
         if (tdOpts?.keepWarm) return;
 
         if (tdOpts?.destroy) {
+          await destroyControlProxy(handle.id);
           await dexec(["rm", "-f", handle.id]).catch(swallowAs("local-sandbox: destroy rm", undefined));
           await disconnectCore(localNetworkName(handle.id));
           await dexec(["network", "rm", localNetworkName(handle.id)]).catch(

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -990,7 +990,7 @@ export function buildApp(
         store: artifactMap<StoredDeployBody>("aws_deploy_bodies"),
       });
     if (config.deployProvider === "fly") return createFlyDeployProvider(config.flyDeploy);
-    return createDockerDeployProvider();
+    return createDockerDeployProvider(config.dockerDeploy);
   })();
   if (config.deployProvider === "aws" && !config.awsDeploy.dataBucket && !config.awsSandbox.s3Bucket) {
     console.warn(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -60,6 +60,48 @@ test("deploy provider defaults to docker and rejects unknown values", () => {
   assert.throws(() => loadConfig({ DEPLOY_PROVIDER: "flly" }), /DEPLOY_PROVIDER="flly" is not recognized/);
 });
 
+test("local sandbox accepts an isolated daemon peer and an internal network", () => {
+  const config = loadConfig({
+    ...productionEnv,
+    LOCAL_SANDBOX_NETWORK_INTERNAL: "true",
+    LOCAL_SANDBOX_CONTROL_NETWORK: "qm-control",
+    LOCAL_SANDBOX_CONTROL_PROXY_IMAGE:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  assert.deepEqual(config.localSandbox, {
+    networkInternal: true,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  assert.throws(
+    () => loadConfig({ ...productionEnv, LOCAL_SANDBOX_NETWORK_INTERNAL: "sometimes" }),
+    /LOCAL_SANDBOX_NETWORK_INTERNAL=.*not a recognized boolean/,
+  );
+});
+
+test("Docker Apps deployment accepts the isolated daemon peer and network", () => {
+  const config = loadConfig({
+    ...productionEnv,
+    DOCKER_DEPLOY_ENDPOINT_HOST: "host.docker.internal",
+    DOCKER_DEPLOY_NETWORK_INTERNAL: "true",
+    DOCKER_DEPLOY_CONTROL_NETWORK: "qm-control",
+    DOCKER_DEPLOY_CONTROL_PROXY_IMAGE:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  assert.deepEqual(config.dockerDeploy, {
+    endpointHost: "host.docker.internal",
+    networkInternal: true,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  });
+  assert.throws(
+    () => loadConfig({ ...productionEnv, DOCKER_DEPLOY_ENDPOINT_HOST: "http://host.docker.internal" }),
+    /DOCKER_DEPLOY_ENDPOINT_HOST must be a hostname/,
+  );
+});
+
 test("production and unauthenticated-core escape hatch are parsed once", () => {
   assert.throws(() => loadConfig({ NODE_ENV: "production" }), /missing or insecure required core secrets/);
   assert.equal(loadConfig(productionEnv).production, true);

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -4,11 +4,89 @@ import { createDockerDeployProvider, dockerDaemonFailure } from "../src/deploy/d
 import { createDeployStore } from "../src/deploy/deploy-store.ts";
 import type { DockerExec } from "../src/sandbox/docker-exec.ts";
 import { scopeId } from "../src/types.ts";
+import { installFakeDocker } from "./support/fake-docker.ts";
+
+test("control mode fails closed unless its workload network is internal", () => {
+  const image = "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  assert.throws(
+    () => createDockerDeployProvider({ controlNetwork: "qm-control", controlProxyImage: image }),
+    /requires networkInternal=true/,
+  );
+  assert.throws(
+    () =>
+      createDockerDeployProvider({ controlNetwork: "qm-control", controlProxyImage: image, networkInternal: false }),
+    /requires networkInternal=true/,
+  );
+});
+
+test("control mode rejects a mutable control proxy image", () => {
+  assert.throws(
+    () =>
+      createDockerDeployProvider({
+        controlNetwork: "qm-control",
+        controlProxyImage: "alpine/socat:1.8.0.0",
+        networkInternal: true,
+      }),
+    /immutable digest/,
+  );
+});
+
+test("control mode does not mistake a Docker inspection failure for a missing App network", async () => {
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U-network-failure"),
+    createdBy: "U-network-failure",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/network-failure",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec: async (args) =>
+      args[0] === "network" && args[1] === "inspect"
+        ? { code: 1, stdout: "", stderr: "Cannot connect to the Docker daemon" }
+        : { code: 0, stdout: "", stderr: "" },
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  await assert.rejects(provider.apply(deployment, deployment.versions[0]!), /network inspect.*Docker daemon/);
+});
+
+test("control mode rechecks a racing App network before accepting it", async () => {
+  let inspections = 0;
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U-network-race"),
+    createdBy: "U-network-race",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/network-race",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec: async (args) => {
+      if (args[0] === "network" && args[1] === "inspect") {
+        inspections++;
+        return inspections === 1
+          ? { code: 1, stdout: "", stderr: "No such network" }
+          : { code: 0, stdout: "false\n", stderr: "" };
+      }
+      if (args[0] === "network" && args[1] === "create") return { code: 1, stdout: "", stderr: "already exists" };
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  await assert.rejects(provider.apply(deployment, deployment.versions[0]!), /must be internal/);
+});
 
 test("Docker deployments use isolated networks and remove them on destroy", async () => {
   const calls: string[][] = [];
   const dockerExec: DockerExec = async (args) => {
     calls.push(args);
+    if (args[0] === "image") return { code: 0, stdout: "sha256:proxy\n", stderr: "" };
     return {
       code: args[1] === "inspect" ? 1 : 0,
       stdout: "",
@@ -43,6 +121,249 @@ test("Docker deployments use isolated networks and remove them on destroy", asyn
   assert.ok(calls.some((args) => args.join(" ") === `network rm ${firstName}-net`));
 });
 
+test("an isolated Docker daemon publishes Apps only to its configured peer on an internal network", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    return {
+      code: args[1] === "inspect" ? 1 : 0,
+      stdout: "",
+      stderr: args[1] === "inspect" ? "No such network" : "",
+    };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U3"),
+    createdBy: "U3",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/isolated",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    endpointHost: "host.docker.internal",
+    networkInternal: true,
+  });
+
+  const endpoint = await provider.apply(deployment, deployment.versions[0]!);
+
+  const name = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  assert.equal(endpoint.host, "host.docker.internal");
+  assert.ok(calls.some((args) => args.join(" ") === `network create --internal ${name}-net`));
+});
+
+test("an App control proxy exposes the App to Core without attaching Core to the App network", async () => {
+  const calls: string[][] = [];
+  const networks = new Set<string>();
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "image") return { code: 0, stdout: "sha256:proxy\n", stderr: "" };
+    if (args[0] === "network" && args[1] === "inspect") {
+      return networks.has(args.at(-1)!)
+        ? { code: 0, stdout: "true\n", stderr: "" }
+        : { code: 1, stdout: "", stderr: "No such network" };
+    }
+    if (args[0] === "network" && args[1] === "create") {
+      networks.add(args.at(-1)!);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return {
+      code: args[1] === "inspect" ? 1 : 0,
+      stdout: "",
+      stderr: args[1] === "inspect" ? "No such network" : "",
+    };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U6"),
+    createdBy: "U6",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/proxied-app",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  const endpoint = await provider.apply(deployment, deployment.versions[0]!);
+
+  const name = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  const proxy = `qm-control-${name}`;
+  assert.deepEqual(endpoint, { host: proxy, port: 8080 });
+  assert.ok(calls.some((args) => args.join(" ") === `network connect qm-control ${proxy}`));
+  const relay = calls.find((args) => args[0] === "run" && args.includes(proxy))!;
+  for (const arg of ["--read-only", "--cap-drop", "--security-opt", "--pids-limit", "--memory", "--cpus", "--user"]) {
+    assert.ok(relay.includes(arg), arg);
+  }
+  const run = calls.find((args) => args[0] === "run" && args.includes(name))!;
+  assert.equal(run.includes("-p"), false);
+  assert.equal(
+    calls.some((args) => args.join(" ").includes(`network connect ${name}-net qm-core`)),
+    false,
+  );
+});
+
+test("control mode rejects an existing App network that permits egress", async () => {
+  const dockerExec: DockerExec = async (args) => {
+    if (args[0] === "network" && args[1] === "inspect") return { code: 0, stdout: "false\n", stderr: "" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U7"),
+    createdBy: "U7",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/non-internal",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  await assert.rejects(provider.apply(deployment, deployment.versions[0]!), /must be internal/);
+});
+
+test("control mode refuses a legacy App with a published port so it is safely reprovisioned", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "inspect" && args.includes("{{json .HostConfig.PortBindings}}")) {
+      return { code: 0, stdout: '{"8080/tcp":[{"HostIp":"127.0.0.1","HostPort":"9200"}]}', stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U8"),
+    createdBy: "U8",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/legacy-port",
+  });
+  await store.setEndpoint(deployment.id, { host: "127.0.0.1", port: 9200 });
+  const running = (await store.get(deployment.id))!;
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  assert.equal(await provider.resolveEndpoint!(running, running.versions[0]!), null);
+  assert.equal(
+    calls.some((args) => args[0] === "network"),
+    false,
+  );
+  assert.equal(
+    calls.some((args) => args[0] === "run"),
+    false,
+  );
+});
+
+test("control mode resolves an unported App through its relay", async () => {
+  const calls: string[][] = [];
+  let appName = "";
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "image") return { code: 0, stdout: "sha256:proxy\n", stderr: "" };
+    if (args[0] === "inspect" && args.includes("{{json .HostConfig.PortBindings}}")) {
+      return { code: 0, stdout: "{}", stderr: "" };
+    }
+    if (args[0] === "inspect" && args.includes("--format")) {
+      return { code: 0, stdout: JSON.stringify({ [`${appName}-net`]: {} }), stderr: "" };
+    }
+    if (args[0] === "inspect") return { code: 1, stdout: "", stderr: "No such object" };
+    if (args[0] === "network" && args[1] === "inspect") return { code: 0, stdout: "true\n", stderr: "" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U9"),
+    createdBy: "U9",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/unported",
+  });
+  appName = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  await store.setEndpoint(deployment.id, { host: "127.0.0.1", port: 9200 });
+  const running = (await store.get(deployment.id))!;
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  assert.deepEqual(await provider.resolveEndpoint!(running, running.versions[0]!), {
+    host: `qm-control-${appName}`,
+    port: 8080,
+  });
+  assert.ok(calls.some((args) => args[0] === "run" && args.includes(`qm-control-${appName}`)));
+});
+
+test("destroy cleans an App relay and network when the App is already gone", async () => {
+  const calls: string[][] = [];
+  let appName = "";
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "rm" && args.at(-1) === appName) return { code: 1, stdout: "", stderr: "No such container" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U10"),
+    createdBy: "U10",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/missing-app",
+  });
+  appName = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  const provider = createDockerDeployProvider({
+    dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+
+  await provider.destroy(deployment);
+
+  assert.ok(calls.some((args) => args.join(" ") === `rm -f qm-control-${appName}`));
+  assert.ok(calls.some((args) => args.join(" ") === `network rm ${appName}-net`));
+});
+
+test("an App relay with an extra network is recreated before reuse", async () => {
+  const fake = installFakeDocker(9200);
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U11"),
+    createdBy: "U11",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-extra-network",
+  });
+  const provider = createDockerDeployProvider({
+    dockerExec: fake.dockerExec,
+    controlNetwork: "qm-control",
+    controlProxyImage:
+      "example.invalid/control-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    networkInternal: true,
+  });
+  const app = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  const proxy = `qm-control-${app}`;
+  await provider.apply(deployment, deployment.versions[0]!);
+  fake.connections.add(`shared-network|${proxy}`);
+  const before = fake.runCount;
+
+  await provider.apply(deployment, deployment.versions[0]!);
+
+  assert.equal(fake.runCount, before + 2);
+  assert.equal(fake.connections.has(`shared-network|${proxy}`), false);
+});
+
 test("Docker provider migrates running deployments off the legacy shared network", async () => {
   const calls: string[][] = [];
   let containerName = "";
@@ -54,7 +375,7 @@ test("Docker provider migrates running deployments off the legacy shared network
     if (args.join(" ") === "network inspect --format {{range .Containers}}{{println .Name}}{{end}} agent-deploynet") {
       return { code: 0, stdout: legacyAttached ? `${containerName}\n` : "", stderr: "" };
     }
-    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "missing" };
+    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "No such network" };
     if (args[0] === "network" && args[1] === "connect" && ++connectAttempts === 1) {
       return { code: 1, stdout: "", stderr: "transient" };
     }
@@ -108,7 +429,7 @@ test("an unrelated legacy migration failure does not block a new deployment", as
       return { code: 0, stdout: "agent-deploy-broken\n", stderr: "" };
     }
     if (args[0] === "inspect") return { code: 1, stdout: "", stderr: "daemon unavailable" };
-    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "missing" };
+    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "No such network" };
     return { code: 0, stdout: "", stderr: "" };
   };
   const store = createDeployStore();

--- a/test/local-sandbox.test.ts
+++ b/test/local-sandbox.test.ts
@@ -19,6 +19,7 @@ import { installFakeDocker, type FakeDocker } from "./support/fake-docker.ts";
 
 const tmp = mkdtempSync(join(tmpdir(), "local-sbx-"));
 const guestHome = join(tmp, "home");
+const controlProxyImage = "alpine/socat@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 let daemon: ChildProcess;
 let daemonPort = 0;
 
@@ -313,4 +314,205 @@ test("containerized core joins each sandbox network and reaches the daemon by co
   assert.ok(seen.includes(`http://${h.id}:8080/health`));
   await sb.teardown(h, { destroy: true });
   assert.equal(fake.connections.has(`${localNetworkName(h.id)}|qm-test-core`), false);
+});
+
+test("an isolated daemon publishes sandbox control only to its configured peer and denies sandbox egress", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const seen: string[] = [];
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    seen.push(url);
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, {
+    agentHost: "host.docker.internal",
+    networkInternal: true,
+    fetchImpl,
+  });
+
+  const h = await sb.provision(rw(scopeId("personal", "U41")));
+  const args = fake.containers.get(h.id)!.args;
+  assert.ok(fake.calls.some((call) => call.join(" ") === `network create --internal ${localNetworkName(h.id)}`));
+  assert.ok(args.includes("-p"));
+  assert.ok(seen.includes(`http://host.docker.internal:${daemonPort}/health`));
+  assert.equal(fake.connections.size, 0);
+  await sb.teardown(h, { destroy: true });
+});
+
+test("a workload control proxy bridges Core without exposing Core to the workload network", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const seen: string[] = [];
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    seen.push(url);
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, {
+    controlNetwork: "qm-control",
+    controlProxyImage,
+    networkInternal: true,
+    fetchImpl,
+  });
+
+  const h = await sb.provision(rw(scopeId("personal", "U42")));
+  const proxy = `qm-control-${h.id}`;
+  assert.ok(fake.containers.has(proxy));
+  assert.ok(fake.connections.has(`qm-control|${proxy}`));
+  assert.ok(seen.includes(`http://${proxy}:8080/health`));
+  const relay = fake.containers.get(proxy)!;
+  for (const arg of ["--read-only", "--cap-drop", "--security-opt", "--pids-limit", "--memory", "--cpus", "--user"]) {
+    assert.ok(relay.args.includes(arg), arg);
+  }
+  const workload = fake.containers.get(h.id)!;
+  assert.equal(workload.args.includes("-p"), false);
+  assert.equal(workload.args.includes("--add-host"), false);
+  assert.equal(fake.connections.has(`${localNetworkName(h.id)}|qm-test-core`), false);
+  await sb.teardown(h, { destroy: true });
+});
+
+test("a stale workload control proxy is recreated before reuse", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, {
+    controlNetwork: "qm-control",
+    controlProxyImage,
+    networkInternal: true,
+    fetchImpl,
+  });
+  const layers = rw(scopeId("personal", "U43"));
+  const first = await sb.provision(layers);
+  const proxy = `qm-control-${first.id}`;
+  fake.imageId = "sha256:image-v2";
+
+  const second = await sb.provision(layers);
+
+  assert.equal(fake.containers.get(proxy)!.imageId, "sha256:image-v2");
+  await sb.teardown(first);
+  await sb.teardown(second, { destroy: true });
+});
+
+test("a tampered workload control proxy is recreated before reuse", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, {
+    controlNetwork: "qm-control",
+    controlProxyImage,
+    networkInternal: true,
+    fetchImpl,
+  });
+  const layers = rw(scopeId("personal", "U43-tampered"));
+  const first = await sb.provision(layers);
+  const proxy = `qm-control-${first.id}`;
+  delete fake.containers.get(proxy)!.labels["qm.sandbox-control"];
+  const before = fake.runCount;
+
+  const second = await sb.provision(layers);
+
+  assert.equal(fake.runCount, before + 1);
+  await sb.teardown(first);
+  await sb.teardown(second, { destroy: true });
+});
+
+test("a control proxy with an extra network is recreated before reuse", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return Promise.resolve(new Response("", { status: 200 }));
+    return Promise.resolve(new Response(JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })));
+  };
+  const sb = makeSandbox(fake, { controlNetwork: "qm-control", controlProxyImage, networkInternal: true, fetchImpl });
+  const layers = rw(scopeId("personal", "U43-extra-network"));
+  const first = await sb.provision(layers);
+  const proxy = `qm-control-${first.id}`;
+  fake.connections.add(`shared-network|${proxy}`);
+  const before = fake.runCount;
+
+  const second = await sb.provision(layers);
+
+  assert.equal(fake.runCount, before + 1);
+  await sb.teardown(first);
+  await sb.teardown(second, { destroy: true });
+});
+
+test("a failed control-proxy health check removes the workload and relay", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const sb = makeSandbox(fake, {
+    controlNetwork: "qm-control",
+    controlProxyImage,
+    networkInternal: true,
+    daemonReadyTimeoutMs: 50,
+    fetchImpl: () => Promise.resolve(new Response("", { status: 503 })),
+  });
+  const scope = scopeId("personal", "U44");
+  const name = localContainerName(scope);
+
+  await assert.rejects(sb.provision(rw(scope)), /exec daemon never became reachable/);
+
+  assert.equal(fake.containers.has(name), false);
+  assert.equal(fake.containers.has(`qm-control-${name}`), false);
+  assert.equal(fake.networks.has(localNetworkName(name)), false);
+});
+
+test("control mode fails closed unless its sandbox network is internal", () => {
+  const workspace = createLocalWorkspaceStore("/tmp/qm-control-mode-validation");
+  assert.throws(
+    () => createLocalSandbox(workspace, { controlNetwork: "qm-control", controlProxyImage: "alpine/socat:1.8.0.0" }),
+    /requires networkInternal=true/,
+  );
+  assert.throws(
+    () =>
+      createLocalSandbox(workspace, {
+        controlNetwork: "qm-control",
+        controlProxyImage: "alpine/socat:1.8.0.0",
+        networkInternal: false,
+      }),
+    /requires networkInternal=true/,
+  );
+});
+
+test("control mode rejects a mutable sandbox control proxy image", () => {
+  const workspace = createLocalWorkspaceStore("/tmp/qm-control-image-validation");
+  assert.throws(
+    () =>
+      createLocalSandbox(workspace, {
+        controlNetwork: "qm-control",
+        controlProxyImage: "alpine/socat:1.8.0.0",
+        networkInternal: true,
+      }),
+    /immutable digest/,
+  );
+});
+
+test("a missing control proxy does not prevent sandbox resource cleanup", async () => {
+  const fake = installFakeDocker(daemonPort);
+  const fetchImpl: typeof fetch = (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve(
+      new Response(url.endsWith("/health") ? "" : JSON.stringify({ code: 0, stdout: "", stderr: "", timedOut: false })),
+    );
+  };
+  const sb = makeSandbox(fake, {
+    controlNetwork: "qm-control",
+    controlProxyImage,
+    networkInternal: true,
+    fetchImpl,
+  });
+  const handle = await sb.provision(rw(scopeId("personal", "U45")));
+  fake.containers.delete(`qm-control-${handle.id}`);
+
+  await sb.teardown(handle, { destroy: true });
+
+  assert.equal(fake.containers.has(handle.id), false);
+  assert.equal(fake.networks.has(localNetworkName(handle.id)), false);
+  assert.equal(fake.volumes.has(localVolumeName(scopeId("personal", "U45"))), false);
 });

--- a/test/support/fake-docker.ts
+++ b/test/support/fake-docker.ts
@@ -6,6 +6,7 @@ export interface FakeContainer {
   running: boolean;
   labels: Record<string, string>;
   volume?: string;
+  network?: string;
   args: string[];
 }
 
@@ -15,6 +16,7 @@ export interface FakeDocker {
   volumes: Set<string>;
   networks: Set<string>;
   connections: Set<string>;
+  calls: string[][];
   runCount: number;
   daemonDown: boolean;
   imageMissing: boolean;
@@ -28,11 +30,13 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
   const volumes = new Set<string>();
   const networks = new Set<string>();
   const connections = new Set<string>();
+  const calls: string[][] = [];
   const self: FakeDocker = {
     containers,
     volumes,
     networks,
     connections,
+    calls,
     runCount: 0,
     daemonDown: false,
     imageMissing: false,
@@ -54,12 +58,14 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const [k = "", v = ""] = args[++i]!.split("=");
         c.labels[k] = v;
       } else if (a === "-v") c.volume = args[++i]!.split(":")[0]!;
+      else if (a === "--network") c.network = args[++i]!;
       else if (a === "-p" || a === "--cpus" || a === "--memory") i++;
     }
     return c;
   }
 
   function exec(args: string[]): { code: number; stdout: string; stderr: string } {
+    calls.push(args);
     const [cmd, ...rest] = args;
     if (self.daemonDown) return fail("Cannot connect to the Docker daemon");
     switch (cmd) {
@@ -75,11 +81,38 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         const name = rest[rest.length - 1]!;
         const c = containers.get(name);
         if (!c) return fail(`Error: No such object: ${name}`);
+        const format = rest[rest.length - 2] ?? "";
+        if (format.includes("qm.sandbox-control")) return ok(c.labels["qm.sandbox-control"] ?? "");
+        if (format.includes("qm.deploy-control")) return ok(c.labels["qm.deploy-control"] ?? "");
+        if (format.includes("NetworkSettings.Networks")) {
+          return ok(
+            JSON.stringify(
+              Object.fromEntries([
+                ...(c.network ? [[c.network, {}]] : []),
+                ...[...connections].filter((v) => v.endsWith(`|${name}`)).map((v) => [v.split("|")[0]!, {}]),
+              ]),
+            ),
+          );
+        }
+        if (format.includes("Config.Cmd")) {
+          const socat = c.args.indexOf("socat");
+          return ok(JSON.stringify(socat < 0 ? [] : c.args.slice(socat)));
+        }
+        if (format.includes("HostConfig.ReadonlyRootfs")) {
+          const has = (arg: string, value?: string) => {
+            const i = c.args.indexOf(arg);
+            return i >= 0 && (value === undefined || c.args[i + 1] === value);
+          };
+          return ok(
+            `${c.args[c.args.indexOf("--user") + 1] ?? ""}|${has("--read-only")}|${JSON.stringify(has("--cap-drop", "ALL") ? ["ALL"] : [])}|${JSON.stringify(has("--security-opt", "no-new-privileges:true") ? ["no-new-privileges:true"] : [])}|${has("--pids-limit", "64") ? "64" : "0"}|${has("--memory", "64m") ? "67108864" : "0"}|${has("--cpus", "0.25") ? "250000000" : "0"}|${JSON.stringify(has("--tmpfs", "/tmp:rw,noexec,nosuid,size=16m") ? { "/tmp": "rw,noexec,nosuid,size=16m" } : {})}`,
+          );
+        }
         return ok(`${c.running} ${c.imageId}`);
       }
       case "network": {
-        const [sub, name] = rest as [string, string];
-        if (sub === "inspect") return networks.has(name) ? ok(name) : fail(`Error: No such network: ${name}`);
+        const sub = rest[0]!;
+        const name = rest[rest.length - 1]!;
+        if (sub === "inspect") return networks.has(name) ? ok("true") : fail(`Error: No such network: ${name}`);
         if (sub === "create") {
           if (networks.has(name)) return fail(`network with name ${name} already exists`);
           networks.add(name);
@@ -87,8 +120,9 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
         }
         if (sub === "rm") return networks.delete(name) ? ok(name) : fail(`Error: No such network: ${name}`);
         if (sub === "connect" || sub === "disconnect") {
+          const network = rest[1]!;
           const container = rest[2]!;
-          const key = `${name}|${container}`;
+          const key = `${network}|${container}`;
           if (sub === "connect") {
             if (connections.has(key)) return fail("endpoint already exists");
             connections.add(key);
@@ -134,6 +168,7 @@ export function installFakeDocker(daemonPort: number): FakeDocker {
       case "rm": {
         const name = rest[rest.length - 1]!;
         containers.delete(name);
+        for (const connection of connections) if (connection.endsWith(`|${name}`)) connections.delete(connection);
         return ok(name);
       }
       case "port": {


### PR DESCRIPTION
## Summary

- add opt-in internal workload networks bridged to Core through an immutable hardened control relay
- validate relay identity, target, hardening, and exact network membership before reuse
- fail closed on mutable relay images, network inspection failures, and legacy published App ports
- safely reprovision ported legacy Apps instead of live-migrating an unsafe endpoint

## Verification

- focused config, local sandbox, and Docker deploy tests: 80 passing
- typecheck
- ESLint
- Prettier check
- git diff --check

The relay mode remains opt-in and deployment wiring is intentionally left to consuming deployments.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952631&installation_model_id=19911&pr_number=902&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F902&signature=d04d3c1e1ef3ffaf2babd4bdc73ba0b757319c7b16ac1a941782cf64809ee894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->