### PR TITLE
feat(projects): let web-only people be found and added as members

### DIFF
--- a/src/api/app-messaging.ts
+++ b/src/api/app-messaging.ts
@@ -89,12 +89,6 @@ export function createMessagingMethods(
   const contextRequests = deps.contextRequests ?? createMemoryMap<SurfaceContextRequest>();
   const contextRequestListeners = new Set<(request: SurfaceContextRequest) => void>();
   const contextRequestTokens = new Map<string, string>();
-  const emailAuthMembers = deps.emailAuthMembers ?? [];
-  const mergedDirectoryMembers = async () => {
-    const stored = await deps.directory.list();
-    const seen = new Set(stored.map((member) => personKey(member.principalId)));
-    return [...stored, ...emailAuthMembers.filter((member) => !seen.has(personKey(member.principalId)))];
-  };
 
   return {
     async createCron(input) {
@@ -400,30 +394,20 @@ export function createMessagingMethods(
         ...(isPrivate !== undefined ? { isPrivate } : {}),
       });
     },
-    async resolveRecipient(query) {
-      const stored = await deps.directory.resolve(query);
-      if (stored.kind !== "none") return stored;
-      const key = personKey(query);
-      const member = emailAuthMembers.find(
-        (candidate) => personKey(candidate.principalId) === key || personKey(candidate.displayName) === key,
-      );
-      return member ? { kind: "one", member } : { kind: "none" };
+    resolveRecipient(query) {
+      return deps.directory.resolve(query);
     },
     resolveChannel(query) {
       return deps.directory.resolveChannel(query);
     },
     directoryMembers() {
-      return mergedDirectoryMembers();
+      return deps.directory.list();
     },
     directoryChannels() {
       return deps.directory.listChannels();
     },
-    async directoryMember(principalId) {
-      return (
-        (await deps.directory.get(principalId)) ??
-        emailAuthMembers.find((member) => personKey(member.principalId) === personKey(principalId)) ??
-        null
-      );
+    directoryMember(principalId) {
+      return deps.directory.get(principalId);
     },
     samePerson(a, b) {
       return samePersonInDirectory(deps.directory, a, b);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -546,7 +546,6 @@ export interface AppDeps {
   webhooks: WebhookStore;
   deliveries: DeliveryStore;
   directory: DirectoryStore;
-  emailAuthMembers?: DirectoryMember[];
   projects?: ProjectStore;
   deploy: DeployService;
   deploymentLayer?: DeploymentLayerRuntime;

--- a/src/directory/directory-store.ts
+++ b/src/directory/directory-store.ts
@@ -1,5 +1,5 @@
 import type { PrincipalType } from "../types.ts";
-import { samePerson } from "./person.ts";
+import { personKey, samePerson } from "./person.ts";
 
 export interface DirectoryMember {
   principalId: string;
@@ -80,7 +80,7 @@ export const MAX_CANDIDATES = 10;
 export const normDirectoryQuery = (s: string): string => s.trim().toLowerCase().replace(/^[@#]/, "");
 
 function pickMatch<T>(
-  items: T[],
+  items: readonly T[],
   query: string,
   id: (t: T) => string,
   label: (t: T) => string,
@@ -97,6 +97,46 @@ function pickMatch<T>(
   if (pool.length === 0) return { kind: "none" };
   if (pool.length === 1) return { kind: "one", item: pool[0]! };
   return { kind: "ambiguous", items: pool.slice(0, MAX_CANDIDATES) };
+}
+
+function resolveMembers(members: readonly DirectoryMember[], query: string): RecipientResolution {
+  const bySlackId = members.find((x) => x.slackId && x.slackId === query.trim());
+  if (bySlackId) return { kind: "one", member: bySlackId };
+  const m = pickMatch(
+    members,
+    query,
+    (x) => x.principalId,
+    (x) => x.displayName,
+  );
+  if (m.kind === "one") return { kind: "one", member: m.item };
+  if (m.kind === "ambiguous") return { kind: "ambiguous", candidates: m.items };
+  return { kind: "none" };
+}
+
+export function withEmailAuthMembers(inner: DirectoryStore, principalIds: readonly string[]): DirectoryStore {
+  const standing: DirectoryMember[] = [...new Set(principalIds.map(personKey).filter(Boolean))].map((principalId) => ({
+    principalId,
+    displayName: principalId,
+    type: "internal",
+  }));
+  if (standing.length === 0) return inner;
+  const list = async (): Promise<DirectoryMember[]> => {
+    const stored = await inner.list();
+    const seen = new Set(stored.map((member) => personKey(member.principalId)));
+    return [...stored, ...standing.filter((member) => !seen.has(member.principalId))];
+  };
+  return {
+    ...inner,
+    list,
+    async get(principalId) {
+      return (
+        (await inner.get(principalId)) ?? standing.find((member) => samePerson(member.principalId, principalId)) ?? null
+      );
+    },
+    async resolve(query) {
+      return resolveMembers(await list(), query);
+    },
+  };
 }
 
 export function createDirectoryStore(): DirectoryStore {
@@ -273,17 +313,7 @@ export function createDirectoryStore(): DirectoryStore {
       return members.find((m) => samePerson(m.principalId, principalId)) ?? null;
     },
     async resolve(query) {
-      const bySlackId = members.find((x) => x.slackId && x.slackId === query.trim());
-      if (bySlackId) return { kind: "one", member: bySlackId };
-      const m = pickMatch(
-        members,
-        query,
-        (x) => x.principalId,
-        (x) => x.displayName,
-      );
-      if (m.kind === "one") return { kind: "one", member: m.item };
-      if (m.kind === "ambiguous") return { kind: "ambiguous", candidates: m.items };
-      return { kind: "none" };
+      return resolveMembers(members, query);
     },
     async resolveChannel(query) {
       const m = pickMatch(

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -69,7 +69,7 @@ import { createMemoryCronFireStore, createPostgresCronFireStore } from "./cron/c
 import { createDeliveryStore, type DeliveryStore } from "./delivery/delivery-store.ts";
 import { createPostgresDeliveryStore } from "./delivery/postgres-delivery-store.ts";
 import { wireRunResultDeliveries } from "./delivery/run-result-delivery.ts";
-import { createDirectoryStore, type DirectoryStore } from "./directory/directory-store.ts";
+import { createDirectoryStore, withEmailAuthMembers, type DirectoryStore } from "./directory/directory-store.ts";
 import { createPostgresDirectoryStore } from "./directory/postgres-directory-store.ts";
 import {
   createMemoryEnvironmentStore,
@@ -1015,7 +1015,10 @@ export function buildApp(
     onCaptureError: (e, scope) =>
       errors.record({ category: "memory", code: "capture_failed", message: errMessage(e), scopeLabel: scope }),
   });
-  const directory = config.databaseUrl ? createPostgresDirectoryStore(config.databaseUrl) : createDirectoryStore();
+  const directory = withEmailAuthMembers(
+    config.databaseUrl ? createPostgresDirectoryStore(config.databaseUrl) : createDirectoryStore(),
+    config.emailAuthPrincipals ?? [],
+  );
   const projects = createProjectStore(artifactMap<Project>("projects"), {
     isActiveMember: (principalId) => identity.isInternal(identity.classify(principalId)),
     advisoryLock,
@@ -1289,15 +1292,6 @@ export function buildApp(
     webhooks,
     deliveries,
     directory,
-    ...(config.emailAuthPrincipals?.length
-      ? {
-          emailAuthMembers: config.emailAuthPrincipals.map((principalId) => ({
-            principalId,
-            displayName: principalId,
-            type: "internal" as const,
-          })),
-        }
-      : {}),
     projects,
     environments,
     deploy: deployService,

--- a/test/directory-store.test.ts
+++ b/test/directory-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { createDirectoryStore, type DirectoryStore } from "../src/directory/directory-store.ts";
+import { createDirectoryStore, withEmailAuthMembers, type DirectoryStore } from "../src/directory/directory-store.ts";
 
 describe("directory resolution (agent → teammate addressing, §10)", () => {
   const dir = async (): Promise<DirectoryStore> => {
@@ -332,5 +332,52 @@ describe("private-channel membership (authorizes private-channel sends, §10)", 
     assert.equal(await d.channelMembership("C-connect", "U-member"), true);
     assert.equal(await d.channelMember("C-connect", "U-member"), false);
     assert.deepEqual(await d.listChannelsFor("U-member"), []);
+  });
+});
+
+describe("email-auth members stand in the directory beside the synced roster", () => {
+  const dir = async (): Promise<DirectoryStore> => {
+    const stored = createDirectoryStore();
+    await stored.replace([
+      { principalId: "U-alice", displayName: "Alice Example", type: "internal", slackId: "U-alice" },
+      { principalId: "shared@example.com", displayName: "Shared Person", type: "internal" },
+    ]);
+    return withEmailAuthMembers(stored, ["Web.Only@Example.com", "SHARED@example.com", "alice.web@example.com"]);
+  };
+
+  it("lists web-only people after the synced roster without duplicating a synced email", async () => {
+    const members = await (await dir()).list();
+    assert.deepEqual(
+      members.map((member) => member.principalId),
+      ["U-alice", "shared@example.com", "web.only@example.com", "alice.web@example.com"],
+    );
+    assert.equal(members.find((member) => member.principalId === "shared@example.com")?.displayName, "Shared Person");
+  });
+
+  it("gets a web-only person by email regardless of case, preferring the synced row", async () => {
+    const d = await dir();
+    assert.equal((await d.get("WEB.ONLY@example.com"))?.principalId, "web.only@example.com");
+    assert.equal((await d.get("shared@example.com"))?.displayName, "Shared Person");
+    assert.equal(await d.get("nobody@example.com"), null);
+  });
+
+  it("resolves a partial query against web-only people too", async () => {
+    const d = await dir();
+    const one = await d.resolve("web.only");
+    assert.equal(one.kind, "one");
+    if (one.kind === "one") assert.equal(one.member.principalId, "web.only@example.com");
+    const both = await d.resolve("alice");
+    assert.equal(both.kind, "ambiguous");
+    if (both.kind === "ambiguous")
+      assert.deepEqual(
+        both.candidates.map((member) => member.principalId),
+        ["U-alice", "alice.web@example.com"],
+      );
+    assert.equal((await d.resolve("zed")).kind, "none");
+  });
+
+  it("is a no-op wrapper when no email-auth people are configured", async () => {
+    const stored = createDirectoryStore();
+    assert.equal(withEmailAuthMembers(stored, []), stored);
   });
 });

--- a/test/projects.test.ts
+++ b/test/projects.test.ts
@@ -1056,3 +1056,38 @@ test("Project slack-channel routes gate on visibility and workspace use, and syn
   assert.equal(await built.projects.membership(groupRef, "member"), true);
   assert.ok(!(await built.app.listSessions("chan-pal")).some((s) => s.scopeId === scope));
 });
+
+test("people who only sign in by email can be found and added to a project", async () => {
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "project-email-member-")),
+      emailAuthPrincipals: ["Web.Only@Example.com"],
+    }),
+  );
+  await built.app.upsertDirectory([
+    { principalId: "owner", displayName: "Owner", type: "internal" },
+    { principalId: "U-slack", displayName: "Web Slacker", type: "internal", slackId: "U-slack" },
+  ]);
+  const project = await built.app.createProject("owner", "Mixed");
+  assert.ok(project);
+
+  const search = await built.app.resolveRecipient("web");
+  assert.equal(search.kind, "ambiguous");
+  if (search.kind === "ambiguous")
+    assert.deepEqual(search.candidates.map((member) => member.principalId).sort(), ["U-slack", "web.only@example.com"]);
+
+  const added = await built.app.addProjectMember(project.id, "owner", "web.only@example.com");
+  assert.equal(added.status, "ok");
+  if (added.status === "ok") {
+    assert.ok(added.changed);
+    assert.deepEqual(
+      added.project.members.map((member) => member.principalId),
+      ["owner", "web.only@example.com"],
+    );
+  }
+  assert.equal((await built.app.listProjects("web.only@example.com")).map((p) => p.id).join(), project.id);
+  assert.equal(
+    (await built.app.addProjectMember(project.id, "owner", "stranger@example.com")).status,
+    "invalid_member",
+  );
+});


### PR DESCRIPTION
People who sign in by email (AUTH_ALLOWED_EMAILS) but have no Slack account were only visible to the directory as an exact-match fallback in the messaging layer, and project add-member validated against the raw Slack roster, so the web picker could neither find them by a partial name nor add them.

Fold those people into the directory store itself with a wrapper applied at wiring time: list, get, and resolve now see the synced roster plus the configured email principals, with the synced row winning on a shared email and partial matches merging into one candidate list. That removes the emailAuthMembers dependency and the three ad-hoc merges from the messaging layer, and every directory reader (project membership, admin users, cron names, keychain scope names) sees the same people.

Claude-Session: https://claude.ai/code/session_017NA5c6F6xJsuSLbcgh4Efe

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953473&installation_model_id=19911&pr_number=903&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F903&signature=c6c4814b63912937184b5ff9a7ce54f7bb6ac7158fe875f34416f3c7e6533bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->