### PR TITLE
Deliver Docker App snapshots through managed volumes

### DIFF
--- a/src/deploy/docker-deploy-provider.ts
+++ b/src/deploy/docker-deploy-provider.ts
@@ -56,6 +56,7 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
   const dexec = opts.dockerExec ?? spawnDockerExec(docker);
 
   const name = (d: Deployment) => `agent-deploy-${d.id.slice(0, 12)}`;
+  const appVolume = (d: Deployment) => `qm-app-${d.id.slice(0, 12)}`;
   const network = (d: Deployment) => `${name(d)}-net`;
   const ensureNetwork = async (net: string): Promise<string> => {
     if ((await dexec(["network", "inspect", net])).code !== 0) {
@@ -65,6 +66,24 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
       }
     }
     return net;
+  };
+  const removeContainerIfPresent = async (container: string): Promise<void> => {
+    const r = await dexec(["rm", "-f", container]);
+    if (r.code !== 0 && !/no such (?:object|container)|not found/i.test(r.stderr)) {
+      throw new Error(`docker rm ${container} failed: ${r.stderr.trim()}`);
+    }
+  };
+  const removeVolumeIfPresent = async (volume: string): Promise<void> => {
+    const r = await dexec(["volume", "rm", volume]);
+    if (r.code !== 0 && !/no such volume|not found/i.test(r.stderr)) {
+      throw new Error(`docker volume rm ${volume} failed: ${r.stderr.trim()}`);
+    }
+  };
+  const cleanupFailedApply = async (d: Deployment, net: string): Promise<void> => {
+    await removeContainerIfPresent(name(d)).catch(() => undefined);
+    await removeVolumeIfPresent(appVolume(d)).catch(() => undefined);
+    await dexec(["network", "rm", net]).catch(() => undefined);
+    freePort(name(d));
   };
 
   const migrateContainer = async (container: string): Promise<boolean> => {
@@ -105,12 +124,17 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
 
     async apply(d: Deployment, version: DeploymentVersion): Promise<DeployEndpoint> {
       const net = await ensureNetwork(network(d));
-      await dexec(["rm", "-f", name(d)]);
+      await removeContainerIfPresent(name(d));
+      await removeVolumeIfPresent(appVolume(d));
+      const volume = await dexec(["volume", "create", appVolume(d)]);
+      if (volume.code !== 0) {
+        await cleanupFailedApply(d, net);
+        throw new Error(`docker volume create ${appVolume(d)} failed: ${volume.stderr.trim()}`);
+      }
       const hostPort = allocPort(name(d));
       const envArgs = Object.entries(version.env ?? {}).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
-      const r = await dexec([
-        "run",
-        "-d",
+      const created = await dexec([
+        "create",
         "--name",
         name(d),
         "--network",
@@ -124,7 +148,7 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
         "-p",
         `127.0.0.1:${hostPort}:${APP_PORT}`,
         "-v",
-        `${version.snapshotDir}:/app:ro`,
+        `${appVolume(d)}:/app`,
         "-w",
         "/app",
         "-e",
@@ -135,11 +159,19 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
         "-c",
         version.entrypoint,
       ]);
-      if (r.code !== 0) {
-        await dexec(["rm", "-f", name(d)]);
-        await dexec(["network", "rm", net]);
-        freePort(name(d));
-        throw new Error(`deploy run failed: ${r.stderr.trim()}`);
+      if (created.code !== 0) {
+        await cleanupFailedApply(d, net);
+        throw new Error(`deploy create failed: ${created.stderr.trim()}`);
+      }
+      const copied = await dexec(["cp", `${version.snapshotDir}/.`, `${name(d)}:/app`]);
+      if (copied.code !== 0) {
+        await cleanupFailedApply(d, net);
+        throw new Error(`deploy snapshot copy failed: ${copied.stderr.trim()}`);
+      }
+      const started = await dexec(["start", name(d)]);
+      if (started.code !== 0) {
+        await cleanupFailedApply(d, net);
+        throw new Error(`deploy start failed: ${started.stderr.trim()}`);
       }
       return { host: "127.0.0.1", port: hostPort };
     },
@@ -153,9 +185,26 @@ export function createDockerDeployProvider(opts: DockerDeployProviderOptions = {
     },
 
     async destroy(d: Deployment): Promise<void> {
-      await dexec(["rm", "-f", name(d)]);
-      await dexec(["network", "rm", network(d)]);
-      freePort(name(d));
+      let failure: unknown;
+      try {
+        await removeContainerIfPresent(name(d));
+      } catch (e) {
+        failure = e;
+      }
+      try {
+        await removeVolumeIfPresent(appVolume(d));
+      } catch (e) {
+        failure ??= e;
+      }
+      try {
+        const removed = await dexec(["network", "rm", network(d)]);
+        if (removed.code !== 0 && !/no such network|not found/i.test(removed.stderr)) {
+          failure ??= new Error(`docker network rm ${network(d)} failed: ${removed.stderr.trim()}`);
+        }
+      } finally {
+        freePort(name(d));
+      }
+      if (failure) throw failure;
     },
 
     async resolveEndpoint(d): Promise<DeployEndpoint | null> {

--- a/test/docker-deploy-provider.test.ts
+++ b/test/docker-deploy-provider.test.ts
@@ -36,11 +36,138 @@ test("Docker deployments use isolated networks and remove them on destroy", asyn
 
   const firstName = `agent-deploy-${first.id.slice(0, 12)}`;
   const secondName = `agent-deploy-${second.id.slice(0, 12)}`;
+  const firstVolume = `qm-app-${first.id.slice(0, 12)}`;
   assert.ok(calls.some((args) => args.join(" ") === `network create ${firstName}-net`));
   assert.ok(calls.some((args) => args.join(" ") === `network create ${secondName}-net`));
   assert.ok(calls.some((args) => args.join(" ").includes(`--name ${firstName} --network ${firstName}-net`)));
   assert.ok(calls.some((args) => args.join(" ").includes(`--name ${secondName} --network ${secondName}-net`)));
   assert.ok(calls.some((args) => args.join(" ") === `network rm ${firstName}-net`));
+  assert.ok(calls.some((args) => args.join(" ") === `volume rm ${firstVolume}`));
+});
+
+test("Docker Apps copy snapshots through managed volumes before starting", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    return {
+      code: args[1] === "inspect" ? 1 : 0,
+      stdout: "",
+      stderr: args[1] === "inspect" ? "No such network" : "",
+    };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U-app-volume"),
+    createdBy: "U-app-volume",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-volume",
+  });
+  const provider = createDockerDeployProvider({ dockerExec });
+
+  await provider.apply(deployment, deployment.versions[0]!);
+
+  const app = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  const volume = `qm-app-${deployment.id.slice(0, 12)}`;
+  const create = calls.findIndex((args) => args[0] === "create" && args.includes(app));
+  const copy = calls.findIndex((args) => args[0] === "cp" && args.includes(`${app}:/app`));
+  const start = calls.findIndex((args) => args[0] === "start" && args.includes(app));
+  assert.ok(calls.some((args) => args.join(" ") === `volume create ${volume}`));
+  assert.ok(create >= 0);
+  assert.ok(copy > create);
+  assert.ok(start > copy);
+  assert.ok(calls[create]!.includes(`${volume}:/app`));
+  assert.equal(calls[create]!.includes(`${deployment.versions[0]!.snapshotDir}:/app:ro`), false);
+});
+
+test("Docker Apps remove the managed volume when snapshot delivery fails", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "No such network" };
+    if (args[0] === "cp") return { code: 1, stdout: "", stderr: "copy failed" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U-app-volume-failure"),
+    createdBy: "U-app-volume-failure",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-volume-failure",
+  });
+  const provider = createDockerDeployProvider({ dockerExec });
+  const app = `agent-deploy-${deployment.id.slice(0, 12)}`;
+  const volume = `qm-app-${deployment.id.slice(0, 12)}`;
+
+  await assert.rejects(provider.apply(deployment, deployment.versions[0]!), /snapshot copy failed: copy failed/);
+
+  const copy = calls.findIndex((args) => args[0] === "cp");
+  assert.ok(calls.findLastIndex((args) => args.join(" ") === `rm -f ${app}`) > copy);
+  assert.ok(calls.findLastIndex((args) => args.join(" ") === `volume rm ${volume}`) > copy);
+  assert.equal(
+    calls.some((args) => args[0] === "start" && args.includes(app)),
+    false,
+  );
+});
+
+test("Docker Apps remove their workload network when App-volume creation fails", async () => {
+  const calls: string[][] = [];
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "No such network" };
+    if (args[0] === "volume" && args[1] === "create") return { code: 1, stdout: "", stderr: "volume unavailable" };
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const deployment = await store.create({
+    ownerScopeId: scopeId("personal", "U-app-volume-create-failure"),
+    createdBy: "U-app-volume-create-failure",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-volume-create-failure",
+  });
+  const provider = createDockerDeployProvider({ dockerExec });
+  const app = `agent-deploy-${deployment.id.slice(0, 12)}`;
+
+  await assert.rejects(provider.apply(deployment, deployment.versions[0]!), /volume create.*volume unavailable/);
+
+  assert.ok(calls.some((args) => args.join(" ") === `network rm ${app}-net`));
+});
+
+test("Docker Apps continue cleanup after managed-volume removal fails", async () => {
+  const calls: string[][] = [];
+  let deployedVolume = "";
+  const dockerExec: DockerExec = async (args) => {
+    calls.push(args);
+    if (args[0] === "network" && args[1] === "inspect") return { code: 1, stdout: "", stderr: "No such network" };
+    if (args[0] === "volume" && args[1] === "create") {
+      deployedVolume = args[2]!;
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[0] === "volume" && args[1] === "rm" && args[2] === deployedVolume) {
+      return { code: 1, stdout: "", stderr: "volume is in use" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  const store = createDeployStore();
+  const first = await store.create({
+    ownerScopeId: scopeId("personal", "U-app-volume-destroy-failure"),
+    createdBy: "U-app-volume-destroy-failure",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-volume-destroy-failure",
+  });
+  const second = await store.create({
+    ownerScopeId: scopeId("personal", "U-app-volume-destroy-retry"),
+    createdBy: "U-app-volume-destroy-retry",
+    entrypoint: "node server.js",
+    snapshotDir: "/snap/app-volume-destroy-retry",
+  });
+  const provider = createDockerDeployProvider({ dockerExec, basePort: 9800 });
+  const firstEndpoint = await provider.apply(first, first.versions[0]!);
+  const app = `agent-deploy-${first.id.slice(0, 12)}`;
+
+  await assert.rejects(provider.destroy(first), /docker volume rm.*volume is in use/);
+
+  assert.ok(calls.some((args) => args.join(" ") === `network rm ${app}-net`));
+  assert.deepEqual(await provider.apply(second, second.versions[0]!), firstEndpoint);
 });
 
 test("Docker provider migrates running deployments off the legacy shared network", async () => {


### PR DESCRIPTION
## Summary
- replace App snapshot host bind mounts with a managed named volume
- transfer snapshots to stopped App containers with Docker archive copy before start
- clean up App containers, volumes, networks, and port allocations on all failure paths

## Verification
- `node --experimental-test-module-mocks --test test/docker-deploy-provider.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

The provider change is intentionally generic and contains no organization-specific integration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790955017&installation_model_id=19911&pr_number=904&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F904&signature=26e978aee94f1aad9341ede1e341ad322bfb9691f56d4073f854f6f4ede17c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->