### PR TITLE
fix: reject empty non-surface Codex completions

### DIFF
--- a/src/harness/agent-tools.ts
+++ b/src/harness/agent-tools.ts
@@ -76,6 +76,7 @@ export interface ToolContextRef {
   abortSignal?: AbortSignal;
   pollFire?: boolean;
   silentRequested?: boolean;
+  attachmentsStaged?: boolean;
 
   goal?: GoalRecord | null;
 
@@ -2904,6 +2905,7 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
       await recordCall(callId, { tool: "attach", files });
       const r = await tc.attach(files);
       if (!r.ok) return recordResult(callId, { tool: "attach", ok: false }, text(`[not attached] ${r.message}`), true);
+      if (r.staged > 0) ref.attachmentsStaged = true;
       const list = r.files.map((f) => `${f.name} (${f.sizeBytes} bytes, ${f.mimetype})`).join("; ");
       const total = r.staged > r.files.length ? ` ${r.staged} file(s) are now staged for this reply.` : "";
       return recordResult(

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -1194,6 +1194,15 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
       } else {
         const terminal = ref.silentRequested || ref.pausedOnApproval;
         const reply = terminal ? "" : textFromTurn(result);
+        if (
+          !turn.surfaceTools &&
+          !ref.pendingApprovals?.length &&
+          !terminal &&
+          !state.stopped &&
+          !ref.attachmentsStaged &&
+          !reply.trim()
+        )
+          throw new NonRetryableTurnError("Codex completed without a final response or delivered output");
         for (const thinking of reasoningFromTurn(result))
           await turn.emit({ type: "thinking", payload: { thinking }, scopeLabel: turn.scopeLabel });
         if (reply && !terminal) {

--- a/test/codex-harness.test.ts
+++ b/test/codex-harness.test.ts
@@ -99,10 +99,16 @@ rl.on("line", (line) => {
     send({ method: "thread/tokenUsage/updated", params: { threadId: "child-1", tokenUsage: { total: { inputTokens: 70 }, last: { inputTokens: 70 } } } });
     send({ method: "item/completed", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "collabAgentToolCall", id: "collab-1", tool: "spawnAgent", status: "completed", senderThreadId: "thread-1", receiverThreadIds: ["child-1"], prompt: "return ALPHA", agentsStates: { "child-1": { status: "completed", message: "ALPHA" } } } } });
     send({ method: "thread/tokenUsage/updated", params: { threadId: "thread-1", tokenUsage: { total: { inputTokens: 250 }, last: { inputTokens: 150 } } } });
+    if (JSON.stringify(msg.params.input).includes("tool-only completion")) return send({ method: "turn/completed", params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [], itemsView: "notLoaded" } } });
+    if (JSON.stringify(msg.params.input).includes("attachment-only completion")) return send({ id: "surface-call", method: "item/tool/call", params: { threadId: "thread-1", turnId: "turn-1", callId: "attach-1", tool: "attach", arguments: { files: ["report.md"] } } });
+    if (JSON.stringify(msg.params.input).includes("surface-only completion")) return send({ id: "surface-call", method: "item/tool/call", params: { threadId: "thread-1", turnId: "turn-1", callId: "surface-1", tool: "web", arguments: { action: "post", text: "posted result" } } });
+    if (JSON.stringify(msg.params.input).includes("surface-read completion")) return send({ id: "surface-call", method: "item/tool/call", params: { threadId: "thread-1", turnId: "turn-1", callId: "surface-1", tool: "web", arguments: { action: "read_thread" } } });
+    if (JSON.stringify(msg.params.input).includes("surface-failed-post completion")) return send({ id: "surface-call", method: "item/tool/call", params: { threadId: "thread-1", turnId: "turn-1", callId: "surface-1", tool: "web", arguments: { action: "post", text: "unsent result" } } });
     send({ method: "item/agentMessage/delta", params: { threadId: "thread-1", turnId: "turn-1", itemId: "item-1", delta: "hello" } });
     send({ method: "item/completed", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "agentMessage", id: "item-1", text: "hello", phase: "final_answer", memoryCitation: null } } });
     return send({ method: "turn/completed", params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [], itemsView: "notLoaded" } } });
   }
+  if (msg.id === "surface-call" && msg.result) return send({ method: "turn/completed", params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", items: [], itemsView: "notLoaded" } } });
   if (msg.method === "turn/interrupt" || msg.method === "turn/steer") return send({ id: msg.id, result: {} });
 });
 `,
@@ -490,6 +496,124 @@ test("Codex harness drives app-server JSON-RPC with a read-only jail", async (t)
   assert.deepEqual(
     (await tasks.list()).map(({ title, status }) => ({ title, status })),
     [{ title: "return ALPHA", status: "completed" }],
+  );
+});
+
+test("Codex rejects a tool-only completion that has no terminal response", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-empty-final-test-"));
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: testHarnessEnv(dir) });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const entries: SessionEntry[] = [];
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  await assert.rejects(
+    harness.turns.runTurn({
+      session: { id: "empty-final" } as Session,
+      input: "tool-only completion",
+      systemPrompt: "return a final answer",
+      history: [],
+      tools: {} as HarnessTurnInput["tools"],
+      scopeLabel: scope,
+      orgScopeId: scope,
+      emit: async (entry) => {
+        const saved = {
+          ...entry,
+          sessionId: "empty-final",
+          seq: entries.length + 1,
+          createdAt: Date.now(),
+        } as SessionEntry;
+        entries.push(saved);
+        return saved;
+      },
+      recordModelCall: () => {},
+    }),
+    /Codex completed without a final response/,
+  );
+  assert.equal(
+    entries.some((entry) => entry.type === "assistant"),
+    false,
+  );
+});
+
+test("Codex accepts a surface-only completion after posting its result", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-surface-final-test-"));
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: testHarnessEnv(dir) });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const entries: SessionEntry[] = [];
+  const posted: string[] = [];
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  const result = await harness.turns.runTurn({
+    session: { id: "surface-final" } as Session,
+    input: "surface-only completion",
+    systemPrompt: "post the result",
+    history: [],
+    tools: {
+      post: async (text: string) => {
+        posted.push(text);
+        return { ok: true, deliveryId: "delivery-1" };
+      },
+    } as HarnessTurnInput["tools"],
+    surfaceTools: true,
+    surfaceName: "web",
+    scopeLabel: scope,
+    orgScopeId: scope,
+    emit: async (entry) => {
+      const saved = {
+        ...entry,
+        sessionId: "surface-final",
+        seq: entries.length + 1,
+        createdAt: Date.now(),
+      } as SessionEntry;
+      entries.push(saved);
+      return saved;
+    },
+    recordModelCall: () => {},
+  });
+
+  assert.deepEqual(posted, ["posted result"]);
+  assert.equal(result.reply, "");
+  assert.equal(
+    entries.some((entry) => entry.type === "assistant"),
+    false,
+  );
+});
+
+test("Codex leaves empty surface completions to native delivery recovery", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-surface-empty-test-"));
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: testHarnessEnv(dir) });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  const run = (input: string, tools: Partial<HarnessTurnInput["tools"]>) =>
+    harness.turns.runTurn({
+      session: { id: input } as Session,
+      input,
+      systemPrompt: "deliver a result",
+      history: [],
+      tools: tools as HarnessTurnInput["tools"],
+      surfaceTools: true,
+      surfaceName: "web",
+      scopeLabel: scope,
+      orgScopeId: scope,
+      emit: async (entry) => ({ ...entry, sessionId: input, seq: 1, createdAt: Date.now() }) as SessionEntry,
+      recordModelCall: () => {},
+    });
+
+  assert.equal(
+    (await run("surface-read completion", { readThread: async () => ({ ok: true, messages: [] }) })).reply,
+    "",
+  );
+  assert.equal(
+    (await run("surface-failed-post completion", { post: async () => ({ ok: false, message: "delivery failed" }) }))
+      .reply,
+    "",
   );
 });
 
@@ -1725,3 +1849,58 @@ test(
     assert.deepEqual(requests, []);
   },
 );
+
+test("Codex accepts file-only completion only when a real attachment is staged", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-file-final-test-"));
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: testHarnessEnv(dir) });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  for (const staged of [0, 1]) {
+    const run = harness.turns.runTurn({
+      session: { id: "file-final" } as Session,
+      input: "attachment-only completion",
+      systemPrompt: "deliver a file",
+      history: [],
+      tools: {
+        attach: async () => ({
+          ok: true,
+          staged,
+          files: staged ? [{ name: "report.md", mimetype: "text/markdown", sizeBytes: 12 }] : [],
+        }),
+      } as unknown as HarnessTurnInput["tools"],
+      scopeLabel: scope,
+      orgScopeId: scope,
+      emit: async (entry) => ({ ...entry, sessionId: "file-final", seq: 1, createdAt: Date.now() }) as SessionEntry,
+      recordModelCall: () => {},
+    });
+    if (staged) assert.equal((await run).reply, "");
+    else await assert.rejects(run, /Codex completed without a final response/);
+  }
+});
+
+test("Codex empty completion preserves a native tool approval", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-codex-approval-final-test-"));
+  const harness = createCodexHarness({ binaryPath: fakeCodexBinary(dir), env: testHarnessEnv(dir) });
+  t.after(async () => {
+    await harness.turns.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+  const scope = { kind: "org", id: "test" } as unknown as ScopeId;
+  const result = await harness.turns.runTurn({
+    session: { id: "approval-final" } as Session,
+    input: "attachment-only completion",
+    systemPrompt: "deliver a file",
+    history: [],
+    tools: {} as HarnessTurnInput["tools"],
+    toolApprovalGate: () => false,
+    scopeLabel: scope,
+    orgScopeId: scope,
+    emit: async (entry) => ({ ...entry, sessionId: "approval-final", seq: 1, createdAt: Date.now() }) as SessionEntry,
+    recordModelCall: () => {},
+  });
+  assert.equal(result.pendingApprovals?.length, 1);
+  assert.equal(result.pausedOnApproval, true);
+});


### PR DESCRIPTION
A Codex completion with no text, files, approval, or explicit terminal outcome can be recorded as a successful empty reply. Reject that result on non-surface turns, while accepting files confirmed by the native attachment-staging tool.

Surface-tool turns remain under QM's existing delivery and addressed-message recovery logic. Approval, silence, and stopped outcomes retain their existing semantics. No automatic outbox harvesting or changing run identifiers are added to the system prompt.

Validation: 134 harness/agent-tool tests pass on Node 24.15, including empty replies, preserved surface recovery, zero versus positive staged attachments, and native tool approvals. TypeScript, affected ESLint, and independent review pass.

Live QA at this revision passed with real Codex: a non-surface harness turn returned the exact requested nonce. An isolated local QM instance with PostgreSQL also displayed the exact requested web reply. Empty-result rejection and the attachment/approval exceptions are exercised deterministically in the targeted tests. This change rejects empty non-surface completion; it does not establish delivery confirmation or require an explicit final_answer phase.

