### PR TITLE
build(deps): patch fast-uri audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4702,9 +4702,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
-      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -4741,9 +4741,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4702,9 +4702,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.3.tgz",
+      "integrity": "sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==",
       "funding": [
         {
           "type": "github",
@@ -4741,9 +4741,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -84,14 +84,14 @@
     "@hono/node-server": "2.0.10",
     "hono": "4.12.34",
     "@fastify/ajv-compiler": {
-      "fast-uri": "3.1.5"
+      "fast-uri": "3.1.6"
     },
     "ajv": {
-      "fast-uri": "3.1.5"
+      "fast-uri": "3.1.6"
     },
     "brace-expansion": "5.0.9",
     "fast-json-stringify": {
-      "fast-uri": "4.1.2"
+      "fast-uri": "4.1.3"
     },
     "protobufjs": "7.6.5"
   },

--- a/package.json
+++ b/package.json
@@ -84,14 +84,14 @@
     "@hono/node-server": "2.0.10",
     "hono": "4.12.34",
     "@fastify/ajv-compiler": {
-      "fast-uri": "3.1.6"
+      "fast-uri": "3.1.7"
     },
     "ajv": {
-      "fast-uri": "3.1.6"
+      "fast-uri": "3.1.7"
     },
     "brace-expansion": "5.0.9",
     "fast-json-stringify": {
-      "fast-uri": "4.1.3"
+      "fast-uri": "4.1.4"
     },
     "protobufjs": "7.6.5"
   },

--- a/test/pi-dependency-security.test.ts
+++ b/test/pi-dependency-security.test.ts
@@ -46,7 +46,7 @@ test("Pi and MCP security overrides are materialized by the root lockfile", () =
   assert.equal(pi?.resolved, piCodingAgentTarball);
   assert.equal(pi?.hasShrinkwrap, true);
   assert.deepEqual(lockedVersions(packages, "brace-expansion"), ["5.0.9"]);
-  assert.deepEqual(lockedVersions(packages, "fast-uri").sort(), ["3.1.5", "4.1.2"]);
+  assert.deepEqual(lockedVersions(packages, "fast-uri").sort(), ["3.1.6", "4.1.3"]);
   assert.deepEqual(lockedVersions(packages, "hono"), ["4.12.34"]);
   assert.deepEqual(lockedVersions(packages, "protobufjs"), ["7.6.5"]);
   assert.deepEqual(lockedVersions(packages, "undici"), ["8.9.0"]);

--- a/test/pi-dependency-security.test.ts
+++ b/test/pi-dependency-security.test.ts
@@ -46,7 +46,7 @@ test("Pi and MCP security overrides are materialized by the root lockfile", () =
   assert.equal(pi?.resolved, piCodingAgentTarball);
   assert.equal(pi?.hasShrinkwrap, true);
   assert.deepEqual(lockedVersions(packages, "brace-expansion"), ["5.0.9"]);
-  assert.deepEqual(lockedVersions(packages, "fast-uri").sort(), ["3.1.6", "4.1.3"]);
+  assert.deepEqual(lockedVersions(packages, "fast-uri").sort(), ["3.1.7", "4.1.4"]);
   assert.deepEqual(lockedVersions(packages, "hono"), ["4.12.34"]);
   assert.deepEqual(lockedVersions(packages, "protobufjs"), ["7.6.5"]);
   assert.deepEqual(lockedVersions(packages, "undici"), ["8.9.0"]);


### PR DESCRIPTION
## Summary

- update the existing `fast-uri` overrides to `3.1.7` and `4.1.4`
- regenerate the root lockfile and its security-version assertion
- clear the production image npm audit gate and the newly published upstream advisories

## Root cause

The AJV and `fast-json-stringify` overrides pinned `fast-uri` to vulnerable patch releases, so updating their parent dependencies did not remove the audit findings. The initially selected patches were also superseded by same-day security releases after two additional high-severity advisories.

## Verification

- ordinary `npm ci --omit=dev --ignore-scripts` under the repository release-age policy
- `npm audit --omit=dev --audit-level=moderate` (`0 vulnerabilities`)
- both installed `fast-uri` copies reject the demonstrated authority-injection input
- `node --test test/pi-dependency-security.test.ts`
- `node --test test/deploy-core-image.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

Live verification: no interactive product surface applies to this dependency-resolution-only change; the production install and audit commands exercise the affected deploy gate directly.