### PR TITLE
docker: isolate container secrets from the client environment

### DIFF
--- a/cli/src/backends/docker-api.ts
+++ b/cli/src/backends/docker-api.ts
@@ -25,7 +25,7 @@ const dockerApiVersion = (): string | undefined => process.env.DOCKER_API_VERSIO
 
 function customHeadersFromEnv(value: string): Record<string, string> {
   if (/[\r\n]/.test(value)) throw new Error();
-  const headers: Record<string, string> = {};
+  const headers = new Map<string, string>();
   const field = /("(?:[^"]|"")*"|[^",]*)(,|$)/y;
   for (;;) {
     const match = field.exec(value);
@@ -33,9 +33,10 @@ function customHeadersFromEnv(value: string): Record<string, string> {
     const entry = match[1]!.startsWith('"') ? match[1]!.slice(1, -1).replaceAll('""', '"') : match[1]!;
     const separator = entry.indexOf("=");
     if (separator < 1) throw new Error();
-    const name = entry.slice(0, separator).trim().toLowerCase();
-    headers[name] = entry.slice(separator + 1);
-    if (match[2] !== ",") return headers;
+    const name = entry.slice(0, separator).replace(/^\p{White_Space}+|\p{White_Space}+$/gu, "");
+    validateHeaderName(name);
+    headers.set(name.toLowerCase(), entry.slice(separator + 1));
+    if (match[2] !== ",") return Object.fromEntries(headers);
   }
 }
 
@@ -48,7 +49,12 @@ export function dockerClientDefaults(): { env: Record<string, string>; headers: 
     };
     const headers = process.env.DOCKER_CUSTOM_HEADERS
       ? customHeadersFromEnv(process.env.DOCKER_CUSTOM_HEADERS)
-      : Object.fromEntries(Object.entries(config.HttpHeaders ?? {}).map(([key, value]) => [key.toLowerCase(), value]));
+      : Object.fromEntries(
+          Object.entries(config.HttpHeaders ?? {}).map(([key, value]) => {
+            validateHeaderName(key);
+            return [key.toLowerCase(), value];
+          }),
+        );
     for (const [key, value] of Object.entries(headers)) {
       if (typeof value !== "string") throw new Error();
       validateHeaderName(key);

--- a/cli/src/backends/docker-api.ts
+++ b/cli/src/backends/docker-api.ts
@@ -1,0 +1,224 @@
+import { execFileSync, spawn } from "node:child_process";
+import { request, validateHeaderName, validateHeaderValue } from "node:http";
+import { Duplex } from "node:stream";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "node:net";
+import { CliError } from "../log.ts";
+import { isEnvVarName } from "../util.ts";
+
+export interface DockerContainer {
+  name: string;
+  image: string;
+  network: string;
+  aliases: string[];
+  labels: Record<string, string>;
+  env: Record<string, string>;
+  headers?: Record<string, string>;
+  binds?: string[];
+  groups?: string[];
+  port?: { host: number; container: number };
+}
+
+export function dockerClientDefaults(): { env: Record<string, string>; headers: Record<string, string> } {
+  const path = join(process.env.DOCKER_CONFIG || join(homedir(), ".docker"), "config.json");
+  try {
+    const config = (existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : {}) as {
+      HttpHeaders?: Record<string, string>;
+      proxies?: Record<string, Record<string, string>>;
+    };
+    const headers = { ...config.HttpHeaders };
+    for (const entry of process.env.DOCKER_CUSTOM_HEADERS?.split(",").filter(Boolean) ?? []) {
+      const separator = entry.indexOf("=");
+      if (separator < 1) throw new Error();
+      headers[entry.slice(0, separator)] = entry.slice(separator + 1);
+    }
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof value !== "string") throw new Error();
+      validateHeaderName(key);
+      validateHeaderValue(key, value);
+    }
+    if (process.env.DOCKER_API_VERSION && !/^\d+\.\d+$/.test(process.env.DOCKER_API_VERSION)) throw new Error();
+    const proxies = config.proxies ?? {};
+    let proxy = proxies.default ?? {};
+    if (Object.keys(proxies).some((key) => key !== "default")) {
+      const host = JSON.parse(
+        execFileSync("docker", ["context", "inspect", "--format", "{{json .Endpoints.docker.Host}}"], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 10_000,
+        }),
+      );
+      proxy = proxies[host] ?? proxy;
+    }
+    const env: Record<string, string> = {};
+    for (const [key, name] of Object.entries({
+      httpProxy: "HTTP_PROXY",
+      httpsProxy: "HTTPS_PROXY",
+      ftpProxy: "FTP_PROXY",
+      allProxy: "ALL_PROXY",
+      noProxy: "NO_PROXY",
+    })) {
+      if (typeof proxy[key] === "string" && proxy[key] !== "") {
+        env[name] = proxy[key];
+        env[name.toLowerCase()] = proxy[key];
+      }
+    }
+    return { env, headers };
+  } catch {
+    throw new CliError("Cannot read Docker client defaults; diagnostic output withheld because it may contain secrets");
+  }
+}
+
+export function validateDockerEnv(env: Record<string, string>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (!isEnvVarName(key)) throw new CliError("container environment contains an invalid variable name");
+    if (value.includes("\0")) throw new CliError(`container environment variable ${key} contains a NUL byte`);
+  }
+}
+
+interface ApiRequest {
+  path: string;
+  body: object;
+  expectedStatus: number;
+  headers?: Record<string, string>;
+}
+
+function dockerRequest(
+  path: string,
+  body: object,
+  expectedStatus: number,
+  headers?: Record<string, string>,
+): string | undefined {
+  let result: { id?: string; error?: string };
+  try {
+    result = JSON.parse(
+      execFileSync(process.execPath, [import.meta.filename], {
+        input: JSON.stringify({
+          path: process.env.DOCKER_API_VERSION
+            ? `/v${encodeURIComponent(process.env.DOCKER_API_VERSION)}${path}`
+            : path,
+          body,
+          expectedStatus,
+          headers,
+        }),
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 30_000,
+        maxBuffer: 1024 * 1024,
+      }),
+    );
+  } catch {
+    throw new CliError("Docker API request failed; diagnostic output withheld because it may contain secrets");
+  }
+  if (result.error) throw new CliError(result.error);
+  return result.id;
+}
+
+async function requestThroughDocker({ path, body, expectedStatus, headers }: ApiRequest): Promise<{ id?: string }> {
+  const child = spawn("docker", ["system", "dial-stdio"], { stdio: ["pipe", "pipe", "ignore"] });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 25_000);
+  const socket = Duplex.from({ readable: child.stdout, writable: child.stdin });
+  try {
+    return await new Promise((resolve, reject) => {
+      const json = JSON.stringify(body);
+      const req = request(
+        {
+          signal: controller.signal,
+          hostname: "docker",
+          path,
+          method: "POST",
+          headers: {
+            ...headers,
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(json),
+            Connection: "close",
+          },
+          createConnection: () => socket as Socket,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          let size = 0;
+          res.on("data", (chunk: Buffer) => {
+            size += chunk.length;
+            if (size > 1024 * 1024) res.destroy(new Error("response too large"));
+            else chunks.push(chunk);
+          });
+          res.on("error", reject);
+          res.on("end", () => {
+            if (res.statusCode !== expectedStatus) {
+              reject(
+                new CliError(
+                  `Docker API request failed (HTTP ${res.statusCode}); response body withheld because it may contain secrets`,
+                ),
+              );
+              return;
+            }
+            if (expectedStatus !== 201) {
+              resolve({});
+              return;
+            }
+            try {
+              const result = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+              if (typeof result.Id !== "string" || !/^[a-f0-9]{64}$/.test(result.Id)) throw new Error();
+              resolve({ id: result.Id });
+            } catch {
+              reject(new CliError("Docker API returned an invalid container identity"));
+            }
+          });
+        },
+      );
+      req.on("error", () => reject(new Error("Docker API connection failed")));
+      child.on("error", () => req.destroy());
+      req.on("finish", () => child.stdin.end());
+      req.end(json);
+    });
+  } finally {
+    clearTimeout(timer);
+    socket.destroy();
+    child.kill("SIGKILL");
+  }
+}
+
+if (process.argv[1] === import.meta.filename) {
+  try {
+    const options = JSON.parse(readFileSync(0, "utf8")) as ApiRequest;
+    const result = await requestThroughDocker(options);
+    process.stdout.write(JSON.stringify(result));
+  } catch (error) {
+    const message =
+      error instanceof CliError
+        ? error.message
+        : "Docker API request failed; diagnostic output withheld because it may contain secrets";
+    process.stdout.write(JSON.stringify({ error: message }));
+  }
+}
+
+export function startDockerContainer(container: DockerContainer): void {
+  validateDockerEnv(container.env);
+  const port = container.port ? `${container.port.container}/tcp` : undefined;
+  const [apiMajor = 1, apiMinor = 41] = (process.env.DOCKER_API_VERSION ?? "1.41").split(".").map(Number);
+  const platform = apiMajor > 1 || apiMinor >= 41 ? process.env.DOCKER_DEFAULT_PLATFORM : undefined;
+  const id = dockerRequest(
+    `/containers/create?name=${encodeURIComponent(container.name)}${platform ? `&platform=${encodeURIComponent(platform)}` : ""}`,
+    {
+      Image: container.image,
+      Env: Object.entries(container.env).map(([key, value]) => `${key}=${value}`),
+      Labels: container.labels,
+      ...(port ? { ExposedPorts: { [port]: {} } } : {}),
+      HostConfig: {
+        NetworkMode: container.network,
+        RestartPolicy: { Name: "no" },
+        Binds: container.binds ?? [],
+        GroupAdd: container.groups ?? [],
+        ...(port ? { PortBindings: { [port]: [{ HostIp: "", HostPort: String(container.port!.host) }] } } : {}),
+      },
+      NetworkingConfig: { EndpointsConfig: { [container.network]: { Aliases: container.aliases } } },
+    },
+    201,
+    container.headers,
+  );
+  dockerRequest(`/containers/${id}/start`, {}, 204, container.headers);
+}

--- a/cli/src/backends/docker-api.ts
+++ b/cli/src/backends/docker-api.ts
@@ -21,6 +21,22 @@ export interface DockerContainer {
   port?: { host: number; container: number };
 }
 
+function customHeadersFromEnv(value: string): Record<string, string> {
+  if (/[\r\n]/.test(value)) throw new Error();
+  const headers: Record<string, string> = {};
+  const field = /("(?:[^"]|"")*"|[^",]*)(,|$)/y;
+  for (;;) {
+    const match = field.exec(value);
+    if (!match) throw new Error();
+    const entry = match[1]!.startsWith('"') ? match[1]!.slice(1, -1).replaceAll('""', '"') : match[1]!;
+    const separator = entry.indexOf("=");
+    if (separator < 1) throw new Error();
+    const name = entry.slice(0, separator).trim().toLowerCase();
+    headers[name] = entry.slice(separator + 1);
+    if (match[2] !== ",") return headers;
+  }
+}
+
 export function dockerClientDefaults(): { env: Record<string, string>; headers: Record<string, string> } {
   const path = join(process.env.DOCKER_CONFIG || join(homedir(), ".docker"), "config.json");
   try {
@@ -28,12 +44,9 @@ export function dockerClientDefaults(): { env: Record<string, string>; headers: 
       HttpHeaders?: Record<string, string>;
       proxies?: Record<string, Record<string, string>>;
     };
-    const headers = { ...config.HttpHeaders };
-    for (const entry of process.env.DOCKER_CUSTOM_HEADERS?.split(",").filter(Boolean) ?? []) {
-      const separator = entry.indexOf("=");
-      if (separator < 1) throw new Error();
-      headers[entry.slice(0, separator)] = entry.slice(separator + 1);
-    }
+    const headers = process.env.DOCKER_CUSTOM_HEADERS
+      ? customHeadersFromEnv(process.env.DOCKER_CUSTOM_HEADERS)
+      : Object.fromEntries(Object.entries(config.HttpHeaders ?? {}).map(([key, value]) => [key.toLowerCase(), value]));
     for (const [key, value] of Object.entries(headers)) {
       if (typeof value !== "string") throw new Error();
       validateHeaderName(key);
@@ -132,9 +145,9 @@ async function requestThroughDocker({ path, body, expectedStatus, headers }: Api
           method: "POST",
           headers: {
             ...headers,
-            "Content-Type": "application/json",
-            "Content-Length": Buffer.byteLength(json),
-            Connection: "close",
+            "content-type": "application/json",
+            "content-length": Buffer.byteLength(json),
+            connection: "close",
           },
           createConnection: () => socket as Socket,
         },

--- a/cli/src/backends/docker-api.ts
+++ b/cli/src/backends/docker-api.ts
@@ -21,6 +21,8 @@ export interface DockerContainer {
   port?: { host: number; container: number };
 }
 
+const dockerApiVersion = (): string | undefined => process.env.DOCKER_API_VERSION?.replace(/^v/, "");
+
 function customHeadersFromEnv(value: string): Record<string, string> {
   if (/[\r\n]/.test(value)) throw new Error();
   const headers: Record<string, string> = {};
@@ -52,7 +54,7 @@ export function dockerClientDefaults(): { env: Record<string, string>; headers: 
       validateHeaderName(key);
       validateHeaderValue(key, value);
     }
-    if (process.env.DOCKER_API_VERSION && !/^\d+\.\d+$/.test(process.env.DOCKER_API_VERSION)) throw new Error();
+    if (dockerApiVersion() && !/^\d+\.\d+$/.test(dockerApiVersion()!)) throw new Error();
     const proxies = config.proxies ?? {};
     let proxy = proxies.default ?? {};
     if (Object.keys(proxies).some((key) => key !== "default")) {
@@ -109,9 +111,7 @@ function dockerRequest(
     result = JSON.parse(
       execFileSync(process.execPath, [import.meta.filename], {
         input: JSON.stringify({
-          path: process.env.DOCKER_API_VERSION
-            ? `/v${encodeURIComponent(process.env.DOCKER_API_VERSION)}${path}`
-            : path,
+          path: dockerApiVersion() ? `/v${encodeURIComponent(dockerApiVersion()!)}${path}` : path,
           body,
           expectedStatus,
           headers,
@@ -212,7 +212,7 @@ if (process.argv[1] === import.meta.filename) {
 export function startDockerContainer(container: DockerContainer): void {
   validateDockerEnv(container.env);
   const port = container.port ? `${container.port.container}/tcp` : undefined;
-  const [apiMajor = 1, apiMinor = 41] = (process.env.DOCKER_API_VERSION ?? "1.41").split(".").map(Number);
+  const [apiMajor = 1, apiMinor = 41] = (dockerApiVersion() ?? "1.41").split(".").map(Number);
   const platform = apiMajor > 1 || apiMinor >= 41 ? process.env.DOCKER_DEFAULT_PLATFORM : undefined;
   const id = dockerRequest(
     `/containers/create?name=${encodeURIComponent(container.name)}${platform ? `&platform=${encodeURIComponent(platform)}` : ""}`,

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -138,9 +138,12 @@ function requireDocker(): void {
   }
 }
 
-function docker(args: string[], allow?: RegExp): string {
+function docker(args: string[], allow?: RegExp, env?: NodeJS.ProcessEnv): string {
   try {
-    return capture("docker", args, allow ? { allow } : {});
+    return capture("docker", args, {
+      ...(allow ? { allow } : {}),
+      ...(env ? { env } : {}),
+    });
   } catch (e) {
     throw dockerError(args, errMessage(e));
   }
@@ -284,9 +287,8 @@ function ensurePostgres(ctx: DockerCtx, dryRun: boolean): string {
     if (!containerRunning(pgName)) {
       step(`Postgres: starting ${pgName}`);
       docker(["rm", "-f", pgName], /No such container|is not running/);
-      const secretFile = writeSecretEnvFile({ POSTGRES_PASSWORD: password });
-      try {
-        docker([
+      docker(
+        [
           "run",
           "-d",
           "--name",
@@ -298,17 +300,17 @@ function ensurePostgres(ctx: DockerCtx, dryRun: boolean): string {
           "pg",
           "--restart",
           "no",
-          "--env-file",
-          secretFile.path,
+          "-e",
+          "POSTGRES_PASSWORD",
           "-e",
           "POSTGRES_DB=qm",
           "-v",
           `${pgVolume(ctx)}:/var/lib/postgresql/data`,
           "postgres:16",
-        ]);
-      } finally {
-        secretFile.cleanup();
-      }
+        ],
+        undefined,
+        { ...process.env, POSTGRES_PASSWORD: password },
+      );
     }
     return url(password);
   });
@@ -433,40 +435,20 @@ function secretEnvKeys(ctx: DockerCtx, service: string): Set<string> {
   return keys;
 }
 
-function writeSecretEnvFile(entries: Record<string, string>): { path: string; cleanup: () => void } {
-  for (const [key, value] of Object.entries(entries)) {
-    if (/[\r\n]/.test(value)) {
-      throw new CliError(
-        `secret ${key} contains a newline — docker --env-file is line-based and cannot carry it. ` +
-          `Provide a single-line value (e.g. base64-encode PEM keys and decode in the consumer).`,
-      );
+function pushEnvArgs(args: string[], env: Record<string, string>, secretKeys: Set<string>): NodeJS.ProcessEnv {
+  const dockerEnv = { ...process.env };
+  for (const [k, v] of Object.entries(env)) {
+    if (secretKeys.has(k)) {
+      args.push("-e", k);
+      dockerEnv[k] = v;
+    } else {
+      args.push("-e", `${k}=${v}`);
     }
   }
-  const dir = mkdtempSync(join(tmpdir(), "qm-env-"));
-  const path = join(dir, "secrets.env");
-  writeFileSync(
-    path,
-    `${Object.entries(entries)
-      .map(([k, v]) => `${k}=${v}`)
-      .join("\n")}\n`,
-    { mode: 0o600 },
-  );
-  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  return dockerEnv;
 }
 
-function pushEnvArgs(args: string[], env: Record<string, string>, secretKeys: Set<string>): () => void {
-  const secrets: Record<string, string> = {};
-  for (const [k, v] of Object.entries(env)) {
-    if (secretKeys.has(k)) secrets[k] = v;
-    else args.push("-e", `${k}=${v}`);
-  }
-  if (!Object.keys(secrets).length) return () => {};
-  const file = writeSecretEnvFile(secrets);
-  args.push("--env-file", file.path);
-  return file.cleanup;
-}
-
-function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: string[]; cleanup: () => void } {
+function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: string[]; env: NodeJS.ProcessEnv } {
   const def = serviceDef(service);
   const args = [
     "run",
@@ -483,7 +465,7 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     "--restart",
     "no",
   ];
-  const cleanup = pushEnvArgs(args, serviceEnv(ctx, service), secretEnvKeys(ctx, service));
+  const env = pushEnvArgs(args, serviceEnv(ctx, service), secretEnvKeys(ctx, service));
   if (service === "core") {
     args.push("-v", `${ctx.prefix}-coredata:/data`);
     for (const m of layerMounts(ctx)) args.push("-v", m);
@@ -498,7 +480,7 @@ function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: s
     args.push("-p", `${baseHostPort(ctx) + def.docker.hostPortOffset}:${def.docker.internalPort}`);
   }
   args.push(image);
-  return { args, cleanup };
+  return { args, env };
 }
 
 function skillMounts(ctx: DockerCtx): string[] {
@@ -683,11 +665,7 @@ export async function dockerUp(
     docker(["rm", "-f", cname(ctx, def.name)], /No such container|is not running/);
     step(`starting ${def.name}`);
     const run = runArgs(ctx, def.name, image);
-    try {
-      docker(run.args);
-    } finally {
-      run.cleanup();
-    }
+    docker(run.args, undefined, run.env);
     await waitReady(ctx, def.name);
     ok(`${def.name} ready`);
   }
@@ -720,13 +698,9 @@ export async function dockerUp(
       ...(ctx.signingSecret && p.coreAccess !== false ? { CORE_SIGNING_SECRET: ctx.signingSecret } : {}),
       ...secretValues(ctx, p.name),
     };
-    const cleanup = pushEnvArgs(args, env, secretEnvKeys(ctx, p.name));
+    const dockerEnv = pushEnvArgs(args, env, secretEnvKeys(ctx, p.name));
     args.push(image);
-    try {
-      docker(args);
-    } finally {
-      cleanup();
-    }
+    docker(args, undefined, dockerEnv);
     await waitPluginUp(cname(ctx, p.name));
     ok(`plugin ${p.name} running`);
   }

--- a/cli/src/backends/docker.ts
+++ b/cli/src/backends/docker.ts
@@ -1,3 +1,4 @@
+import { startDockerContainer, validateDockerEnv, dockerClientDefaults, type DockerContainer } from "./docker-api.ts";
 import { httpDeploymentLayerTransport, type DeploymentLayerTransport } from "../deployment-layer.ts";
 
 import { randomBytes } from "node:crypto";
@@ -43,11 +44,11 @@ export const dockerDeploymentLayerTransport: DeploymentLayerTransport = httpDepl
 
 const safe = (s: string): string => s.replace(/[^A-Za-z0-9_.-]/g, "-");
 const ORG_LABEL_KEY = "qm.org";
-const orgLabelArgs = (ctx: DockerCtx): string[] => ["--label", `${ORG_LABEL_KEY}=${ctx.config.orgId}`];
 const baseHostPort = (ctx: DockerCtx): number => dockerBasePort(ctx.config);
 
 interface DockerCtx {
   config: QmConfig;
+  dockerDefaults?: ReturnType<typeof dockerClientDefaults>;
   configDir: string;
   sandboxDir: string;
   network: string;
@@ -138,12 +139,9 @@ function requireDocker(): void {
   }
 }
 
-function docker(args: string[], allow?: RegExp, env?: NodeJS.ProcessEnv): string {
+function docker(args: string[], allow?: RegExp): string {
   try {
-    return capture("docker", args, {
-      ...(allow ? { allow } : {}),
-      ...(env ? { env } : {}),
-    });
+    return capture("docker", args, allow ? { allow } : {});
   } catch (e) {
     throw dockerError(args, errMessage(e));
   }
@@ -281,36 +279,24 @@ function ensurePostgres(ctx: DockerCtx, dryRun: boolean): string {
       password = state?.pgPassword ?? randomBytes(16).toString("hex");
     }
 
+    validateDockerEnv({ POSTGRES_PASSWORD: password });
     const stateOut: DeploymentState = { orgId: ctx.config.orgId, network: ctx.network, pgPassword: password };
     writeDeploymentState(stateOut);
 
     if (!containerRunning(pgName)) {
       step(`Postgres: starting ${pgName}`);
       docker(["rm", "-f", pgName], /No such container|is not running/);
-      docker(
-        [
-          "run",
-          "-d",
-          "--name",
-          pgName,
-          ...orgLabelArgs(ctx),
-          "--network",
-          ctx.network,
-          "--network-alias",
-          "pg",
-          "--restart",
-          "no",
-          "-e",
-          "POSTGRES_PASSWORD",
-          "-e",
-          "POSTGRES_DB=qm",
-          "-v",
-          `${pgVolume(ctx)}:/var/lib/postgresql/data`,
-          "postgres:16",
-        ],
-        undefined,
-        { ...process.env, POSTGRES_PASSWORD: password },
-      );
+      if (!inspectExists(["image", "inspect", "postgres:16"], /No such image/i)) dockerInherit(["pull", "postgres:16"]);
+      startDockerContainer({
+        name: pgName,
+        image: "postgres:16",
+        labels: { [ORG_LABEL_KEY]: ctx.config.orgId },
+        network: ctx.network,
+        aliases: ["pg"],
+        env: { ...ctx.dockerDefaults?.env, POSTGRES_PASSWORD: password, POSTGRES_DB: "qm" },
+        headers: ctx.dockerDefaults?.headers,
+        binds: [`${pgVolume(ctx)}:/var/lib/postgresql/data`],
+      });
     }
     return url(password);
   });
@@ -406,6 +392,7 @@ function serviceEnv(ctx: DockerCtx, service: ServiceName): Record<string, string
   }
   const virtualEnv = service === "core" ? virtualServiceEnv(config.services, config.env) : {};
   const env = {
+    ...ctx.dockerDefaults?.env,
     ...out,
     ...virtualEnv,
     ...config.env[service],
@@ -424,63 +411,47 @@ function serviceEnv(ctx: DockerCtx, service: ServiceName): Record<string, string
   return env;
 }
 
-function secretEnvKeys(ctx: DockerCtx, service: string): Set<string> {
-  const keys = new Set(Object.keys(secretValues(ctx, service)));
-  const plugin = ctx.config.plugins.find((entry) => entry.name === service);
-  if (ctx.signingSecret && plugin?.coreAccess !== false) keys.add("CORE_SIGNING_SECRET");
-  if (service === "core") {
-    keys.add("DATABASE_URL");
-    for (const key of ctx.sandboxSecretKeys) keys.add(key);
-  }
-  return keys;
-}
-
-function pushEnvArgs(args: string[], env: Record<string, string>, secretKeys: Set<string>): NodeJS.ProcessEnv {
-  const dockerEnv = { ...process.env };
-  for (const [k, v] of Object.entries(env)) {
-    if (secretKeys.has(k)) {
-      args.push("-e", k);
-      dockerEnv[k] = v;
-    } else {
-      args.push("-e", `${k}=${v}`);
-    }
-  }
-  return dockerEnv;
-}
-
-function runArgs(ctx: DockerCtx, service: ServiceName, image: string): { args: string[]; env: NodeJS.ProcessEnv } {
+function serviceContainer(ctx: DockerCtx, service: ServiceName, image: string): DockerContainer {
   const def = serviceDef(service);
-  const args = [
-    "run",
-    "-d",
-    "--name",
-    cname(ctx, service),
-    ...orgLabelArgs(ctx),
-    "--network",
-    ctx.network,
-    "--network-alias",
-    service,
-    "--network-alias",
-    `${cname(ctx, service)}.internal`,
-    "--restart",
-    "no",
-  ];
-  const env = pushEnvArgs(args, serviceEnv(ctx, service), secretEnvKeys(ctx, service));
+  const container: DockerContainer = {
+    name: cname(ctx, service),
+    image,
+    network: ctx.network,
+    aliases: [service, `${cname(ctx, service)}.internal`],
+    labels: { [ORG_LABEL_KEY]: ctx.config.orgId },
+    env: serviceEnv(ctx, service),
+    headers: ctx.dockerDefaults?.headers,
+  };
   if (service === "core") {
-    args.push("-v", `${ctx.prefix}-coredata:/data`);
-    for (const m of layerMounts(ctx)) args.push("-v", m);
-    for (const m of skillMounts(ctx)) args.push("-v", m);
+    container.binds = [`${ctx.prefix}-coredata:/data`, ...layerMounts(ctx), ...skillMounts(ctx)];
     if (localSandboxActive(ctx.config)) {
       const socket = hostDockerSocket();
-      args.push("-v", `${socket.path}:/var/run/docker.sock`);
-      if (socket.gid) args.push("--group-add", socket.gid);
+      container.binds.push(`${socket.path}:/var/run/docker.sock`);
+      if (socket.gid) container.groups = [socket.gid];
     }
   }
   if (def.docker.hostPortOffset !== undefined) {
-    args.push("-p", `${baseHostPort(ctx) + def.docker.hostPortOffset}:${def.docker.internalPort}`);
+    container.port = { host: baseHostPort(ctx) + def.docker.hostPortOffset, container: def.docker.internalPort };
   }
-  args.push(image);
-  return { args, env };
+  return container;
+}
+
+function pluginEnv(ctx: DockerCtx, plugin: ResolvedPlugin): Record<string, string> {
+  return {
+    ...ctx.dockerDefaults?.env,
+    ...(plugin.coreAccess === false ? {} : { CORE_API_URL: "http://core:8080" }),
+    ...orgEnv(
+      plugin.name,
+      ctx.config.orgId,
+      ctx.config.publicUrl,
+      ctx.config.services.includes("portal"),
+      brandEnvOf(ctx.config),
+    ),
+    PORT: "8080",
+    ...plugin.env,
+    ...(ctx.signingSecret && plugin.coreAccess !== false ? { CORE_SIGNING_SECRET: ctx.signingSecret } : {}),
+    ...secretValues(ctx, plugin.name),
+  };
 }
 
 function skillMounts(ctx: DockerCtx): string[] {
@@ -655,6 +626,11 @@ export async function dockerUp(
     );
   }
 
+  ctx.dockerDefaults = dockerClientDefaults();
+  validateDockerEnv(ctx.dockerDefaults.env);
+  ctx.databaseUrl = externalDatabaseUrl(ctx) ?? "";
+  for (const def of ordered(runnableServices(config.services))) validateDockerEnv(serviceEnv(ctx, def.name));
+  for (const plugin of plugins) validateDockerEnv(pluginEnv(ctx, plugin));
   if (localSandboxActive(config)) ensureLocalSandboxImage(config);
   ensureNetwork(ctx);
   ctx.databaseUrl = ensurePostgres(ctx, false);
@@ -664,8 +640,7 @@ export async function dockerUp(
     const image = resolveImage(ctx, def.name);
     docker(["rm", "-f", cname(ctx, def.name)], /No such container|is not running/);
     step(`starting ${def.name}`);
-    const run = runArgs(ctx, def.name, image);
-    docker(run.args, undefined, run.env);
+    startDockerContainer(serviceContainer(ctx, def.name, image));
     await waitReady(ctx, def.name);
     ok(`${def.name} ready`);
   }
@@ -674,33 +649,15 @@ export async function dockerUp(
     const image = resolvePluginImage(ctx, p);
     docker(["rm", "-f", cname(ctx, p.name)], /No such container|is not running/);
     step(`starting plugin ${p.name} (${image})`);
-    const args = [
-      "run",
-      "-d",
-      "--name",
-      cname(ctx, p.name),
-      ...orgLabelArgs(ctx),
-      "--network",
-      ctx.network,
-      "--network-alias",
-      p.name,
-      "--restart",
-      "no",
-    ];
-    const wiring = {
-      ...(p.coreAccess === false ? {} : { CORE_API_URL: "http://core:8080" }),
-      ...orgEnv(p.name, config.orgId, config.publicUrl, config.services.includes("portal"), brandEnvOf(config)),
-      PORT: "8080",
-    };
-    const env = {
-      ...wiring,
-      ...p.env,
-      ...(ctx.signingSecret && p.coreAccess !== false ? { CORE_SIGNING_SECRET: ctx.signingSecret } : {}),
-      ...secretValues(ctx, p.name),
-    };
-    const dockerEnv = pushEnvArgs(args, env, secretEnvKeys(ctx, p.name));
-    args.push(image);
-    docker(args, undefined, dockerEnv);
+    startDockerContainer({
+      name: cname(ctx, p.name),
+      image,
+      labels: { [ORG_LABEL_KEY]: ctx.config.orgId },
+      network: ctx.network,
+      aliases: [p.name],
+      env: pluginEnv(ctx, p),
+      headers: ctx.dockerDefaults?.headers,
+    });
     await waitPluginUp(cname(ctx, p.name));
     ok(`plugin ${p.name} running`);
   }

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -22,11 +22,27 @@ const SECRETS = {
   EXAMPLE_SCREEN_TOKEN: "security-screen-supersecret",
 };
 
-function fakeDocker(dir: string): { argvLog: string; envCopy: string } {
+interface CreateRequest {
+  path: string;
+  headers: string;
+  body: {
+    Env: string[];
+    Image: string;
+    Labels: Record<string, string>;
+    HostConfig: { Binds: string[]; GroupAdd: string[]; PortBindings?: Record<string, { HostPort: string }[]> };
+    NetworkingConfig: { EndpointsConfig: Record<string, { Aliases: string[] }> };
+  };
+}
+
+function fakeDocker(dir: string): { argvLog: string; envCopy: string; requestsLog: string; clientEnv: string } {
   const argvLog = join(dir, "docker-argv.log");
   const envCopy = join(dir, "env-copy.log");
   writeFileSync(argvLog, "");
   writeFileSync(envCopy, "");
+  const requestsLog = join(dir, "requests.log");
+  const clientEnv = join(dir, "client-env.log");
+  writeFileSync(requestsLog, "");
+  writeFileSync(clientEnv, "");
   const bin = join(dir, "docker");
   writeFileSync(
     bin,
@@ -35,15 +51,28 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(argvLog)}, JSON.stringify(args) + "\\n");
 if (args[0] === "version") { console.log("25.0"); process.exit(0); }
-if (args[0] === "run") {
-  for (let i = 0; i < args.length - 1; i++) {
-    if (args[i] !== "-e" || args[i + 1].includes("=")) continue;
-    const name = args[i + 1];
-    fs.appendFileSync(${JSON.stringify(envCopy)}, name + "=" + (process.env[name] ?? "") + "\\n");
+if (args[0] === "system" && args[1] === "dial-stdio") {
+  const raw = fs.readFileSync(0, "utf8");
+  const path = raw.split(" ")[1];
+  const body = JSON.parse(raw.slice(raw.indexOf("\\r\\n\\r\\n") + 4));
+  fs.appendFileSync(${JSON.stringify(requestsLog)}, JSON.stringify({path, body, headers: raw.slice(0, raw.indexOf("\\r\\n\\r\\n"))}) + "\\n");
+  fs.appendFileSync(${JSON.stringify(clientEnv)}, JSON.stringify(Object.fromEntries(["DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG", "DOCKER_API_VERSION", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "LD_PRELOAD", "PATH", "HOME", "CORE_SIGNING_SECRET", "PLUG_TOKEN"].map(k => [k, process.env[k]]))) + "\\n");
+  if (body.Env) fs.appendFileSync(${JSON.stringify(envCopy)}, body.Env.join("\\n") + "\\n---\\n");
+  const modePath = ${JSON.stringify(join(dir, "api-mode"))};
+  const mode = fs.existsSync(modePath) ? fs.readFileSync(modePath, "utf8") : "";
+  const created = JSON.stringify({Id: "a".repeat(64)});
+  if (mode === "process-error") { console.error(JSON.stringify(body)); process.exit(1); }
+  if (mode === "truncated") { process.stdout.write("HTTP/1.1 201 Created\\r\\nContent-Length: 1000\\r\\n\\r\\n{"); process.exit(0); }
+  if (mode === "invalid-id") { process.stdout.write('HTTP/1.1 201 Created\\r\\nContent-Length: 12\\r\\n\\r\\n{"Id":"bad"}'); process.exit(0); }
+  if (mode === "chunked" && path.includes("/create?")) { process.stdout.write("HTTP/1.1 201 Created\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n" + Buffer.byteLength(created).toString(16) + "\\r\\n" + created + "\\r\\n0\\r\\n\\r\\n"); process.exit(0); }
+  if (mode === "informational") process.stdout.write("HTTP/1.1 100 Continue\\r\\n\\r\\n");
+  if (fs.existsSync(${JSON.stringify(join(dir, "reject-api"))})) {
+    process.stdout.write("HTTP/1.1 500 Server Error\\r\\nConnection: close\\r\\n\\r\\n" + JSON.stringify(body));
+    process.exit(0);
   }
-  fs.appendFileSync(${JSON.stringify(envCopy)}, "---\\n");
-  console.log("cid");
-  process.exit(0);
+  process.stdout.write(path.includes("/create?") ? 'HTTP/1.1 201 Created\\r\\nContent-Length: 73\\r\\n\\r\\n{"Id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' : "HTTP/1.1 204 No Content\\r\\n\\r\\n");
+  if (mode === "linger") setInterval(() => {}, 1000);
+  else process.exit(0);
 }
 if (args[0] === "logs") { console.log("listening on :8080"); process.exit(0); }
 if (args[0] === "volume") { console.error("No such volume"); process.exit(1); }
@@ -56,7 +85,7 @@ process.exit(0);
 `,
   );
   chmodSync(bin, 0o755);
-  return { argvLog, envCopy };
+  return { argvLog, envCopy, requestsLog, clientEnv };
 }
 
 test("docker up keeps secret values off the docker argv", { timeout: 60_000 }, async () => {
@@ -147,26 +176,44 @@ test("docker up keeps secret values off the docker argv", { timeout: 60_000 }, a
     );
     assert.ok(!argv.includes("config-placeholder"), "non-secret config env cannot shadow or expose secret values");
     assert.ok(!argv.includes("--env-file"), "docker runs do not need a temporary env file");
-    assert.ok(argv.includes('"CORE_SIGNING_SECRET"'), "secret names travel as name-only -e flags");
-    assert.ok(argv.includes("FLY_RESIDENT_ENV_TZ=UTC"), "sandbox.env literals are not secrets");
-    assert.ok(argv.includes("LINEAR_REGION=us"), "undeclared plugin env still flows as -e");
-    const signerArgs = argv
+    const requests = readFileSync(fake.requestsLog, "utf8")
+      .trim()
       .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as string[])
-      .find((args) => args.includes("qm-sekrit-signer"));
-    assert.ok(signerArgs, "coreless plugin starts");
-    assert.ok(!signerArgs.includes("CORE_API_URL=http://core:8080"), "coreless plugin gets no core endpoint");
-    assert.ok(!signerArgs.includes("CORE_SIGNING_SECRET"), "coreless plugin gets no source-auth secret");
-    assert.ok(argv.includes("SECURITY_SCREEN_BACKEND=proxy"));
-    assert.ok(argv.includes("SECURITY_SCREEN_PROXY_PROVIDER=example-screen"));
-    assert.ok(argv.includes("SECURITY_SCREEN_PROXY_ENDPOINT=https://screen.example.test/classify"));
-    assert.ok(argv.includes("SECURITY_SCREEN_PROXY_ROLLOUT=enforce"));
-
+      .map((line) => JSON.parse(line) as CreateRequest);
+    const creates = requests.filter((request) => request.path.startsWith("/containers/create?"));
+    const signer = creates.find((request) => request.path.endsWith("name=qm-sekrit-signer"));
+    assert.ok(signer, "the actual coreless container-create request is inspected");
     assert.ok(
-      argv.includes("WEB_UI_PUBLIC_URL=http://folded.example.com/web-ui"),
-      "virtual-service env folds into the core env",
+      !signer.body.Env.some((entry) => entry.startsWith("CORE_API_URL=")),
+      "coreless plugin gets no core endpoint",
     );
+    assert.ok(
+      !signer.body.Env.some((entry) => entry.startsWith("CORE_SIGNING_SECRET=")),
+      "coreless plugin gets no source-auth secret",
+    );
+    const core = creates.find((request) => request.path.endsWith("name=qm-sekrit-core"))!;
+    assert.deepEqual(core.body.HostConfig.PortBindings, { "8080/tcp": [{ HostIp: "", HostPort: "8080" }] });
+    assert.ok(core.body.HostConfig.Binds.includes("qm-sekrit-coredata:/data"));
+    assert.deepEqual(core.body.NetworkingConfig.EndpointsConfig["qm-sekrit"]!.Aliases, [
+      "core",
+      "qm-sekrit-core.internal",
+    ]);
+    assert.equal(core.body.Labels["qm.org"], "sekrit");
+    const sentEnv = creates.flatMap((request) => request.body.Env);
+    for (const entry of [
+      "FLY_RESIDENT_ENV_TZ=UTC",
+      "LINEAR_REGION=us",
+      "SECURITY_SCREEN_BACKEND=proxy",
+      "SECURITY_SCREEN_PROXY_PROVIDER=example-screen",
+      "SECURITY_SCREEN_PROXY_ENDPOINT=https://screen.example.test/classify",
+      "SECURITY_SCREEN_PROXY_ROLLOUT=enforce",
+      "WEB_UI_PUBLIC_URL=http://folded.example.com/web-ui",
+    ])
+      assert.ok(sentEnv.includes(entry), entry);
+    const clientEnv = readFileSync(fake.clientEnv, "utf8");
+    assert.ok(!clientEnv.includes(SECRETS.CORE_SIGNING_SECRET));
+    assert.ok(!clientEnv.includes(SECRETS.PLUG_TOKEN));
+
     assert.ok(
       lines.some((l) => /\.env keys not forwarded/.test(l) && l.includes("HARNESS")),
       "unforwarded .env keys are warned about",
@@ -215,7 +262,7 @@ test("docker up keeps secret values off the docker argv", { timeout: 60_000 }, a
       "a secretEnv alias delivers the stored value under its declared env name",
     );
     assert.match(envFiles, new RegExp(`^SECURITY_SCREEN_PROXY_TOKEN=${SECRETS.EXAMPLE_SCREEN_TOKEN}$`, "m"));
-    assert.ok(!envFiles.includes("FLY_RESIDENT_ENV_TZ"), "literal sandbox env is absent from secret delivery");
+
     assert.equal(process.env.CORE_SIGNING_SECRET, undefined, "secret delivery does not mutate the parent environment");
   } finally {
     console.log = log;
@@ -273,17 +320,21 @@ test(
 
       const argv = readFileSync(fake.argvLog, "utf8");
       assert.ok(!argv.includes(password), "the pg password must not reach the docker argv");
-      assert.ok(argv.includes('"POSTGRES_PASSWORD"'), "POSTGRES_PASSWORD travels as a name-only -e flag");
+      const requests = readFileSync(fake.requestsLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as CreateRequest);
+      const pg = requests.find((request) => request.path.endsWith("name=qm-sekritpg-pg"))!;
+      assert.equal(pg.body.Image, "postgres:16");
+      assert.deepEqual(pg.body.HostConfig.Binds, ["qm-sekritpg-pgdata:/var/lib/postgresql/data"]);
+      assert.ok(pg.body.Env.includes("POSTGRES_DB=qm"));
       assert.ok(!argv.includes("postgres://"), "the derived DATABASE_URL must not reach the docker argv");
 
       const envFiles = readFileSync(fake.envCopy, "utf8");
-      assert.ok(
-        envFiles.includes(`POSTGRES_PASSWORD=${password}`),
-        "pg gets its password through the docker process env",
-      );
+      assert.ok(envFiles.includes(`POSTGRES_PASSWORD=${password}`), "pg gets its password through the Docker API body");
       assert.ok(
         envFiles.includes(`DATABASE_URL=postgres://postgres:${password}@pg:5432/qm`),
-        "the core gets DATABASE_URL through the docker process env",
+        "the core gets DATABASE_URL through the Docker API body",
       );
     } finally {
       console.log = log;
@@ -348,7 +399,7 @@ test(
   },
 );
 
-test("a multi-line secret value is delivered through the docker process environment", { timeout: 60_000 }, async () => {
+test("a multi-line secret value is delivered through the Docker API body", { timeout: 60_000 }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-docker-secrets-nl-"));
   const priorPath = process.env.PATH;
   const priorDb = process.env.DATABASE_URL;
@@ -380,7 +431,7 @@ test("a multi-line secret value is delivered through the docker process environm
     await dockerUp(config, dir, {});
     assert.ok(
       readFileSync(fake.envCopy, "utf8").includes("CORE_SIGNING_SECRET=-----BEGIN KEY-----\nabc\n-----END KEY-----"),
-      "name-only delivery preserves multi-line secret values",
+      "API delivery preserves multi-line secret values",
     );
   } finally {
     console.log = log;
@@ -392,4 +443,222 @@ test("a multi-line secret value is delivered through the docker process environm
     else process.env.CORE_SIGNING_SECRET = priorSecret;
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+async function withDockerSecrets(
+  extraConfig: Record<string, unknown>,
+  secrets: Record<string, string>,
+  check: (fixture: ReturnType<typeof fakeDocker> & { dir: string; up: () => Promise<void> }) => Promise<void>,
+): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "qm-docker-api-secrets-"));
+  const priorPath = process.env.PATH;
+  const priorDb = process.env.DATABASE_URL;
+  const log = console.log,
+    warn = console.warn;
+  try {
+    writeFileSync(
+      join(dir, CONFIG_FILENAME),
+      JSON.stringify({
+        contract: 1,
+        orgId: "apisecrets",
+        publicUrl: "http://localhost:8080",
+        target: "docker",
+        services: ["core"],
+        ...extraConfig,
+      }),
+    );
+    writeFileSync(
+      join(dir, ".env"),
+      Object.entries({ ...SECRETS, DATABASE_URL: "postgres://sentinel:db@db/qm", ...secrets })
+        .map(([key, value]) => `${key}=${value}`)
+        .join("\n"),
+    );
+    const fake = fakeDocker(dir);
+    process.env.PATH = `${dir}:${priorPath}`;
+    delete process.env.DATABASE_URL;
+    console.log = (): void => {};
+    console.warn = console.log;
+    const { config } = loadConfigAt(join(dir, CONFIG_FILENAME));
+    await check({ ...fake, dir, up: () => dockerUp(config, dir, {}) });
+  } finally {
+    console.log = log;
+    console.warn = warn;
+    process.env.PATH = priorPath;
+    if (priorDb === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDb;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+for (const plugin of [false, true]) {
+  test(`container control variables never alter the Docker client (${plugin ? "plugin" : "core"})`, async () => {
+    const names = [
+      "DOCKER_HOST",
+      "DOCKER_CONTEXT",
+      "DOCKER_CONFIG",
+      "DOCKER_API_VERSION",
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "ALL_PROXY",
+      "NO_PROXY",
+      "LD_PRELOAD",
+      "PATH",
+      "HOME",
+    ];
+    const values = Object.fromEntries(names.map((name) => [name, `sentinel-container-${name}`]));
+    const aliases = Object.fromEntries(names.map((name) => [name, `STORED_${name}`]));
+    const extraConfig = plugin
+      ? {
+          plugins: [
+            {
+              name: "signer",
+              image: "example.invalid/signer:1",
+              coreAccess: false,
+              secrets: names.map((name) => ({ name })),
+            },
+          ],
+        }
+      : { secretEnv: { core: aliases } };
+    const secrets = plugin ? values : Object.fromEntries(names.map((name) => [aliases[name], values[name]]));
+    await withDockerSecrets(extraConfig, secrets, async (fixture) => {
+      const expected = Object.fromEntries(names.map((name) => [name, process.env[name]]));
+      await fixture.up();
+      const clients = readFileSync(fixture.clientEnv, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, string>);
+      assert.ok(clients.length > 0);
+      for (const client of clients) for (const name of names) assert.equal(client[name], expected[name], name);
+      const creates = readFileSync(fixture.requestsLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as CreateRequest);
+      const request = creates.find((entry) => entry.path.endsWith(`name=qm-apisecrets-${plugin ? "signer" : "core"}`))!;
+      for (const name of names) assert.ok(request.body.Env.includes(`${name}=${values[name]}`));
+      if (plugin) assert.ok(!request.body.Env.some((entry) => entry.startsWith("CORE_SIGNING_SECRET=")));
+      for (const name of names) assert.equal(process.env[name], expected[name]);
+    });
+  });
+}
+
+for (const source of ["core", "plugin", "database", "literal"]) {
+  test(`NUL in ${source} environment is rejected without values before deployment changes`, async () => {
+    const sentinel = "sentinel-private-prefix\0private-suffix";
+    const configs: Record<string, Record<string, unknown>> = {
+      plugin: {
+        plugins: [
+          { name: "signer", image: "example.invalid/signer:1", coreAccess: false, secrets: [{ name: "PLUG_TOKEN" }] },
+        ],
+      },
+      literal: { env: { core: { CUSTOM_VALUE: sentinel } } },
+    };
+    const keys: Record<string, string> = { plugin: "PLUG_TOKEN", database: "DATABASE_URL" };
+    const key = keys[source] ?? "CAPABILITY_SECRET";
+    const extraConfig = configs[source] ?? {};
+    const secrets = source === "literal" ? {} : { [key]: sentinel };
+    await withDockerSecrets(extraConfig, secrets, async (fixture) => {
+      await assert.rejects(fixture.up(), (error: Error) => {
+        assert.match(error.message, /NUL byte/);
+        assert.ok(!error.message.includes("sentinel-private-prefix"));
+        assert.ok(!error.message.includes("private-suffix"));
+        return true;
+      });
+      const commands = readFileSync(fixture.argvLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      assert.deepEqual(
+        commands.map((args) => args[0]),
+        ["version"],
+      );
+      assert.equal(readFileSync(fixture.requestsLog, "utf8"), "");
+    });
+  });
+}
+
+test("Docker API error bodies containing secrets are withheld", async () => {
+  await withDockerSecrets({}, {}, async (fixture) => {
+    writeFileSync(join(fixture.dir, "reject-api"), "");
+    await assert.rejects(fixture.up(), (error: Error) => {
+      assert.match(error.message, /HTTP 500/);
+      for (const secret of Object.values(SECRETS)) assert.ok(!error.message.includes(secret));
+      assert.equal(error.cause, undefined);
+      return true;
+    });
+  });
+});
+
+for (const mode of ["process-error", "truncated", "invalid-id"]) {
+  test(`Docker API ${mode} fails closed without starting a container or disclosing values`, async () => {
+    await withDockerSecrets({}, {}, async (fixture) => {
+      writeFileSync(join(fixture.dir, "api-mode"), mode);
+      await assert.rejects(fixture.up(), (error: Error) => {
+        assert.match(error.message, /Docker API/);
+        for (const value of Object.values(SECRETS)) assert.ok(!error.message.includes(value));
+        return true;
+      });
+      assert.ok(!readFileSync(fixture.requestsLog, "utf8").includes("/start"));
+    });
+  });
+}
+
+for (const mode of ["chunked", "informational", "linger"]) {
+  test(`Docker API handles ${mode} and starts the returned ID rather than the mutable name`, async () => {
+    await withDockerSecrets({}, {}, async (fixture) => {
+      writeFileSync(join(fixture.dir, "api-mode"), mode);
+      const before = Date.now();
+      await fixture.up();
+      assert.ok(Date.now() - before < 10_000, "a complete response must not wait for the proxy to exit");
+      const requests = readFileSync(fixture.requestsLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as CreateRequest);
+      assert.equal(requests[1]!.path, `/containers/${"a".repeat(64)}/start`);
+    });
+  });
+}
+
+test("Docker proxy defaults, explicit overrides, custom headers and default platform survive API delivery", async () => {
+  await withDockerSecrets({ env: { core: { HTTPS_PROXY: "explicit-proxy" } } }, {}, async (fixture) => {
+    const priorConfig = process.env.DOCKER_CONFIG;
+    const priorPlatform = process.env.DOCKER_DEFAULT_PLATFORM;
+    const priorVersion = process.env.DOCKER_API_VERSION;
+    const priorHeaders = process.env.DOCKER_CUSTOM_HEADERS;
+    try {
+      process.env.DOCKER_CONFIG = fixture.dir;
+      process.env.DOCKER_DEFAULT_PLATFORM = "linux/arm64";
+      process.env.DOCKER_API_VERSION = "1.47";
+      process.env.DOCKER_CUSTOM_HEADERS = "X-Launcher-Test=launcher-header-sentinel";
+      writeFileSync(
+        join(fixture.dir, "config.json"),
+        JSON.stringify({
+          proxies: { default: { httpProxy: "http://default-proxy", httpsProxy: "https://default-proxy" } },
+          HttpHeaders: { "X-Docker-Test": "header-sentinel" },
+        }),
+      );
+      await fixture.up();
+      const requests = readFileSync(fixture.requestsLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as CreateRequest);
+      assert.ok(requests[0]!.path.startsWith("/v1.47/containers/create?"));
+      assert.ok(requests[0]!.path.endsWith("&platform=linux%2Farm64"));
+      for (const request of requests) assert.match(request.headers, /X-Launcher-Test: launcher-header-sentinel/i);
+      for (const request of requests) assert.match(request.headers, /X-Docker-Test: header-sentinel/i);
+      const env = requests[0]!.body.Env;
+      assert.ok(env.includes("HTTP_PROXY=http://default-proxy"));
+      assert.ok(env.includes("http_proxy=http://default-proxy"));
+      assert.ok(env.includes("HTTPS_PROXY=explicit-proxy"));
+      assert.ok(env.includes("https_proxy=https://default-proxy"));
+    } finally {
+      if (priorConfig === undefined) delete process.env.DOCKER_CONFIG;
+      else process.env.DOCKER_CONFIG = priorConfig;
+      if (priorPlatform === undefined) delete process.env.DOCKER_DEFAULT_PLATFORM;
+      else process.env.DOCKER_DEFAULT_PLATFORM = priorPlatform;
+      if (priorVersion === undefined) delete process.env.DOCKER_API_VERSION;
+      else process.env.DOCKER_API_VERSION = priorVersion;
+      if (priorHeaders === undefined) delete process.env.DOCKER_CUSTOM_HEADERS;
+      else process.env.DOCKER_CUSTOM_HEADERS = priorHeaders;
+    }
+  });
 });

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CONFIG_FILENAME, loadConfigAt } from "../src/config.ts";
@@ -36,12 +36,12 @@ const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(argvLog)}, JSON.stringify(args) + "\\n");
 if (args[0] === "version") { console.log("25.0"); process.exit(0); }
 if (args[0] === "run") {
-  const i = args.indexOf("--env-file");
-  if (i !== -1) {
-    const path = args[i + 1];
-    const mode = (fs.statSync(path).mode & 0o777).toString(8);
-    fs.appendFileSync(${JSON.stringify(envCopy)}, "mode=" + mode + "\\n" + fs.readFileSync(path, "utf8") + "---\\n");
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] !== "-e" || args[i + 1].includes("=")) continue;
+    const name = args[i + 1];
+    fs.appendFileSync(${JSON.stringify(envCopy)}, name + "=" + (process.env[name] ?? "") + "\\n");
   }
+  fs.appendFileSync(${JSON.stringify(envCopy)}, "---\\n");
   console.log("cid");
   process.exit(0);
 }
@@ -59,7 +59,7 @@ process.exit(0);
   return { argvLog, envCopy };
 }
 
-test("docker up delivers secrets via a 0600 env-file, never on the docker argv", { timeout: 60_000 }, async () => {
+test("docker up keeps secret values off the docker argv", { timeout: 60_000 }, async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-docker-secrets-"));
   const priorPath = process.env.PATH;
   const priorDb = process.env.DATABASE_URL;
@@ -146,7 +146,8 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       "a BYO DATABASE_URL (it embeds a password) must not reach the docker argv",
     );
     assert.ok(!argv.includes("config-placeholder"), "non-secret config env cannot shadow or expose secret values");
-    assert.ok(argv.includes("--env-file"), "secrets travel via --env-file");
+    assert.ok(!argv.includes("--env-file"), "docker runs do not need a temporary env file");
+    assert.ok(argv.includes('"CORE_SIGNING_SECRET"'), "secret names travel as name-only -e flags");
     assert.ok(argv.includes("FLY_RESIDENT_ENV_TZ=UTC"), "sandbox.env literals are not secrets");
     assert.ok(argv.includes("LINEAR_REGION=us"), "undeclared plugin env still flows as -e");
     const signerArgs = argv
@@ -156,7 +157,7 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       .find((args) => args.includes("qm-sekrit-signer"));
     assert.ok(signerArgs, "coreless plugin starts");
     assert.ok(!signerArgs.includes("CORE_API_URL=http://core:8080"), "coreless plugin gets no core endpoint");
-    assert.ok(!signerArgs.includes("--env-file"), "coreless plugin gets no source-auth secret");
+    assert.ok(!signerArgs.includes("CORE_SIGNING_SECRET"), "coreless plugin gets no source-auth secret");
     assert.ok(argv.includes("SECURITY_SCREEN_BACKEND=proxy"));
     assert.ok(argv.includes("SECURITY_SCREEN_PROXY_PROVIDER=example-screen"));
     assert.ok(argv.includes("SECURITY_SCREEN_PROXY_ENDPOINT=https://screen.example.test/classify"));
@@ -181,12 +182,9 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       !envFiles.includes("config-placeholder"),
       "secret-store values win over colliding config env on services and plugins",
     );
-    assert.ok(envFiles.includes("DATABASE_URL=postgres://external/db"), "DATABASE_URL routes through the env-file");
-    assert.ok(
-      envFiles.includes(`FLY_RESIDENT_ENV_SB_TOKEN=${SECRETS.SB_TOKEN}`),
-      "secretEnv values route through the file",
-    );
-    assert.ok(envFiles.includes(`PLUG_TOKEN=${SECRETS.PLUG_TOKEN}`), "plugin secrets route through the file");
+    assert.ok(envFiles.includes("DATABASE_URL=postgres://external/db"), "DATABASE_URL reaches docker");
+    assert.ok(envFiles.includes(`FLY_RESIDENT_ENV_SB_TOKEN=${SECRETS.SB_TOKEN}`), "secretEnv values reach docker");
+    assert.ok(envFiles.includes(`PLUG_TOKEN=${SECRETS.PLUG_TOKEN}`), "plugin secrets reach docker");
     assert.match(
       envFiles,
       new RegExp(`^ANTHROPIC_API_KEY=${ambientAnthropic}$`, "m"),
@@ -209,7 +207,7 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
     assert.match(
       envFiles,
       new RegExp(`^EXTRA_API_KEY=${SECRETS.EXTRA_API_KEY}$`, "m"),
-      "config secretEnv extras route through the file",
+      "config secretEnv extras reach docker",
     );
     assert.match(
       envFiles,
@@ -217,15 +215,8 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       "a secretEnv alias delivers the stored value under its declared env name",
     );
     assert.match(envFiles, new RegExp(`^SECURITY_SCREEN_PROXY_TOKEN=${SECRETS.EXAMPLE_SCREEN_TOKEN}$`, "m"));
-    assert.ok(!envFiles.includes("FLY_RESIDENT_ENV_TZ"), "literal sandbox env is not in the secret file");
-    for (const mode of envFiles.match(/^mode=.*$/gm) ?? []) assert.equal(mode, "mode=600");
-
-    for (const line of readFileSync(fake.argvLog, "utf8").split("\n").filter(Boolean)) {
-      const args = JSON.parse(line) as string[];
-      const index = args.indexOf("--env-file");
-      if (index !== -1)
-        assert.ok(!existsSync(args[index + 1]!), "the env-file is removed once the container is created");
-    }
+    assert.ok(!envFiles.includes("FLY_RESIDENT_ENV_TZ"), "literal sandbox env is absent from secret delivery");
+    assert.equal(process.env.CORE_SIGNING_SECRET, undefined, "secret delivery does not mutate the parent environment");
   } finally {
     console.log = log;
     console.warn = warn;
@@ -282,14 +273,17 @@ test(
 
       const argv = readFileSync(fake.argvLog, "utf8");
       assert.ok(!argv.includes(password), "the pg password must not reach the docker argv");
-      assert.ok(!argv.includes("POSTGRES_PASSWORD"), "POSTGRES_PASSWORD travels via the env-file, not -e");
+      assert.ok(argv.includes('"POSTGRES_PASSWORD"'), "POSTGRES_PASSWORD travels as a name-only -e flag");
       assert.ok(!argv.includes("postgres://"), "the derived DATABASE_URL must not reach the docker argv");
 
       const envFiles = readFileSync(fake.envCopy, "utf8");
-      assert.ok(envFiles.includes(`POSTGRES_PASSWORD=${password}`), "pg gets its password via the env-file");
+      assert.ok(
+        envFiles.includes(`POSTGRES_PASSWORD=${password}`),
+        "pg gets its password through the docker process env",
+      );
       assert.ok(
         envFiles.includes(`DATABASE_URL=postgres://postgres:${password}@pg:5432/qm`),
-        "the core gets DATABASE_URL via the env-file",
+        "the core gets DATABASE_URL through the docker process env",
       );
     } finally {
       console.log = log;
@@ -354,48 +348,48 @@ test(
   },
 );
 
-test(
-  "a multi-line secret value fails loudly, naming the key (docker --env-file cannot carry newlines)",
-  { timeout: 60_000 },
-  async () => {
-    const dir = mkdtempSync(join(tmpdir(), "qm-docker-secrets-nl-"));
-    const priorPath = process.env.PATH;
-    const priorDb = process.env.DATABASE_URL;
-    const priorSecret = process.env.CORE_SIGNING_SECRET;
-    const log = console.log,
-      warn = console.warn;
-    try {
-      writeFileSync(
-        join(dir, CONFIG_FILENAME),
-        JSON.stringify({
-          contract: 1,
-          orgId: "sekritnl",
-          publicUrl: "http://localhost:8080",
-          target: "docker",
-          services: ["core"],
-        }),
-      );
-      writeFileSync(
-        join(dir, ".env"),
-        `CAPABILITY_SECRET=capability\nCONNECTOR_SECRET_KEY=${"connector".repeat(4)}\nPORTAL_IDENTITY_SECRET=identity\nSKILL_SIGNING_SECRET=${"ok".repeat(16)}\n`,
-      );
-      fakeDocker(dir);
-      process.env.PATH = `${dir}:${priorPath}`;
-      process.env.DATABASE_URL = "postgres://external/db";
-      process.env.CORE_SIGNING_SECRET = "-----BEGIN KEY-----\nabc\n-----END KEY-----";
-      console.log = (): void => {};
-      console.warn = console.log;
-      const { config } = loadConfigAt(join(dir, CONFIG_FILENAME));
-      await assert.rejects(dockerUp(config, dir, {}), /CORE_SIGNING_SECRET contains a newline/);
-    } finally {
-      console.log = log;
-      console.warn = warn;
-      process.env.PATH = priorPath;
-      if (priorDb === undefined) delete process.env.DATABASE_URL;
-      else process.env.DATABASE_URL = priorDb;
-      if (priorSecret === undefined) delete process.env.CORE_SIGNING_SECRET;
-      else process.env.CORE_SIGNING_SECRET = priorSecret;
-      rmSync(dir, { recursive: true, force: true });
-    }
-  },
-);
+test("a multi-line secret value is delivered through the docker process environment", { timeout: 60_000 }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-docker-secrets-nl-"));
+  const priorPath = process.env.PATH;
+  const priorDb = process.env.DATABASE_URL;
+  const priorSecret = process.env.CORE_SIGNING_SECRET;
+  const log = console.log,
+    warn = console.warn;
+  try {
+    writeFileSync(
+      join(dir, CONFIG_FILENAME),
+      JSON.stringify({
+        contract: 1,
+        orgId: "sekritnl",
+        publicUrl: "http://localhost:8080",
+        target: "docker",
+        services: ["core"],
+      }),
+    );
+    writeFileSync(
+      join(dir, ".env"),
+      `CAPABILITY_SECRET=capability\nCONNECTOR_SECRET_KEY=${"connector".repeat(4)}\nPORTAL_IDENTITY_SECRET=identity\nSKILL_SIGNING_SECRET=${"ok".repeat(16)}\n`,
+    );
+    const fake = fakeDocker(dir);
+    process.env.PATH = `${dir}:${priorPath}`;
+    process.env.DATABASE_URL = "postgres://external/db";
+    process.env.CORE_SIGNING_SECRET = "-----BEGIN KEY-----\nabc\n-----END KEY-----";
+    console.log = (): void => {};
+    console.warn = console.log;
+    const { config } = loadConfigAt(join(dir, CONFIG_FILENAME));
+    await dockerUp(config, dir, {});
+    assert.ok(
+      readFileSync(fake.envCopy, "utf8").includes("CORE_SIGNING_SECRET=-----BEGIN KEY-----\nabc\n-----END KEY-----"),
+      "name-only delivery preserves multi-line secret values",
+    );
+  } finally {
+    console.log = log;
+    console.warn = warn;
+    process.env.PATH = priorPath;
+    if (priorDb === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDb;
+    if (priorSecret === undefined) delete process.env.CORE_SIGNING_SECRET;
+    else process.env.CORE_SIGNING_SECRET = priorSecret;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -681,12 +681,19 @@ test("Docker custom headers use CSV syntax and replace rather than merge config 
       ['"X-Quoted=one""two",X-Equal=one=two', { "x-quoted": 'one"two', "x-equal": "one=two" }],
       [" X-Spaces = value  ,X-Empty=", { "x-spaces": " value  ", "x-empty": "" }],
       ["X-Case=first,x-case=second", { "x-case": "second" }],
+      ["__PROTO__=value", JSON.parse('{"__proto__":"value"}') as Record<string, string>],
     ] as const) {
       process.env.DOCKER_CUSTOM_HEADERS = input;
       assert.deepEqual(dockerClientDefaults().headers, expected);
       assert.ok(!Object.hasOwn(dockerClientDefaults().headers, "authorization"));
     }
+    delete process.env.DOCKER_CUSTOM_HEADERS;
+    writeFileSync(join(dir, "config.json"), JSON.stringify({ HttpHeaders: { "X-Key": "synthetic-private-header" } }));
+    assert.throws(() => dockerClientDefaults(), /Cannot read Docker client defaults/);
+    writeFileSync(join(dir, "config.json"), "{}");
     for (const input of [
+      "X-Key=synthetic-private-header",
+      "\ufeffX-Test=synthetic-private-header",
       '"X-Bad=synthetic-private-header',
       'X-Bad=se"cret',
       "X-Bad=synthetic-private-header,",

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CONFIG_FILENAME, loadConfigAt } from "../src/config.ts";
 import { dockerUp } from "../src/backends/docker.ts";
+import { dockerClientDefaults } from "../src/backends/docker-api.ts";
 
 const SECRETS = {
   ANTHROPIC_API_KEY: "anthropic-supersecret",
@@ -644,7 +645,7 @@ test("Docker proxy defaults, explicit overrides, custom headers and default plat
       assert.ok(requests[0]!.path.startsWith("/v1.47/containers/create?"));
       assert.ok(requests[0]!.path.endsWith("&platform=linux%2Farm64"));
       for (const request of requests) assert.match(request.headers, /X-Launcher-Test: launcher-header-sentinel/i);
-      for (const request of requests) assert.match(request.headers, /X-Docker-Test: header-sentinel/i);
+      for (const request of requests) assert.doesNotMatch(request.headers, /X-Docker-Test:/i);
       const env = requests[0]!.body.Env;
       assert.ok(env.includes("HTTP_PROXY=http://default-proxy"));
       assert.ok(env.includes("http_proxy=http://default-proxy"));
@@ -661,4 +662,53 @@ test("Docker proxy defaults, explicit overrides, custom headers and default plat
       else process.env.DOCKER_CUSTOM_HEADERS = priorHeaders;
     }
   });
+});
+
+test("Docker custom headers use CSV syntax and replace rather than merge config headers", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-docker-headers-"));
+  const priorConfig = process.env.DOCKER_CONFIG;
+  const priorHeaders = process.env.DOCKER_CUSTOM_HEADERS;
+  try {
+    process.env.DOCKER_CONFIG = dir;
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify({ HttpHeaders: { Authorization: "old-credential", "X-Config": "config-value" } }),
+    );
+    delete process.env.DOCKER_CUSTOM_HEADERS;
+    assert.deepEqual(dockerClientDefaults().headers, { authorization: "old-credential", "x-config": "config-value" });
+    for (const [input, expected] of [
+      ['"X-Comma=one,two",X-Plain=value', { "x-comma": "one,two", "x-plain": "value" }],
+      ['"X-Quoted=one""two",X-Equal=one=two', { "x-quoted": 'one"two', "x-equal": "one=two" }],
+      [" X-Spaces = value  ,X-Empty=", { "x-spaces": " value  ", "x-empty": "" }],
+      ["X-Case=first,x-case=second", { "x-case": "second" }],
+    ] as const) {
+      process.env.DOCKER_CUSTOM_HEADERS = input;
+      assert.deepEqual(dockerClientDefaults().headers, expected);
+      assert.ok(!Object.hasOwn(dockerClientDefaults().headers, "authorization"));
+    }
+    for (const input of [
+      '"X-Bad=synthetic-private-header',
+      'X-Bad=se"cret',
+      "X-Bad=synthetic-private-header,",
+      "=synthetic-private-header",
+      "X-Bad",
+      "X-Bad=synthetic-private-header\r\nInjected: value",
+    ]) {
+      process.env.DOCKER_CUSTOM_HEADERS = input;
+      assert.throws(
+        () => dockerClientDefaults(),
+        (error: Error) => {
+          assert.match(error.message, /Cannot read Docker client defaults/);
+          assert.ok(!error.message.includes("synthetic-private-header"));
+          return true;
+        },
+      );
+    }
+  } finally {
+    if (priorConfig === undefined) delete process.env.DOCKER_CONFIG;
+    else process.env.DOCKER_CONFIG = priorConfig;
+    if (priorHeaders === undefined) delete process.env.DOCKER_CUSTOM_HEADERS;
+    else process.env.DOCKER_CUSTOM_HEADERS = priorHeaders;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -712,3 +712,30 @@ test("Docker custom headers use CSV syntax and replace rather than merge config 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("Docker API versions accept an optional v prefix and gate platform below 1.41", async () => {
+  await withDockerSecrets({}, {}, async (fixture) => {
+    const priorVersion = process.env.DOCKER_API_VERSION;
+    const priorPlatform = process.env.DOCKER_DEFAULT_PLATFORM;
+    try {
+      process.env.DOCKER_DEFAULT_PLATFORM = "linux/arm64";
+      for (const version of ["1.40", "v1.40", "1.41", "v1.41"]) {
+        process.env.DOCKER_API_VERSION = version;
+        writeFileSync(fixture.requestsLog, "");
+        await fixture.up();
+        const requests = readFileSync(fixture.requestsLog, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as CreateRequest);
+        const normalized = version.replace(/^v/, "");
+        for (const request of requests) assert.ok(request.path.startsWith(`/v${normalized}/containers/`));
+        assert.equal(requests[0]!.path.includes("platform="), normalized === "1.41");
+      }
+    } finally {
+      if (priorVersion === undefined) delete process.env.DOCKER_API_VERSION;
+      else process.env.DOCKER_API_VERSION = priorVersion;
+      if (priorPlatform === undefined) delete process.env.DOCKER_DEFAULT_PLATFORM;
+      else process.env.DOCKER_DEFAULT_PLATFORM = priorPlatform;
+    }
+  });
+});


### PR DESCRIPTION
Container secret values must not enter Docker's process arguments, temporary files, or client-control environment. Name-only `-e` flags avoid argv disclosure, but names such as `DOCKER_HOST` then control the deployment client itself.

## Changes
- Send container configuration as a JSON request body through `docker system dial-stdio`, retaining the selected Docker connection without injecting container variables into the client environment.
- Preflight environment values before deployment changes; reject NUL bytes with variable-name-only errors.
- Use native HTTP framing, validate the returned container ID, and start that ID rather than a mutable name. Withhold secret-bearing API/process error output and bound request lifetimes.
- Preserve Docker proxy defaults, custom headers, explicit API version, platform selection, mounts, groups, ports, labels, and network aliases.
- Inspect actual container-create payloads in coreless-isolation tests, rather than the earlier remove command.

## Verification
- 132 affected CLI tests passed.
- CLI typecheck and build; repository ESLint; changed-file Oxlint and Prettier checks passed.
- Before/after probes with Docker CLI 27.5.1 and synthetic secrets confirm control-variable isolation, NUL rejection, multiline preservation, optional-value semantics and coreless isolation.
- Source and built-artifact probes exercised local TCP/TLS endpoints, named Docker contexts, HTTP framing, client defaults and error redaction. No real daemon/container/database lifecycle was exercised in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790997912&installation_model_id=19911&pr_number=913&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F913&signature=d5ec6ff8310e9418c6535ebb4258e9248e105a3a69eaeac067e893b32533fd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->