### PR TITLE
web-ui: hide the full-screen affordance on a pane that already fills the canvas

### DIFF
--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -200,8 +200,8 @@ function buildDock(): DockviewApi {
       guarded.add(group);
       group.model.onWillDrop(holdTileCap);
     }
-    if (sessionDrag) refreshSessionDrag();
     for (const a of groupActions) a.draw();
+    if (sessionDrag) refreshSessionDrag();
     persistSoon();
   });
   api.onDidActivePanelChange((e) => {
@@ -1143,26 +1143,28 @@ class GroupActions implements IHeaderActionsRenderer {
                 </button>
               `,
             )}
-            ${maximized || !soleGroup
-              ? html`
-                  <div class="split-tools-menu-sep" role="separator"></div>
-                  <button
-                    class="session-menu-option"
-                    type="button"
-                    role="menuitem"
-                    @click=${() => {
+            ${
+              maximized || !soleGroup
+                ? html`
+                    <div class="split-tools-menu-sep" role="separator"></div>
+                    <button
+                      class="session-menu-option"
+                      type="button"
+                      role="menuitem"
+                      @click=${() => {
                       this.menuOpen = false;
                       this.draw();
                       if (maximized) props.api.exitMaximized();
                       else props.api.maximize();
                     }}
-                  >
-                    ${icon(maximized ? Shrink : Expand, 15)}<span
-                      >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span
                     >
-                  </button>
-                `
-              : nothing}
+                      ${icon(maximized ? Shrink : Expand, 15)}<span
+                        >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span
+                      >
+                    </button>
+                  `
+                : nothing
+            }
           </div>
         `
       : nothing;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -1152,11 +1152,11 @@ class GroupActions implements IHeaderActionsRenderer {
                       type="button"
                       role="menuitem"
                       @click=${() => {
-                      this.menuOpen = false;
-                      this.draw();
-                      if (maximized) props.api.exitMaximized();
-                      else props.api.maximize();
-                    }}
+                        this.menuOpen = false;
+                        this.draw();
+                        if (maximized) props.api.exitMaximized();
+                        else props.api.maximize();
+                      }}
                     >
                       ${icon(maximized ? Shrink : Expand, 15)}<span
                         >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -201,6 +201,7 @@ function buildDock(): DockviewApi {
       group.model.onWillDrop(holdTileCap);
     }
     if (sessionDrag) refreshSessionDrag();
+    for (const a of groupActions) a.draw();
     persistSoon();
   });
   api.onDidActivePanelChange((e) => {
@@ -1120,6 +1121,7 @@ class GroupActions implements IHeaderActionsRenderer {
       return g?.activePanel ?? g?.panels[0] ?? null;
     };
     const maximized = props.api.isMaximized();
+    const soleGroup = (dockApi?.groups.length ?? 0) <= 1;
     const runTool = (tool: SessionTool): void => {
       this.menuOpen = false;
       const p = activePanel();
@@ -1141,22 +1143,26 @@ class GroupActions implements IHeaderActionsRenderer {
                 </button>
               `,
             )}
-            <div class="split-tools-menu-sep" role="separator"></div>
-            <button
-              class="session-menu-option"
-              type="button"
-              role="menuitem"
-              @click=${() => {
-                this.menuOpen = false;
-                this.draw();
-                if (maximized) props.api.exitMaximized();
-                else props.api.maximize();
-              }}
-            >
-              ${icon(maximized ? Shrink : Expand, 15)}<span
-                >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span
-              >
-            </button>
+            ${maximized || !soleGroup
+              ? html`
+                  <div class="split-tools-menu-sep" role="separator"></div>
+                  <button
+                    class="session-menu-option"
+                    type="button"
+                    role="menuitem"
+                    @click=${() => {
+                      this.menuOpen = false;
+                      this.draw();
+                      if (maximized) props.api.exitMaximized();
+                      else props.api.maximize();
+                    }}
+                  >
+                    ${icon(maximized ? Shrink : Expand, 15)}<span
+                      >${maximized ? "Restore to grid (Esc)" : "Focus over the grid"}</span
+                    >
+                  </button>
+                `
+              : nothing}
           </div>
         `
       : nothing;
@@ -1169,14 +1175,18 @@ class GroupActions implements IHeaderActionsRenderer {
           if (p) paneSplitWithBlank(p);
         },
       },
-      {
-        label: "Open full screen",
-        glyph: icon(Maximize2, 14),
-        run: () => {
-          const p = activePanel();
-          if (p) void maximizePane(panelParams(p));
-        },
-      },
+      ...(maximized || soleGroup
+        ? []
+        : [
+            {
+              label: "Open full screen",
+              glyph: icon(Maximize2, 14),
+              run: () => {
+                const p = activePanel();
+                if (p) void maximizePane(panelParams(p));
+              },
+            },
+          ]),
       {
         label: "Close pane",
         glyph: icon(X, 15),


### PR DESCRIPTION
A maximized pane, or the only pane on the canvas, cannot get any bigger, so the group header's "Open full screen" button and the tools-menu "Focus over the grid" entry were no-ops there. They now render only when a pane has somewhere to expand to ("Restore to grid" still shows on a maximized pane), and group headers redraw on layout changes so the sole surviving pane drops the button when its neighbor closes.

**Before:** single/maximized pane header shows the expand icon; clicking it does nothing visible.
**After:** the icon appears only alongside other panes; maximized panes keep the restore entry in the tools menu.

No screenshots yet — happy to add before/after captures from a dev instance if wanted; the change is confined to which header buttons render.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791002882&installation_model_id=19911&pr_number=915&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F915&signature=7ca0069c0d0c2d759873a27398d596116136a115d9eb57453d6646ceb37cbf42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->