### PR TITLE
Keep local model keys out of launcher state

### DIFF
--- a/.codex/skills/dev-instance/SKILL.md
+++ b/.codex/skills/dev-instance/SKILL.md
@@ -161,6 +161,17 @@ The launcher reads values from, in priority order: exported shell env, the machi
 worktree's `.env` (seeded from the main checkout in linked worktrees). Slack pool tokens
 default to `~/.config/qm/slack-pool`.
 
+For a local model API key stored in 1Password, export its secret reference instead of its
+value. The local supervisor resolves the reference with `op read` when it assembles the
+runtime environment. The durable `boot-spec.json` stores the `op://` reference, not the
+resolved value. A raw `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` export still works, but the
+launcher omits its value from `boot-spec.json`.
+
+```bash
+export ANTHROPIC_API_KEY='op://Development/Anthropic API/credential'
+bash scripts/dev-instance.sh up
+```
+
 When a cloud sandbox backend is configured it also validates that provider's access at
 startup, refreshes a stale provider token from the provider CLI's own logged-in session
 where it can, and — if a tunnel binary is present — opens a quick tunnel so sandbox

--- a/scripts/dev/cli.ts
+++ b/scripts/dev/cli.ts
@@ -28,7 +28,7 @@ import {
   supervisorAlive,
   takenSummary,
 } from "./lib/lease.ts";
-import { callerEnvSnapshot, currentBranch, repoRoot } from "./lib/envctx.ts";
+import { callerEnvSnapshot, currentBranch, persistableCallerEnv, repoRoot } from "./lib/envctx.ts";
 import { killTree, pidAlive, portHolders, spawnDetached } from "./lib/proc.ts";
 import {
   resolveSocketPath,
@@ -243,7 +243,7 @@ async function bootOnSlot(slot: string, worktree: string, branch: string): Promi
         slot,
         worktree,
         branch,
-        callerEnv,
+        callerEnv: persistableCallerEnv(callerEnv),
         watch: !opts["no-watch"] && callerEnv.DEV_INSTANCE_WATCH !== "0",
         sandbox: opts.sandbox as "local" | "sprites" | "smolmachines" | "porter" | "auto",
         canaryChannel,

--- a/scripts/dev/lib/envctx.ts
+++ b/scripts/dev/lib/envctx.ts
@@ -24,6 +24,56 @@ const DEV_SECURITY_SECRET_KEYS = [
   "PORTAL_SESSION_SECRET",
 ] as const;
 
+const MODEL_API_KEY_NAMES = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"] as const;
+
+function onePasswordReference(value: string | undefined): string {
+  const reference = value?.trim() ?? "";
+  return reference.startsWith("op://") ? reference : "";
+}
+
+export function persistableCallerEnv(callerEnv: Record<string, string>): Record<string, string> {
+  const persisted = { ...callerEnv };
+  for (const key of MODEL_API_KEY_NAMES) {
+    const reference = onePasswordReference(persisted[key]);
+    if (reference) persisted[key] = reference;
+    else delete persisted[key];
+  }
+  return persisted;
+}
+
+export function callerEnvWithRuntimeModelKeys(
+  callerEnv: Record<string, string>,
+  runtimeEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const runtimeCallerEnv = { ...callerEnv };
+  for (const key of MODEL_API_KEY_NAMES) {
+    if (!runtimeCallerEnv[key] && runtimeEnv[key]) runtimeCallerEnv[key] = runtimeEnv[key];
+  }
+  return runtimeCallerEnv;
+}
+
+async function readOnePasswordSecret(reference: string): Promise<string> {
+  const result = await run("op", ["read", "--no-newline", reference], { timeoutMs: 15_000 });
+  if (result.code !== 0 || !result.stdout) throw new Error("1Password CLI could not read the secret");
+  return result.stdout;
+}
+
+async function resolveModelApiKey(
+  key: (typeof MODEL_API_KEY_NAMES)[number],
+  value: string | undefined,
+  resolver: (reference: string) => Promise<string>,
+): Promise<{ value: string | undefined; fromOnePassword: boolean }> {
+  const reference = onePasswordReference(value);
+  if (!reference) return { value, fromOnePassword: false };
+  try {
+    const resolved = await resolver(reference);
+    if (!resolved) throw new Error("empty secret");
+    return { value: resolved, fromOnePassword: true };
+  } catch {
+    throw new Error(`${key} could not be resolved by the 1Password CLI`);
+  }
+}
+
 export function completeDevSecuritySecrets(env: Record<string, string>, seed: string): void {
   for (const key of DEV_SECURITY_SECRET_KEYS) {
     if (!env[key]) env[key] = sha256Hex(`qm-dev\0${seed}\0${key}`);
@@ -95,6 +145,7 @@ export async function assembleEnv(opts: {
   allowMock: boolean;
   log: (msg: string) => void;
   probeLoginShell?: () => Promise<string>;
+  resolveOnePasswordSecret?: (reference: string) => Promise<string>;
 }): Promise<AssembledEnv> {
   const warnings: string[] = [];
   const liveEnvFile = liveEnvPath();
@@ -126,6 +177,14 @@ export async function assembleEnv(opts: {
     env.OPENAI_API_KEY = wtEnv.OPENAI_API_KEY;
     openaiKeySource = "the worktree .env";
   }
+
+  const resolver = opts.resolveOnePasswordSecret ?? readOnePasswordSecret;
+  const anthropicKey = await resolveModelApiKey("ANTHROPIC_API_KEY", env.ANTHROPIC_API_KEY, resolver);
+  if (anthropicKey.value) env.ANTHROPIC_API_KEY = anthropicKey.value;
+  if (anthropicKey.fromOnePassword) anthropicKeySource = `${anthropicKeySource} via 1Password`;
+  const openaiKey = await resolveModelApiKey("OPENAI_API_KEY", env.OPENAI_API_KEY, resolver);
+  if (openaiKey.value) env.OPENAI_API_KEY = openaiKey.value;
+  if (openaiKey.fromOnePassword) openaiKeySource = `${openaiKeySource} via 1Password`;
 
   if (!env.CODEX_AUTH_FILE && wtEnv.CODEX_AUTH_FILE) env.CODEX_AUTH_FILE = wtEnv.CODEX_AUTH_FILE;
   let codexAuthSource = "";

--- a/scripts/dev/supervisor/main.ts
+++ b/scripts/dev/supervisor/main.ts
@@ -14,7 +14,15 @@ import {
   writeState,
 } from "../lib/lease.ts";
 import { slotPorts, slotTokens, poolStore } from "../lib/pool.ts";
-import { assembleEnv, completeDevSecuritySecrets, currentBranch, gitHead, seedEnvFromMain } from "../lib/envctx.ts";
+import {
+  assembleEnv,
+  callerEnvWithRuntimeModelKeys,
+  completeDevSecuritySecrets,
+  currentBranch,
+  gitHead,
+  persistableCallerEnv,
+  seedEnvFromMain,
+} from "../lib/envctx.ts";
 import { ensureDeps } from "../lib/deps.ts";
 import { destroyLocalDevSandboxes, resolveSandbox, type SandboxResolution } from "../lib/sandbox.ts";
 import { adminGrantCount, checkPostgres, ensureLocalPostgres, firstAdminPrincipal } from "../lib/postgres.ts";
@@ -307,10 +315,11 @@ function persistState(): void {
 async function assembleAndPrepare(spec: BootSpec): Promise<SpecInputs> {
   phase("env", "start");
   seedEnvFromMain(worktree, log);
+  const callerEnv = callerEnvWithRuntimeModelKeys(spec.callerEnv);
   const assembled = await assembleEnv({
     worktree,
-    callerEnv: spec.callerEnv,
-    allowMock: spec.callerEnv.DEV_INSTANCE_ALLOW_MOCK === "1",
+    callerEnv,
+    allowMock: callerEnv.DEV_INSTANCE_ALLOW_MOCK === "1",
     log,
   });
   for (const w of assembled.warnings) phase("env", "warn", w);
@@ -678,10 +687,11 @@ async function reload(body: Record<string, unknown>): Promise<Record<string, unk
     : "";
   const newSpec: BootSpec = { ...spec, callerEnv, canaryChannel: freshCanary };
   if (dryRun) {
+    const runtimeCallerEnv = callerEnvWithRuntimeModelKeys(callerEnv);
     const assembled = await assembleEnv({
       worktree,
-      callerEnv,
-      allowMock: callerEnv.DEV_INSTANCE_ALLOW_MOCK === "1",
+      callerEnv: runtimeCallerEnv,
+      allowMock: runtimeCallerEnv.DEV_INSTANCE_ALLOW_MOCK === "1",
       log,
     });
     const dryEnvSha = computeEnvSha(assembled.env);
@@ -696,7 +706,8 @@ async function reload(body: Record<string, unknown>): Promise<Record<string, unk
       dryRun: true,
     };
   }
-  writeFileSync(join(lock, "boot-spec.json"), JSON.stringify(newSpec, null, 2), { mode: 0o600 });
+  const persistedSpec = { ...newSpec, callerEnv: persistableCallerEnv(callerEnv) };
+  writeFileSync(join(lock, "boot-spec.json"), JSON.stringify(persistedSpec, null, 2), { mode: 0o600 });
   const inputs = await assembleAndPrepare(newSpec);
   const newEnvSha = computeEnvSha(inputs.baseEnv);
   const newGitSha = gitHead(worktree);

--- a/test/dev-cli-lib.test.ts
+++ b/test/dev-cli-lib.test.ts
@@ -28,7 +28,12 @@ import {
   writeHeartbeat,
   writeMeta,
 } from "../scripts/dev/lib/lease.ts";
-import { assembleEnv, completeDevSecuritySecrets } from "../scripts/dev/lib/envctx.ts";
+import {
+  assembleEnv,
+  callerEnvWithRuntimeModelKeys,
+  completeDevSecuritySecrets,
+  persistableCallerEnv,
+} from "../scripts/dev/lib/envctx.ts";
 import { buildChildSpecs, type SpecInputs } from "../scripts/dev/supervisor/specs.ts";
 import { loadConfig, OPENCODE_RUNTIME_VERSION, providerKeysPresent } from "../src/config.ts";
 import type { LeaseInfo } from "../scripts/dev/lib/types.ts";
@@ -321,6 +326,91 @@ test("env assembly precedence: caller > login shell > dev.env > worktree .env; h
   assert.equal(mock.harness, "mock");
   if (prevLive === undefined) delete process.env.QM_DEV_ENV;
   else process.env.QM_DEV_ENV = prevLive;
+  rmSync(worktree, { recursive: true, force: true });
+});
+
+test("persisted caller env keeps model secret references but omits model API key values", () => {
+  const callerEnv = {
+    ANTHROPIC_API_KEY: "anthropic-value",
+    OPENAI_API_KEY: "  op://Development/OpenAI/credential  ",
+    DEV_INSTANCE_ORG_ID: "acme",
+  };
+  const persisted = persistableCallerEnv(callerEnv);
+  assert.deepEqual(persisted, {
+    OPENAI_API_KEY: "op://Development/OpenAI/credential",
+    DEV_INSTANCE_ORG_ID: "acme",
+  });
+  assert.equal(callerEnv.ANTHROPIC_API_KEY, "anthropic-value");
+  assert.doesNotMatch(JSON.stringify(persisted), /anthropic-value/);
+});
+
+test("runtime model keys restore omitted values without replacing persisted references", () => {
+  const callerEnv = callerEnvWithRuntimeModelKeys(
+    {
+      OPENAI_API_KEY: "op://Development/OpenAI/credential",
+      DEV_INSTANCE_ORG_ID: "acme",
+    },
+    {
+      ANTHROPIC_API_KEY: "anthropic-runtime-value",
+      OPENAI_API_KEY: "openai-runtime-value",
+    },
+  );
+  assert.deepEqual(callerEnv, {
+    ANTHROPIC_API_KEY: "anthropic-runtime-value",
+    OPENAI_API_KEY: "op://Development/OpenAI/credential",
+    DEV_INSTANCE_ORG_ID: "acme",
+  });
+});
+
+test("env assembly resolves model API key references through 1Password without logging values", async () => {
+  const worktree = mkdtempSync(join(tmpdir(), "qm-wt-"));
+  mkdirSync(join(worktree, ".git"));
+  writeFileSync(join(worktree, ".env"), "");
+  const liveEnv = join(worktree, "dev.env");
+  writeFileSync(liveEnv, "");
+  const previousLiveEnv = process.env.QM_DEV_ENV;
+  process.env.QM_DEV_ENV = liveEnv;
+  const logLines: string[] = [];
+  const references: string[] = [];
+  const assembled = await assembleEnv({
+    worktree,
+    callerEnv: {
+      HARNESS: "codex",
+      OPENAI_API_KEY: "op://Development/OpenAI/credential",
+    },
+    allowMock: false,
+    log: (message) => logLines.push(message),
+    probeLoginShell: async () => "",
+    resolveOnePasswordSecret: async (reference) => {
+      references.push(reference);
+      return "openai-resolved-value";
+    },
+  });
+  assert.equal(assembled.env.OPENAI_API_KEY, "openai-resolved-value");
+  assert.equal(assembled.openaiKeySource, "your shell export via 1Password");
+  assert.deepEqual(references, ["op://Development/OpenAI/credential"]);
+  assert.doesNotMatch(logLines.join("\n"), /openai-resolved-value/);
+
+  await assert.rejects(
+    assembleEnv({
+      worktree,
+      callerEnv: { ANTHROPIC_API_KEY: "op://Development/Anthropic/credential" },
+      allowMock: false,
+      log: (message) => logLines.push(message),
+      probeLoginShell: async () => "",
+      resolveOnePasswordSecret: async () => {
+        throw new Error("op://Development/Anthropic/credential");
+      },
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /ANTHROPIC_API_KEY could not be resolved/);
+      assert.doesNotMatch(error.message, /Development\/Anthropic/);
+      return true;
+    },
+  );
+  if (previousLiveEnv === undefined) delete process.env.QM_DEV_ENV;
+  else process.env.QM_DEV_ENV = previousLiveEnv;
   rmSync(worktree, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

- Resolve local model API keys from `op://` references inside the dev supervisor.
- Keep raw Anthropic and OpenAI API key values out of initial and reloaded `boot-spec.json` files.
- Document the 1Password reference workflow for local dev instances.

## Validation

- `node --experimental-test-module-mocks --test test/dev-cli-lib.test.ts` - 20 tests passed.
- `npm run typecheck` - passed.
- `npx eslint scripts/dev/cli.ts scripts/dev/lib/envctx.ts scripts/dev/supervisor/main.ts test/dev-cli-lib.test.ts` - passed.
- Independent security review - no findings.

## Risks / Notes

- The change is limited to the local dev-instance launcher.
- `op://` references require an installed and authenticated 1Password CLI.
- The tests inject the secret resolver and do not access a live 1Password vault.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791034271&installation_model_id=19911&pr_number=916&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F916&signature=14aad6c9152b15f8222143bf9947862002f8c4ba8721cf1fbbd79c6d5b3eb7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->