### PR TITLE
Compact tool activity rows in the web UI

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -2171,7 +2171,7 @@ export function createChatSurface(
     if (row.approval) {
       const p = (row.approval.payload ?? {}) as ToolPayload;
       return html`<div class="tool-row tool-approval">
-        <span class="tool-icon">${icon(Wrench, 15)}</span>
+        <span class="tool-icon">${icon(Wrench, 13)}</span>
         <span class="tool-label"
           >Approval
           needed${p.reason ? html` <span class="tool-detail">${firstLine(p.reason, 90)}</span>` : nothing}</span
@@ -2194,7 +2194,7 @@ export function createChatSurface(
     const attempts = row.attempts && row.attempts > 1 ? `${row.attempts} attempts` : "";
     const detail = [base, why, attempts].filter(Boolean).join(" · ");
     const classes = ["tool-row", `tool-${kind}`].join(" ");
-    const head = html`<span class="tool-icon">${icon(meta.icon, 15)}</span>
+    const head = html`<span class="tool-icon">${icon(meta.icon, 13)}</span>
       <span class="tool-label">${label}${detail ? html` <span class="tool-detail">${detail}</span>` : nothing}</span>`;
     if (tool === "execute" && row.result && (result.stdout || result.stderr)) {
       return html`<details class="${classes} tool-expandable">

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1778,29 +1778,30 @@ a.chat-row-open {
 .work-divider {
   height: 1px;
   background: var(--border);
-  margin: 12px 0 18px;
+  margin: 8px 0 10px;
 }
 .work-rows {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 5px;
 }
 
 .tool-row,
 .tool-row .tool-summary {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
-  font-size: 15px;
-  line-height: 1.4;
+  font-size: 13px;
+  line-height: 1.35;
   color: color-mix(in srgb, var(--muted-foreground) 80%, var(--background));
 }
 .tool-row.tool-running {
   color: var(--muted-foreground);
 }
-.tool-row.tool-summary {
+.tool-row .tool-summary {
   cursor: pointer;
+  min-height: 24px;
 }
 .tool-icon {
   display: inline-flex;

--- a/plugins/web-ui/test/work-fold-source.test.ts
+++ b/plugins/web-ui/test/work-fold-source.test.ts
@@ -32,3 +32,12 @@ test("a demoted post-delivery self-log remains auditable but is omitted from the
 test("the fold chevron rotates when a work-fold is open", () => {
   assert.match(css, /\.work-fold\[open\] > summary\.work-head \.icon \{[\s\S]{0,80}?transform: rotate\(90deg\);/);
 });
+
+test("expanded tool activity uses a compact log rhythm", () => {
+  assert.match(css, /\.work-divider \{[\s\S]{0,120}?margin: 8px 0 10px;/);
+  assert.match(css, /\.work-rows \{[\s\S]{0,120}?gap: 5px;/);
+  assert.match(css, /\.tool-row,[\s\S]{0,220}?font-size: 13px;[\s\S]{0,80}?line-height: 1\.35;/);
+  assert.match(css, /\.tool-row \.tool-summary \{[\s\S]{0,80}?min-height: 24px;/);
+  assert.match(chat, /icon\(meta\.icon, 13\)/);
+  assert.match(chat, /icon\(Wrench, 13\)/);
+});


### PR DESCRIPTION
## Summary

- tighten expanded tool activity from a spacious timeline into a compact log
- reduce tool text and icon size while preserving the existing muted visual treatment
- retain a 24px minimum target for expandable command rows

## Visual evidence

Rendered against synthetic tool activity with the production stylesheet:

```text
6 tool calls
────────────────────────────────────────
✓ Read file          plugins/web-ui/src/chat.ts
✓ Searched history   tool activity · 18 results
✓ Ran command        rg -n "tool-row" plugins/web-ui
✓ Read file          plugins/web-ui/src/shell.css
× Tried command      npm test · exit 1
◌ Running command    npm run build
```

- Six static rows occupy 130px, down from approximately 216px before the change.
- At a 390px viewport, the row container has no horizontal overflow and long details ellipsize.
- Expandable command summaries retain a 24px minimum interaction height.

## Verification

- `npm test` in `plugins/web-ui` (599 tests)
- `npm run typecheck` in `plugins/web-ui`
- `npm run build` in `plugins/web-ui`
- targeted ESLint and Prettier checks
- production-shaped local app boot and desktop/narrow visual QA
- independent adversarial review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791042662&installation_model_id=19911&pr_number=918&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F918&signature=1602137e2acb0dd8d00c17897298f84a5eedd8cb0ee1ae9a151427246e8dcdf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->