### PR TITLE
Layer queued messages behind the composer

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1091,7 +1091,8 @@ export function createChatSurface(
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${backgroundActivityStrip()} ${liveWorkDock(agent)} ${ctx.composer.composerForm(agent)}
+            ${backgroundActivityStrip()} ${liveWorkDock(agent)} ${ctx.composer.queuedStrip(agent)}
+            ${ctx.composer.composerForm(agent)}
           </div>
         </div>
       `,

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -533,7 +533,6 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
               `
             : nothing
         }
-        ${queuedStrip(agent)}
         ${
           approvalPauses.length
             ? composerApprovalPanel(approvalPauses)
@@ -1677,6 +1676,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   return {
     state: composerState,
     composerForm,
+    queuedStrip,
     queuedRunsFor,
     setQueuedRuns,
     resetComposer,

--- a/plugins/web-ui/src/conv-types.ts
+++ b/plugins/web-ui/src/conv-types.ts
@@ -115,6 +115,7 @@ interface ComposerState {
 export interface ComposerSurface {
   state: ComposerState;
   composerForm(agent: Agent): TemplateResult;
+  queuedStrip(agent: Agent): TemplateResult | typeof import("lit").nothing;
   queuedRunsFor(threadRef: string | null): QueuedRun[];
   setQueuedRuns(threadRef: string, runs: QueuedRun[]): void;
   resetComposer(): void;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1513,20 +1513,23 @@ a.chat-row-open {
   margin-top: 9px;
 }
 .queued-strip {
+  position: relative;
+  z-index: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-top: 9px;
+  width: min(calc(var(--content-w) - 24px), calc(100% - 56px));
+  margin: 0 auto -10px;
 }
 .queued-chip {
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 28px;
-  padding: 4px 6px 4px 8px;
-  border: 1px dashed var(--border);
-  border-radius: 8px;
-  background: var(--background);
+  min-height: 38px;
+  padding: 6px 6px 14px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 14px 14px 10px 10px;
+  background: color-mix(in srgb, var(--background) 88%, var(--secondary));
   color: var(--muted-foreground);
   font-size: 12px;
   line-height: 1.2;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2367,6 +2367,7 @@ a.chat-row-open {
 
 .composer-wrap {
   position: relative;
+  z-index: 1;
   width: min(var(--content-w), calc(100% - 32px));
   margin: 0 auto max(18px, calc(10px + env(safe-area-inset-bottom)));
   padding: 12px;
@@ -7211,6 +7212,11 @@ h3.ambient-field-label {
     margin-right: max(16px, calc(10px + env(safe-area-inset-right)));
     margin-left: max(16px, calc(10px + env(safe-area-inset-left)));
   }
+  .queued-strip {
+    width: auto;
+    margin-right: max(28px, calc(22px + env(safe-area-inset-right)));
+    margin-left: max(28px, calc(22px + env(safe-area-inset-left)));
+  }
 }
 @container chat (max-width: 470px) {
   .custom-chat-shell {
@@ -7223,6 +7229,10 @@ h3.ambient-field-label {
     margin-bottom: calc(10px + env(safe-area-inset-bottom));
     margin-left: calc(10px + env(safe-area-inset-left));
     border-radius: 18px;
+  }
+  .queued-strip {
+    margin-right: calc(22px + env(safe-area-inset-right));
+    margin-left: calc(22px + env(safe-area-inset-left));
   }
   .live-work-dock {
     margin-right: calc(10px + env(safe-area-inset-right));

--- a/plugins/web-ui/test/queue-by-default.test.ts
+++ b/plugins/web-ui/test/queue-by-default.test.ts
@@ -7,6 +7,7 @@ const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "u
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const bridge = readFileSync(new URL("../src/core-bridge.ts", import.meta.url), "utf8");
 const server = readFileSync(new URL("../server/index.ts", import.meta.url), "utf8");
+const shell = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 
 test("a mid-turn Enter queues the message — it no longer steers the running turn", () => {
   assert.match(composer, /if \(agent\.state\.isStreaming\) return queueDraft\(agent\);/);
@@ -168,6 +169,15 @@ test("the queued strip sits behind and outside the composer form", () => {
   assert.match(chat, /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent\)/);
   const composerMarkup = composer.slice(composer.indexOf('<form class="composer-wrap"'), composer.indexOf("</form>"));
   assert.doesNotMatch(composerMarkup, /queuedStrip\(agent\)/);
+  assert.match(
+    shell,
+    /\.queued-strip \{[\s\S]*?z-index: 0;[\s\S]*?width: min\(calc\(var\(--content-w\) - 24px\), calc\(100% - 56px\)\);[\s\S]*?margin: 0 auto -10px;/,
+  );
+  assert.match(shell, /\.composer-wrap \{[\s\S]*?position: relative;\s*z-index: 1;/);
+  assert.match(shell, /margin-right: max\(28px, calc\(22px \+ env\(safe-area-inset-right\)\)\);/);
+  assert.match(shell, /margin-left: max\(28px, calc\(22px \+ env\(safe-area-inset-left\)\)\);/);
+  assert.match(shell, /margin-right: calc\(22px \+ env\(safe-area-inset-right\)\);/);
+  assert.match(shell, /margin-left: calc\(22px \+ env\(safe-area-inset-left\)\);/);
 });
 
 // Nothing is sent when a turn settles: core already started the next queued run. The client's only

--- a/plugins/web-ui/test/queue-by-default.test.ts
+++ b/plugins/web-ui/test/queue-by-default.test.ts
@@ -164,6 +164,12 @@ test("the strip renders core's queue, refreshed from the same read that names th
   assert.match(server, /json\(res, 200, \{ runId, run, \.\.\.\(waiting\.length \? \{ queued: waiting \} : \{\}\) \}\)/);
 });
 
+test("the queued strip sits behind and outside the composer form", () => {
+  assert.match(chat, /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent\)/);
+  const composerMarkup = composer.slice(composer.indexOf('<form class="composer-wrap"'), composer.indexOf("</form>"));
+  assert.doesNotMatch(composerMarkup, /queuedStrip\(agent\)/);
+});
+
 // Nothing is sent when a turn settles: core already started the next queued run. The client's only
 // job is to show it, so a client that never comes back costs the person nothing but the view.
 test("settling a turn follows the next queued run instead of sending it", () => {

--- a/plugins/web-ui/test/queue-by-default.test.ts
+++ b/plugins/web-ui/test/queue-by-default.test.ts
@@ -169,15 +169,28 @@ test("the queued strip sits behind and outside the composer form", () => {
   assert.match(chat, /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent\)/);
   const composerMarkup = composer.slice(composer.indexOf('<form class="composer-wrap"'), composer.indexOf("</form>"));
   assert.doesNotMatch(composerMarkup, /queuedStrip\(agent\)/);
-  assert.match(
-    shell,
-    /\.queued-strip \{[\s\S]*?z-index: 0;[\s\S]*?width: min\(calc\(var\(--content-w\) - 24px\), calc\(100% - 56px\)\);[\s\S]*?margin: 0 auto -10px;/,
+  const queuedRule = shell.match(/(?:^|\n)\.queued-strip \{[^}]*\}/)?.[0] ?? "";
+  const composerRule = shell.match(/(?:^|\n)\.composer-wrap \{[^}]*\}/)?.[0] ?? "";
+  assert.match(queuedRule, /z-index: 0;/);
+  assert.match(queuedRule, /width: min\(calc\(var\(--content-w\) - 24px\), calc\(100% - 56px\)\);/);
+  assert.match(queuedRule, /margin: 0 auto -10px;/);
+  assert.match(composerRule, /position: relative;\s*z-index: 1;/);
+  const midWidth = shell.slice(
+    shell.indexOf("@container chat (max-width: 860px)"),
+    shell.indexOf("@container chat (max-width: 470px)"),
   );
-  assert.match(shell, /\.composer-wrap \{[\s\S]*?position: relative;\s*z-index: 1;/);
-  assert.match(shell, /margin-right: max\(28px, calc\(22px \+ env\(safe-area-inset-right\)\)\);/);
-  assert.match(shell, /margin-left: max\(28px, calc\(22px \+ env\(safe-area-inset-left\)\)\);/);
-  assert.match(shell, /margin-right: calc\(22px \+ env\(safe-area-inset-right\)\);/);
-  assert.match(shell, /margin-left: calc\(22px \+ env\(safe-area-inset-left\)\);/);
+  const narrow = shell.slice(
+    shell.indexOf("@container chat (max-width: 470px)"),
+    shell.indexOf('[data-density="card"]', shell.indexOf("@container chat (max-width: 470px)")),
+  );
+  assert.match(
+    midWidth,
+    /\.queued-strip \{[^}]*margin-right: max\(28px, calc\(22px \+ env\(safe-area-inset-right\)\)\);[^}]*margin-left: max\(28px, calc\(22px \+ env\(safe-area-inset-left\)\)\);[^}]*\}/,
+  );
+  assert.match(
+    narrow,
+    /\.queued-strip \{[^}]*margin-right: calc\(22px \+ env\(safe-area-inset-right\)\);[^}]*margin-left: calc\(22px \+ env\(safe-area-inset-left\)\);[^}]*\}/,
+  );
 });
 
 // Nothing is sent when a turn settles: core already started the next queued run. The client's only


### PR DESCRIPTION
## Why

Queued messages rendered inside the composer form, making them read like content in the text input instead of work waiting behind the active turn.

## What changed

- render the queued-message strip immediately above and outside the composer form
- inset the strip and overlap its lower edge so the composer visibly sits in front
- preserve the 12px inset across desktop, pane, and safe-area-aware mobile layouts
- lock the DOM order, paint order, overlap, width, and responsive safe-area contract in tests

## Validation

- 26 affected web UI tests
- web UI typecheck
- root typecheck
- ESLint and Prettier checks for changed files
- live dev-instance QA with synthetic queued-message data

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791046939&installation_model_id=19911&pr_number=919&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F919&signature=2ec7877bba9f5c4bc28d0521c69f12cd1d60846ef540e4af7a6599e213ab93d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->