### PR TITLE
Consolidated Porter env block in docs

### DIFF
--- a/docs/porter.md
+++ b/docs/porter.md
@@ -7,12 +7,22 @@ AWS, GCP, or Azure account. qm can use it two ways, independently:
   home volume.
 - `DEPLOY_PROVIDER=porter` — apps the agent publishes run on the same cluster.
 
-Both need a Porter API token and the project and cluster that own the sandbox API:
+Both need a Porter API token and the project and cluster that own the sandbox API. The
+complete environment for a Porter-backed instance, verified against a live deployment:
 
 ```bash
+SANDBOX_BACKEND=porter
+DEPLOY_PROVIDER=porter
 PORTER_DEPLOY_API_TOKEN=<ADMIN-role api token from Settings -> API tokens>
 PORTER_DEPLOY_PROJECT_ID=<project id>
 PORTER_DEPLOY_CLUSTER_ID=<cluster id>
+PORTER_SANDBOX_IMAGE=ghcr.io/porter-dev/qm-sandbox:latest
+PORTER_DEPLOY_RUNNER_IMAGE=ghcr.io/porter-dev/qm-app-runner:latest
+# PORTER_DEPLOY_URL=            # only when the API host is not https://dashboard.porter.run
+# PORTER_DEPLOY_APPS_DOMAIN=    # optional; the cluster names apps itself (see below)
+# PORTER_DEPLOY_VISIBILITY=public  # public Porter ingress serves apps to ANYONE with the
+                                   # URL, bypassing qm's sign-in gate — leave private and
+                                   # use /d/<app>/ or DEPLOY_APPS_DOMAIN unless that is the intent
 ```
 
 ## Onboarding checklist


### PR DESCRIPTION
Follow-up to #911 from external validation: a Porter engineer got qm running off the PR and listed the env set he needed — nothing in the docs presented it in one place. This adds the complete, live-verified block to the top of docs/porter.md, with inline caveats on the two easy mistakes: setting `PORTER_DEPLOY_URL` unnecessarily (the default is already the API host) and `PORTER_DEPLOY_VISIBILITY=public` (serves apps to anyone with the URL, bypassing the sign-in gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791047639&installation_model_id=19911&pr_number=920&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F920&signature=33ba0077f8e7248fcdc5f1a63bf7a72741f6bd3ca8892d7bdee430e280512e17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->