### PR TITLE
fix(cli): accept secret-backed Codex credentials

### DIFF
--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -13,6 +13,7 @@ type SecretCondition =
   | { kind: "service-absent"; service: DeclaredServiceName }
   | { kind: "all"; conditions: SecretCondition[] }
   | { kind: "any"; conditions: SecretCondition[] }
+  | { kind: "not"; condition: SecretCondition }
   | { kind: "target"; target: QmConfig["target"] }
   | { kind: "model-provider"; provider: ModelProvider };
 
@@ -60,15 +61,30 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
     service: "core",
     required: {
       when: {
-        kind: "any",
+        kind: "all",
         conditions: [
-          { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
-          { kind: "model-provider", provider: "openai" },
+          {
+            kind: "any",
+            conditions: [
+              { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
+              { kind: "model-provider", provider: "openai" },
+            ],
+          },
+          {
+            kind: "not",
+            condition: {
+              kind: "all",
+              conditions: [
+                { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
+                { kind: "env-present", service: "core", name: "CODEX_AUTH_CREDENTIAL" },
+              ],
+            },
+          },
         ],
       },
     },
     description:
-      'OpenAI API key: the Codex harness needs it (its CLI cannot do browser OAuth in a container), and it bills the base model when modelProvider is "openai".',
+      'OpenAI API key: the Codex harness needs it unless a keychain credential supplies model auth, and it bills the base model when modelProvider is "openai".',
   },
   {
     name: "PUBLIC_API_URL",
@@ -478,22 +494,27 @@ function conditionMatches(config: QmConfig, condition: SecretCondition): boolean
   if (condition.kind === "service-absent") return !config.services.includes(condition.service);
   if (condition.kind === "all") return condition.conditions.every((nested) => conditionMatches(config, nested));
   if (condition.kind === "any") return condition.conditions.some((nested) => conditionMatches(config, nested));
+  if (condition.kind === "not") return !conditionMatches(config, condition.condition);
   if (condition.kind === "target") return config.target === condition.target;
   if (condition.kind === "model-provider") return effectiveModelProvider(config) === condition.provider;
   if (condition.kind === "env-all-absent") {
-    return condition.names.every((name) => !config.env[condition.service]?.[name]?.trim());
+    return condition.names.every((name) => !configuredEnvPresent(config, condition.service, name));
   }
-  const configuredSandboxBackend =
-    condition.service === "core" && condition.name === "SANDBOX_BACKEND" ? config.sandbox?.backend : undefined;
-  const value = (
-    config.env[condition.service]?.[condition.name] ??
-    configuredSandboxBackend ??
-    targetEnvDefault(config, condition.service, condition.name)
-  )?.trim();
-  if (condition.kind === "env-absent") return !value;
-  if (condition.kind === "env-present") return Boolean(value);
+  const value = configuredEnvValue(config, condition.service, condition.name);
+  if (condition.kind === "env-absent") return !configuredEnvPresent(config, condition.service, condition.name);
+  if (condition.kind === "env-present") return configuredEnvPresent(config, condition.service, condition.name);
   if (condition.kind === "env-in") return value !== undefined && condition.values.includes(value);
   return value === condition.value;
+}
+
+function configuredEnvValue(config: QmConfig, service: DeclaredServiceName, name: string): string | undefined {
+  const sandboxBackend = service === "core" && name === "SANDBOX_BACKEND" ? config.sandbox?.backend : undefined;
+  return (config.env[service]?.[name] ?? sandboxBackend ?? targetEnvDefault(config, service, name))?.trim();
+}
+
+function configuredEnvPresent(config: QmConfig, service: DeclaredServiceName, name: string): boolean {
+  const value = configuredEnvValue(config, service, name);
+  return Boolean(value || config.secretEnv?.[service]?.[name]?.trim());
 }
 
 function targetEnvDefault(config: QmConfig, service: string, name: string): string | undefined {
@@ -684,6 +705,7 @@ function conditionClause(condition: SecretCondition): string {
   if (condition.kind === "service-absent") return `the ${condition.service} service is not enabled`;
   if (condition.kind === "all") return condition.conditions.map(conditionClause).join(" and ");
   if (condition.kind === "any") return condition.conditions.map(conditionClause).join(" or ");
+  if (condition.kind === "not") return `not (${conditionClause(condition.condition)})`;
   if (condition.kind === "target") return `the target is ${condition.target}`;
   if (condition.kind === "env-all-absent")
     return `none of env.${condition.service}.{${condition.names.join(", ")}} are set`;

--- a/cli/test/secrets.test.ts
+++ b/cli/test/secrets.test.ts
@@ -223,6 +223,18 @@ test("an OpenAI base model and the Codex harness agree on one required key", () 
   assert.equal(matches[0]!.required, true);
 });
 
+test("a secret-backed Codex credential replaces the OpenAI API key requirement", () => {
+  const credentialBacked = makeConfig({
+    modelProvider: "openai",
+    env: { core: { HARNESS: "codex" } },
+    secretEnv: { core: { CODEX_AUTH_CREDENTIAL: "CODEX_AUTH_CREDENTIAL" } },
+  });
+  assert.ok(!computedSecrets(credentialBacked).some((secret) => secret.name === "OPENAI_API_KEY"));
+  const credential = secretByName(credentialBacked, "CODEX_AUTH_CREDENTIAL");
+  assert.equal(credential.required, true);
+  assert.deepEqual(runtimeSecretNames("core", credential), ["CODEX_AUTH_CREDENTIAL"]);
+});
+
 test("omitting modelProvider preserves the pre-existing deferred-to-Admin behavior", () => {
   const deferred = makeConfig();
   assert.equal(secretByName(deferred, "ANTHROPIC_API_KEY").required, false);
@@ -373,4 +385,54 @@ test("runtime model provider override controls the required billing key", () => 
   });
   assert.equal(secretByName(config, "OPENROUTER_API_KEY").required, true);
   assert.equal(secretByName(config, "ANTHROPIC_API_KEY").required, false);
+});
+
+for (const target of ["docker", "aws", "fly"] as const) {
+  for (const storage of ["env", "secretEnv"] as const) {
+    test(`${target} ${storage} subscription credentials only replace Codex API authentication`, () => {
+      for (const harness of ["codex", "pi"] as const) {
+        for (const credential of ["credential-id", "", "   "]) {
+          const config = makeConfig({
+            target,
+            modelProvider: "openai",
+            env: { core: { HARNESS: harness, ...(storage === "env" ? { CODEX_AUTH_CREDENTIAL: credential } : {}) } },
+            ...(storage === "secretEnv" ? { secretEnv: { core: { CODEX_AUTH_CREDENTIAL: credential } } } : {}),
+          });
+          assert.equal(
+            computedSecrets(config).some((secret) => secret.name === "OPENAI_API_KEY" && secret.required),
+            harness !== "codex" || !credential.trim(),
+          );
+        }
+      }
+    });
+  }
+}
+
+test("Codex still requires authentication independently of the selected model provider", () => {
+  for (const modelProvider of [undefined, "anthropic"] as const) {
+    const config = makeConfig({ modelProvider, env: { core: { HARNESS: "codex" } } });
+    assert.equal(secretByName(config, "OPENAI_API_KEY").required, true);
+  }
+});
+
+test("an explicit sandbox backend overrides the structured sandbox setting", () => {
+  const config = makeConfig({
+    target: "aws",
+    sandbox: { backend: "sprites" },
+    env: { core: { SANDBOX_BACKEND: "aws" } },
+  });
+  assert.ok(!computedSecrets(config).some((secret) => secret.name === "SPRITES_TOKEN"));
+});
+
+test("secret-backed portal trust satisfies the existing alternatives", () => {
+  for (const reference of ["TRUSTED_EMAILS", "", "   "]) {
+    const config = makeConfig({
+      services: ["core", "portal"],
+      secretEnv: { portal: { OIDC_ALLOWED_EMAILS: reference } },
+    });
+    assert.equal(
+      computedSecrets(config).some((secret) => secret.name === "PORTAL_EXPECTED_TEAM_ID"),
+      !reference.trim(),
+    );
+  }
 });


### PR DESCRIPTION
A deployment using the Codex harness with a ChatGPT credential stored through `secretEnv` still asks for an OpenAI API key. Recognize configured secret references when evaluating credential presence, and waive the API key only when Codex has its own credential. Pi with an OpenAI model still requires its API key even if a Codex credential is present.

Rebased on current main. The shared resolver keeps explicit environment, structured sandbox configuration, and target-default precedence; unknown secret values only establish presence.

Validation: 41 secret-catalog tests passed, including Docker/AWS/Fly, literal and secret-backed credentials, whitespace values, provider selection, portal trust alternatives, and sandbox precedence. CLI typecheck and affected-file ESLint passed.
