### PR TITLE
fix: open revealed conversations at the end

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -888,7 +888,10 @@ export function createChatSurface(
                               requestAnimationFrame(() => {
                                 const scrollerNow = container?.querySelector<HTMLElement>(".chat-scroll");
                                 if (!scrollerNow) return;
+                                const prev = scrollerNow.style.scrollBehavior;
+                                scrollerNow.style.scrollBehavior = "auto";
                                 scrollerNow.scrollTop = priorTop + (scrollerNow.scrollHeight - priorHeight);
+                                scrollerNow.style.scrollBehavior = prev;
                               });
                             } catch {
                               btn.disabled = false;
@@ -918,6 +921,7 @@ export function createChatSurface(
     readonlyRedraw = draw;
     draw();
     container.replaceChildren(host);
+    if (!sameSession) scrollToBottom();
     readOnlyView = { id: s.id, threadRef: s.threadRef, session: s, anchorSeq };
     ctx.ensureDeliveryStream();
     consumeBackgroundPanelRequest();
@@ -2306,8 +2310,13 @@ export function createChatSurface(
     stickToBottom = s.scrollHeight - s.scrollTop - s.clientHeight <= 120;
   }
 
+  function scrollToBottom(): void {
+    stickToBottom = true;
+    scrollTranscript(true);
+  }
+
   function scrollTranscript(force = false): void {
-    const scroller = chatState.host?.querySelector<HTMLElement>(".chat-scroll");
+    const scroller = ctx.container()?.querySelector<HTMLElement>(".chat-scroll");
     if (!scroller) return;
     if (!force && !stickToBottom) return;
     requestAnimationFrame(() => {
@@ -2337,6 +2346,7 @@ export function createChatSurface(
     mountContinuable,
     mountReadOnly,
     mountLoadingPane,
+    scrollToBottom,
     drawActiveChat,
     setTranscriptWindow,
     requestBackgroundPanel,

--- a/plugins/web-ui/src/conv-types.ts
+++ b/plugins/web-ui/src/conv-types.ts
@@ -84,6 +84,7 @@ export interface ChatSurface {
     inheritedMessages?: ReturnType<typeof entriesToMessages>,
   ): void;
   mountLoadingPane(): void;
+  scrollToBottom(): void;
   drawActiveChat(agent?: Agent | null, opts?: { forceScroll?: boolean }): void;
   setTranscriptWindow(anchorSeq: number | null, earlierCount: number, hasEarlier?: boolean): void;
   requestBackgroundPanel(sessionId: string | null, threadRef: string | null): void;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -453,7 +453,7 @@ export function openBackgroundInCanvas(s: CoreSession): boolean {
   if (!s.id || !mountRestoredCanvas() || !dockApi) return false;
   const showing = paneShowing(s.id);
   if (showing) {
-    showing.api.setActive();
+    activatePanel(showing);
     paneContents.get(showing.id)?.conversation.requestBackgroundPanel(s.id, s.threadRef);
     return true;
   }
@@ -467,7 +467,7 @@ function focusExistingPane(sessionId: string, exceptPaneId?: string): boolean {
   const dup = paneShowing(sessionId);
   if (!dup) return false;
   if (dup.id !== exceptPaneId) {
-    dup.api.setActive();
+    activatePanel(dup);
     canvasToast("Already open in a pane");
   }
   return true;
@@ -570,10 +570,15 @@ function maximizePane(params: PaneParams): void {
   else panel.api.maximize();
 }
 
+function activatePanel(panel: IDockviewPanel): void {
+  if (panel.group.activePanel === panel) panel.group.api.setActive();
+  else panel.api.setActive();
+}
+
 function focusPane(paneId: string): void {
   const panel = dockApi?.getPanel(paneId);
   if (!panel || panel.api.isActive) return;
-  preservingFocus(document, () => panel.api.setActive());
+  preservingFocus(document, () => activatePanel(panel));
 }
 
 export function canvasToast(msg: string): void {
@@ -852,6 +857,7 @@ class PaneContent implements IContentRenderer {
         return;
       }
       this.syncDensity();
+      this.conversation.scrollToBottom();
     });
     if (p.api.isVisible) void this.load();
   }

--- a/plugins/web-ui/test/layout-thrash.test.ts
+++ b/plugins/web-ui/test/layout-thrash.test.ts
@@ -34,3 +34,16 @@ test("bottom-stickiness is tracked by the scroller's own scroll listener, and a 
   assert.match(chat, /stickToBottom = s\.scrollHeight - s\.scrollTop - s\.clientHeight <= 120;/);
   assert.match(chat, /let stickToBottom = true;/);
 });
+
+test("revealing a transcript re-arms auto-follow; read-only mounts start at the end except pagination", () => {
+  assert.match(chat, /function scrollToBottom\(\): void \{\s*stickToBottom = true;\s*scrollTranscript\(true\);/);
+  assert.match(chat, /if \(!sameSession\) scrollToBottom\(\);/);
+  assert.match(chat, /const scroller = ctx\.container\(\)\?\.querySelector/);
+});
+
+test("both pagination paths adjust their anchor without smooth scrolling", () => {
+  const anchors = chat.match(
+    /const prev = scrollerNow\.style\.scrollBehavior;\s*scrollerNow\.style\.scrollBehavior = "auto";\s*scrollerNow\.scrollTop = priorTop \+ \(scrollerNow\.scrollHeight - priorHeight\);\s*scrollerNow\.style\.scrollBehavior = prev;/g,
+  );
+  assert.equal(anchors?.length, 2);
+});

--- a/plugins/web-ui/test/pane-focus.test.ts
+++ b/plugins/web-ui/test/pane-focus.test.ts
@@ -45,5 +45,5 @@ test("a pane focusin never re-activates the pane it is already in", () => {
   const focusPane = split.match(/function focusPane\([\s\S]*?\n\}/)?.[0] ?? "";
   assert.ok(focusPane, "focusPane not found");
   assert.match(focusPane, /if \(!panel \|\| panel\.api\.isActive\) return;/, "re-activation remounts the pane");
-  assert.match(focusPane, /preservingFocus\(document, \(\) => panel\.api\.setActive\(\)\)/, "activation drops focus");
+  assert.match(focusPane, /preservingFocus\(document, \(\) => activatePanel\(panel\)\)/, "activation drops focus");
 });

--- a/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
+++ b/plugins/web-ui/test/tab-switch-scroll-snap.test.ts
@@ -5,10 +5,24 @@ import test from "node:test";
 const split = readFileSync(new URL("../src/split.ts", import.meta.url), "utf8");
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 
-test("pane visibility changes preserve the transcript viewport", () => {
+test("shown panes start at the end after refreshing their density", () => {
   const handler = split.match(/onDidVisibilityChange\(\(e\) => \{[\s\S]*?\}\);/)?.[0] ?? "";
-  assert.doesNotMatch(handler, /forceScroll/, "grid visibility is presentation state, not scroll intent");
+  assert.match(handler, /this\.conversation\.scrollToBottom\(\)/);
   assert.match(handler, /this\.syncDensity\(\)/, "shown panes still refresh their responsive presentation");
+});
+
+test("hidden tabs do not require attached transcript DOM", () => {
+  assert.doesNotMatch(split, /defaultRenderer: "always"/);
+  assert.doesNotMatch(split, /restoreTranscriptViewport/);
+  assert.doesNotMatch(chat, /transcriptTop/);
+});
+
+test("showing a pane that is already its tile's active tab does not re-open it", () => {
+  const fn = split.match(/function activatePanel\(panel: IDockviewPanel\): void \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(fn, /panel\.group\.activePanel === panel\) panel\.group\.api\.setActive\(\)/);
+  const focus = split.match(/function focusPane\(paneId: string\): void \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(focus, /activatePanel\(panel\)/);
+  assert.doesNotMatch(focus, /panel\.api\.setActive\(\)/);
 });
 
 test("responsive pane summaries do not replace the transcript scroller", () => {


### PR DESCRIPTION
Lazy-load conversations and show the latest messages whenever a conversation opens or a hidden tab is shown, without keeping hidden panes attached.

- Preserve active reading and pagination anchors.
- Verification: 603 web UI tests, typecheck, formatting, and lint pass; Chromium checks against a local full stack cover open/reveal, lazy loading, hidden-pane detachment, live updates, and pagination.
