### PR TITLE
core: pass a turn's surface name to the harness on every turn

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2453,15 +2453,9 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             ...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
             ...(typeof effectiveFastMode === "boolean" ? { fastMode: effectiveFastMode } : {}),
             ...(strictReadOnly ? { readOnly: true } : {}),
-            ...(input.surfaceTools && surfaceToolDeps
-              ? {
-                  surfaceTools: true,
-                  surfaceName:
-                    input.origin.kind === "automation" && input.origin.destination
-                      ? "slack"
-                      : (input.surface ?? "slack"),
-                }
-              : {}),
+            surfaceName:
+              input.origin.kind === "automation" && input.origin.destination ? "slack" : (input.surface ?? "slack"),
+            ...(input.surfaceTools && surfaceToolDeps ? { surfaceTools: true } : {}),
             ...(isPollFire ? { pollFire: true } : {}),
             ...(effectiveTurnWallClockMs !== undefined ? { turnWallClockMs: effectiveTurnWallClockMs } : {}),
             ...(securityPolicy.inboundScreening === "external"

--- a/src/harness/mock-harness.ts
+++ b/src/harness/mock-harness.ts
@@ -252,6 +252,8 @@ export function createMockHarness(): Harness {
           reply = turn.systemPrompt;
         } else if (command0 === "!wallclock") {
           reply = `wallclock:${turn.turnWallClockMs ?? 0}`;
+        } else if (command0 === "!surfacename") {
+          reply = `surface:${turn.surfaceName ?? "none"}`;
         } else if (command0.startsWith("!askagent ")) {
           const rest = command0.slice("!askagent ".length).trim();
           const sp = rest.indexOf(" ");

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -3412,3 +3412,9 @@ test("denying a quarantine release upholds the block", async () => {
   const rerun = await built.app.turn(dm(cmd));
   assert.match(rerun.reply ?? "", /quarantined by Auto security posture/, "the payload stays out of context");
 });
+
+test("a turn carries its surface name to the harness, DM or not", async () => {
+  const built = freshApp();
+  assert.equal((await built.app.turn(dm("!surfacename", { surface: "web" }))).reply, "surface:web");
+  assert.equal((await built.app.turn(dm("!surfacename", { surface: "slack" }))).reply, "surface:slack");
+});


### PR DESCRIPTION
Surface-name plumbing was folded into the surface-tools branch, so a turn without surface tools reached the harness with no surface name — and tools gated on the surface, the web playground tool among them, were never offered in direct messages. The surface name is now always passed; surface tools stay independently gated.

- `typecheck`, `eslint`, `prettier --check` clean
- `test/orchestrator.test.ts` 133 pass, incl. a new regression test that fails without the change
- `test/pi-tools.test.ts` 72 pass
- live dev instance: a playground renders in a DM, and is absent when the change is reverted

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791088223&installation_model_id=19911&pr_number=930&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F930&signature=1acb451e26d0c2f395a6633d8010f4d8f376d460bce2eaf8e9dc88ab08ba2c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->