### PR TITLE
fix(connectors): keep OAuth flow context out of the authorize state

### DIFF
--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -7,6 +7,7 @@ import type { McpToolService } from "../mcp/mcp-tool-service.ts";
 import type { ReplayDedupe } from "../auth/replay-dedupe.ts";
 import type { FetchLike, OAuthClientResolver } from "../connectors/oauth.ts";
 import type { ConsentLinkStore } from "../connectors/consent-link.ts";
+import type { OAuthFlowStore } from "../connectors/oauth-flow-store.ts";
 import type { OrgBranding, ScopedConfigStore } from "../resolution/config-store.ts";
 import type { AclStore } from "../acl/acl-store.ts";
 import type { CredentialUsageSink } from "../admin/credential-usage-sink.ts";
@@ -76,6 +77,7 @@ export interface ServerDeps {
   oauthEnv?: NodeJS.ProcessEnv;
   resolveClient?: OAuthClientResolver;
   consentLinks?: ConsentLinkStore;
+  oauthFlows?: OAuthFlowStore;
   apiBaseUrl?: string;
   publicUrl?: string;
   portalUrl?: string;

--- a/src/api/routes/connectors.ts
+++ b/src/api/routes/connectors.ts
@@ -10,6 +10,7 @@ import {
   codeChallengeS256,
   type OAuthClientResolver,
   type AccountType,
+  type OAuthState,
 } from "../../connectors/oauth.ts";
 import { bestOAuthTokenStatus, CONNECTOR_STATUS_ACCOUNT_TYPES } from "../../credentials/connector-status.ts";
 import type { OAuthTokenStatus } from "../../credentials/keychain.ts";
@@ -27,6 +28,19 @@ function oauthStateSecret(deps: ServerDeps, signingSecret: string | undefined): 
   const value = deps.oauthStateSecret ?? signingSecret;
   if (!value) throw new Error("OAuth state secret required");
   return value;
+}
+
+type OAuthFlowContext = Omit<OAuthState, "issuedAt" | "nonce">;
+
+function beginOAuthFlow(deps: ServerDeps, secret: string | undefined, state: OAuthFlowContext): Promise<string> {
+  if (deps.oauthFlows) return deps.oauthFlows.start(state);
+  return sealOAuthState(state, { secret: oauthStateSecret(deps, secret) });
+}
+
+async function resumeOAuthFlow(deps: ServerDeps, secret: string | undefined, param: string): Promise<OAuthState> {
+  const stored = deps.oauthFlows ? await deps.oauthFlows.finish(param) : null;
+  if (stored) return stored;
+  return openOAuthState(param, { secret: oauthStateSecret(deps, secret), maxAgeMs: OAUTH_STATE_MAX_AGE_MS });
 }
 
 export function resolverFor(deps: ServerDeps): OAuthClientResolver {
@@ -126,10 +140,7 @@ async function oauthCallback(ctx: BaseCtx): Promise<void> {
   if (!code || !stateParam) return sendJson(res, 400, { error: "bad_request", message: "code and state required" });
   let state;
   try {
-    state = await openOAuthState(stateParam, {
-      secret: oauthStateSecret(deps, secret),
-      maxAgeMs: OAUTH_STATE_MAX_AGE_MS,
-    });
+    state = await resumeOAuthFlow(deps, secret, stateParam);
     if (state.provider !== oauthRoute.provider) throw new Error("OAuth provider mismatch");
     if (state.orgId !== undefined && state.orgId !== configOrgId()) {
       throw new Error("OAuth state is for a different org");
@@ -225,20 +236,17 @@ async function consentRedeem(ctx: ApiCtx): Promise<void> {
     }
     const returnTo = safeReturnTo(url.searchParams.get("returnTo")) ?? rec.returnTo;
     const codeVerifier = PROVIDERS[rec.provider]?.pkce ? generateCodeVerifier() : undefined;
-    const state = await sealOAuthState(
-      {
-        provider: rec.provider,
-        principalId: rec.principalId,
-        redirectUri: rec.redirectUri,
-        orgId: configOrgId(),
-        ...(rec.accountType !== "default" ? { accountType: rec.accountType } : {}),
-        clientRef: client.clientRef,
-        ...(returnTo ? { returnTo } : {}),
-        ...(codeVerifier ? { codeVerifier } : {}),
-        consentLinkId: linkId,
-      },
-      { secret: oauthStateSecret(deps, secret) },
-    );
+    const state = await beginOAuthFlow(deps, secret, {
+      provider: rec.provider,
+      principalId: rec.principalId,
+      redirectUri: rec.redirectUri,
+      orgId: configOrgId(),
+      ...(rec.accountType !== "default" ? { accountType: rec.accountType } : {}),
+      clientRef: client.clientRef,
+      ...(returnTo ? { returnTo } : {}),
+      ...(codeVerifier ? { codeVerifier } : {}),
+      consentLinkId: linkId,
+    });
     const consentUrl = authorizeUrl(rec.provider, {
       redirectUri: rec.redirectUri,
       state,
@@ -359,21 +367,18 @@ async function oauthStart(ctx: ApiCtx): Promise<void> {
       });
     }
     const codeVerifier = provider.pkce ? generateCodeVerifier() : undefined;
-    const state = await sealOAuthState(
-      {
-        provider: oauthRoute.provider,
-        principalId,
-        redirectUri,
-        orgId: configOrgId(),
-        ...(accountType !== "default" ? { accountType } : {}),
-        clientRef: client.clientRef,
-        ...(safeReturnTo(url.searchParams.get("returnTo"))
-          ? { returnTo: safeReturnTo(url.searchParams.get("returnTo")) }
-          : {}),
-        ...(codeVerifier ? { codeVerifier } : {}),
-      },
-      { secret: oauthStateSecret(deps, secret) },
-    );
+    const state = await beginOAuthFlow(deps, secret, {
+      provider: oauthRoute.provider,
+      principalId,
+      redirectUri,
+      orgId: configOrgId(),
+      ...(accountType !== "default" ? { accountType } : {}),
+      clientRef: client.clientRef,
+      ...(safeReturnTo(url.searchParams.get("returnTo"))
+        ? { returnTo: safeReturnTo(url.searchParams.get("returnTo")) }
+        : {}),
+      ...(codeVerifier ? { codeVerifier } : {}),
+    });
     const consentUrl = authorizeUrl(oauthRoute.provider, {
       redirectUri,
       state,

--- a/src/auth/signed-token.ts
+++ b/src/auth/signed-token.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { CompactSign, compactVerify, decodeProtectedHeader } from "jose";
 import { constantTimeEqual } from "../util/crypto.ts";
 
@@ -6,7 +6,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 export function signingKeyId(secret: string): string {
-  return createHash("sha256").update(secret).digest("base64url").slice(0, 8);
+  return createHmac("sha256", secret).update("qm-signing-key-id").digest("base64url").slice(0, 8);
 }
 
 export function mintSignedPayload(value: unknown, secret: string): Promise<string> {

--- a/src/connectors/oauth-flow-store.ts
+++ b/src/connectors/oauth-flow-store.ts
@@ -1,0 +1,40 @@
+import { randomBytes } from "node:crypto";
+import type { DurableMap } from "../persistence/durable-map.ts";
+import type { OAuthState } from "./oauth.ts";
+
+/**
+ * The authorize `state` parameter has to survive a provider round trip, and
+ * providers cap its length — X rejects anything over 500 characters. Signing
+ * the whole flow context into the parameter makes its size grow with the
+ * principal id, redirect URI and returnTo path, so ordinary deployments
+ * overflowed that cap. Keep the context here, keyed by a short opaque id, so
+ * the parameter is a fixed 43 characters and the PKCE verifier never travels
+ * through the browser.
+ */
+export interface OAuthFlowStore {
+  start(state: Omit<OAuthState, "issuedAt" | "nonce">, now?: number): Promise<string>;
+  finish(flowId: string, now?: number): Promise<OAuthState | null>;
+}
+
+const OAUTH_FLOW_TTL_MS = 10 * 60_000;
+
+export function createOAuthFlowStore(
+  backing: DurableMap<OAuthState>,
+  opts: { ttlMs?: number; now?: () => number } = {},
+): OAuthFlowStore {
+  const ttl = opts.ttlMs ?? OAUTH_FLOW_TTL_MS;
+  const clock = opts.now ?? (() => Date.now());
+  return {
+    async start(state, now) {
+      const flowId = randomBytes(32).toString("base64url");
+      await backing.put(flowId, { ...state, issuedAt: now ?? clock(), nonce: flowId });
+      return flowId;
+    },
+    async finish(flowId, now) {
+      const rec = await backing.take(flowId).catch(() => null);
+      if (!rec) return null;
+      if ((now ?? clock()) - rec.issuedAt > ttl) return null;
+      return rec;
+    },
+  };
+}

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -166,7 +166,7 @@ import {
   type DeviceFlowCutoverReset,
   type DeviceFlowCutoverStore,
 } from "./credentials/device-flow-cutover.ts";
-import { makeRefresh, type OAuthClientResolver } from "./connectors/oauth.ts";
+import { makeRefresh, type OAuthClientResolver, type OAuthState } from "./connectors/oauth.ts";
 import {
   createConnectorClientResolver,
   deriveConnectorKey,
@@ -183,6 +183,7 @@ import { createPostgresCredentialUsageSink } from "./admin/postgres-credential-u
 import { createEgressAuditSink, type EgressAuditSink } from "./admin/egress-audit-sink.ts";
 import { createPostgresEgressAuditSink } from "./admin/postgres-egress-audit-sink.ts";
 import { createConsentLinkStore, type ConsentLinkStore, type ConsentLinkRecord } from "./connectors/consent-link.ts";
+import { createOAuthFlowStore, type OAuthFlowStore } from "./connectors/oauth-flow-store.ts";
 import { createModelGateway, type ModelGateway } from "./model/model-gateway.ts";
 import { createModelCredentialStore, type ModelCredentialStore } from "./model/model-credential-store.ts";
 import { refreshChatGPTTokens, refreshClaudeTokens } from "./model/subscription-oauth.ts";
@@ -352,6 +353,7 @@ export interface BuiltApp {
   slackInstallation: SlackInstallationStore;
   resolveClient: OAuthClientResolver;
   consentLinks: ConsentLinkStore;
+  oauthFlows: OAuthFlowStore;
   secretDrops: SecretDropStore;
   modelGateway: ModelGateway;
   modelCredentials: ModelCredentialStore;
@@ -805,6 +807,7 @@ export function buildApp(
     : undefined;
   const connectorTokens = withOperatorTokenFallback(credentialStore, config.egressServiceHosts ?? [], secretSource);
   const consentLinks: ConsentLinkStore = createConsentLinkStore(artifactMap<ConsentLinkRecord>("consent_links"));
+  const oauthFlows: OAuthFlowStore = createOAuthFlowStore(artifactMap<OAuthState>("oauth_flows"));
   const secretDrops: SecretDropStore = createSecretDropStore(artifactMap<SecretDropRecord>("secret_drops"));
   const modelGateway = createModelGateway();
 
@@ -1685,6 +1688,7 @@ export function buildApp(
     slackInstallation,
     resolveClient,
     consentLinks,
+    oauthFlows,
     secretDrops,
     modelGateway,
     modelCredentials,
@@ -1775,6 +1779,7 @@ export function serverDeps(
     ...(slackEnvBotToken ? { slackEnvBotToken } : {}),
     resolveClient: built.resolveClient,
     consentLinks: built.consentLinks,
+    oauthFlows: built.oauthFlows,
     secretDrops: built.secretDrops,
     ...(built.fireDropResolution ? { fireDropResolution: built.fireDropResolution } : {}),
     ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),

--- a/test/oauth-routes.test.ts
+++ b/test/oauth-routes.test.ts
@@ -27,7 +27,10 @@ function sign(method: string, pathWithQuery: string, body = ""): Record<string, 
   };
 }
 
-function start(fetchImpl: FetchLike): { base: string; built: BuiltApp; close: () => Promise<void> } {
+function start(
+  fetchImpl: FetchLike,
+  opts: { oauthEnv?: NodeJS.ProcessEnv } = {},
+): { base: string; built: BuiltApp; close: () => Promise<void> } {
   const built = buildApp(
     testConfig({
       dataDir: mkdtempSync(join(tmpdir(), "oauth-routes-")),
@@ -37,8 +40,9 @@ function start(fetchImpl: FetchLike): { base: string; built: BuiltApp; close: ()
     signingSecret: SECRET,
     replayDedupe: built.replayDedupe,
     connectorTokens: built.connectorTokens,
+    oauthFlows: built.oauthFlows,
     auditLog: built.auditLog,
-    oauthEnv,
+    oauthEnv: opts.oauthEnv ?? oauthEnv,
     oauthFetch: fetchImpl,
   });
   server.listen(0);
@@ -79,7 +83,7 @@ test("OAuth start, unsigned callback, status, and revoke are principal-bound", a
     assert.equal(exchanged, true);
     const replay = await fetch(`${srv.base}${callbackPath}`);
     assert.equal(replay.status, 400);
-    assert.match(((await replay.json()) as { message: string }).message, /already used/);
+    assert.match(((await replay.json()) as { message: string }).message, /already used|invalid OAuth state/);
     assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U1"), "at-google");
     assert.equal(await srv.built.connectorTokens.connectorAccessToken("gmail.googleapis.com", "U2"), null);
 
@@ -194,6 +198,45 @@ test("connector token route normalizes expiry seconds before storing", async () 
     const status = await srv.built.connectorTokens.connectorTokenStatus("api.example.test", "U1");
     assert.equal(status.connected, true);
     assert.equal(status.expiresAt, expiresAtMs);
+  } finally {
+    await srv.close();
+  }
+});
+
+const X_ENV = { X_OAUTH_CLIENT_ID: "xid", X_OAUTH_CLIENT_SECRET: "xsecret" } as NodeJS.ProcessEnv;
+const X_STATE_LIMIT = 500;
+
+test("authorize state stays inside the tightest provider limit and still carries the PKCE verifier", async () => {
+  let body = "";
+  const srv = start(
+    async (_url, init) => {
+      body = init.body;
+      return { ok: true, status: 200, json: async () => ({ access_token: "at-x", expires_in: 7200 }) };
+    },
+    { oauthEnv: X_ENV },
+  );
+  try {
+    const redirectUri = "https://acme-portal.fly.dev/v1/connectors/oauth/x/callback";
+    const query = `principalId=${encodeURIComponent("person@acme-corp.com")}&redirectUri=${encodeURIComponent(redirectUri)}&returnTo=${encodeURIComponent("/keychain")}`;
+    const startPath = `/v1/connectors/oauth/x/start?${query}`;
+    const startRes = await fetch(`${srv.base}${startPath}`, { headers: sign("GET", startPath) });
+    assert.equal(startRes.status, 200);
+    const consent = new URL(((await startRes.json()) as { authorizeUrl: string }).authorizeUrl);
+    const state = consent.searchParams.get("state") ?? "";
+    assert.ok(
+      state.length <= X_STATE_LIMIT,
+      `state is ${state.length} chars — X rejects authorize when state exceeds ${X_STATE_LIMIT}`,
+    );
+    assert.ok(consent.searchParams.get("code_challenge"));
+
+    const callbackPath = `/v1/connectors/oauth/x/callback?code=code-x&state=${encodeURIComponent(state)}`;
+    const cb = await fetch(`${srv.base}${callbackPath}`, { redirect: "manual" });
+    assert.equal(cb.status, 302, await cb.text());
+    assert.equal(cb.headers.get("location"), "/keychain?connector=x&status=connected");
+    assert.match(body, /code_verifier=/);
+    assert.equal(await srv.built.connectorTokens.connectorAccessToken("api.x.com", "person@acme-corp.com"), "at-x");
+    const replayed = await fetch(`${srv.base}${callbackPath}`, { redirect: "manual" });
+    assert.equal(replayed.status, 400, "the state is single-use");
   } finally {
     await srv.close();
   }

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -13,8 +13,11 @@ import {
   PROVIDERS,
   type FetchLike,
   type ResolvedClient,
+  type OAuthState,
 } from "../src/connectors/oauth.ts";
 import { createEnvSecretSource } from "../src/credentials/secret-source.ts";
+import { createOAuthFlowStore } from "../src/connectors/oauth-flow-store.ts";
+import { createMemoryMap } from "../src/persistence/durable-map.ts";
 
 const env = {
   GOOGLE_OAUTH_CLIENT_ID: "gid",
@@ -481,4 +484,24 @@ test("X refresh captures the ROTATED refresh token (single-use) — the connecti
   assert.equal(fresh.accessToken, "xat2");
   assert.equal(fresh.refreshToken, "new-rt", "the rotated refresh token replaces the old one");
   assert.equal(fresh.expiresAt, 5_000 + 7200_000);
+});
+
+test("oauth flow store — a short opaque state resolves once, then expires", async () => {
+  const store = createOAuthFlowStore(createMemoryMap<OAuthState>(), { now: () => 1_000 });
+  const flowId = await store.start({
+    provider: "x",
+    principalId: "person@example.com",
+    redirectUri: "https://example.test/v1/connectors/oauth/x/callback",
+    codeVerifier: "verifier",
+  });
+  assert.equal(flowId.length, 43);
+  assert.equal(await store.finish("nope"), null);
+  const opened = await store.finish(flowId);
+  assert.equal(opened?.codeVerifier, "verifier");
+  assert.equal(opened?.nonce, flowId);
+  assert.equal(await store.finish(flowId), null, "single use");
+
+  const stale = createOAuthFlowStore(createMemoryMap<OAuthState>(), { now: () => 1_000, ttlMs: 10 });
+  const staleId = await stale.start({ provider: "x", principalId: "U1", redirectUri: "https://example.test/cb" }, 0);
+  assert.equal(await stale.finish(staleId), null, "expired");
 });

--- a/test/signed-token.test.ts
+++ b/test/signed-token.test.ts
@@ -1,6 +1,7 @@
+import { createHash } from "node:crypto";
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { decodeProtectedHeader } from "jose";
+import { CompactSign, decodeProtectedHeader } from "jose";
 import { mintSignedPayload, signingKeyId, verifySignedPayload } from "../src/auth/signed-token.ts";
 
 const SECRET = "test-secret";
@@ -26,6 +27,15 @@ test("rejects tampered payloads, tampered signatures, and the wrong secret", asy
   assert.equal(await verifySignedPayload(`${header}.${payload}.${sig}`, SECRET), null);
   assert.equal(await verifySignedPayload(token.slice(0, -1) + "X", SECRET), null);
   assert.equal(await verifySignedPayload(token, "other-secret"), null);
+});
+
+test("still verifies tokens carrying the previous key identifier", async () => {
+  const value = { version: "previous-kid" };
+  const previousKid = createHash("sha256").update(SECRET).digest("base64url").slice(0, 8);
+  const token = await new CompactSign(new TextEncoder().encode(JSON.stringify(value)))
+    .setProtectedHeader({ alg: "HS256", kid: previousKid })
+    .sign(new TextEncoder().encode(SECRET));
+  assert.deepEqual(await verifySignedPayload(token, SECRET), value);
 });
 
 test("key rotation: a verifier holding several secrets accepts tokens minted under any of them", async () => {


### PR DESCRIPTION
Fixes #152. The OAuth authorize `state` parameter carried the whole flow context, so its length grew with the principal id and redirect URI and could exceed a provider's documented state limit. The context now lives in a durable store keyed by a short opaque id, giving a fixed 43-character state for every provider; the PKCE verifier no longer travels through the browser. Deployments without the store wired keep the previous signed-state path, which the callback still accepts.

- verification: new route + store tests, full connector suite, `tsc --noEmit`, eslint/oxlint/prettier
- live dev build: state 523 → 43 characters

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791088442&installation_model_id=19911&pr_number=931&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F931&signature=d1020586caa4e0aa8deff8dd3df89a08b9e990c723a70f3e1d81611ee954ac79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->