### PR TITLE
feat(models): add GPT-6 Astra

### DIFF
--- a/plugins/web-ui/src/model-options.ts
+++ b/plugins/web-ui/src/model-options.ts
@@ -38,6 +38,10 @@ const MODEL_CATALOG: Record<string, ModelMeta> = {
     label: "Fable 5",
     buttonLabel: "Fable 5",
   },
+  "gpt-6-astra": {
+    label: "GPT-6 Astra",
+    buttonLabel: "Astra",
+  },
   "gpt-5.6-sol": {
     label: "GPT-5.6 Sol",
     buttonLabel: "5.6 Sol",

--- a/plugins/web-ui/src/pi-models.ts
+++ b/plugins/web-ui/src/pi-models.ts
@@ -7,6 +7,7 @@ const CLONE_TEMPLATES: Readonly<Record<string, { template: string; name: string 
   "claude-fable-5": { template: "claude-opus-4-8", name: "Claude Fable 5" },
   "claude-opus-5": { template: "claude-opus-4-8", name: "Claude Opus 5" },
   "claude-sonnet-5": { template: "claude-sonnet-4-6", name: "Claude Sonnet 5" },
+  "gpt-6-astra": { template: "gpt-5.5", name: "GPT-6 Astra" },
   "gpt-5.6-sol": { template: "gpt-5.5", name: "GPT-5.6 Sol" },
   "gpt-5.6-terra": { template: "gpt-5.5", name: "GPT-5.6 Terra" },
   "gpt-5.6-luna": { template: "gpt-5.5", name: "GPT-5.6 Luna" },

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -50,6 +50,13 @@ interface ModelEntry {
     cacheWrite?: number;
     contextWindow: number;
     maxTokens: number;
+    tiers?: readonly {
+      inputTokensAbove: number;
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+    }[];
   };
 }
 
@@ -99,6 +106,22 @@ export const MODEL_REGISTRY: readonly ModelEntry[] = [
     base: true,
     auxiliary: true,
     clone: { ...GPT_56_CLONE, input: 1, output: 6 },
+  },
+  {
+    id: "gpt-6-astra",
+    name: "GPT-6 Astra",
+    fastMode: false,
+    webui: true,
+    base: true,
+    clone: {
+      template: "gpt-5.5",
+      input: 10,
+      output: 50,
+      cacheWrite: 12.5,
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+      tiers: [{ inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 }],
+    },
   },
   { id: "openrouter/auto", name: "OpenRouter Auto", fastMode: false, webui: true, base: true },
   { id: "claude-opus-4-7", name: "Claude Opus 4.7", fastMode: true, webui: false, base: false },
@@ -193,6 +216,7 @@ export function resolveModel(id: string): PiModel | undefined {
             output: entry.clone.output,
             cacheRead: entry.clone.input / 10,
             cacheWrite: entry.clone.cacheWrite ?? 0,
+            ...(entry.clone.tiers ? { tiers: entry.clone.tiers.map((tier) => ({ ...tier })) } : {}),
           },
         })
       : undefined;

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -67,6 +67,7 @@ test("admin model credentials are encrypted, write-only, live, and removable", a
         { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
         { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
         { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+        { id: "gpt-6-astra", name: "GPT-6 Astra", provider: "openai" },
         { id: "openrouter/auto", name: "OpenRouter Auto", provider: "openrouter" },
       ],
     });

--- a/test/model-registry.test.ts
+++ b/test/model-registry.test.ts
@@ -44,6 +44,28 @@ test("regression: gpt-5.6-sol is web-ui-enabled (the reported 403)", () => {
   assert.equal(validateWebTurnModelOptions({ model: "gpt-5.6-sol" }, null), null);
 });
 
+test("gpt-6-astra is offered with its published context, output ceiling, and rates", () => {
+  const model = resolveModel("gpt-6-astra");
+  assert.ok(model, "gpt-6-astra must resolve");
+  assert.equal(model.provider, "openai");
+  assert.equal(model.contextWindow, 1_050_000);
+  assert.equal(model.maxTokens, 128_000);
+  assert.deepEqual(
+    {
+      input: model.cost.input,
+      output: model.cost.output,
+      cacheRead: model.cost.cacheRead,
+      cacheWrite: model.cost.cacheWrite,
+    },
+    { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  );
+  assert.deepEqual((model.cost as { tiers?: unknown }).tiers, [
+    { inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 },
+  ]);
+  assert.ok(DEFAULT_WEBUI_MODEL_IDS.includes("gpt-6-astra"));
+  assert.equal(validateWebTurnModelOptions({ model: "gpt-6-astra" }, null), null);
+});
+
 test("FAST_MODE_MODEL_IDS derives from the registry — the web-ui client reads this, keeps no copy", () => {
   assert.deepEqual(
     [...FAST_MODE_MODEL_IDS].sort(),

--- a/test/pi-models.test.ts
+++ b/test/pi-models.test.ts
@@ -98,6 +98,7 @@ test("the curated catalog contains only current model families", () => {
       "gpt-5.6-sol",
       "gpt-5.6-terra",
       "gpt-5.6-luna",
+      "gpt-6-astra",
       "openrouter/auto",
     ],
   );


### PR DESCRIPTION
Adds GPT-6 Astra (`gpt-6-astra`) to the model registry and web UI picker with its published context window, output ceiling, and standard and long-context pricing.

- verification: typecheck, lint, all core test shards, Postgres tests, CLI, plugins, and CodeQL pass
- existing defaults are unchanged: `claude-opus-5` remains the general agent default; `gpt-5.6-sol` remains the Codex/OpenAI fallback
