### PR TITLE
fix(admin): keep the hidden utility from losing to component display rules

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -209,9 +209,6 @@
         grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
         min-height: calc(100dvh - var(--header-total-h));
       }
-      .admin-app.hidden {
-        display: none;
-      }
       .admin-sidebar {
         position: sticky;
         top: var(--header-total-h);
@@ -692,9 +689,6 @@
         background: var(--surface);
         box-shadow: 0 12px 32px rgba(16, 24, 40, 0.12);
       }
-      .scope-menu.hidden {
-        display: none;
-      }
       .scope-menu .scope-filter {
         padding: 8px;
         border-bottom: 1px solid var(--border);
@@ -1075,9 +1069,6 @@
         flex-wrap: wrap;
         margin: 0 0 10px;
       }
-      .pack-adv.hidden {
-        display: none;
-      }
       .pack-adv input {
         flex: 1 1 150px;
         min-width: 0;
@@ -1128,9 +1119,6 @@
         border: 1px solid var(--border);
         border-radius: 8px;
         box-shadow: 0 8px 24px rgba(16, 24, 40, 0.12);
-      }
-      .ovmenu.hidden {
-        display: none;
       }
       .ovmenu button {
         text-align: left;
@@ -1189,9 +1177,6 @@
       .dense-row .file-thumb {
         width: 36px;
         height: 28px;
-      }
-      .dense-row.hidden {
-        display: none;
       }
       .scope-link {
         border: 0;
@@ -1366,7 +1351,7 @@
         font-variant-numeric: tabular-nums;
       }
       .hidden {
-        display: none;
+        display: none !important;
       }
 
       tr.openable {
@@ -3127,9 +3112,6 @@
       }
       #view-governance section.card.setting-row {
         padding: 12px 14px;
-      }
-      #view-governance .setting-row.hidden {
-        display: none;
       }
       #view-governance .setting-row > .head {
         display: block;

--- a/plugins/admin/test/default-view.test.ts
+++ b/plugins/admin/test/default-view.test.ts
@@ -4,6 +4,31 @@ import test from "node:test";
 
 const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
 
+function resolvedDisplay(classes: string[]) {
+  const styles = [...html.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) => m[1]).join("\n");
+  const held = new Set(classes);
+  let display = "";
+  let important = false;
+  for (const [, selectors, body] of styles.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const matches = selectors.split(",").some(
+      (selector) =>
+        /^(\.[A-Za-z0-9_-]+)+$/.test(selector.trim()) &&
+        selector
+          .trim()
+          .split(".")
+          .filter(Boolean)
+          .every((name) => held.has(name)),
+    );
+    if (!matches) continue;
+    for (const [, value, bang] of body.matchAll(/display:\s*([a-z-]+)\s*(!important)?\s*;/g)) {
+      if (important && !bang) continue;
+      display = value;
+      important = !!bang;
+    }
+  }
+  return display;
+}
+
 test("admin shell uses the QM identity with org-injectable branding", () => {
   assert.match(html, /<title>QM Admin<\/title>/);
   assert.match(html, /<meta name="brand-self-label" content="Agent" \/>/);
@@ -186,7 +211,7 @@ test("compact governance rows preserve policy detail and collapse before they ov
   );
   assert.match(html, /#view-governance \.setting-row > \.foot \.status[^}]*overflow-wrap: anywhere/);
   assert.match(html, /#view-governance section\.card\.setting-row\s*\{\s*padding:\s*12px 14px;\s*\}/);
-  assert.match(html, /#view-governance \.setting-row\.hidden\s*\{\s*display:\s*none;\s*\}/);
+  assert.equal(resolvedDisplay(["setting-row", "hidden"]), "none");
 });
 
 test("governance reviews high-impact changes in product and preserves drafts", () => {
@@ -310,4 +335,14 @@ test("governance SOUL workbench shows draft diff, history, and conflict-safe res
   assert.match(html, /expectedVersion: soulVersion/);
   assert.match(html, /function refreshSoulConflict\(\)/);
   assert.match(html, /Restore SOUL version/);
+});
+
+test("the hidden utility hides an element whose component rule is declared later", () => {
+  assert.match(html, /<aside class="environment-notice hidden" id="environment-notice"/);
+  assert.match(html, /notice\.classList\.toggle\("hidden", !attachment\)/);
+  assert.equal(resolvedDisplay(["environment-notice"]), "flex");
+  assert.equal(resolvedDisplay(["environment-notice", "hidden"]), "none");
+  for (const component of ["admin-app", "scope-menu", "pack-adv", "ovmenu", "dense-row", "setting-row"]) {
+    assert.equal(resolvedDisplay([component, "hidden"]), "none");
+  }
 });


### PR DESCRIPTION
The admin governance page rendered an empty "named environment" banner on every scope: the element ships with the `hidden` utility class, but its component rule sets a display value later in the same stylesheet at equal specificity, so the utility lost the cascade. Make `.hidden` authoritative and drop the six per-component copies that worked around the same ordering.

- verification: `npm test` in `plugins/admin` — 87 pass; new test resolves the stylesheet cascade and fails on the old CSS (`flex` vs `none`)
- verification: headless-browser check of the built page — banner computes `display: none`; the six components it replaces are unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791090828&installation_model_id=19911&pr_number=933&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F933&signature=8d54b318b243d48411b28f9c2f8ed9d0fbff0b9ea11732b6ac1c59de0a2a3be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->