### PR TITLE
fix(sandbox): read QM_CORE_CONTAINER where the local sandbox can use it

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -260,7 +260,6 @@ function awsSandboxEnv(env: NodeJS.ProcessEnv): AwsSandboxEnv {
     ...(numEnvStrict("AWS_SANDBOX_SNAPSHOT_INTERVAL_MS", env.AWS_SANDBOX_SNAPSHOT_INTERVAL_MS) !== undefined
       ? { snapshotIntervalMs: numEnvStrict("AWS_SANDBOX_SNAPSHOT_INTERVAL_MS", env.AWS_SANDBOX_SNAPSHOT_INTERVAL_MS) }
       : {}),
-    ...(env.QM_CORE_CONTAINER ? { coreContainer: env.QM_CORE_CONTAINER } : {}),
     ...(numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) !== undefined
       ? { defaultTimeoutSec: numEnvStrict("SANDBOX_TIMEOUT_SEC", env.SANDBOX_TIMEOUT_SEC) }
       : {}),
@@ -288,6 +287,11 @@ interface LocalSandboxEnv {
 function localSandboxEnv(env: NodeJS.ProcessEnv): LocalSandboxEnv {
   return {
     ...(env.LOCAL_SANDBOX_IMAGE ? { image: env.LOCAL_SANDBOX_IMAGE } : {}),
+    // Set by the docker target for exactly this backend. With it the sandbox
+    // joins core to its network and is reached by container name; without it
+    // the sandbox publishes a port and core resolves the exec daemon at
+    // 127.0.0.1, which inside a containerized core is core itself.
+    ...(env.QM_CORE_CONTAINER ? { coreContainer: env.QM_CORE_CONTAINER } : {}),
     ...(env.LOCAL_SANDBOX_DOCKER_BIN ? { dockerBin: env.LOCAL_SANDBOX_DOCKER_BIN } : {}),
     ...(numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) !== undefined
       ? { cpus: numEnvStrict("LOCAL_SANDBOX_CPUS", env.LOCAL_SANDBOX_CPUS) }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -344,6 +344,19 @@ test("HARNESS=claude uses native Claude authentication and does not require an A
   assert.equal(loadConfig({ HARNESS: "claude", CLAUDE_MODEL: "claude-opus-4-8" }).claudeModel, "claude-opus-4-8");
 });
 
+test("QM_CORE_CONTAINER reaches the local sandbox, which is the only backend that reads it", () => {
+  // The docker target sets QM_CORE_CONTAINER so the local sandbox can join core
+  // to the sandbox network and reach the exec daemon by container name. Without
+  // it the sandbox publishes a port and core resolves 127.0.0.1, which inside a
+  // containerized core is core itself, so every tool call fails with
+  // "exec daemon never became reachable".
+  assert.equal(
+    loadConfig({ ...productionEnv, QM_CORE_CONTAINER: "qm-acme-core" }).localSandbox.coreContainer,
+    "qm-acme-core",
+  );
+  assert.equal(loadConfig({ ...productionEnv }).localSandbox.coreContainer, undefined);
+});
+
 test("SANDBOX_BACKEND: unset defaults to local (dev only); the secondary must be recognized and differ", () => {
   assert.equal(loadConfig({}).sandboxBackend, "local");
   assert.throws(


### PR DESCRIPTION
## What breaks

The `docker` target sets `QM_CORE_CONTAINER` on core (`cli/src/backends/docker.ts:358`) for exactly one purpose: telling the **local** sandbox backend that core runs in a container. `createLocalSandbox` uses it to connect core to the sandbox's network and address the exec daemon as `http://<container>:8080`. Without it, the sandbox is started with a published port and core addresses `http://127.0.0.1:<port>` — which, inside a containerized core, is core itself.

`config.ts` read the variable in `awsSandboxEnv()` instead of `localSandboxEnv()`. `AwsSandboxEnv` does not declare `coreContainer` and `aws-sandbox.ts` never reads one, so the assignment was dead where it sat and missing where it was needed.

## What it looks like

Every tool call on a docker deployment using `sandbox.backend: "local"` fails:

```
skills | tree_materialize_failed | local sandbox qm-sbx-...:
        exec daemon never became reachable: fetch failed
```

The agent retries, gives up, and tells the user its execution environment is unreachable. Chat works; anything needing a tool does not.

Observed on such a deployment:

| Probe | Result |
| --- | --- |
| `GET http://127.0.0.1:<published port>/` from the host | `404` — the daemon is alive |
| the same URL from inside the core container | connection refused |
| networks core is attached to | only the deployment network, never the sandbox's |
| `getent hosts <sandbox container>` inside core | no result |

## Why it survived

Coverage sits on both sides of the gap and not across it:

- `test/local-sandbox.test.ts` passes `coreContainer` straight into the constructor, so container mode itself is well covered;
- `cli/test/auth-broker.test.ts` asserts the variable is in the docker service env;
- `cli/test/e2e/docker-lifecycle.e2e.test.ts` asserts it is **present on the container**, and stops there.

None assert that anything consumes it, and none run an agent turn that uses a tool. The same code path is also correct under `qm dev`, where core is a host process and `127.0.0.1:<published port>` really is the sandbox — so the mode developers use all day is unaffected.

## The change

Move the line to `localSandboxEnv()`, and add a config test that crosses the gap: it fails with the line in its old place and passes with it moved.

`npm test` 4286 pass / 0 fail, typecheck and lint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791115323&installation_model_id=19911&pr_number=934&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F934&signature=5ee0ddd6708230b5f9fd7d013b7a7ed887704d2d58c1ee4930300c68a540c956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->