### PR TITLE
fix(cli): retain bounded failed-canary diagnostics

### DIFF
--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -1025,6 +1025,83 @@ interface EcsServiceRevision {
   taskDefinition?: string;
 }
 
+const CANARY_FAILURE_LOG_LINES = 40;
+const CANARY_FAILURE_LOG_BYTES = 8 * 1024;
+
+function redactCanaryFailureLog(value: string): string {
+  return value
+    .replace(/-----BEGIN [^-\r\n]*PRIVATE KEY-----[\s\S]*?(?:-----END [^-\r\n]*PRIVATE KEY-----|$)/g, "[REDACTED]")
+    .replace(/^[A-Za-z0-9+/]{32,}={0,2}\s*$/gm, "[REDACTED]")
+    .replace(
+      /\b(?:https?|postgres(?:ql)?|mysql|redis|mongodb(?:\+srv)?):\/\/[^\s/@:]+:[^\s/@]+@[^\s]+/gi,
+      "[REDACTED_URL]",
+    )
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[REDACTED_EMAIL]")
+    .replace(/\bBearer\s+[^\s,;]+/gi, "Bearer [REDACTED]")
+    .replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "[REDACTED]")
+    .replace(/\b(?:xox[baprs]-[A-Za-z0-9-]{10,}|gh[pousr]_[A-Za-z0-9]{10,})\b/g, "[REDACTED]")
+    .replace(/\b(?:sk-(?:ant-|proj-|or-v1-)?|sk_live_|rk_live_|AIza)[A-Za-z0-9_-]{16,}\b/g, "[REDACTED]")
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]")
+    .replace(
+      /(\b[A-Za-z0-9_-]*(?:authorization|cookie|secret|token|password|passwd|api[_-]?key|access[_-]?key)[A-Za-z0-9_-]*\b["']?\s*(?:=|:)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;}\]]+)/gi,
+      "$1[REDACTED]",
+    );
+}
+
+function utf8Tail(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value) <= maxBytes) return value;
+  let low = 0;
+  let high = value.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (Buffer.byteLength(value.slice(middle)) <= maxBytes) high = middle;
+    else low = middle + 1;
+  }
+  return value.slice(low);
+}
+
+function canaryFailureLogs(config: QmConfig, taskArn: string): { stream: string; body: string } | null {
+  const aws = requireAws(config);
+  const taskId = taskArn.split("/").at(-1);
+  if (!taskId || !/^[A-Za-z0-9_-]+$/.test(taskId)) return null;
+  const spec = aws.services.core;
+  if (!spec) return null;
+  const stream = `core/core/${taskId}`;
+  try {
+    const response = awsJson<{ events?: Array<{ message?: string; timestamp?: number; ingestionTime?: number }> }>(
+      aws,
+      [
+        "logs",
+        "get-log-events",
+        "--log-group-name",
+        spec.logGroup ?? `/ecs/${spec.ecsService}`,
+        "--log-stream-name",
+        stream,
+        "--limit",
+        String(CANARY_FAILURE_LOG_LINES),
+        "--no-start-from-head",
+      ],
+    );
+    const messages = [...(response.events ?? [])]
+      .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0) || (a.ingestionTime ?? 0) - (b.ingestionTime ?? 0))
+      .flatMap((event) => (typeof event.message === "string" ? [event.message] : []));
+    const joined = redactCanaryFailureLog(messages.join("\n"))
+      .split(/\r?\n/)
+      .filter((line) => line.length > 0)
+      .slice(-CANARY_FAILURE_LOG_LINES)
+      .join("\n");
+    if (!joined) return null;
+    if (Buffer.byteLength(joined) <= CANARY_FAILURE_LOG_BYTES) return { stream, body: joined };
+    const marker = "…";
+    return {
+      stream,
+      body: `${marker}${utf8Tail(joined, CANARY_FAILURE_LOG_BYTES - Buffer.byteLength(marker))}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function awsLiveSession(config: QmConfig, core: EcsServiceState): void {
   const aws = requireAws(config);
   if (!core.taskDefinition) throw new Error("core service has no live task definition");
@@ -1108,8 +1185,10 @@ function awsLiveSession(config: QmConfig, core: EcsServiceState): void {
   const task = stopped.tasks?.[0];
   const coreContainer = task?.containers?.find((container) => container.name === "core");
   if (coreContainer?.exitCode !== 0) {
+    const logs = canaryFailureLogs(config, taskArn);
+    const diagnostics = logs ? `\ncanary task logs (${logs.stream}):\n${logs.body}` : "";
     throw new Error(
-      `canary task exited ${coreContainer?.exitCode ?? "without a code"}: ${coreContainer?.reason ?? task?.stoppedReason ?? "unknown reason"}`,
+      `canary task exited ${coreContainer?.exitCode ?? "without a code"}: ${coreContainer?.reason ?? task?.stoppedReason ?? "unknown reason"}${diagnostics}`,
     );
   }
 }

--- a/cli/templates/deployment/references/aws.md
+++ b/cli/templates/deployment/references/aws.md
@@ -50,7 +50,9 @@ Existing deployments created before private session canaries must rerun
 `npm exec qm -- infra render`, review the Terraform plan, and apply it with
 infrastructure-administrator credentials before enabling `check --live`. This
 adds the deploy role's stack-scoped permission to run and inspect the one-off
-core canary task.
+core canary task. When that task fails, the check includes a bounded, redacted
+tail from that task's exact core log stream; it does not search other service
+or task logs.
 
 The package image manifest supplies first-party control-plane images. The AWS
 backend transfers them into deployment-owned ECR and records immutable digests.

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -369,9 +369,10 @@ else if (a.includes("ecs describe-service-revisions")) {
 else if (a.includes("ecs list-tasks")) console.log(JSON.stringify({ taskArns: process.env.AWS_FAKE_NO_RUNNING_TASK ? [] : [...(process.env.AWS_FAKE_LARGE_ROLLOUT ? Array.from({ length: 100 }, (_, i) => "arn:aws:ecs:us-west-2:123456789012:task/old-core-" + i) : []), "arn:aws:ecs:us-west-2:123456789012:task/live-core"] }));
 else if (a.includes("ecs describe-tasks") && a.includes("task/old-core-")) console.log(JSON.stringify({ tasks: [] }));
 else if (a.includes("ecs describe-tasks") && a.includes("task/live-core")) console.log(JSON.stringify({ tasks: [{ taskDefinitionArn: process.env.AWS_FAKE_STALE_CORE ? "stale-task-definition" : s.services["acme-core"].taskDefinition, lastStatus: "RUNNING", healthStatus: "HEALTHY", containers: [{ name: "core", networkInterfaces: [{ privateIpv4Address: "10.0.1.8" }] }] }] }));
-else if (a.includes("ecs run-task")) console.log(JSON.stringify({ tasks: [{ taskArn: "arn:aws:ecs:us-west-2:123456789012:task/canary" }] }));
+else if (a.includes("ecs run-task")) console.log(JSON.stringify({ tasks: [{ taskArn: "arn:aws:ecs:us-west-2:123456789012:task/acme-qm/canary" }] }));
 else if (a.includes("ecs wait tasks-stopped")) console.log("");
 else if (a.includes("ecs describe-tasks")) { const exitCode = Number(process.env.AWS_FAKE_CANARY_EXIT || "0") || ${JSON.stringify(opts.migrationExitCode ?? 0)}; console.log(JSON.stringify({ tasks: [{ stoppedReason: "Essential container in task exited", containers: [{ name: "core", exitCode, reason: process.env.AWS_FAKE_CANARY_REASON ?? (exitCode && ${JSON.stringify(Boolean(opts.migrationExitCode ?? 0))} ? "migration failed" : undefined) }] }], failures: [] })); }
+else if (a.includes("logs get-log-events")) console.log(JSON.stringify({ events: JSON.parse(process.env.AWS_FAKE_CANARY_LOGS || "[]").map((event, index) => typeof event === "string" ? { message: event, timestamp: index } : event) }));
 else if (a.includes("ecs describe-task-definition")) {
   const id = after("--task-definition");
   console.log(JSON.stringify({ taskDefinition: s.definitions[id] }));
@@ -1156,7 +1157,7 @@ test("AWS portal ALB adopts pinned target groups and requires exactly the env-de
   }
 });
 
-test("AWS up scales services to the configured desired count and live check flags drift from it", async () => {
+test("AWS scaling and failed live canary diagnostics stay exact, bounded, redacted, and failure-only", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-aws-desired-count-"));
   const dockerBin = join(dir, "docker");
   writeFileSync(dockerBin, `#!/usr/bin/env node\nconsole.log("Digest: sha256:${"a".repeat(64)}");\n`);
@@ -1168,6 +1169,7 @@ test("AWS up scales services to the configured desired count and live check flag
   const fake = statefulAws(dir, scaled());
   const priorPath = process.env.PATH;
   const priorCanaryExit = process.env.AWS_FAKE_CANARY_EXIT;
+  const priorCanaryLogs = process.env.AWS_FAKE_CANARY_LOGS;
   process.env.PATH = `${dir}:${priorPath}`;
   try {
     await awsUp(scaled(), dir, { yes: true });
@@ -1187,13 +1189,68 @@ test("AWS up scales services to the configured desired count and live check flag
       readFileSync(fake.log, "utf8"),
       /ecs run-task .*postdeploy-smoke\.ts.*session.*http:\/\/10\.0\.1\.8:8080/,
     );
+    assert.doesNotMatch(readFileSync(fake.log, "utf8"), /logs get-log-events/);
     process.env.AWS_FAKE_CANARY_EXIT = "1";
-    await assert.rejects(
-      () => awsCheckLive(scaled(), { report: false }),
-      /core: private live session smoke failed: canary task exited 1/,
+    process.env.AWS_FAKE_CANARY_LOGS = JSON.stringify([
+      {
+        timestamp: 2,
+        message:
+          'newest request failed for alice@example.com authorization: Bearer bearer-value CORE_SIGNING_SECRET="signing-value" api_key=json-value xoxb-1234567890-secret ghp_1234567890secret eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA.c2lnbmF0dXJl sk-proj-1234567890abcdefghijklmnop https://user:password@example.com/db',
+      },
+      {
+        timestamp: 1,
+        message: Array.from({ length: 60 }, (_, index) => `older-${index}-${"x".repeat(300)}`).join("\n"),
+      },
+    ]);
+    let canaryFailure: Error | undefined;
+    try {
+      await awsCheckLive(scaled(), { report: false });
+    } catch (error) {
+      canaryFailure = error as Error;
+    }
+    assert.ok(canaryFailure);
+    assert.match(canaryFailure.message, /core: private live session smoke failed: canary task exited 1/);
+    const marker = "canary task logs (core/core/canary):\n";
+    assert.ok(canaryFailure.message.includes(marker));
+    const diagnostic = canaryFailure.message.slice(canaryFailure.message.indexOf(marker) + marker.length);
+    assert.ok(diagnostic.split("\n").length <= 40);
+    assert.ok(Buffer.byteLength(diagnostic) <= 8 * 1024);
+    assert.doesNotMatch(
+      diagnostic,
+      /older-0-|alice@example\.com|bearer-value|signing-value|json-value|xoxb-|ghp_|eyJ|sk-proj-|user:password/,
     );
+    assert.match(diagnostic, /^…/);
+    assert.match(diagnostic, /older-59-/);
+    assert.match(diagnostic, /newest request failed/);
+    assert.ok(diagnostic.indexOf("older-59-") < diagnostic.indexOf("newest request failed"));
+    assert.match(diagnostic, /\[REDACTED_EMAIL\]|\[REDACTED\]/);
+    const keyLine = "c3ludGhldGljLWtleS1ieXRlcy1mb3ItcmVkYWN0aW9uLXRlc3Qtb25seQ==";
+    for (const fragment of [
+      ["-----BEGIN PRIVATE KEY-----", ...Array(60).fill(keyLine), "-----END PRIVATE KEY-----"].join("\n"),
+      [keyLine, "-----END PRIVATE KEY-----"].join("\n"),
+      ["-----BEGIN PRIVATE KEY-----", keyLine].join("\n"),
+    ]) {
+      process.env.AWS_FAKE_CANARY_LOGS = JSON.stringify([{ timestamp: 1, message: fragment }]);
+      await assert.rejects(
+        () => awsCheckLive(scaled(), { report: false }),
+        (error: Error) => {
+          assert.match(error.message, /canary task logs/);
+          assert.doesNotMatch(error.message, new RegExp(keyLine));
+          assert.match(error.message, /REDACTED/);
+          return true;
+        },
+      );
+    }
+    const canaryLogRead = readFileSync(fake.log, "utf8");
+    assert.match(
+      canaryLogRead,
+      /logs get-log-events --log-group-name \/ecs\/acme-core --log-stream-name core\/core\/canary --limit 40 --no-start-from-head/,
+    );
+    assert.doesNotMatch(canaryLogRead, /logs (?:filter-log-events|describe-log-streams|tail)/);
     if (priorCanaryExit === undefined) delete process.env.AWS_FAKE_CANARY_EXIT;
     else process.env.AWS_FAKE_CANARY_EXIT = priorCanaryExit;
+    if (priorCanaryLogs === undefined) delete process.env.AWS_FAKE_CANARY_LOGS;
+    else process.env.AWS_FAKE_CANARY_LOGS = priorCanaryLogs;
     rolledBack.services["acme-core"].desiredCount = 1;
     writeFileSync(fake.state, JSON.stringify(rolledBack));
     await assert.rejects(
@@ -1203,6 +1260,8 @@ test("AWS up scales services to the configured desired count and live check flag
   } finally {
     if (priorCanaryExit === undefined) delete process.env.AWS_FAKE_CANARY_EXIT;
     else process.env.AWS_FAKE_CANARY_EXIT = priorCanaryExit;
+    if (priorCanaryLogs === undefined) delete process.env.AWS_FAKE_CANARY_LOGS;
+    else process.env.AWS_FAKE_CANARY_LOGS = priorCanaryLogs;
     process.env.PATH = priorPath;
     fake.restore();
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
When the private AWS session canary fails, retain a bounded diagnostic from that canary task's exact CloudWatch log stream. Successful checks do not read logs, and missing logs preserve the original failure.

Rebased on current main without changing its task selection or migration flow. Sort events by timestamp, redact before truncating, and cap the result at 40 lines/8 KiB. Redaction covers credential-shaped values and complete or clipped private-key blocks.

Validation: four affected AWS CLI tests passed, including the full failed-canary path, event ordering, output bounds, secret redaction, and clipped-key cases. CLI typecheck, affected-file ESLint, and diff checks passed. An independent review found no blocking issues.
