### PR TITLE
fix(cli): plan AWS deployments using secret metadata

### DIFF
--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -799,12 +799,12 @@ async function runAwsCandidateMigration(config: QmConfig, coreImage: string, lab
   }
 }
 
-export function secretArns(config: QmConfig): Record<string, string> {
+export function secretArns(config: QmConfig, options: { metadataOnly?: boolean } = {}): Record<string, string> {
   const aws = requireAws(config);
   const pairs = computedSecrets(config).flatMap((secret) => {
     const id = `${aws.secretsPrefix}${secret.name}`;
     try {
-      if (!secret.required) {
+      if (options.metadataOnly || !secret.required) {
         const metadata = awsJson<{
           ARN?: string;
           DeletedDate?: string;
@@ -813,7 +813,10 @@ export function secretArns(config: QmConfig): Record<string, string> {
         const hasCurrent = Object.values(metadata.VersionIdsToStages ?? {}).some((stages) =>
           stages.includes("AWSCURRENT"),
         );
-        return metadata.ARN && !metadata.DeletedDate && hasCurrent ? [[secret.name, metadata.ARN] as const] : [];
+        if (metadata.ARN && !metadata.DeletedDate && hasCurrent) return [[secret.name, metadata.ARN] as const];
+        if (secret.required)
+          throw new CliError(`required AWS secret ${secret.name} has no available AWSCURRENT version`);
+        return [];
       }
       const value = awsJson<{ ARN?: string; SecretString?: string }>(aws, [
         "secretsmanager",
@@ -1953,13 +1956,14 @@ export async function awsUp(config: QmConfig, _configDir: string, opts: AwsUpOpt
   assertAwsCallerAccount(aws);
   assertAwsPublicFrontDoor(config);
   if (!opts.dryRun && !opts.inactive) await assertAwsPublicNetwork(config);
-  assertAwsPublicApiUrl(config);
+  if (!opts.dryRun) assertAwsPublicApiUrl(config);
   assertAwsDeployImage(config);
   header(`qm ${opts.dryRun ? "plan" : "up"} — ${config.orgId} (aws)`);
   const allServices = Object.keys(aws.services);
   assertOwnedServices(config, describedServices(config, allServices), allServices);
-  const arns = secretArns(config);
+  const arns = secretArns(config, { metadataOnly: opts.dryRun });
   if (opts.dryRun) {
+    note("Secret metadata verified; value and PUBLIC_API_URL validation run during qm up.");
     step(
       aws.predeployDbSnapshot === false
         ? "pre-deploy database restore point: disabled (aws.predeployDbSnapshot)"

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -150,7 +150,7 @@ else if (a.includes("elbv2 describe-rules")) {
   console.log(JSON.stringify({ Rules: rules }));
 }
 else if (a.includes("elbv2 describe-target-health")) console.log(JSON.stringify({ TargetHealthDescriptions: [{ TargetHealth: { State: process.env.AWS_FAKE_UNHEALTHY_TARGET === "1" ? "unhealthy" : "healthy" } }] }));
-else if (a.includes("secretsmanager describe-secret")) console.log(JSON.stringify({ ARN: "arn:aws:secretsmanager:us-west-2:123456789012:secret:test-AbCdEf", DeletedDate: process.env.AWS_FAKE_SECRET_DELETED || undefined, VersionIdsToStages: { current: ["AWSCURRENT"] } }));
+else if (a.includes("secretsmanager describe-secret")) console.log(JSON.stringify({ ARN: "arn:aws:secretsmanager:us-west-2:123456789012:secret:test-AbCdEf", DeletedDate: process.env.AWS_FAKE_SECRET_DELETED || undefined, VersionIdsToStages: { current: process.env.AWS_FAKE_SECRET_NO_CURRENT ? ["AWSPREVIOUS"] : ["AWSCURRENT"] } }));
 else {
 ${script}
 }
@@ -3581,6 +3581,8 @@ test("AWS plan uses the package-pinned source image without consulting or mutati
   try {
     await awsUp(single, dir, { dryRun: true });
     const calls = readFileSync(fake.log, "utf8");
+    assert.doesNotMatch(calls, /secretsmanager get-secret-value/);
+    assert.match(calls, /secretsmanager describe-secret/);
     assert.doesNotMatch(calls, /ecr describe-images|ecr batch-delete-image|dynamodb put-item|ecs update-service/);
     assert.doesNotMatch(readFileSync(dockerLog, "utf8"), /buildx imagetools inspect/);
     assert.match(lines.join("\n"), new RegExp(`qm-core@sha256:${"a".repeat(64)}`));
@@ -4458,6 +4460,30 @@ test("AWS layer deadline aborts a native response body that never finishes", asy
     else process.env.CORE_SIGNING_SECRET = priorSecret;
     server.closeAllConnections();
     await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("AWS metadata-only secret discovery rejects required deleted or non-current secrets", () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-aws-secret-plan-"));
+  const fake = fakeAws(dir, 'console.log("");');
+  try {
+    for (const name of ["AWS_FAKE_SECRET_DELETED", "AWS_FAKE_SECRET_NO_CURRENT"]) {
+      const prior = process.env[name];
+      process.env[name] = "true";
+      try {
+        assert.throws(
+          () => secretArns(oneServiceConfig(), { metadataOnly: true }),
+          /required AWS secret .* has no available AWSCURRENT version/,
+        );
+      } finally {
+        if (prior === undefined) delete process.env[name];
+        else process.env[name] = prior;
+      }
+    }
+    assert.doesNotMatch(readFileSync(fake.log, "utf8"), /secretsmanager get-secret-value/);
+  } finally {
+    fake.restore();
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
`qm plan` currently retrieves required secret values, so read-only planning needs plaintext-secret access even though task definitions only need ARNs. Resolve required and optional secret ARNs from metadata during planning, reject deleted secrets or missing AWSCURRENT versions, and explicitly state that value and PUBLIC_API_URL validation occur during `qm up`.

Deployment, migrations, doctor, and live checks retain their current value validation. This change makes AWS planning metadata-only; it does not claim secretless deployment.

Validation: six targeted AWS CLI tests, CLI TypeScript, affected ESLint, and independent review pass. The plan regression asserts zero `get-secret-value` calls; deployment still rejects unavailable required values before mutation.
