### PR TITLE
fix(skills): say which credential a skill pack sent, and keep it out of the error

### DIFF
--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -150,6 +150,43 @@ function scrub(s: string, auth: GitAuth | undefined): string {
   return auth ? s.split(auth.secret).join("***").split(auth.value).join("***") : s;
 }
 
+const CREDENTIAL_REFUSED_RE =
+  /could not read (Username|Password)|terminal prompts disabled|Authentication failed|invalid credentials|error: 40[13]/i;
+
+const REPOSITORY_MISSING_RE = /[Rr]epository ['"]?[^'"]*['"]? ?not found|error: 404/;
+
+function credentialDiagnosis(
+  pack: Pick<SkillPack, "authCredentialSlug">,
+  auth: GitAuth | undefined,
+  resolverConfigured: boolean,
+): string {
+  if (auth) {
+    return pack.authCredentialSlug
+      ? `the credential this pack names (${pack.authCredentialSlug}) was sent as the ${auth.header} header and the server refused it`
+      : `a connector token for this host was sent as the ${auth.header} header and the server refused it`;
+  }
+  if (!resolverConfigured) {
+    return "no credential was sent: this deployment resolves none for skill packs, so a pack can only reach a public repository";
+  }
+  return pack.authCredentialSlug
+    ? `no credential was sent: the one this pack names (${pack.authCredentialSlug}) is missing, disabled, or delivered by environment rather than through the broker`
+    : "no credential was sent: this pack names none, and no connector token was available for its host";
+}
+
+function scrubbedCause(e: unknown, auth: GitAuth | undefined): { cause: unknown } {
+  if (!auth || !(e instanceof Error)) return { cause: e };
+  const safe = new Error(scrub(e.message, auth));
+  safe.name = e.name;
+  return { cause: safe };
+}
+
+function appended(message: string, diagnosis: string): string {
+  if (CREDENTIAL_REFUSED_RE.test(message)) return diagnosis;
+  if (REPOSITORY_MISSING_RE.test(message))
+    return `a repository that does not exist and one the credential cannot see are answered the same way, so ${diagnosis}`;
+  return "";
+}
+
 export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher {
   const gitBin = opts.gitBin ?? "git";
   const timeoutMs = opts.timeoutMs ?? 60_000;
@@ -188,6 +225,7 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
     cwd: string,
     auth: GitAuth | undefined,
     config: Array<[string, string]> = [],
+    diagnosis?: string,
   ): Promise<string> {
     try {
       return (
@@ -201,8 +239,10 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
       ).stdout;
     } catch (e) {
       if ((e as { killed?: boolean }).killed)
-        throw new Error(`git ${args[0]} timed out after ${timeoutMs}ms`, { cause: e });
-      throw new Error(scrub(errMessage(e), auth), { cause: e });
+        throw new Error(`git ${args[0]} timed out after ${timeoutMs}ms`, scrubbedCause(e, auth));
+      const message = scrub(errMessage(e), auth).trimEnd();
+      const extra = diagnosis ? appended(message, diagnosis) : "";
+      throw new Error(extra ? `${extra} — ${message}` : message, scrubbedCause(e, auth));
     }
   }
 
@@ -249,7 +289,13 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
       const work = await mkdtemp(join(tmpdir(), "qm-skill-src-"));
       const repoDir = join(work, "repo");
       try {
-        await git(["clone", "--no-checkout", "--quiet", repo.url, "repo"], work, auth, repo.gitConfig);
+        await git(
+          ["clone", "--no-checkout", "--quiet", repo.url, "repo"],
+          work,
+          auth,
+          repo.gitConfig,
+          credentialDiagnosis(pack, auth, opts.resolveAuth !== undefined),
+        );
         await git(["checkout", "--detach", "--quiet", ref || "HEAD"], repoDir, undefined);
         const commit = (await git(["rev-parse", "HEAD"], repoDir, undefined)).trim();
         const files = await readTree(repoDir);
@@ -267,7 +313,13 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
       const target = ref && BRANCH_RE.test(ref) && !SHA_RE.test(ref) ? ref : "HEAD";
       const work = await mkdtemp(join(tmpdir(), "qm-skill-ref-"));
       try {
-        const out = await git(["ls-remote", repo.url, target], work, auth, repo.gitConfig);
+        const out = await git(
+          ["ls-remote", repo.url, target],
+          work,
+          auth,
+          repo.gitConfig,
+          credentialDiagnosis(pack, auth, opts.resolveAuth !== undefined),
+        );
         const sha =
           out
             .split("\n")

--- a/test/pack-fetcher.test.ts
+++ b/test/pack-fetcher.test.ts
@@ -4,8 +4,11 @@ import { execFileSync } from "node:child_process";
 import { chmodSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { inspect } from "node:util";
 import { createGitFetcher, resolvePackAuth } from "../src/skills/pack-fetcher.ts";
 import type { SkillPack } from "../src/skills/skill-pack-store.ts";
+
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 function makeSourceRepo(): { dir: string; sha: string } {
   const dir = mkdtempSync(join(tmpdir(), "qm-src-fixture-"));
@@ -255,6 +258,195 @@ test("rejects repositories resolving to a private network before invoking Git", 
         ),
       /public network address/,
     );
+  }
+});
+
+function refusingGit(dir: string): string {
+  const git = join(dir, "git");
+  writeFileSync(
+    git,
+    "#!/bin/sh\n" +
+      "echo \"fatal: could not read Username for 'https://git.example': terminal prompts disabled\" >&2\n" +
+      "exit 128\n",
+  );
+  chmodSync(git, 0o700);
+  return git;
+}
+
+function leakingGit(dir: string): string {
+  const git = join(dir, "git");
+  writeFileSync(
+    git,
+    "#!/bin/sh\n" +
+      'echo "fatal: could not read Username" >&2\n' +
+      "env | grep ^GIT_CONFIG_VALUE_ >&2\n" +
+      "exit 128\n",
+  );
+  chmodSync(git, 0o700);
+  return git;
+}
+
+const AUTH = (await resolvePackAuth(
+  {
+    serviceCredential: async () => ({ secret: "supersecret", host: "git.example", enabled: true }),
+    connectorToken: async () => undefined,
+  },
+  { url: "https://git.example/repo", authCredentialSlug: "repo-token", createdBy: "u1" },
+))!;
+
+test("a rejected credential is reported as rejected rather than as a missing one", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-auth-refused-"));
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: refusingGit(dir),
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => AUTH,
+        }).fetch(src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" })),
+      (err: Error) => {
+        assert.match(err.message, /could not read Username/);
+        assert.match(err.message, /the credential this pack names \(repo-token\) was sent as the Authorization header/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("both halves of the credential are scrubbed out of what git said", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-scrub-"));
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: leakingGit(dir),
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => AUTH,
+        }).fetch(src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" })),
+      (err: Error) => {
+        assert.match(err.message, /GIT_CONFIG_VALUE_/, "the stub really did echo the injected git config");
+        assert.match(err.message, /Authorization: .*\*\*\*/, "including the auth header, with its value masked");
+        assert.doesNotMatch(err.message, /supersecret/);
+        assert.doesNotMatch(err.message, new RegExp(escapeRe(AUTH.value)));
+        const printed = inspect(err, { depth: 4 });
+        assert.doesNotMatch(printed, /supersecret/, "and the cause chain console.error walks carries none of it");
+        assert.doesNotMatch(printed, new RegExp(escapeRe(AUTH.value)));
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a connector token is named as one, because the remedy is not a keychain edit", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-connector-"));
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: refusingGit(dir),
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => AUTH,
+        }).fetch(src({ url: "https://git.example/repo" })),
+      /a connector token for this host was sent as the Authorization header/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a pack that names a credential which did not resolve is not told it names none", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-auth-unresolved-"));
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: refusingGit(dir),
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => undefined,
+        }).fetch(src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" })),
+      (err: Error) => {
+        assert.match(
+          err.message,
+          /the one this pack names \(repo-token\) is missing, disabled, or delivered by environment/,
+        );
+        assert.doesNotMatch(err.message, /this pack names none/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a deployment that resolves no credentials at all says so instead of blaming the pack", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-no-resolver-"));
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({ gitBin: refusingGit(dir), lookup: async () => ["93.184.216.34"] }).fetch(
+          src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" }),
+        ),
+      (err: Error) => {
+        assert.match(err.message, /this deployment resolves none for skill packs/);
+        assert.doesNotMatch(err.message, /repo-token/, "the pack is not blamed for a deployment-level gap");
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a not-found is answered with the ambiguity it actually carries", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-notfound-"));
+  const git = join(dir, "git");
+  writeFileSync(git, "#!/bin/sh\necho 'remote: Repository not found.' >&2\nexit 128\n");
+  chmodSync(git, 0o700);
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: git,
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => AUTH,
+        }).fetch(src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" })),
+      (err: Error) => {
+        assert.match(err.message, /answered the same way/);
+        assert.match(err.message, /repo-token/, "and it still names which credential was sent");
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a git failure that is about neither credentials nor a missing repo is passed through untouched", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-git-other-failure-"));
+  const git = join(dir, "git");
+  writeFileSync(git, "#!/bin/sh\necho 'fatal: unable to access: SSL certificate problem' >&2\nexit 128\n");
+  chmodSync(git, 0o700);
+  try {
+    await assert.rejects(
+      () =>
+        createGitFetcher({
+          gitBin: git,
+          lookup: async () => ["93.184.216.34"],
+          resolveAuth: async () => AUTH,
+        }).fetch(src({ url: "https://git.example/repo", authCredentialSlug: "repo-token" })),
+      (err: Error) => {
+        assert.match(err.message, /SSL certificate problem/);
+        assert.doesNotMatch(err.message, /was sent as the/);
+        assert.doesNotMatch(err.message, / — $/, "and no dangling separator is left behind");
+        return true;
+      },
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## What

When a skill pack fails to clone, the error an operator reads is git's:

```
fatal: could not read Username for 'https://…': terminal prompts disabled
```

That sentence describes a *missing* credential, and the fetcher raises it verbatim. It is what git says whenever the server answers 401 and there is no terminal to prompt at — equally true when a credential was sent and refused. The reader cannot tell the two apart, and the message actively points at the wrong one.

The fetcher knows which case it is in, so it now says. Four situations, each with a different remedy:

| situation | appended |
| --- | --- |
| a pack-named credential was sent and refused | `the credential this pack names (repo-token) was sent as the Authorization header and the server refused it` |
| a connector token was sent and refused | `a connector token for this host was sent as the Authorization header and the server refused it` |
| the pack names one that did not resolve | `no credential was sent: the one this pack names (repo-token) is missing, disabled, or delivered by environment rather than through the broker` |
| the deployment resolves none at all | `no credential was sent: this deployment resolves none for skill packs, so a pack can only reach a public repository` |

The distinctions are not cosmetic. `wiring.ts` omits `resolveAuth` entirely when there is no keychain, and filters an `env`-delivered credential to `undefined` — so a blanket "this pack has no credential" blames the pack for two things that are not its fault and sends an operator to set a field they already set. Naming the connector-token path separately matters for the same reason: its remedy is reconnecting the account, not editing the keychain.

## The 404

GitHub answers a *valid but unauthorized* token with `remote: Repository not found.` rather than 403, deliberately, so as not to leak repository existence. That is the most common real authorization failure on the one host this file special-cases, and it does not look like an auth error at all. A not-found now carries the ambiguity it actually has — that a repository which does not exist and one the credential cannot see are answered the same way — followed by which credential was sent.

## The credential was still in the error object

The thrown message was masked while `{ cause: e }` kept `execFile`'s original error, whose `.stderr` holds the injected `Authorization` header verbatim. `util.inspect` walks causes by default, so `console.error(err)` printed the credential in full. Only a masked copy of the cause is attached now.

This is why the new `scrub()` coverage asserts against `inspect(err, { depth: 4 })` rather than `err.message` — the first version of that test passed while the object being thrown still carried the secret, which is worse than having no test at all.

## Smaller things in the same path

`execFile`'s message ends in a newline, so the appended clause landed on its own line after a stray space; the message is trimmed first. A failure that is about neither credentials nor a missing repository passes through byte-for-byte, with no dangling separator.

## Where this message still does not reach an operator

`registerSkillPack` catches the fetch failure, writes it to `lastImport.error`, and returns the pack — so `POST /v1/admin/skill-packs` answers 200 and the admin renders it as success. Nothing in the admin reads `lastImport.error`. So on the register path, which is where a mistyped `authCredentialSlug` is most likely to be introduced, an operator sees "registered" and a row with no skills, and never reads this sentence; only `/sync` and `/catalog` surface it.

That is a real gap and it is not this file's to close — it is either a UI change or a change to what the register route returns. Worth a follow-up.

## Verified

`test/pack-fetcher.test.ts` covers all four situations, the 404, and the untouched pass-through.

It also gains the first test of `scrub()` in the repository. The stub git echoes its injected `GIT_CONFIG_VALUE_*` back on stderr, and the test asserts the header appears as `Authorization: ***` and that neither the secret nor its base64 form survives. Without the stub actually emitting the credential, every "the secret does not appear" assertion passes on a stub that never had it to leak — which is what the first version of this test did.

`npm run typecheck`, lint and `prettier --check` pass.

---

**Related:** #938 changes a different function in the same file (`src/skills/pack-fetcher.ts`) and adds cases to the same test file. Each stands alone; whichever lands second needs a rebase. #941 is the companion referred to above: it validates the slug this message names.
