### PR TITLE
fix(skills): make the skill-pack globs mean what an operator writes

### DIFF
--- a/src/skills/ingest.ts
+++ b/src/skills/ingest.ts
@@ -53,6 +53,13 @@ function matchesAny(path: string, globs: string[] | undefined): boolean {
   return !!globs && globs.some((g) => globToRegExp(g).test(path));
 }
 
+const SKILL_MANIFEST_SUFFIX = "/SKILL.md";
+
+function asSkillDirGlob(glob: string): string {
+  if (glob === "SKILL.md") return "";
+  return glob.endsWith(SKILL_MANIFEST_SUFFIX) ? glob.slice(0, -SKILL_MANIFEST_SUFFIX.length) : glob;
+}
+
 function skillDirOf(skillMdPath: string): string {
   const i = skillMdPath.lastIndexOf("/");
   return i < 0 ? "" : skillMdPath.slice(0, i);
@@ -172,14 +179,31 @@ export interface IngestContext {
 
 export function planIngest(repo: FetchedRepo, ctx: IngestContext): IngestPlan {
   const cfg = ctx.config;
-  const counts = { total: 0, eligible: 0, scope: 0, private: 0, collision: 0, "binary-asset": 0, malformed: 0 };
+  const counts = {
+    total: 0,
+    filtered: 0,
+    eligible: 0,
+    scope: 0,
+    private: 0,
+    collision: 0,
+    "binary-asset": 0,
+    malformed: 0,
+  };
   const candidates: IngestCandidate[] = [];
+  const selected = cfg?.skillGlobs?.length ? cfg.skillGlobs.map(asSkillDirGlob) : undefined;
+  const excluded = cfg?.exclude?.map(asSkillDirGlob);
 
   for (const f of repo.files) {
     if (lastSegment(f.path) !== "SKILL.md") continue;
     const skillDir = skillDirOf(f.path);
-    if (cfg?.skillGlobs && !matchesAny(skillDir, cfg.skillGlobs)) continue;
-    if (matchesAny(skillDir, cfg?.exclude)) continue;
+    if (selected && !matchesAny(skillDir, selected)) {
+      counts.filtered++;
+      continue;
+    }
+    if (isExcludedPath(skillDir, excluded)) {
+      counts.filtered++;
+      continue;
+    }
 
     counts.total++;
     const upstreamName = lastSegment(skillDir) || lastSegment(f.path);

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -54,6 +54,103 @@ test("planIngest classifies eligibility with reasons and excludes by config", ()
   assert.equal(counts.malformed, 1);
 });
 
+test("skillGlobs match the SKILL.md path as well as the skill directory", () => {
+  const nativeNames = new Set<string>();
+
+  const byPath = planIngest(repo(), { config: { skillGlobs: ["skills/*/SKILL.md"] }, nativeNames });
+  assert.equal(byPath.counts.total, 9, "a glob written against the file the pattern names selects every skill");
+  assert.equal(byPath.counts.filtered, 1, "and the one outside skills/ is reported as filtered, not as absent");
+
+  const byDir = planIngest(repo(), { config: { skillGlobs: ["skills/*"] }, nativeNames });
+  assert.equal(byDir.counts.total, 9, "a glob written against the directory keeps working unchanged");
+  assert.equal(byDir.counts.filtered, 1);
+
+  const neither = planIngest(repo(), { config: { skillGlobs: ["packs/*"] }, nativeNames });
+  assert.equal(neither.counts.total, 0);
+  assert.equal(
+    neither.counts.filtered,
+    10,
+    "a filter that matches nothing says so rather than looking like an empty repository",
+  );
+});
+
+test("an empty repository and a filtered-out one are distinguishable", () => {
+  const nativeNames = new Set<string>();
+  const empty = planIngest({ commit: "abc", files: [] }, { nativeNames });
+
+  assert.equal(empty.counts.total, 0);
+  assert.equal(empty.counts.filtered, 0, "nothing was filtered because there was nothing to filter");
+
+  const filtered = planIngest(repo(), { config: { skillGlobs: ["nope/*"] }, nativeNames });
+  assert.equal(filtered.counts.total, 0);
+  assert.notEqual(filtered.counts.filtered, 0);
+});
+
+test("exclude is counted as filtered too", () => {
+  const { counts } = planIngest(repo(), { config: { exclude: ["trusted/*"] }, nativeNames: new Set<string>() });
+  assert.equal(counts.filtered, 1);
+  assert.equal(counts.total, 9);
+});
+
+test("exclude matches a skill by ancestor and by SKILL.md path, as it already did for bundle files", () => {
+  const nativeNames = new Set<string>();
+  const byAncestor = planIngest(repo(), { config: { exclude: ["trusted"] }, nativeNames });
+  assert.equal(
+    byAncestor.candidates.find((c) => c.upstreamName === "stalker-watch"),
+    undefined,
+    "a bare directory name excludes the skill under it, not only its bundle files",
+  );
+  assert.equal(byAncestor.counts.filtered, 1);
+
+  const byManifest = planIngest(repo(), { config: { exclude: ["trusted/*/SKILL.md"] }, nativeNames });
+  assert.equal(
+    byManifest.candidates.find((c) => c.upstreamName === "stalker-watch"),
+    undefined,
+  );
+  assert.equal(byManifest.counts.filtered, 1);
+});
+
+test("a directory-shaped glob is not widened by the SKILL.md leniency", () => {
+  const { counts } = planIngest(repo(), { config: { skillGlobs: ["skills/*/*"] }, nativeNames: new Set<string>() });
+  assert.equal(counts.total, 0, "no skill sits at that depth, and none is admitted by its manifest path");
+  assert.equal(counts.filtered, 10);
+});
+
+test("exclude is normalized like skillGlobs, so a file-shaped glob does not uninstall the pack", () => {
+  const nativeNames = new Set<string>();
+
+  const docs = planIngest(repo(), { config: { exclude: ["**/*.md"] }, nativeNames });
+  assert.equal(docs.counts.total, 10, "stripping .md out of the bundle leaves every skill selected");
+  assert.equal(docs.counts.filtered, 0);
+
+  const deeper = planIngest(repo(), { config: { exclude: ["skills/*/*"] }, nativeNames });
+  assert.equal(deeper.counts.total, 10, "a depth-2 glob does not reach a skill at depth 1 through its manifest");
+  assert.equal(deeper.counts.filtered, 0);
+});
+
+test("a bare SKILL.md glob selects the repository-root skill", () => {
+  const rootRepo = {
+    commit: "abc1234",
+    files: [
+      { path: "SKILL.md", text: md("name: root-skill\ndescription: d\nscope: company"), binary: false },
+      { path: "skills/other/SKILL.md", text: md("name: other\ndescription: d\nscope: company"), binary: false },
+    ],
+  };
+  const { counts, candidates } = planIngest(rootRepo, {
+    config: { skillGlobs: ["SKILL.md"] },
+    nativeNames: new Set<string>(),
+  });
+  assert.equal(counts.total, 1);
+  assert.equal(counts.filtered, 1, "and the one under skills/ is filtered, not silently absent");
+  assert.equal(candidates[0]!.skillPath, "SKILL.md");
+});
+
+test("an empty skillGlobs means unset rather than nothing", () => {
+  const { counts } = planIngest(repo(), { config: { skillGlobs: [] }, nativeNames: new Set<string>() });
+  assert.equal(counts.total, 10, "an empty allowlist does not silently uninstall the pack");
+  assert.equal(counts.filtered, 0);
+});
+
 test("importPack publishes eligible skills with provenance + assets; native publish untouched", async () => {
   const store = createSkillStore();
   const org = scopeId("org", "acme");


### PR DESCRIPTION
## What

`config.skillGlobs` on a skill pack was matched against the skill's *directory*, never against the path of the `SKILL.md` that defines it:

```ts
const skillDir = skillDirOf(f.path);
if (cfg?.skillGlobs && !matchesAny(skillDir, cfg.skillGlobs)) continue;
```

So the natural way to write the pattern — `skills/*/SKILL.md`, which is the path the glob appears to be filtering — matched nothing, every skill was skipped, and the catalog reported `total 0` with no error. The pack read as empty rather than as misconfigured.

Four changes, three of which are failures found in the same guard.

**1. A trailing `/SKILL.md` is stripped from the glob, and the directory is matched.** Normalizing the pattern rather than also matching the file path matters: the OR form would widen every directory-shaped glob, because `skills/*/*` — written to select `skills/<team>/<skill>` — also matches `skills/<team>/SKILL.md` as a file path. An imported pack skill injects instructions into every session in the target scope, so an allowlist admitting a skill it did not name is not only untidy.

**2. `exclude` gets the same leniency, because as a denylist it was failing open.** It also meant two different things in one config: `collectSharedBundle` filters bundle files through `isExcludedPath`, which walks ancestor prefixes, while this path compared the skill directory exactly. `exclude: ["trusted"]` therefore dropped every bundle file under `trusted/` and imported the skill sitting in it, and `exclude: ["trusted/*/SKILL.md"]` matched nothing at all. Both call sites now go through `isExcludedPath`, which is one rule instead of two.

**3. An empty `skillGlobs` means unset rather than "nothing".** `asConfig` sets `cfg.skillGlobs = []` whenever the client sends an array — a cleared field, or an array of non-strings. An empty array is truthy and `matchesAny(x, [])` is false, so every skill was dropped; on the next sync `importPack` returned an empty `kept` and `archiveRemoved` archived every skill the pack had ever published into each target scope. A cleared field silently uninstalled the pack.

**4. `counts.filtered` reports how many `SKILL.md` files were dropped by either list before any other classification.** `total 0, filtered 7` says the filter is the cause; `total 0, filtered 0` says the repository has no skills. Those were indistinguishable, which is what made the first failure hard to find.

**5. `exclude` is normalized the same way, and matched against the directory.** Routing it through `isExcludedPath` on the raw `SKILL.md` path would widen it exactly as matching `skillGlobs` against that path would: `exclude: ["**/*.md"]` — an operator stripping documentation out of the shared bundle — dropped 2 of 3 skills in a test repository, and `skills/*/*` reached a skill one level up through its manifest. That is not a missing import: a skill that never becomes a candidate is absent from `kept`, so `archiveRemoved` archives every already-imported skill of the pack on the next sync.

**6. A bare `SKILL.md` glob selects the repository-root skill.** `planIngest` supports a manifest at the root, and the glob an operator would write for it has no directory part to strip.

## Deliberately not included

`counts.filtered` reaches the API and not the admin. The pack catalog renders a fixed `PILL_ORDER` with no `filtered` entry, so an operator still sees an empty candidate list with no explanation. Adding `"filtered"` to `PILL_ORDER` and a `REASON` entry is enough — `pillCount` already falls through to `counts[key]` and `pillShown` already hides a zero — but it should not be clickable, because filtering to it shows an empty table: those skills never became candidates.

That is a visible change to the admin and this repository asks for a demo with one. It is left out rather than shipped undemonstrated, and is worth a follow-up — two review passes asked for it, so treat it as wanted rather than optional. The count is not dead in the meantime: it is in the catalog response and is persisted by `recordImport`, so a sync's own record says what its filters dropped.

## Verified

`test/ingest.test.ts` covers a glob ending in `/SKILL.md`, a directory glob (unchanged), a glob matching neither, a directory-shaped glob that must not be widened, an empty `skillGlobs`, `exclude` by ancestor and by manifest path, and the `filtered` count separating a filtered pack from an empty one.

`npm run typecheck`, lint, `prettier --check`, and the ingest, sync-engine, pack-store, bundle and skill-pack-routes suites pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791128671&installation_model_id=19911&pr_number=940&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F940&signature=026878e0e12f301b9cb965e8d4a29eeaef34995f513928f1e811ed5ad2beaa58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->