### PR TITLE
fix(api): stop the skill-pack routes discarding what a caller sent

### DIFF
--- a/src/api/routes/skill-packs.ts
+++ b/src/api/routes/skill-packs.ts
@@ -4,6 +4,7 @@ import { audit, authorizeAdmin, orgScope } from "./shared.ts";
 import type { NewSkillPack, SkillPack } from "../../skills/skill-pack-store.ts";
 import type { PackConfig } from "../../skills/normalize.ts";
 import { parseScopeId, type ScopeId } from "../../types.ts";
+import { isValidCredentialSlug } from "../../credentials/keychain.ts";
 
 function asSubset(v: unknown): "all" | string[] | undefined {
   if (v === "all" || v === undefined) return "all";
@@ -24,16 +25,41 @@ function asScopeIds(v: unknown): ScopeId[] | undefined {
   return [...new Set(out)];
 }
 
-function asConfig(v: unknown): PackConfig | undefined {
-  if (v === undefined) return undefined;
-  if (typeof v !== "object" || v === null) return undefined;
+type Read<T> = { value: T } | { error: string };
+
+function readGlobs(field: string, v: unknown): Read<string[]> {
+  if (!Array.isArray(v) || v.some((x) => typeof x !== "string"))
+    return { error: `config.${field} must be an array of strings` };
+  return { value: v as string[] };
+}
+
+function readConfig(v: unknown): Read<PackConfig | undefined> {
+  if (v === undefined || v === null) return { value: undefined };
+  if (typeof v !== "object" || Array.isArray(v)) return { error: "config must be an object, or null to clear it" };
   const o = v as Record<string, unknown>;
   const cfg: PackConfig = {};
-  if (Array.isArray(o.skillGlobs)) cfg.skillGlobs = o.skillGlobs.filter((x): x is string => typeof x === "string");
-  if (Array.isArray(o.exclude)) cfg.exclude = o.exclude.filter((x): x is string => typeof x === "string");
-  if (o.fieldOverrides && typeof o.fieldOverrides === "object")
+  for (const field of ["skillGlobs", "exclude"] as const) {
+    if (o[field] === undefined) continue;
+    const globs = readGlobs(field, o[field]);
+    if ("error" in globs) return globs;
+    cfg[field] = globs.value;
+  }
+  if (o.fieldOverrides !== undefined) {
+    if (typeof o.fieldOverrides !== "object" || o.fieldOverrides === null || Array.isArray(o.fieldOverrides))
+      return { error: "config.fieldOverrides must be an object" };
     cfg.fieldOverrides = o.fieldOverrides as Record<string, string>;
-  return cfg;
+  }
+  return { value: cfg };
+}
+
+function readCredentialSlug(v: unknown): Read<string | undefined> {
+  if (v === undefined || v === null) return { value: undefined };
+  if (typeof v !== "string") return { error: "authCredentialSlug must be a string, or null to clear it" };
+  const slug = v.trim();
+  if (!slug) return { value: undefined };
+  if (!isValidCredentialSlug(slug))
+    return { error: "authCredentialSlug must be lowercase kebab-case (a-z, 0-9, -), at most 63 characters" };
+  return { value: slug };
 }
 
 async function listPacks(ctx: ApiCtx): Promise<void> {
@@ -68,6 +94,11 @@ async function registerPack(ctx: ApiCtx): Promise<void> {
   const subset = asSubset(b.subset);
   if (subset === undefined)
     return sendJson(ctx.res, 400, { error: "bad_request", message: "subset must be 'all' or string[]" });
+  const registered = readCredentialSlug(b.authCredentialSlug);
+  if ("error" in registered) return sendJson(ctx.res, 400, { error: "bad_request", message: registered.error });
+  const configured = readConfig(b.config);
+  if ("error" in configured) return sendJson(ctx.res, 400, { error: "bad_request", message: configured.error });
+  const config = configured.value;
   const input: NewSkillPack = {
     kind: "git",
     url: b.url.trim(),
@@ -78,10 +109,8 @@ async function registerPack(ctx: ApiCtx): Promise<void> {
     targetScopeId: orgScope(ctx.deps),
     subset,
     createdBy: actor.id,
-    ...(asConfig(b.config) ? { config: asConfig(b.config) } : {}),
-    ...(typeof b.authCredentialSlug === "string" && b.authCredentialSlug
-      ? { authCredentialSlug: b.authCredentialSlug }
-      : {}),
+    ...(config ? { config } : {}),
+    ...(registered.value ? { authCredentialSlug: registered.value } : {}),
   };
   const pack = await ctx.app.registerSkillPack(input);
   audit(ctx.deps, {
@@ -89,6 +118,7 @@ async function registerPack(ctx: ApiCtx): Promise<void> {
     action: "skill_pack.register",
     resource: pack.id,
     scopeLabel: pack.targetScopeId,
+    ...(registered.value ? { detail: `authCredentialSlug=${registered.value}` } : {}),
   });
   sendJson(ctx.res, 200, { pack });
 }
@@ -157,13 +187,25 @@ async function patchPack(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "bad_request", message: "subset must be 'all' or string[]" });
     patch.subset = subset;
   }
-  if (b.config !== undefined) patch.config = asConfig(b.config);
+  if (b.config !== undefined) {
+    const configured = readConfig(b.config);
+    if ("error" in configured) return sendJson(ctx.res, 400, { error: "bad_request", message: configured.error });
+    patch.config = configured.value;
+  }
+  if (b.authCredentialSlug !== undefined) {
+    const read = readCredentialSlug(b.authCredentialSlug);
+    if ("error" in read) return sendJson(ctx.res, 400, { error: "bad_request", message: read.error });
+    patch.authCredentialSlug = read.value;
+  }
   const pack = await ctx.app.updateSkillPack(ctx.params.id!, patch);
   audit(ctx.deps, {
     principalId: actor.id,
     action: "skill_pack.update",
     resource: pack.id,
     scopeLabel: pack.targetScopeId,
+    ...("authCredentialSlug" in patch
+      ? { detail: `authCredentialSlug=${patch.authCredentialSlug ?? "(cleared)"}` }
+      : {}),
   });
   sendJson(ctx.res, 200, { pack });
 }

--- a/test/skill-packs-routes.test.ts
+++ b/test/skill-packs-routes.test.ts
@@ -569,6 +569,118 @@ test("re-import archives removed/renamed/now-ineligible skills and keeps unchang
   }
 });
 
+test("a pack's authCredentialSlug can be set, replaced and cleared, and is validated on both routes", async () => {
+  const repo = makeFixtureRepo();
+  const s = start();
+  const packOf = async (id: string): Promise<any> =>
+    (await json(await fetch(`${s.base}/v1/admin/skill-packs`, { headers: ADMIN }))).packs.find((p: any) => p.id === id);
+  const register = (body: unknown): Promise<Response> =>
+    fetch(`${s.base}/v1/admin/skill-packs`, { method: "POST", headers: ADMIN, body: JSON.stringify(body) });
+  const patch = (id: string, body: unknown): Promise<Response> =>
+    fetch(`${s.base}/v1/admin/skill-packs/${id}`, { method: "PATCH", headers: ADMIN, body: JSON.stringify(body) });
+
+  try {
+    const reg = await json(await register({ url: repo.dir, ref: repo.sha }));
+    const id = reg.pack.id as string;
+    assert.equal(reg.pack.authCredentialSlug, undefined, "registered without one");
+
+    assert.equal(
+      (await json(await patch(id, { authCredentialSlug: "repo-token" }))).pack.authCredentialSlug,
+      "repo-token",
+    );
+    assert.equal((await packOf(id)).authCredentialSlug, "repo-token", "and it is what the store returns");
+
+    assert.equal(
+      (await json(await patch(id, { authCredentialSlug: "other-token" }))).pack.authCredentialSlug,
+      "other-token",
+      "a wrong credential can be corrected without deleting the pack",
+    );
+
+    assert.equal(
+      (await json(await patch(id, { syncMode: "tracked" }))).pack.authCredentialSlug,
+      "other-token",
+      "a patch that does not mention it leaves it alone",
+    );
+
+    assert.equal((await json(await patch(id, { authCredentialSlug: null }))).pack.authCredentialSlug, undefined);
+    assert.equal((await packOf(id)).authCredentialSlug, undefined, "null clears it in the store");
+
+    await patch(id, { authCredentialSlug: "repo-token" });
+    assert.equal(
+      (await json(await patch(id, { authCredentialSlug: "   " }))).pack.authCredentialSlug,
+      undefined,
+      "so does a blank string",
+    );
+
+    assert.equal((await patch(id, { authCredentialSlug: 7 })).status, 400, "a non-string is refused");
+
+    await patch(id, { authCredentialSlug: "repo-token" });
+
+    assert.equal((await patch(id, { authCredentialSlug: "Repo-Token" })).status, 400, "uppercase is not storable");
+    assert.equal((await patch(id, { authCredentialSlug: "-leading" })).status, 400, "nor is a leading dash");
+    assert.equal(
+      (await patch(id, { authCredentialSlug: "a".repeat(64) })).status,
+      400,
+      "nor is one over 63 characters",
+    );
+    assert.equal((await packOf(id)).authCredentialSlug, "repo-token", "and a refused patch changed nothing");
+
+    assert.equal((await register({ url: repo.dir, authCredentialSlug: "Repo-Token" })).status, 400);
+    const padded = await json(await register({ url: repo.dir, ref: repo.sha, authCredentialSlug: " repo-token " }));
+    assert.equal(padded.pack.authCredentialSlug, "repo-token", "a padded slug is trimmed rather than stored unusable");
+  } finally {
+    await s.close();
+    rmSync(repo.dir, { recursive: true, force: true });
+  }
+});
+
+test("PATCH refuses a malformed config instead of silently deleting the stored one", async () => {
+  const repo = makeFixtureRepo();
+  const s = start();
+  const patch = (id: string, body: unknown): Promise<Response> =>
+    fetch(`${s.base}/v1/admin/skill-packs/${id}`, { method: "PATCH", headers: ADMIN, body: JSON.stringify(body) });
+
+  try {
+    const reg = await json(
+      await fetch(`${s.base}/v1/admin/skill-packs`, {
+        method: "POST",
+        headers: ADMIN,
+        body: JSON.stringify({ url: repo.dir, ref: repo.sha, config: { exclude: ["trusted/*"] } }),
+      }),
+    );
+    const id = reg.pack.id as string;
+    assert.deepEqual(reg.pack.config.exclude, ["trusted/*"]);
+
+    assert.equal((await patch(id, { config: "oops" })).status, 400);
+    assert.equal((await patch(id, { config: ["oops"] })).status, 400);
+
+    assert.equal((await patch(id, { config: { exclude: "trusted/*" } })).status, 400);
+    assert.equal((await patch(id, { config: { skillGlobs: [7] } })).status, 400);
+    assert.equal((await patch(id, { config: { fieldOverrides: ["nope"] } })).status, 400);
+
+    const after = await json(await fetch(`${s.base}/v1/admin/skill-packs`, { headers: ADMIN }));
+    assert.deepEqual(
+      after.packs.find((p: any) => p.id === id).config.exclude,
+      ["trusted/*"],
+      "the exclude globs survive a refused patch — losing them silently re-imports what was excluded",
+    );
+
+    assert.equal((await json(await patch(id, { config: null }))).pack.config, undefined, "null still clears it");
+
+    const badRegister = (body: unknown): Promise<Response> =>
+      fetch(`${s.base}/v1/admin/skill-packs`, { method: "POST", headers: ADMIN, body: JSON.stringify(body) });
+    assert.equal(
+      (await badRegister({ url: repo.dir, ref: repo.sha, config: "oops" })).status,
+      400,
+      "register refuses it too rather than registering an unconfigured pack",
+    );
+    assert.equal((await badRegister({ url: repo.dir, ref: repo.sha, config: { exclude: "trusted/*" } })).status, 400);
+  } finally {
+    await s.close();
+    rmSync(repo.dir, { recursive: true, force: true });
+  }
+});
+
 test("sync refreshes IMPORTED skills (update + archive) but does NOT add un-imported ones; PATCH flips syncMode", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-sync-"));
   const env = {


### PR DESCRIPTION
## What

Four silent failures across the two skill-pack routes, all the same shape: a 200 that throws away or destroys the field it was given.

**`PATCH` ignored `authCredentialSlug`,** which `POST` accepts. A pack registered against a private repository without a credential, or with the wrong one, could never be given the right one — the request answered 200 with the pack unchanged, and the only way forward was to delete the pack and register it again, which archives its imported skills. It now sets the slug, clears it on `null` or a blank string, and 400s on anything else.

**Neither route validated the slug** against `isValidCredentialSlug`, which is already enforced where a credential is created and in the git HTTP broker. `Repo-Token` stored fine and could never match anything, and `resolvePackAuth` answers `undefined` for a slug it cannot resolve rather than throwing — so the next sync fetched the private repository unauthenticated. `registerPack` also stored the slug untrimmed while `patchPack` trimmed it. Both routes now share one reader.

**`config` was destroyed by a malformed value on `PATCH` and dropped by one on `POST`.** `asConfig` returned a fresh object keeping only well-typed fields, and `DurableMap.merge` deletes a key whose patch value is `undefined` — so `PATCH {"config":"oops"}` answered 200 and silently wiped the pack's `exclude` globs, after which the next sync imported the skills the operator had excluded.

Checking only the outer shape is not enough, and that is worth stating because it was the first attempt at this fix: `{"exclude": "trusted/*"}` — a string where an array belongs, which is the natural single-glob mistake — is a well-formed object, so it passed, and `asConfig` still returned `{}`. `asConfig` is now a parse-or-error reader like the slug's, so a wrong type *inside* the config is a 400 naming the field, and the shape predicate beside it is gone rather than extended.

**The audit event** for a credential change carries the slug in `detail`, on both routes. Which credential a pack may use is a security-relevant binding; without it a re-point was indistinguishable from a `syncMode` flip, and a pack registered with a credential recorded nothing at all.

## Deliberately not included

**A slug is not checked for existence.** Registering a pack before creating its credential is a legitimate order, so a 400 on an unknown slug would refuse a valid workflow. The failure it would catch — a typo'd slug quietly fetching a private repository unauthenticated — is better addressed where the credential is resolved, and is what the companion change to the fetcher's failure message reports: it names the slug and says the credential is missing, disabled, or env-delivered.

**The admin UI is unchanged.** It offers the field on the register form only and does not display which credential a pack uses, so this correction is reachable by API and not yet from the page. That is a front-end change and wants a demo with it.

## Verified

`test/skill-packs-routes.test.ts` covers setting a slug, replacing one, clearing with `null` and `""`, a patch that does not mention the field, a non-string, three unstorable shapes with the stored value unchanged after each, the same rule on the register route including a padded slug, a malformed `config` on both routes at the outer *and* inner level, and that the `exclude` globs survive every refused patch.

Both new tests register against the file's existing local fixture repository rather than a remote URL, so neither reaches DNS.

`npm run typecheck`, lint, `prettier --check`, `lint:knip` and the full suite pass.

---

**Related:** the companion change to the fetcher's failure message referred to above is #939.
