### PR TITLE
test: keep the porter abort case from passing without an abort

### DIFF
--- a/test/porter-sandbox.test.ts
+++ b/test/porter-sandbox.test.ts
@@ -1,4 +1,5 @@
 import { test, after, beforeEach } from "node:test";
+import { spawnSync } from "node:child_process";
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -31,6 +32,9 @@ beforeEach(() => {
   sandbox = make();
 });
 after(() => fake?.cleanup());
+
+const GROUP_LEADER_PROBE = 'exec setsid sh -c \'test "$$" = "$(ps -o pgid= -p $$ | tr -d " ")"\'';
+const groupKillWorks = spawnSync("sh", ["-c", GROUP_LEADER_PROBE], { stdio: "ignore" }).status === 0;
 
 test("provision runs commands with env and cwd", async () => {
   const h = await sandbox.provision(layers, { env: { MY_VAR: "v1" } });
@@ -139,16 +143,29 @@ test("scratch bodies are isolated, refcounted, and removed on release", async ()
   assert.equal(remaining.length, 0);
 });
 
-test("abort signal kills an in-flight exec", async () => {
-  const h = await sandbox.provision(layers);
-  const ac = new AbortController();
-  const started = Date.now();
-  const p = sandbox.run(h, "sleep 30; echo done", { timeoutMs: 60_000, signal: ac.signal });
-  setTimeout(() => ac.abort(), 300);
-  const r = await p;
-  assert.ok(Date.now() - started < 15_000);
-  assert.notEqual(r.code, 0);
-});
+test(
+  "abort signal kills an in-flight exec",
+  {
+    skip: groupKillWorks
+      ? false
+      : "setsid does not make a command its own process group leader here, so a group kill cannot work",
+  },
+  async () => {
+    const h = await sandbox.provision(layers);
+    const ac = new AbortController();
+    const started = Date.now();
+    const p = sandbox.run(h, "echo running > started.txt; sleep 30; echo done > finished.txt", {
+      timeoutMs: 60_000,
+      signal: ac.signal,
+    });
+    setTimeout(() => ac.abort(), 300);
+    const r = await p;
+    assert.ok(Date.now() - started < 15_000);
+    assert.notEqual(r.code, 0);
+    assert.equal(await sandbox.readFile(h, "started.txt"), "running\n");
+    assert.equal(await sandbox.readFile(h, "finished.txt"), null);
+  },
+);
 
 test("destroy terminates the body and deletes the volume", async () => {
   const h = await sandbox.provision(layers);


### PR DESCRIPTION
`test/porter-sandbox.test.ts`'s "abort signal kills an in-flight exec" has no
honest outcome on a host without a working `setsid`.

`killableScript` wraps the command as `exec setsid sh -c …`, has the inner
shell record `$$` as a process group id, and `killScript` cancels with
`kill -KILL -"$pgid"`. That is only correct when `setsid` starts a new session,
which is what makes the inner shell a group leader so `pid == pgid`.

Where `setsid` is missing, the wrapper never starts: the exec returns 127
instantly, which satisfies both of the test's assertions — fast, and non-zero.
The case reports green without launching the command, let alone aborting one.

Where a `setsid` exists that does not create a session (a `#!/bin/sh` /
`exec "$@"` shim on PATH is enough), the recorded pid is not a group id, the
group kill matches nothing, and the command runs to completion — failing the
case for a reason unrelated to the code under test.

This probes for the property the mechanism needs, that `setsid` makes a
command its own process group leader, and skips with that reason when it does
not hold. It then asserts the command started and did not finish, so an exec
that never ran cannot satisfy the case.

Verified in all three states: `setsid` absent → skips with the reason; a
non-session shim on PATH → skips with the reason; a genuine `setsid` → runs and
passes in ~0.5s, with the two new assertions holding. Linux CI is the third
state, so coverage there is unchanged apart from the added assertions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791129535&installation_model_id=19911&pr_number=943&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F943&signature=d790e8c66e89c9ae4b71d028eb4916be3c07a9326d01d73c7cabb613de25ccad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->