### PR TITLE
claude harness: end the turn on the SDK's command lifecycle, not a result-per-prompt count

### DIFF
--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { chownSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -181,11 +181,12 @@ class MessageQueue implements AsyncIterable<SDKUserMessage> {
   private readonly waiters: Array<(value: IteratorResult<SDKUserMessage>) => void> = [];
   private ended = false;
 
-  push(value: SDKUserMessage): void {
-    if (this.ended) return;
+  push(value: SDKUserMessage): boolean {
+    if (this.ended) return false;
     const waiter = this.waiters.shift();
     if (waiter) waiter({ value, done: false });
     else this.values.push(value);
+    return true;
   }
 
   close(): void {
@@ -277,9 +278,16 @@ function promptText(turn: HarnessTurnInput): string {
   return [replay, prior, turn.input, turn.environment].filter((value) => value?.trim()).join("\n\n");
 }
 
+function commandLifecycle(message: SDKMessage): { commandUuid: string; settled: boolean } | null {
+  const raw = message as { type?: string; command_uuid?: string; state?: string };
+  if (raw.type !== "command_lifecycle" || typeof raw.command_uuid !== "string") return null;
+  return { commandUuid: raw.command_uuid, settled: raw.state !== "queued" && raw.state !== "started" };
+}
+
 function userMessage(text: string, images: HarnessTurnInput["images"] = []): SDKUserMessage {
   return {
     type: "user",
+    uuid: randomUUID(),
     message: {
       role: "user",
       content: [
@@ -407,7 +415,8 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
     const model = modelSupportedByHarness(turn.model, "claude") ? turn.model! : resolveModelId(turn.scopeLabel);
     const text = promptText(turn);
     const initial = userMessage(text, turn.images);
-    let pendingPrompts = 1;
+    const openCommands = new Set<string>();
+    let commandLifecycleTracked = false;
     let stopped = false;
     let result: SDKResultMessage | null = null;
     const thinking: string[] = [];
@@ -537,8 +546,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
                   scopeLabel: turn.scopeLabel,
                 });
                 steerPrompts.push(steer);
-                pendingPrompts++;
-                queue.push(userMessage(steer));
+                pushCommand(userMessage(steer));
               },
             },
             { onError: (error) => swallow("claude signal poll", error) },
@@ -547,6 +555,17 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
     const wallMs = turn.turnWallClockMs ?? defaultTurnWallClockMs;
     let timer: NodeJS.Timeout | undefined;
     let signalsStopped = false;
+    const pushCommand = (message: SDKUserMessage) => {
+      if (queue.push(message)) openCommands.add(message.uuid!);
+    };
+    const settleCommand = async (commandUuid: string | undefined) => {
+      if (commandUuid === undefined || !openCommands.delete(commandUuid) || openCommands.size > 0) return;
+      if (!signalsStopped) {
+        await stopSignals?.();
+        signalsStopped = true;
+      }
+      queue.close();
+    };
     const recordedEnvelope = {
       system: turn.systemPrompt,
       tools: allowSubagents ? ["Agent"] : [],
@@ -601,10 +620,17 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
     try {
       await sdkQuery.initializationResult();
       await appendTape(initial, true);
-      queue.push(initial);
+      pushCommand(initial);
       const consume = (async () => {
         for await (const message of sdkQuery) {
           if (settled) break;
+          if (message.type === "system" && message.subtype === "init")
+            commandLifecycleTracked = message.capabilities?.includes("msg_lifecycle_v1") ?? false;
+          const lifecycle = commandLifecycle(message);
+          if (lifecycle) {
+            if (lifecycle.settled) await settleCommand(lifecycle.commandUuid);
+            continue;
+          }
           if (message.type === "assistant") {
             const usage = message.message.usage;
             const seen = {
@@ -716,13 +742,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
               scopeLabel: turn.scopeLabel,
             });
           streamedText = "";
-          pendingPrompts = Math.max(0, pendingPrompts - 1);
-          if (pendingPrompts > 0) continue;
-          if (!signalsStopped) {
-            await stopSignals?.();
-            signalsStopped = true;
-          }
-          if (pendingPrompts === 0) queue.close();
+          if (!commandLifecycleTracked) await settleCommand(openCommands.values().next().value);
         }
       })();
       try {

--- a/test/claude-harness-turn.test.ts
+++ b/test/claude-harness-turn.test.ts
@@ -144,6 +144,88 @@ test("a steered turn persists every reply, not only the last result's", async ()
   assert.deepEqual(userTexts, ["what is the capital of france?", "now do the other three"]);
 });
 
+function lifecycle(commandUuid: unknown, state: string): FakeSdkMessage {
+  return { type: "command_lifecycle", command_uuid: commandUuid, state };
+}
+
+test(
+  "a steer folded into the running turn ends the turn on the SDK's lifecycle signal, not a second result",
+  { timeout: 5_000 },
+  async () => {
+    const signals = createMemoryRunSignalStore();
+    const runId = "run-steer-folded";
+    currentScript = async function* (prompts) {
+      const iterator = prompts[Symbol.asyncIterator]();
+      const initial = (await iterator.next()).value as { uuid: string };
+      yield { type: "system", subtype: "init", capabilities: ["interrupt_receipt_v1", "msg_lifecycle_v1"] };
+      yield lifecycle(initial.uuid, "queued");
+      yield lifecycle(initial.uuid, "started");
+      await signals.send(runId, { kind: "steer", text: "also include the word STEERED", ts: "123.456" });
+      const steer = (await iterator.next()).value as { uuid: string };
+      yield lifecycle(steer.uuid, "queued");
+      yield lifecycle(steer.uuid, "started");
+      yield assistantMessage("msg_A", "DONE1 STEERED", {
+        input_tokens: 3,
+        output_tokens: 8,
+        cache_read_input_tokens: 50,
+        cache_creation_input_tokens: 0,
+      });
+      yield lifecycle(steer.uuid, "completed");
+      yield resultMessage("DONE1 STEERED", { num_turns: 2 });
+      yield lifecycle(initial.uuid, "completed");
+      assert.equal(
+        (await iterator.next()).done,
+        true,
+        "the harness closes its prompt queue once every command settled",
+      );
+    };
+
+    const harness = createClaudeHarness({ signals });
+    const { turn, entries } = harnessTurn({ runId });
+    const result = await harness.turns.runTurn(turn);
+
+    assert.equal(result.reply, "DONE1 STEERED");
+    const userTexts = entries
+      .filter((entry) => entry.type === "user")
+      .map((entry) => (entry.payload as { text: string }).text);
+    assert.deepEqual(userTexts, ["what is the capital of france?", "also include the word STEERED"]);
+  },
+);
+
+test(
+  "a steer that arrives after the model's last reply gets its own turn, and the turn waits for it",
+  { timeout: 5_000 },
+  async () => {
+    const signals = createMemoryRunSignalStore();
+    const runId = "run-steer-queued";
+    currentScript = async function* (prompts) {
+      const iterator = prompts[Symbol.asyncIterator]();
+      const initial = (await iterator.next()).value as { uuid: string };
+      yield { type: "system", subtype: "init", capabilities: ["msg_lifecycle_v1"] };
+      yield lifecycle(initial.uuid, "started");
+      await signals.send(runId, { kind: "steer", text: "now say STEERED", ts: "123.457" });
+      const steer = (await iterator.next()).value as { uuid: string };
+      yield lifecycle(steer.uuid, "queued");
+      yield resultMessage("The capital of France is Paris.");
+      yield lifecycle(initial.uuid, "completed");
+      yield lifecycle(steer.uuid, "started");
+      yield resultMessage("STEERED", { num_turns: 1 });
+      yield lifecycle(steer.uuid, "completed");
+      assert.equal((await iterator.next()).done, true);
+    };
+
+    const harness = createClaudeHarness({ signals });
+    const { turn, entries } = harnessTurn({ runId });
+    const result = await harness.turns.runTurn(turn);
+
+    assert.equal(result.reply, "STEERED");
+    const assistantTexts = entries
+      .filter((entry) => entry.type === "assistant")
+      .map((entry) => (entry.payload as { text: string }).text);
+    assert.deepEqual(assistantTexts, ["The capital of France is Paris.", "STEERED"]);
+  },
+);
+
 test("model calls are counted per API response and charged their real input tokens", async () => {
   currentScript = async function* (prompts) {
     await prompts[Symbol.asyncIterator]().next();


### PR DESCRIPTION
## Problem

Users on the Claude harness were seeing `I hit an error and couldn't finish — Claude turn exceeded 2000s wall clock` (or whatever `TURN_WALL_CLOCK_SEC` is set to) on turns that had in fact already produced their reply. With no wall clock configured the same turns hung until the run reaper.

The trigger is a mid-turn steer. The Claude Agent SDK runs Claude Code as a child process with a streaming input queue. A user message pushed while a turn is in flight is **folded into that running turn** at the next tool boundary and shares its single `result` message. The harness assumed one `result` per prompt it pushed (`pendingPrompts`), so after a folded steer it waited for a second `result` that never came, idled until the wall clock fired, and threw the wall-clock error in place of the reply it had already streamed.

Verified against the real SDK (0.3.211 / CLI 2.1.259):

- steer pushed during a tool call → folded into the turn, **one** `result`, harness hung
- steer pushed after the model's last message → its own turn, **two** `result`s, harness fine

## Fix

The SDK emits `command_lifecycle` events (`queued` → `started` → `completed`/`cancelled`) for every uuid-stamped inbound user message and advertises this as the `msg_lifecycle_v1` capability on `system/init`. The harness now:

- stamps every pushed user message with a `uuid`
- tracks open command uuids in a set and settles one on a terminal lifecycle state
- closes its prompt queue (after stopping the signal poll) when the set empties, whether a command ran as its own turn or was folded into an earlier one
- falls back to the old one-result-per-prompt accounting, through the same settle path, when `init` does not advertise the capability (older CLIs)

## Tests

- New: a steer folded into the running turn ends the turn on the lifecycle signal. Times out at 5s on the previous code, passes now.
- New: a steer queued behind the model's last reply still gets its own turn and the harness waits for it.
- Existing steer tests exercise the legacy (no-capability) path unchanged.
- Live: ran the real harness against the real SDK with a steer sent during an `Agent` subagent call; the steer was absorbed into the reply and the turn returned in ~15s.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791137314&installation_model_id=19911&pr_number=945&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F945&signature=29e4cfec957208fce30b3ee9f590b48e8fb7a3197f8901817897e0889738678e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->