### PR TITLE
fix(web-ui): keep a wide pane's composer on the transcript column

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -7254,8 +7254,10 @@ h3.ambient-field-label {
   flex-wrap: wrap;
   align-items: flex-end;
   gap: 2px;
-  width: auto;
-  margin: 0 10px 10px;
+  /* Chrome only: the column width and side gutters stay with the rules above, which key off
+     the surface's own width — a pane that fills a wide window centres the composer on the
+     transcript column instead of stretching across it, and a narrow one still runs full-bleed. */
+  margin-bottom: 10px;
   padding: 6px 8px;
   border-radius: 16px;
 }

--- a/plugins/web-ui/test/pane-composer-source.test.ts
+++ b/plugins/web-ui/test/pane-composer-source.test.ts
@@ -13,6 +13,13 @@ test("pane composer collapses to a single line — keyed off the pane, not a who
   assert.match(composer, /Math\.max\(ctx\.pane \? 0 : 48, content\)/);
 });
 
+test("a pane's composer tracks the transcript column instead of the whole surface", () => {
+  const block = css.match(/\[data-density\] \.composer-wrap \{[^}]*\}/)?.[0] ?? "";
+  assert.doesNotMatch(block, /width:/, "the column width comes from the surface-width rules, not the tier");
+  assert.doesNotMatch(block, /margin(-inline|-left|-right)?:/, "so do the side gutters");
+  assert.match(block, /margin-bottom: 10px;/, "the tier only tightens the dock's own chrome");
+});
+
 test("phone touch layout cannot inflate a pane's composer controls", () => {
   assert.match(
     css,


### PR DESCRIPTION
## Symptom

In a maximized/full-width web UI window the message input spans the entire window while the transcript sits in its centred 820px column, so the composer no longer lines up with the conversation. Narrower surfaces look right.

## Cause

`PaneContent.syncDensity()` writes `data-density` on every pane for every measured tier — including `full`. The pane composer's compact chrome in `shell.css` keys off the bare `[data-density]` selector (unlike the neighbouring rules, which are scoped to `compact`/`card`/`strip`), and that block declares `width: auto; margin: 0 10px 10px`. At `[data-density] .composer-wrap` specificity it beats both the base rule and the `@container chat` gutter rules, so a pane at any size — even one filling a wide window — got a full-bleed composer.

Measured in a headless browser against the real stylesheet, 1600px-wide surface:

| surface | transcript column | composer |
| --- | --- | --- |
| pane (before) | 820px | **1524px** |
| window, no attribute | 820px | 844px |
| pane (after) | 820px | 836px |

The remaining 16px is the composer's own padding/border; its text edge lands on the column edge, same as the main window.

## Fix

Remove the `width` and inline-margin overrides from `[data-density] .composer-wrap` so the composer keeps the width and gutter rules it already shares with the main window — the ones driven by the surface's own inline size. A wide pane centres it on the column; a narrow pane still runs full-bleed with the gutters a window that size would use. Only the tighter bottom margin stays tier-specific, and the rest of the compact chrome (single-row toolbar, 34px controls) is untouched.

Re-measured at 1600/1200/900/700/420px across the `full`, `compact` and no-attribute cases: the composer matches the transcript column everywhere, and narrow surfaces are unchanged.

## Tests

Adds a source test in `plugins/web-ui/test/pane-composer-source.test.ts` pinning that the tier block no longer sets its own width or side margins. Existing pane/density source tests still pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791141078&installation_model_id=19911&pr_number=946&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F946&signature=501ffdc09b2b4ede4721de21e113734f86a56932ddd23843bc2caa2684d69703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->