### PR TITLE
Add offline skill pack uploads and durable source snapshots

### DIFF
--- a/docs/operator/skill-pack-sources.md
+++ b/docs/operator/skill-pack-sources.md
@@ -1,0 +1,52 @@
+# Skill pack sources
+
+Administrators can register an HTTPS Git repository or upload an offline ZIP from
+Admin → Skills. Both sources use the same skill preview, scope selection, validation,
+import, and materialization pipeline. Uploading a ZIP alone does not install skills.
+Open **Browse skills…**, review eligibility, select target scopes, and import.
+
+## Offline ZIPs
+
+A ZIP must contain at least one `SKILL.md`. A common enclosing directory is removed.
+UTF-8 instructions, configuration files, scripts, and text assets are accepted.
+Binary attachments, Git history, encrypted entries, links, unsafe paths, duplicate
+paths, and corrupt entries are rejected. macOS metadata is ignored. The limits are
+16 MiB compressed, 32 MiB expanded, and 5,000 entries.
+
+The archive SHA-256 identifies its version. Source contents persist in the same
+Postgres-backed artifact store as other skill state. No repository connection is
+needed for preview, import, or an application restart.
+
+Use **Upload new ZIP…** on an existing pack to stage a replacement. The installed
+skills remain at their current version until **Apply uploaded version** refreshes
+already-imported skills. New skills still require Browse. The immediately previous
+selected archive is retained: **Select previous version** selects it, and applying
+that version updates the installed skills. This is a one-version rollback, not a
+complete archive history. Keep original ZIPs if more history is needed.
+
+## Repository download cache
+
+A successful repository fetch saves a durable source snapshot. Branch and tag
+previews reuse it for five minutes; an explicit full commit hash remains reusable.
+Preview responses include the snapshot commit, and imports from the admin UI use
+that exact snapshot without downloading it again. The current and immediately
+previous snapshots can satisfy a previewed import. An expired or invalidated preview
+returns a conflict and must be opened again.
+
+Manual sync and tracked synchronization request a fresh repository download.
+Download failures remain visible as failures and leave installed skills intact;
+previously saved source contents are not silently presented as a successful sync.
+Changing the URL, ref, owner, or credential identity invalidates snapshot reuse.
+Removing a pack removes its saved source snapshot.
+
+## API
+
+Stage ZIP bytes through the existing signed `POST /v1/blobs` endpoint. Then submit
+`{ "blobId": "...", "name": "skills.zip" }` to
+`POST /v1/admin/skill-packs/upload`, or
+`POST /v1/admin/skill-packs/:id/upload` for an archive replacement. Both require
+organization administrator access. Archives retain third-party trust by default.
+
+`GET /v1/admin/skill-packs/:id/catalog` returns a `commit` alongside the plan.
+Pass it as `expectedCommit` to the existing import endpoint to bind the import to
+that preview. Legacy callers that omit it continue to request a fresh fetch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "porter-sandbox": "^0.1.41",
         "tar-stream": "^3.2.0",
         "typebox": "^1.1.38",
+        "yauzl": "^3.2.0",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -45,6 +46,7 @@
         "@types/node": "^24.0.0",
         "@types/pg": "^8.11.10",
         "@types/tar-stream": "^3.1.4",
+        "@types/yauzl": "^2.10.3",
         "@yc-software/qm": "file:./cli",
         "eslint": "^10.4.1",
         "globals": "^17.6.0",
@@ -61,7 +63,7 @@
     },
     "cli": {
       "name": "@yc-software/qm",
-      "version": "0.1.9",
+      "version": "0.1.6",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3386,6 +3388,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
@@ -3951,6 +3963,15 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -6553,6 +6574,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
@@ -7774,6 +7801,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "porter-sandbox": "^0.1.41",
     "tar-stream": "^3.2.0",
     "typebox": "^1.1.38",
+    "yauzl": "^3.2.0",
     "zod": "4.4.3"
   },
   "overrides": {
@@ -101,6 +102,7 @@
     "@types/node": "^24.0.0",
     "@types/pg": "^8.11.10",
     "@types/tar-stream": "^3.1.4",
+    "@types/yauzl": "^2.10.3",
     "@yc-software/qm": "file:./cli",
     "eslint": "^10.4.1",
     "globals": "^17.6.0",

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -10013,7 +10013,12 @@
           dataCache.clear();
           renderData();
         };
-        row.append(url, advToggle, btn, status);
+        const upload = document.createElement("button");
+        upload.type = "button";
+        upload.textContent = "Upload ZIP";
+        upload.title = "Upload a text-only skill pack, up to 16 MiB. No repository connection is needed.";
+        upload.onclick = () => chooseSkillPackArchive(null, status);
+        row.append(url, advToggle, btn, upload, status);
         box.append(row, adv);
 
         const rows = packs.map((s) => {
@@ -10062,12 +10067,13 @@
               "Upstream advanced past the imported commit — Sync now (or turn on Auto-sync) to apply.",
             );
           else setStatusText(li ? "up to date" : "not imported", "muted", delta);
-          const isTracked = s.syncMode === "tracked";
+          const isArchive = s.kind === "archive";
+          const isTracked = !isArchive && s.syncMode === "tracked";
           let busy = false;
           const menu = overflowMenu([
             { label: "Browse skills…", onClick: () => browsePack(s, detail) },
             {
-              label: "Sync now",
+              label: isArchive ? "Apply uploaded version" : "Sync now",
               title:
                 "Pull the pack's latest commit and refresh already-imported skills (update changed, archive removed). Does NOT add new skills — use Browse for that.",
               onClick: async () => {
@@ -10096,26 +10102,51 @@
                 }, 1200);
               },
             },
-            {
-              label: isTracked ? "Turn off auto-sync" : "Turn on auto-sync",
-              title: isTracked
-                ? "Auto-sync is ON — re-imports when the upstream advances."
-                : "Auto-sync is OFF — manual Sync only.",
-              onClick: async () => {
-                if (busy) return;
-                busy = true;
-                const r = await api("PATCH", "/api/skill-packs/" + encodeURIComponent(s.id), {
-                  syncMode: isTracked ? "pinned" : "tracked",
-                });
-                busy = false;
-                if (!r.ok) {
-                  alert(r.data?.message || "Failed (" + r.status + ").");
-                  return;
-                }
-                dataCache.clear();
-                renderData();
-              },
-            },
+            ...(isArchive
+              ? [
+                  {
+                    label: "Upload new ZIP…",
+                    onClick: () => chooseSkillPackArchive(s, st),
+                  },
+                  ...(s.previousRef
+                    ? [
+                        {
+                          label: "Select previous version",
+                          onClick: async () => {
+                            const r = await api("PATCH", "/api/skill-packs/" + encodeURIComponent(s.id), {
+                              ref: s.previousRef,
+                            });
+                            if (!r.ok)
+                              return setStatusText(r.data?.message || "Could not select the previous version.", "err");
+                            dataCache.clear();
+                            renderData();
+                          },
+                        },
+                      ]
+                    : []),
+                ]
+              : [
+                  {
+                    label: isTracked ? "Turn off auto-sync" : "Turn on auto-sync",
+                    title: isTracked
+                      ? "Auto-sync is ON — re-imports when the upstream advances."
+                      : "Auto-sync is OFF — manual Sync only.",
+                    onClick: async () => {
+                      if (busy) return;
+                      busy = true;
+                      const r = await api("PATCH", "/api/skill-packs/" + encodeURIComponent(s.id), {
+                        syncMode: isTracked ? "pinned" : "tracked",
+                      });
+                      busy = false;
+                      if (!r.ok) {
+                        alert(r.data?.message || "Failed (" + r.status + ").");
+                        return;
+                      }
+                      dataCache.clear();
+                      renderData();
+                    },
+                  },
+                ]),
             {
               label: "Remove pack",
               danger: true,
@@ -10135,7 +10166,7 @@
           return [
             { node: packNode },
             { node: skillsNode, cls: "num" },
-            { text: s.trustTier + (isTracked ? " · auto-sync" : ""), cls: "subline" },
+            { text: s.trustTier + (isArchive ? " · offline" : isTracked ? " · auto-sync" : ""), cls: "subline" },
             { node: st },
             { node: menu, cls: "num" },
           ];
@@ -10317,6 +10348,56 @@
         renderChips();
         return pick;
       }
+      let skillPackUploadBusy = false;
+      function chooseSkillPackArchive(pack, status) {
+        if (skillPackUploadBusy) return;
+        const picker = document.createElement("input");
+        picker.type = "file";
+        picker.accept = ".zip,application/zip";
+        picker.hidden = true;
+        picker.oncancel = () => picker.remove();
+        picker.onchange = async () => {
+          const file = picker.files?.[0];
+          picker.remove();
+          if (!file) return;
+          if (!/\.zip$/i.test(file.name) || file.size > 16 * 1024 * 1024) {
+            status.className = "status err";
+            status.textContent = "Choose a ZIP file up to 16 MiB.";
+            return;
+          }
+          skillPackUploadBusy = true;
+          status.className = "status";
+          status.textContent = "Uploading and validating ZIP…";
+          try {
+            const path = "/api/skill-packs/" + (pack ? encodeURIComponent(pack.id) + "/" : "") + "upload";
+            const response = await fetch(API_BASE + path, {
+              method: "POST",
+              credentials: "same-origin",
+              headers: {
+                "content-type": "application/zip",
+                "x-file-name": encodeURIComponent(file.name),
+                "x-content-sha256": await fileSha256(file),
+              },
+              body: file,
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.message || "ZIP upload failed (" + response.status + ").");
+            if (data.pack?.lastImport?.status === "error" && !pack)
+              throw new Error(data.pack.lastImport.error || "ZIP validation failed.");
+            status.className = "status ok";
+            status.textContent = "ZIP ready. Browse skills to choose where to import them.";
+            dataCache.clear();
+            renderData();
+          } catch (error) {
+            status.className = "status err";
+            status.textContent = error.message || "ZIP upload failed.";
+          } finally {
+            skillPackUploadBusy = false;
+          }
+        };
+        document.body.appendChild(picker);
+        picker.click();
+      }
       async function browsePack(s, holder) {
         holder.textContent = "";
         const loading = document.createElement("div");
@@ -10461,6 +10542,7 @@
           const r2 = await api("POST", "/api/skill-packs/" + encodeURIComponent(s.id) + "/import", {
             selected: allEligible ? "all" : names,
             scopeIds: scopes,
+            expectedCommit: plan.commit,
           });
           importButtons.forEach((b) => {
             b.disabled = false;

--- a/plugins/admin/src/index.ts
+++ b/plugins/admin/src/index.ts
@@ -4,7 +4,7 @@ import { Readable } from "node:stream";
 import { createGzip, gzipSync } from "node:zlib";
 import { createHash } from "node:crypto";
 import { signedRequestHeaders, withSourceAuthNonce } from "../../chassis/src/core-client.ts";
-import { json, readBody, cookie } from "../../chassis/src/http.ts";
+import { json, readBody, readBytes, PayloadTooLargeError, cookie } from "../../chassis/src/http.ts";
 import { createBrandingCache, injectBranding, type OrgBranding } from "../../chassis/src/branding.ts";
 import { verifyPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
 import { errMessage } from "../../chassis/src/errors.ts";
@@ -194,7 +194,7 @@ function uploadFileName(req: IncomingMessage): string {
   }
 }
 
-async function stageUploadStream(req: IncomingMessage, sha256: string): Promise<Response> {
+async function stageUploadStream(req: IncomingMessage | Buffer, sha256: string): Promise<Response> {
   const corePath = withSourceAuthNonce("/v1/blobs", CORE_SIGNING_SECRET);
   const headers = signedRequestHeaders(CORE_SIGNING_SECRET, "POST", corePath, sha256, {
     "content-type": "application/octet-stream",
@@ -206,6 +206,45 @@ async function stageUploadStream(req: IncomingMessage, sha256: string): Promise<
     body: req as unknown as RequestInit["body"],
     duplex: "half",
   } as RequestInit & { duplex: "half" });
+}
+
+async function uploadSkillPackFromRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  principal: string,
+  corePath: string,
+): Promise<void> {
+  const who = await coreWhoami(principal);
+  if (!who?.isAdmin) {
+    req.resume();
+    return json(res, who ? 403 : 502, {
+      error: who ? "forbidden" : "core_unreachable",
+      message: "admin status could not be verified",
+    });
+  }
+  const sha256 = typeof req.headers["x-content-sha256"] === "string" ? req.headers["x-content-sha256"] : "";
+  const name = uploadFileName(req);
+  if (!/^[0-9a-f]{64}$/.test(sha256) || !/^[^/\\\x00-\x1f]{1,160}\.zip$/i.test(name)) {
+    req.resume();
+    return json(res, 400, { error: "bad_request", message: "a ZIP filename and x-content-sha256 are required" });
+  }
+  try {
+    const bytes = await readBytes(req, 16 * 1024 * 1024);
+    const staged = await stageUploadStream(bytes, sha256);
+    const body = await staged.text();
+    if (!staged.ok) {
+      res.writeHead(staged.status, { "content-type": "application/json" });
+      return void res.end(body);
+    }
+    const { blobId } = JSON.parse(body) as { blobId: string };
+    return forward(req, res, principal, "POST", corePath, JSON.stringify({ name, blobId }));
+  } catch (error) {
+    req.resume();
+    if (error instanceof PayloadTooLargeError)
+      return json(res, 413, { error: "payload_too_large", message: "skill pack ZIP exceeds 16 MiB" });
+    console.error("[admin] skill pack upload failed:", errMessage(error));
+    return json(res, 502, { error: "upload_failed", message: "skill pack upload failed" });
+  }
 }
 
 async function uploadFileFromRequest(
@@ -458,6 +497,9 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     if (!principal) return json(res, 401, { error: "signed_out" });
     const m = method as "POST" | "PUT" | "PATCH" | "DELETE";
     const corePath = `/v1/admin/${rest}${url.search}`;
+    if (method === "POST" && /^skill-packs\/(?:[^/]+\/)?upload$/.test(rest)) {
+      return uploadSkillPackFromRequest(req, res, principal, corePath);
+    }
     return m === "DELETE"
       ? forward(req, res, principal, m, corePath)
       : forward(req, res, principal, m, corePath, await readBody(req));

--- a/plugins/admin/test/skill-packs.test.ts
+++ b/plugins/admin/test/skill-packs.test.ts
@@ -16,7 +16,11 @@ const core = createServer((req: IncomingMessage, res) => {
       body,
     });
     res.writeHead(200, { "content-type": "application/json" });
-    res.end(JSON.stringify({ ok: true }));
+    const path = new URL(req.url ?? "/", "http://core.test").pathname;
+    let result: Record<string, unknown> = { ok: true };
+    if (path === "/v1/admin/whoami") result = { isAdmin: req.headers["x-admin-actor"] === "U-admin@acme" };
+    if (path === "/v1/blobs") result = { blobId: "uploaded-zip" };
+    res.end(JSON.stringify(result));
   });
 });
 await new Promise<void>((r) => core.listen(0, r));
@@ -121,4 +125,42 @@ test("skill-pack writes require a signed-in cookie", async () => {
   });
   assert.equal(r.status, 401);
   assert.equal(calls.length, before, "a signed-out request is rejected at the surface, never forwarded");
+});
+
+test("ZIP uploads authorize first, stage signed bytes and forward only the blob reference", async () => {
+  const r = await fetch(`${base}/api/skill-packs/upload`, {
+    method: "POST",
+    headers: {
+      cookie: ADMIN,
+      "content-type": "application/zip",
+      "x-file-name": "skills.zip",
+      "x-content-sha256": "a".repeat(64),
+    },
+    body: "zip bytes",
+  });
+  assert.equal(r.status, 200);
+  const staged = calls.at(-2)!;
+  assert.equal(new URL(staged.url, "http://core.test").pathname, "/v1/blobs");
+  assert.equal(staged.body, "zip bytes");
+  assert.equal(staged.signed, true);
+  assert.equal(calls.at(-1)!.url, "/v1/admin/skill-packs/upload");
+  assert.deepEqual(JSON.parse(calls.at(-1)!.body), { name: "skills.zip", blobId: "uploaded-zip" });
+});
+
+test("ZIP uploads reject non-admins, invalid hashes and oversized bodies before staging", async () => {
+  for (const [cookie, hash, body, status] of [
+    ["admin=U-user", "a".repeat(64), "zip", 403],
+    [ADMIN, "invalid", "zip", 400],
+    [ADMIN, "a".repeat(64), "a".repeat(16 * 1024 * 1024 + 1), 413],
+  ] as const) {
+    const before = calls.length;
+    const r = await fetch(`${base}/api/skill-packs/upload`, {
+      method: "POST",
+      headers: { cookie, "x-file-name": "skills.zip", "x-content-sha256": hash },
+      body,
+    });
+    assert.equal(r.status, status);
+    assert.ok(calls.slice(before).every((c) => !c.url.startsWith("/v1/blobs")));
+    await r.text();
+  }
 });

--- a/plugins/chassis/src/http.ts
+++ b/plugins/chassis/src/http.ts
@@ -12,15 +12,19 @@ export function json(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
-export async function readBody(req: IncomingMessage, maxBytes = Infinity): Promise<string> {
+export async function readBytes(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
   const chunks: Buffer[] = [];
   let size = 0;
-  for await (const c of req) {
+  for await (const c of req.iterator({ destroyOnReturn: false })) {
     size += (c as Buffer).length;
     if (size > maxBytes) throw new PayloadTooLargeError();
     chunks.push(c as Buffer);
   }
-  return Buffer.concat(chunks).toString("utf8");
+  return Buffer.concat(chunks);
+}
+
+export async function readBody(req: IncomingMessage, maxBytes = Infinity): Promise<string> {
+  return (await readBytes(req, maxBytes)).toString("utf8");
 }
 
 export function cookie(req: IncomingMessage, name: string): string | null {

--- a/plugins/portal/src/proxy.ts
+++ b/plugins/portal/src/proxy.ts
@@ -11,6 +11,8 @@ const FORWARD_REQUEST_HEADERS = [
   "user-agent",
   "accept-encoding",
   "sec-fetch-dest",
+  "x-file-name",
+  "x-content-sha256",
 ];
 
 const DROP_RESPONSE_HEADERS = new Set([

--- a/plugins/portal/test/router.test.ts
+++ b/plugins/portal/test/router.test.ts
@@ -600,3 +600,24 @@ test("impersonate: an admin starts it; the web-ui hop carries target + impersona
   assert.equal(stop.status, 200);
   assert.match(stop.headers.get("set-cookie") ?? "", /portal_impersonate=;[^,]*Max-Age=0/);
 });
+
+test("surface proxy preserves upload metadata while retaining the portal identity", async () => {
+  const r = await fetch(`${base}/admin/api/skill-packs/upload`, {
+    method: "POST",
+    headers: {
+      cookie: sessionCookie("U-admin"),
+      origin: PUBLIC,
+      "content-type": "application/zip",
+      "x-file-name": "skills.zip",
+      "x-content-sha256": "a".repeat(64),
+      "x-admin-actor": "forged",
+    },
+    body: "zip bytes",
+  });
+  assert.equal(r.status, 200);
+  const result = (await r.json()) as { headers: Record<string, string> };
+  assert.equal(result.headers["x-file-name"], "skills.zip");
+  assert.equal(result.headers["x-content-sha256"], "a".repeat(64));
+  assert.equal(result.headers["x-admin-actor"], undefined);
+  assert.ok(result.headers["x-portal-identity"]);
+});

--- a/src/api/app-skills.ts
+++ b/src/api/app-skills.ts
@@ -101,12 +101,13 @@ async function reconcilePack(
   fetcher: SkillPackFetcher,
   id: string,
   targets: ReconcileTarget[],
+  fetchOptions?: { refresh?: boolean; expectedCommit?: string },
 ): Promise<ImportResult> {
   const pack = await packs.get(id);
   if (!pack) throw new Error(`unknown skill pack: ${id}`);
   let repo: Awaited<ReturnType<SkillPackFetcher["fetch"]>>;
   try {
-    repo = await fetcher.fetch(pack);
+    repo = await fetcher.fetch(pack, fetchOptions);
   } catch (e) {
     await packs.recordImport(id, {
       at: Date.now(),
@@ -201,6 +202,7 @@ export function createSkillMethods(
   | "listSkillPacks"
   | "getSkillPack"
   | "registerSkillPack"
+  | "updateSkillPackArchive"
   | "updateSkillPack"
   | "skillPackCatalog"
   | "importSkillPack"
@@ -296,9 +298,20 @@ export function createSkillMethods(
     getSkillPack(id) {
       return deps.skillPacks ? deps.skillPacks.get(id) : Promise.resolve(null);
     },
-    async registerSkillPack(input) {
+    async registerSkillPack(input, archive) {
       const { packs, fetcher } = requireRegistry(deps);
+      if (input.kind === "archive" && (!archive || !fetcher.storeArchive)) {
+        throw new Error("offline skill pack source is required");
+      }
       const pack = await packs.create(input);
+      if (archive) {
+        try {
+          await fetcher.storeArchive!(pack, archive);
+        } catch (error) {
+          await packs.remove(pack.id);
+          throw error;
+        }
+      }
       try {
         const repo = await fetcher.fetch(pack);
         const nativeNames = await nativeNamesFor(deps, pack.id, pack.targetScopeId);
@@ -315,8 +328,43 @@ export function createSkillMethods(
       }
     },
     async updateSkillPack(id, patch) {
-      const { packs } = requireRegistry(deps);
-      return withSkillMutationLock(deps, () => packs.update(id, patch));
+      const { packs, fetcher } = requireRegistry(deps);
+      return withSkillMutationLock(deps, async () => {
+        const pack = await packs.get(id);
+        if (!pack) throw new Error(`unknown skill pack: ${id}`);
+        if (pack.kind === "archive") {
+          if (patch.syncMode === "tracked" || (patch.url !== undefined && patch.url !== pack.url)) {
+            throw new Error("offline packs use uploaded ZIP versions; Git URL and auto-sync are unavailable");
+          }
+          if (patch.ref && patch.ref !== pack.ref) {
+            await fetcher.fetch({ ...pack, ref: patch.ref });
+            patch.previousRef = pack.ref;
+            patch.updateAvailable = true;
+          }
+        }
+        return packs.update(id, patch);
+      });
+    },
+    async updateSkillPackArchive(id, name, archive) {
+      const { packs, fetcher } = requireRegistry(deps);
+      return withSkillMutationLock(deps, async () => {
+        const pack = await packs.get(id);
+        if (!pack || pack.kind !== "archive" || !fetcher.storeArchive) throw new Error("offline skill pack not found");
+        const previousRef = archive.commit === pack.ref ? pack.previousRef : pack.ref;
+        const next = { ...pack, url: name, ref: archive.commit, previousRef };
+        await fetcher.storeArchive(next, archive);
+        const plan = planIngest(archive, {
+          config: pack.config,
+          nativeNames: await nativeNamesFor(deps, id, pack.targetScopeId),
+        });
+        return packs.update(id, {
+          url: name,
+          ref: archive.commit,
+          previousRef,
+          available: plan.counts.eligible,
+          updateAvailable: archive.commit !== pack.lastImport?.commit,
+        });
+      });
     },
     async skillPackCatalog(id) {
       const { packs, fetcher } = requireRegistry(deps);
@@ -334,6 +382,7 @@ export function createSkillMethods(
       }
       return {
         ...plan,
+        commit: repo.commit,
         bundlePaths,
         candidates: plan.candidates.map((c) => ({
           ...c,
@@ -341,7 +390,7 @@ export function createSkillMethods(
         })),
       };
     },
-    async importSkillPack(id, selected, scopeIds) {
+    async importSkillPack(id, selected, scopeIds, expectedCommit) {
       const { packs, fetcher } = requireRegistry(deps);
       const pack = await packs.get(id);
       if (!pack) throw new Error(`unknown skill pack: ${id}`);
@@ -352,6 +401,7 @@ export function createSkillMethods(
         fetcher,
         id,
         scopes.map((scopeId) => ({ scopeId, selected })),
+        expectedCommit ? { expectedCommit } : { refresh: true },
       );
     },
     async syncSkillPack(id) {
@@ -366,15 +416,17 @@ export function createSkillMethods(
       }
       const targets = [...importedByScope].map(([scopeId, selected]) => ({ scopeId, selected }));
       if (!targets.length) targets.push({ scopeId: pack.targetScopeId, selected: [] });
-      return reconcilePack(deps, packs, fetcher, id, targets);
+      return reconcilePack(deps, packs, fetcher, id, targets, { refresh: true });
     },
     async removeSkillPack(id) {
-      const { packs } = requireRegistry(deps);
+      const { packs, fetcher } = requireRegistry(deps);
       return withSkillMutationLock(deps, async () => {
+        const pack = await packs.get(id);
         const mine = (await deps.skills.list()).filter((s) => s.createdBy === `pack:${id}`);
         for (const s of mine) await deps.skills.delete(s.id);
         await deps.skillBundles?.delete(id);
         await packs.remove(id);
+        if (pack) await fetcher.remove?.(pack);
         return { removed: mine.length };
       });
     },

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -37,7 +37,7 @@ import type { AclStore } from "../acl/acl-store.ts";
 import type { SkillStore, Skill, SkillResolution } from "../skills/skill-store.ts";
 import type { SkillPack, NewSkillPack, SkillPackStore } from "../skills/skill-pack-store.ts";
 import type { SkillPackFetcher } from "../skills/pack-fetcher.ts";
-import { type IngestPlan, type ImportResult } from "../skills/ingest.ts";
+import { type IngestPlan, type ImportResult, type FetchedRepo } from "../skills/ingest.ts";
 import { type SkillBundleStore } from "../skills/skill-bundle-store.ts";
 import type { AuditLog } from "../audit/audit-log.ts";
 import type { CapabilityClaims } from "../auth/capability-token.ts";
@@ -460,10 +460,16 @@ export interface App {
   restoreOwnedSkill(id: string, principalId: string): Promise<Skill | null>;
   listSkillPacks(): Promise<SkillPack[]>;
   getSkillPack(id: string): Promise<SkillPack | null>;
-  registerSkillPack(input: NewSkillPack): Promise<SkillPack>;
+  registerSkillPack(input: NewSkillPack, archive?: FetchedRepo): Promise<SkillPack>;
+  updateSkillPackArchive(id: string, name: string, archive: FetchedRepo): Promise<SkillPack>;
   updateSkillPack(id: string, patch: Partial<Omit<SkillPack, "id" | "createdAt">>): Promise<SkillPack>;
-  skillPackCatalog(id: string): Promise<IngestPlan & { bundlePaths: string[] }>;
-  importSkillPack(id: string, selected: "all" | string[], scopeIds?: ScopeId[]): Promise<ImportResult>;
+  skillPackCatalog(id: string): Promise<IngestPlan & { bundlePaths: string[]; commit: string }>;
+  importSkillPack(
+    id: string,
+    selected: "all" | string[],
+    scopeIds?: ScopeId[],
+    expectedCommit?: string,
+  ): Promise<ImportResult>;
   syncSkillPack(id: string): Promise<ImportResult>;
   removeSkillPack(id: string): Promise<{ removed: number }>;
   createOwnedSkill(input: {

--- a/src/api/routes/skill-packs.ts
+++ b/src/api/routes/skill-packs.ts
@@ -4,6 +4,8 @@ import { audit, authorizeAdmin, orgScope } from "./shared.ts";
 import type { NewSkillPack, SkillPack } from "../../skills/skill-pack-store.ts";
 import type { PackConfig } from "../../skills/normalize.ts";
 import { parseScopeId, type ScopeId } from "../../types.ts";
+import { MAX_SKILL_ARCHIVE_BYTES, readSkillPackArchive, SkillPackArchiveError } from "../../skills/pack-archive.ts";
+import { SkillPackSourceError } from "../../skills/pack-source-cache.ts";
 
 function asSubset(v: unknown): "all" | string[] | undefined {
   if (v === "all" || v === undefined) return "all";
@@ -119,7 +121,20 @@ async function importPack(ctx: ApiCtx): Promise<void> {
       error: "bad_request",
       message: "scopeIds must be an array of 'kind:ref' scope ids",
     });
-  const result = await ctx.app.importSkillPack(ctx.params.id!, subset, scopeIds);
+  if (
+    body.expectedCommit !== undefined &&
+    (typeof body.expectedCommit !== "string" || !/^[a-f0-9]{40,64}$/.test(body.expectedCommit))
+  ) {
+    return sendJson(ctx.res, 400, { error: "bad_request", message: "expectedCommit must be a commit hash" });
+  }
+  let result;
+  try {
+    result = await ctx.app.importSkillPack(ctx.params.id!, subset, scopeIds, body.expectedCommit as string | undefined);
+  } catch (error) {
+    if (error instanceof SkillPackSourceError)
+      return sendJson(ctx.res, 409, { error: "source_changed", message: error.message });
+    throw error;
+  }
   audit(ctx.deps, {
     principalId: actor.id,
     action: "skill_pack.import",
@@ -127,6 +142,58 @@ async function importPack(ctx: ApiCtx): Promise<void> {
     scopeLabel: scopeIds.length ? scopeIds.join(",") : orgScope(ctx.deps),
   });
   sendJson(ctx.res, 200, result);
+}
+
+async function uploadArchive(ctx: ApiCtx): Promise<void> {
+  const actor = await authorizeAdmin(ctx, orgScope(ctx.deps));
+  if (!actor) return;
+  const body = (ctx.body ?? {}) as Record<string, unknown>;
+  if (
+    typeof body.blobId !== "string" ||
+    typeof body.name !== "string" ||
+    !/^[^/\\\x00-\x1f]{1,160}\.zip$/i.test(body.name)
+  ) {
+    return sendJson(ctx.res, 400, { error: "bad_request", message: "a blobId and a ZIP filename are required" });
+  }
+  const blob = await ctx.deps.blobTransfer?.open(body.blobId);
+  if (!blob) return sendJson(ctx.res, 404, { error: "not_found", message: "uploaded ZIP is unavailable" });
+  let response: { status: number; body: Record<string, unknown> };
+  try {
+    if (blob.sizeBytes > MAX_SKILL_ARCHIVE_BYTES) {
+      response = { status: 413, body: { error: "payload_too_large", message: "skill pack ZIP exceeds 16 MiB" } };
+    } else {
+      const repo = await readSkillPackArchive(blob.stream);
+      const pack = ctx.params.id
+        ? await ctx.app.updateSkillPackArchive(ctx.params.id, body.name, repo)
+        : await ctx.app.registerSkillPack(
+            {
+              kind: "archive",
+              url: body.name,
+              ref: repo.commit,
+              syncMode: "pinned",
+              trustTier: "third-party",
+              targetScopeId: orgScope(ctx.deps),
+              subset: "all",
+              createdBy: actor.id,
+            },
+            repo,
+          );
+      audit(ctx.deps, {
+        principalId: actor.id,
+        action: "skill_pack.upload",
+        resource: pack.id,
+        scopeLabel: pack.targetScopeId,
+      });
+      response = { status: 200, body: { pack } };
+    }
+  } catch (error) {
+    if (!(error instanceof SkillPackArchiveError)) throw error;
+    response = { status: 400, body: { error: "invalid_archive", message: error.message } };
+  } finally {
+    blob.stream.destroy();
+    await ctx.deps.blobTransfer!.delete(body.blobId);
+  }
+  sendJson(ctx.res, response.status, response.body);
 }
 
 async function syncPack(ctx: ApiCtx): Promise<void> {
@@ -182,6 +249,8 @@ async function removePack(ctx: ApiCtx): Promise<void> {
 }
 
 export const skillPackRoutes: ReadonlyArray<Route<ApiCtx>> = [
+  { method: "POST", path: "/v1/admin/skill-packs/upload", auth: "either", handle: uploadArchive },
+  { method: "POST", path: "/v1/admin/skill-packs/:id/upload", auth: "either", handle: uploadArchive },
   { method: "POST", path: "/v1/admin/skill-packs", auth: "either", handle: registerPack },
   { method: "GET", path: "/v1/admin/skill-packs", auth: "either", handle: listPacks },
   { method: "GET", path: "/v1/admin/skill-packs/:id/catalog", auth: "either", handle: packCatalog },

--- a/src/skills/pack-archive.ts
+++ b/src/skills/pack-archive.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+import { crc32 } from "node:zlib";
+import { fromBuffer, type Entry, type ZipFile } from "yauzl";
+import type { Readable } from "node:stream";
+import { isProbablyBinary } from "./seed.ts";
+import { safeSkillFilePath } from "./skill-store.ts";
+import type { FetchedRepo, RepoFile } from "./ingest.ts";
+
+export const MAX_SKILL_ARCHIVE_BYTES = 16 * 1024 * 1024;
+const MAX_UNPACKED_BYTES = 32 * 1024 * 1024;
+const MAX_ENTRIES = 5000;
+
+export class SkillPackArchiveError extends Error {}
+
+export async function readSkillPackArchive(stream: AsyncIterable<Uint8Array>): Promise<FetchedRepo> {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  for await (const chunk of stream) {
+    bytes += chunk.byteLength;
+    if (bytes > MAX_SKILL_ARCHIVE_BYTES) throw new SkillPackArchiveError("skill pack ZIP exceeds 16 MiB");
+    chunks.push(Buffer.from(chunk));
+  }
+  const buffer = Buffer.concat(chunks);
+  const files = await unzip(buffer).catch((error: unknown) => {
+    throw new SkillPackArchiveError(error instanceof Error ? error.message : "invalid skill pack ZIP");
+  });
+  const filePaths = new Set(files.map((file) => file.path));
+  for (const file of files) {
+    const parts = file.path.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      if (filePaths.has(parts.slice(0, i).join("/"))) {
+        throw new SkillPackArchiveError(`conflicting ZIP path: ${file.path}`);
+      }
+    }
+  }
+  const first = files[0]?.path.split("/")[0];
+  const wrapped = first && files.every((file) => file.path.startsWith(first + "/"));
+  if (wrapped) for (const file of files) file.path = file.path.slice(first.length + 1);
+  if (!files.some((file) => file.path === "SKILL.md" || file.path.endsWith("/SKILL.md"))) {
+    throw new SkillPackArchiveError("ZIP does not contain a SKILL.md file");
+  }
+  return { commit: createHash("sha256").update(buffer).digest("hex"), files };
+}
+
+async function entryStream(zip: ZipFile, entry: Entry): Promise<Readable> {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (error, stream) => (error ? reject(error) : resolve(stream!)));
+  });
+}
+
+function unzip(buffer: Buffer): Promise<RepoFile[]> {
+  return new Promise((resolve, reject) => {
+    fromBuffer(buffer, { lazyEntries: true, strictFileNames: true, validateEntrySizes: true }, (error, zip) => {
+      if (error || !zip) return reject(error ?? new Error("invalid ZIP"));
+      const files: RepoFile[] = [];
+      const paths = new Set<string>();
+      let total = 0;
+      let count = 0;
+      let failed = false;
+      const fail = (cause: unknown): void => {
+        failed = true;
+        zip.close();
+        reject(cause);
+      };
+      zip.on("error", fail);
+      zip.on("end", () => {
+        if (!failed) resolve(files.sort((a, b) => a.path.localeCompare(b.path)));
+      });
+      zip.on("entry", (entry: Entry) => {
+        void (async () => {
+          count++;
+          if (count > MAX_ENTRIES) throw new Error("skill pack ZIP exceeds 5000 entries");
+          const directory = entry.fileName.endsWith("/");
+          const path = safeSkillFilePath(directory ? entry.fileName.slice(0, -1) : entry.fileName);
+          if (paths.has(path)) throw new Error(`duplicate ZIP path: ${path}`);
+          paths.add(path);
+          const mode = (entry.externalFileAttributes >>> 16) & 0xf000;
+          if (mode && mode !== (directory ? 0x4000 : 0x8000)) throw new Error(`unsupported ZIP entry: ${path}`);
+          if (entry.generalPurposeBitFlag & 1) throw new Error("encrypted skill pack ZIPs are not supported");
+          if (directory) {
+            if (entry.uncompressedSize) throw new Error(`invalid ZIP directory: ${path}`);
+            zip.readEntry();
+            return;
+          }
+          total += entry.uncompressedSize;
+          if (total > MAX_UNPACKED_BYTES) throw new Error("expanded skill pack exceeds 32 MiB");
+          const stream = await entryStream(zip, entry);
+          const chunks: Buffer[] = [];
+          let size = 0;
+          for await (const chunk of stream) {
+            const bytes = Buffer.from(chunk);
+            size += bytes.length;
+            if (size > entry.uncompressedSize || size > MAX_UNPACKED_BYTES) {
+              throw new Error(`ZIP size mismatch: ${path}`);
+            }
+            chunks.push(bytes);
+          }
+          const bytes = Buffer.concat(chunks);
+          if (bytes.length !== entry.uncompressedSize || crc32(bytes) !== entry.crc32) {
+            throw new Error(`ZIP integrity check failed: ${path}`);
+          }
+          if (path.split("/").includes(".git")) throw new Error("remove .git history before uploading the skill pack");
+          if (!path.split("/").some((part) => part === "__MACOSX" || part === ".DS_Store")) {
+            if (isProbablyBinary(bytes))
+              throw new Error(`binary attachment is not supported: ${path}; upload a text-only skill pack`);
+            const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+            files.push({ path, text, binary: false });
+          }
+          if (!failed) zip.readEntry();
+        })().catch(fail);
+      });
+      zip.readEntry();
+    });
+  });
+}

--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -12,8 +12,10 @@ import type { FetchedRepo, RepoFile } from "./ingest.ts";
 import type { SkillPack } from "./skill-pack-store.ts";
 
 export interface SkillPackFetcher {
-  fetch(pack: SkillPack): Promise<FetchedRepo>;
+  fetch(pack: SkillPack, options?: { refresh?: boolean; expectedCommit?: string }): Promise<FetchedRepo>;
   resolveRef(pack: SkillPack): Promise<string>;
+  storeArchive?(pack: SkillPack, repo: FetchedRepo): Promise<void>;
+  remove?(pack: SkillPack): Promise<void>;
 }
 
 export interface GitFetcherOptions {

--- a/src/skills/pack-source-cache.ts
+++ b/src/skills/pack-source-cache.ts
@@ -1,0 +1,89 @@
+import type { DurableMap } from "../persistence/durable-map.ts";
+import type { FetchedRepo } from "./ingest.ts";
+import type { SkillPackFetcher } from "./pack-fetcher.ts";
+import type { SkillPack } from "./skill-pack-store.ts";
+
+export interface SkillPackSourceSnapshot {
+  sourceKey: string;
+  fetchedAt: number;
+  repo: FetchedRepo;
+  previous?: FetchedRepo;
+}
+
+export class SkillPackSourceError extends Error {}
+
+function sourceKey(pack: SkillPack): string {
+  return JSON.stringify(
+    pack.kind === "archive"
+      ? [pack.kind, pack.createdBy]
+      : [pack.kind, pack.url, pack.ref, pack.createdBy, pack.authCredentialSlug ?? null],
+  );
+}
+
+export function createCachedSkillPackFetcher(options: {
+  git: SkillPackFetcher;
+  snapshots: DurableMap<SkillPackSourceSnapshot>;
+  now?: () => number;
+  ttlMs?: number;
+}): SkillPackFetcher {
+  const { git, snapshots } = options;
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? 300_000;
+  const inFlight = new Map<string, Promise<FetchedRepo>>();
+
+  async function save(pack: SkillPack, repo: FetchedRepo): Promise<void> {
+    const key = sourceKey(pack);
+    const old = await snapshots.get(pack.id);
+    let previous: FetchedRepo | undefined;
+    if (old?.sourceKey === key) {
+      previous = old.repo.commit === repo.commit ? old.previous : old.repo;
+      if (pack.kind === "archive" && pack.previousRef) {
+        previous = [old.repo, old.previous].find((candidate) => candidate?.commit === pack.previousRef);
+      }
+    }
+    await snapshots.put(pack.id, { sourceKey: key, fetchedAt: now(), repo, ...(previous ? { previous } : {}) });
+  }
+
+  return {
+    async fetch(pack, request = {}) {
+      const key = sourceKey(pack);
+      const stored = await snapshots.get(pack.id);
+      const cached = stored?.sourceKey === key ? stored : null;
+      if (pack.kind === "archive") {
+        if (request.expectedCommit && request.expectedCommit !== pack.ref) {
+          throw new SkillPackSourceError("skill pack version changed; browse the pack again before importing");
+        }
+        const repo = [cached?.repo, cached?.previous].find((repo) => repo?.commit === pack.ref);
+        if (!repo) throw new SkillPackSourceError("offline skill pack source is unavailable; upload the archive again");
+        return repo;
+      }
+      if (request.expectedCommit) {
+        const repo = [cached?.repo, cached?.previous].find((repo) => repo?.commit === request.expectedCommit);
+        if (!repo) throw new SkillPackSourceError("skill pack preview expired; browse the pack again before importing");
+        return repo;
+      }
+      if (cached && !request.refresh && (/^[a-f0-9]{40}$/.test(pack.ref) || now() - cached.fetchedAt < ttlMs)) {
+        return cached.repo;
+      }
+      const pendingKey = JSON.stringify([pack.id, key]);
+      const pending = inFlight.get(pendingKey);
+      if (pending) return pending;
+      const fetch = git.fetch(pack).then(async (repo) => {
+        await save(pack, repo);
+        return repo;
+      });
+      inFlight.set(pendingKey, fetch);
+      try {
+        return await fetch;
+      } finally {
+        if (inFlight.get(pendingKey) === fetch) inFlight.delete(pendingKey);
+      }
+    },
+    resolveRef: (pack) => (pack.kind === "archive" ? Promise.resolve(pack.ref) : git.resolveRef(pack)),
+    async storeArchive(pack, repo) {
+      if (pack.kind !== "archive" || pack.ref !== repo.commit) throw new Error("offline skill pack version mismatch");
+      await save(pack, repo);
+    },
+    remove: (pack) => snapshots.delete(pack.id),
+  };
+}

--- a/src/skills/skill-pack-store.ts
+++ b/src/skills/skill-pack-store.ts
@@ -3,7 +3,7 @@ import type { ScopeId } from "../types.ts";
 import { createMemoryMap, type DurableMap } from "../persistence/durable-map.ts";
 import type { PackConfig } from "./normalize.ts";
 
-type PackKind = "git";
+type PackKind = "git" | "archive";
 type SyncMode = "pinned" | "tracked";
 type TrustTier = "internal" | "third-party";
 
@@ -31,6 +31,7 @@ export interface SkillPack {
   lastImport?: ImportRecord;
   updateAvailable?: boolean;
   available?: number;
+  previousRef?: string;
 }
 
 export type NewSkillPack = Omit<SkillPack, "id" | "createdAt" | "lastImport">;

--- a/src/skills/skill-sync-engine.ts
+++ b/src/skills/skill-sync-engine.ts
@@ -26,6 +26,7 @@ export function createSkillSyncEngine(deps: SkillSyncDeps): SkillSyncEngine {
   async function syncOne(packId: string): Promise<void> {
     const pack = await deps.packs.get(packId);
     if (!pack) return;
+    if (pack.kind === "archive") return;
     if (pack.syncMode === "tracked") {
       const head = await deps.fetcher.resolveRef(pack);
       if (pack.lastImport?.status === "ok" && head === pack.lastImport.commit) return;

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -41,6 +41,7 @@ import { createSkillStore, type SkillStore, type Skill } from "./skills/skill-st
 import { createSkillPackStore, type SkillPack } from "./skills/skill-pack-store.ts";
 import { createSkillBundleStore, type SkillBundle, type SkillBundleStore } from "./skills/skill-bundle-store.ts";
 import { createGitFetcher, resolvePackAuth, type SkillPackFetcher } from "./skills/pack-fetcher.ts";
+import { createCachedSkillPackFetcher, type SkillPackSourceSnapshot } from "./skills/pack-source-cache.ts";
 import { installSeedSkills } from "./skills/seed.ts";
 import { createMemoryMap, createPostgresMapFactory, type DurableMap } from "./persistence/durable-map.ts";
 import type { PersistedUiState, UiStateStore } from "./surfaces/ui-state.ts";
@@ -1224,7 +1225,7 @@ export function buildApp(
 
   wireRunResultDeliveries(runs, deliveries, tasks);
   const idempotency = createIdempotencyStore(artifactMap<IdempotencyRecord>("idempotency"));
-  const skillFetcher = createGitFetcher(
+  const gitSkillFetcher = createGitFetcher(
     keychain
       ? {
           allowLocalRepos: !config.production,
@@ -1243,6 +1244,10 @@ export function buildApp(
         }
       : { allowLocalRepos: !config.production },
   );
+  const skillFetcher = createCachedSkillPackFetcher({
+    git: gitSkillFetcher,
+    snapshots: artifactMap<SkillPackSourceSnapshot>("skill_pack_sources"),
+  });
   const reaper: Reaper = createReaper(runs, sessions, {
     intervalMs: config.reaperIntervalMs,
     leaderLease,

--- a/test/pack-archive.test.ts
+++ b/test/pack-archive.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { createHash } from "node:crypto";
+import { readSkillPackArchive, MAX_SKILL_ARCHIVE_BYTES } from "../src/skills/pack-archive.ts";
+import { skillZip } from "./support/skill-zip.ts";
+
+const md = "---\nname: zip-skill\ndescription: a skill\n---\n# Instructions\nRead rules.json.\n";
+const read = (bytes: Buffer) => readSkillPackArchive(Readable.from([bytes]));
+
+test("reads wrapped UTF-8 skill packs and preserves the complete text assets", async () => {
+  const bytes = skillZip([
+    { path: "pack/", text: "" },
+    { path: "pack/SKILL.md", text: md },
+    { path: "pack/rules.json", text: '{"label":"配色"}' },
+  ]);
+  const repo = await read(bytes);
+  assert.equal(repo.commit, createHash("sha256").update(bytes).digest("hex"));
+  assert.deepEqual(repo.files.map((file) => file.path).sort(), ["SKILL.md", "rules.json"]);
+  assert.equal(repo.files.find((file) => file.path === "rules.json")?.text, '{"label":"配色"}');
+});
+
+for (const [name, entry, expected] of [
+  ["parent traversal", { path: "../SKILL.md", text: md }, /invalid|relative/i],
+  ["absolute paths", { path: "/SKILL.md", text: md }, /absolute|invalid/i],
+  ["backslashes", { path: "pack\\SKILL.md", text: md }, /backslash|invalid/i],
+  ["symlinks", { path: "SKILL.md", text: md, mode: 0o120777 }, /unsupported ZIP entry/],
+  ["encrypted entries", { path: "SKILL.md", text: md, flags: 0x801 }, /encrypted/],
+  ["bad CRC", { path: "SKILL.md", text: md, crc: 1 }, /integrity/],
+  ["dishonest expanded size", { path: "SKILL.md", text: md, size: 1 }, /size|byte/i],
+  ["binary attachments", { path: "image.png", bytes: Buffer.from([0x89, 0x50, 0, 1]) }, /binary attachment/],
+  ["invalid UTF-8", { path: "SKILL.md", bytes: Buffer.from([0xc3, 0x28]) }, /encoded data|encoding|binary attachment/i],
+  ["Git history", { path: ".git/config", text: "internal" }, /remove .git/],
+] as const) {
+  test(`rejects ${name}`, async () => {
+    await assert.rejects(read(skillZip([entry])), expected);
+  });
+}
+
+test("rejects duplicate paths, empty archives and archives without skills", async () => {
+  await assert.rejects(
+    read(
+      skillZip([
+        { path: "SKILL.md", text: md },
+        { path: "SKILL.md", text: "other" },
+      ]),
+    ),
+    /duplicate/,
+  );
+  await assert.rejects(read(skillZip([])), /SKILL.md/);
+  await assert.rejects(read(skillZip([{ path: "README.md", text: "readme" }])), /SKILL.md/);
+  await assert.rejects(read(Buffer.from("not a zip")), /ZIP|zip/i);
+});
+
+test("bounds compressed and expanded input, including highly compressible payloads", async () => {
+  await assert.rejects(read(Buffer.alloc(MAX_SKILL_ARCHIVE_BYTES + 1)), /16 MiB/);
+  const bomb = skillZip([{ path: "SKILL.md", text: "a".repeat(32 * 1024 * 1024 + 1) }]);
+  assert.ok(bomb.length < 100000);
+  await assert.rejects(read(bomb), /32 MiB/);
+  await assert.rejects(
+    read(skillZip(Array.from({ length: 5001 }, (_, i) => ({ path: `file-${i}`, text: "" })))),
+    /5000 entries/,
+  );
+});
+
+test("rejects a file used as the parent of another file", async () => {
+  await assert.rejects(
+    read(
+      skillZip([
+        { path: "SKILL.md", text: md },
+        { path: "assets", text: "file" },
+        { path: "assets/rules.json", text: "{}" },
+      ]),
+    ),
+    /conflicting ZIP path/,
+  );
+});

--- a/test/pack-source-cache.test.ts
+++ b/test/pack-source-cache.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createMemoryMap } from "../src/persistence/durable-map.ts";
+import { createCachedSkillPackFetcher, type SkillPackSourceSnapshot } from "../src/skills/pack-source-cache.ts";
+import type { SkillPack } from "../src/skills/skill-pack-store.ts";
+import type { FetchedRepo } from "../src/skills/ingest.ts";
+
+const pack: SkillPack = {
+  id: "source-test",
+  kind: "git",
+  url: "https://example.com/skills",
+  ref: "main",
+  createdBy: "admin",
+  createdAt: 1,
+  syncMode: "pinned",
+  trustTier: "third-party",
+  subset: "all",
+  targetScopeId: "org:test",
+};
+const repo = (commit: string): FetchedRepo => ({
+  commit,
+  files: [{ path: "SKILL.md", text: "# skill", binary: false }],
+});
+
+test("reuses downloaded snapshots across fetchers and locks import to the previewed commit", async () => {
+  const snapshots = createMemoryMap<SkillPackSourceSnapshot>();
+  let calls = 0;
+  let now = 100;
+  const git = { fetch: async () => repo(String(++calls).repeat(40)), resolveRef: async () => "1".repeat(40) };
+  const first = createCachedSkillPackFetcher({ git, snapshots, now: () => now, ttlMs: 10 });
+  const one = await first.fetch(pack);
+  const restarted = createCachedSkillPackFetcher({ git, snapshots, now: () => now, ttlMs: 10 });
+  assert.deepEqual(await restarted.fetch(pack), one);
+  assert.equal(calls, 1);
+  now += 100;
+  assert.deepEqual(await restarted.fetch(pack, { expectedCommit: one.commit }), one);
+  assert.equal(calls, 1);
+  const two = await restarted.fetch(pack);
+  assert.equal(calls, 2);
+  assert.notEqual(two.commit, one.commit);
+  assert.deepEqual(await restarted.fetch(pack, { expectedCommit: one.commit }), one);
+  await assert.rejects(restarted.fetch(pack, { expectedCommit: "f".repeat(40) }), /preview expired/);
+});
+
+test("never reuses a snapshot after source or credential identity changes", async () => {
+  let calls = 0;
+  const source = createCachedSkillPackFetcher({
+    snapshots: createMemoryMap(),
+    git: { fetch: async () => repo(String(++calls).repeat(40)), resolveRef: async () => "" },
+  });
+  const first = await source.fetch(pack);
+  await assert.rejects(
+    source.fetch({ ...pack, url: "https://example.com/other" }, { expectedCommit: first.commit }),
+    /preview expired/,
+  );
+  await source.fetch({ ...pack, authCredentialSlug: "new-token" });
+  await source.fetch({ ...pack, createdBy: "other-admin" });
+  await source.fetch({ ...pack, ref: "other-branch" });
+  assert.equal(calls, 4);
+});
+
+test("a failed forced refresh preserves the previous snapshot but does not report success", async () => {
+  let fail = false;
+  const source = createCachedSkillPackFetcher({
+    snapshots: createMemoryMap(),
+    git: {
+      fetch: async () => {
+        if (fail) throw new Error("offline");
+        return repo("a".repeat(40));
+      },
+      resolveRef: async () => "",
+    },
+  });
+  const original = await source.fetch(pack);
+  fail = true;
+  await assert.rejects(source.fetch(pack, { refresh: true }), /offline/);
+  assert.deepEqual(await source.fetch(pack, { expectedCommit: original.commit }), original);
+});
+
+test("deduplicates concurrent downloads and retries after failures", async () => {
+  let calls = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const source = createCachedSkillPackFetcher({
+    snapshots: createMemoryMap(),
+    git: {
+      fetch: async () => {
+        calls++;
+        await gate;
+        return repo("a".repeat(40));
+      },
+      resolveRef: async () => "",
+    },
+  });
+  const a = source.fetch(pack);
+  const b = source.fetch(pack);
+  release();
+  assert.deepEqual(await a, await b);
+  assert.equal(calls, 1);
+});
+
+test("offline packs survive reconstruction, retain one previous upload and never call Git", async () => {
+  const snapshots = createMemoryMap<SkillPackSourceSnapshot>();
+  const git = {
+    fetch: async () => {
+      throw new Error("Git must not run");
+    },
+    resolveRef: async () => {
+      throw new Error("Git must not run");
+    },
+  };
+  const archive = { ...pack, kind: "archive" as const, ref: "a".repeat(64), url: "pack.zip" };
+  const first = createCachedSkillPackFetcher({ snapshots, git });
+  await first.storeArchive!(archive, repo(archive.ref));
+  const restarted = createCachedSkillPackFetcher({ snapshots, git });
+  assert.equal((await restarted.fetch(archive)).commit, archive.ref);
+  assert.equal(await restarted.resolveRef(archive), archive.ref);
+  const next = { ...archive, ref: "b".repeat(64), url: "new.zip" };
+  await restarted.storeArchive!(next, repo(next.ref));
+  assert.equal((await restarted.fetch(next)).commit, next.ref);
+  assert.equal((await restarted.fetch(archive)).commit, archive.ref);
+  await assert.rejects(restarted.fetch(next, { expectedCommit: archive.ref }), /version changed/);
+  await restarted.remove!(archive);
+  await assert.rejects(restarted.fetch(archive), /unavailable/);
+});

--- a/test/skill-packs-routes.test.ts
+++ b/test/skill-packs-routes.test.ts
@@ -10,6 +10,7 @@ import type { AddressInfo } from "node:net";
 import { createInsecureTestServer } from "../src/api/server.ts";
 import { buildApp } from "../src/wiring.ts";
 import { testConfig } from "./support/test-config.ts";
+import { skillZip } from "./support/skill-zip.ts";
 
 const ADMIN = { "x-admin-actor": "admin-alice@default-org", "content-type": "application/json" };
 const json = async (r: Response): Promise<any> => r.json();
@@ -106,6 +107,7 @@ function start() {
     auditLog: built.auditLog,
     sessions: built.sessions,
     errors: built.errors,
+    blobTransfer: built.blobTransfer,
   });
   server.listen(0);
   return {
@@ -114,6 +116,151 @@ function start() {
     close: () => new Promise<void>((r) => server.close(() => r())),
   };
 }
+
+test("offline upload previews, imports, updates and selects the previous version through the same pack", async () => {
+  const s = start();
+  const upload = async (description: string, id?: string) => {
+    const bytes = skillZip([
+      { path: "bundle/SKILL.md", text: md(`name: offline-basic\ndescription: ${description}`) },
+      { path: "bundle/config.json", text: '{"ready":true}' },
+    ]);
+    const { blobId } = await s.built.blobTransfer.put(bytes);
+    const response = await fetch(`${s.base}/v1/admin/skill-packs/${id ? id + "/" : ""}upload`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ blobId, name: "offline.zip" }),
+    });
+    await response.clone().text();
+    assert.equal(await s.built.blobTransfer.open(blobId), null);
+    return response;
+  };
+  const importVersion = (id: string, commit: string) =>
+    fetch(`${s.base}/v1/admin/skill-packs/${id}/import`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ selected: "all", expectedCommit: commit }),
+    });
+  try {
+    const firstResponse = await upload("first");
+    assert.equal(firstResponse.status, 200);
+    const first = (await json(firstResponse)).pack;
+    assert.equal(first.kind, "archive");
+    assert.equal(first.trustTier, "third-party");
+    assert.equal(first.available, 1);
+    assert.equal((await s.built.skills.list()).filter((skill) => skill.pack?.packId === first.id).length, 0);
+    const preview = await json(await fetch(`${s.base}/v1/admin/skill-packs/${first.id}/catalog`, { headers: ADMIN }));
+    assert.equal(preview.commit, first.ref);
+    assert.equal((await importVersion(first.id, preview.commit)).status, 200);
+    let installed = (await s.built.skills.list()).find((skill) => skill.pack?.packId === first.id)!;
+    assert.equal(installed.manifest.description, "first");
+    assert.equal(installed.manifest.files?.[0]?.path, "config.json");
+
+    const nextResponse = await upload("second", first.id);
+    assert.equal(nextResponse.status, 200);
+    const next = (await json(nextResponse)).pack;
+    assert.equal(next.previousRef, first.ref);
+    assert.notEqual(next.ref, first.ref);
+    const stale = await importVersion(first.id, first.ref);
+    assert.equal(stale.status, 409);
+    installed = (await s.built.skills.list()).find((skill) => skill.pack?.packId === first.id)!;
+    assert.equal(installed.manifest.description, "first");
+    assert.equal((await importVersion(first.id, next.ref)).status, 200);
+    installed = (await s.built.skills.list()).find((skill) => skill.pack?.packId === first.id)!;
+    assert.equal(installed.manifest.description, "second");
+    const rollback = await fetch(`${s.base}/v1/admin/skill-packs/${first.id}`, {
+      method: "PATCH",
+      headers: ADMIN,
+      body: JSON.stringify({ ref: first.ref }),
+    });
+    assert.equal(rollback.status, 200);
+    assert.equal((await importVersion(first.id, first.ref)).status, 200);
+    installed = (await s.built.skills.list()).find((skill) => skill.pack?.packId === first.id)!;
+    assert.equal(installed.manifest.description, "first");
+    const thirdResponse = await upload("third", first.id);
+    assert.equal(thirdResponse.status, 200);
+    const third = (await json(thirdResponse)).pack;
+    assert.equal(third.previousRef, first.ref);
+    assert.equal((await importVersion(first.id, third.ref)).status, 200);
+    const rollbackAgain = await fetch(`${s.base}/v1/admin/skill-packs/${first.id}`, {
+      method: "PATCH",
+      headers: ADMIN,
+      body: JSON.stringify({ ref: first.ref }),
+    });
+    assert.equal(rollbackAgain.status, 200);
+    assert.equal((await importVersion(first.id, first.ref)).status, 200);
+    installed = (await s.built.skills.list()).find((skill) => skill.pack?.packId === first.id)!;
+    assert.equal(installed.manifest.description, "first");
+    const list = await json(await fetch(`${s.base}/v1/admin/skill-packs`, { headers: ADMIN }));
+    assert.equal(list.packs.length, 1);
+    assert.equal(list.packs[0].importedCount, 1);
+  } finally {
+    await s.close();
+  }
+});
+
+test("offline upload rejects non-admin callers and malformed archives without creating packs", async () => {
+  const s = start();
+  try {
+    const { blobId } = await s.built.blobTransfer.put(Buffer.from("not a ZIP"));
+    const request = { method: "POST", body: JSON.stringify({ blobId, name: "bad.zip" }) };
+    const denied = await fetch(`${s.base}/v1/admin/skill-packs/upload`, {
+      ...request,
+      headers: { "content-type": "application/json" },
+    });
+    assert.equal(denied.status, 403);
+    const invalid = await fetch(`${s.base}/v1/admin/skill-packs/upload`, { ...request, headers: ADMIN });
+    assert.equal(invalid.status, 400);
+    assert.equal((await json(invalid)).error, "invalid_archive");
+    assert.equal(await s.built.blobTransfer.open(blobId), null);
+    const oversized = await s.built.blobTransfer.put(Buffer.alloc(16 * 1024 * 1024 + 1));
+    const tooLarge = await fetch(`${s.base}/v1/admin/skill-packs/upload`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ blobId: oversized.blobId, name: "large.zip" }),
+    });
+    assert.equal(tooLarge.status, 413);
+    await tooLarge.text();
+    assert.equal(await s.built.blobTransfer.open(oversized.blobId), null);
+    assert.equal((await s.built.app.listSkillPacks()).length, 0);
+  } finally {
+    await s.close();
+  }
+});
+
+test("Git registration, preview and version-bound import reuse the downloaded tree while the source is offline", async () => {
+  const fixture = makeFixtureRepo();
+  const s = start();
+  try {
+    const registered = await json(
+      await fetch(`${s.base}/v1/admin/skill-packs`, {
+        method: "POST",
+        headers: ADMIN,
+        body: JSON.stringify({ url: fixture.dir }),
+      }),
+    );
+    const id = registered.pack.id;
+    rmSync(fixture.dir, { recursive: true, force: true });
+    const preview = await json(await fetch(`${s.base}/v1/admin/skill-packs/${id}/catalog`, { headers: ADMIN }));
+    assert.equal(preview.commit, fixture.sha);
+    const imported = await fetch(`${s.base}/v1/admin/skill-packs/${id}/import`, {
+      method: "POST",
+      headers: ADMIN,
+      body: JSON.stringify({ selected: "all", expectedCommit: preview.commit }),
+    });
+    assert.equal(imported.status, 200);
+    const before = JSON.stringify(await s.built.skills.list());
+    const refresh = await fetch(`${s.base}/v1/admin/skill-packs/${id}/sync`, {
+      method: "POST",
+      headers: ADMIN,
+      body: "{}",
+    });
+    assert.equal(refresh.status, 500);
+    assert.equal(JSON.stringify(await s.built.skills.list()), before);
+  } finally {
+    await s.close();
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
 
 test("register → browse → import → list → remove a git skill pack (org scope)", async () => {
   const repo = makeFixtureRepo();
@@ -435,8 +582,8 @@ test("an older tracked-pack fetch cannot roll back a newer reconciliation", asyn
       release = resolve;
     });
     let first = true;
-    s.built.skillFetcher.fetch = async (pack) => {
-      const fetched = await originalFetch(pack);
+    s.built.skillFetcher.fetch = async (pack, options) => {
+      const fetched = await originalFetch(pack, options);
       if (first) {
         first = false;
         entered();

--- a/test/support/skill-zip.ts
+++ b/test/support/skill-zip.ts
@@ -1,0 +1,56 @@
+import { crc32, deflateRawSync } from "node:zlib";
+
+export function skillZip(
+  entries: Array<{
+    path: string;
+    text?: string;
+    bytes?: Buffer;
+    mode?: number;
+    flags?: number;
+    size?: number;
+    crc?: number;
+  }>,
+): Buffer {
+  const local: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const name = Buffer.from(entry.path);
+    const bytes = entry.bytes ?? Buffer.from(entry.text ?? "");
+    const compressed = deflateRawSync(bytes);
+    const checksum = entry.crc ?? crc32(bytes);
+    const size = entry.size ?? bytes.length;
+    const head = Buffer.alloc(30);
+    head.writeUInt32LE(0x04034b50, 0);
+    head.writeUInt16LE(20, 4);
+    head.writeUInt16LE(entry.flags ?? 0x800, 6);
+    head.writeUInt16LE(8, 8);
+    head.writeUInt32LE(checksum, 14);
+    head.writeUInt32LE(compressed.length, 18);
+    head.writeUInt32LE(size, 22);
+    head.writeUInt16LE(name.length, 26);
+    local.push(head, name, compressed);
+    const directory = Buffer.alloc(46);
+    directory.writeUInt32LE(0x02014b50, 0);
+    directory.writeUInt16LE(0x0314, 4);
+    directory.writeUInt16LE(20, 6);
+    directory.writeUInt16LE(entry.flags ?? 0x800, 8);
+    directory.writeUInt16LE(8, 10);
+    directory.writeUInt32LE(checksum, 16);
+    directory.writeUInt32LE(compressed.length, 20);
+    directory.writeUInt32LE(size, 24);
+    directory.writeUInt16LE(name.length, 28);
+    directory.writeUInt32LE(((entry.mode ?? (entry.path.endsWith("/") ? 0o40755 : 0o100644)) << 16) >>> 0, 38);
+    directory.writeUInt32LE(offset, 42);
+    central.push(directory, name);
+    offset += head.length + name.length + compressed.length;
+  }
+  const centralBytes = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralBytes.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return Buffer.concat([...local, centralBytes, end]);
+}


### PR DESCRIPTION
Offline or unreliable repository access currently prevents skill-pack installation, and preview/import downloads the same source repeatedly. This adds text-only ZIP uploads to Admin → Skills and durable source snapshots shared by repository previews and imports.

ZIPs are validated before installation and imported through the existing scope-aware pipeline. Uploading a replacement stages a version; applying it refreshes already-imported skills. The immediately previous selected ZIP remains available for rollback, including after selecting an older version and uploading a new one. Repository previews reuse a five-minute snapshot, while imports bind to the previewed commit and explicit sync still requires a fresh download.

Uploads keep third-party trust, enforce compressed/expanded/entry limits, reject unsafe or binary entries, and clean up staged transfer blobs. The portal preserves upload metadata without forwarding caller-supplied identity headers.

Validation: 112 affected tests passed across archive/source-cache/routes, existing pack store/fetcher/sync behavior, admin upload/file proxy, and portal routing. Core, admin, and portal typechecks and root ESLint passed. Independent review findings on version retention and temporary-blob cleanup were fixed and rechecked.

A local dev instance with real Postgres completed browser upload → preview → org import → core restart → preview again. The agent harness was mocked and Slack was disabled; neither is involved in this admin workflow. Browser QA used a public text-only skill pack and a synthetic organization, with no production data.

Draft gate: rendered demo screenshots and upstream CI review remain pending. No deployment is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791223202&installation_model_id=19911&pr_number=956&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F956&signature=69ed0fdc5724a93854a73eb421f7e5c5212cd6b5ec1ce0c275ddec4ec51e4ab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->