### PR TITLE
fix(web-ui): stop animating programmatic transcript scrolls

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -900,10 +900,7 @@ export function createChatSurface(
                               requestAnimationFrame(() => {
                                 const scrollerNow = container?.querySelector<HTMLElement>(".chat-scroll");
                                 if (!scrollerNow) return;
-                                const prev = scrollerNow.style.scrollBehavior;
-                                scrollerNow.style.scrollBehavior = "auto";
                                 scrollerNow.scrollTop = priorTop + (scrollerNow.scrollHeight - priorHeight);
-                                scrollerNow.style.scrollBehavior = prev;
                               });
                             } catch {
                               btn.disabled = false;
@@ -1002,10 +999,7 @@ export function createChatSurface(
       requestAnimationFrame(() => {
         const scrollerNow = chatState.host?.querySelector<HTMLElement>(".chat-scroll");
         if (!scrollerNow) return;
-        const prev = scrollerNow.style.scrollBehavior;
-        scrollerNow.style.scrollBehavior = "auto";
         scrollerNow.scrollTop = priorTop + (scrollerNow.scrollHeight - priorHeight);
-        scrollerNow.style.scrollBehavior = prev;
       });
     } catch {
       void 0;
@@ -2332,15 +2326,6 @@ export function createChatSurface(
     if (!scroller) return;
     if (!force && !stickToBottom) return;
     requestAnimationFrame(() => {
-      if (force) {
-        const prev = scroller.style.scrollBehavior;
-        scroller.style.scrollBehavior = "auto";
-        scroller.scrollTop = scroller.scrollHeight;
-        requestAnimationFrame(() => {
-          scroller.style.scrollBehavior = prev;
-        });
-        return;
-      }
       scroller.scrollTop = scroller.scrollHeight;
     });
   }

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -881,9 +881,7 @@ export function createChatSurface(
                                 anchorSeq !== null ? { beforeSeq: anchorSeq, tailTurns: TAIL_TURNS } : undefined,
                               );
                               if (chatState.sessionId !== s.id) return;
-                              const scroller = container?.querySelector<HTMLElement>(".chat-scroll");
-                              const priorHeight = scroller?.scrollHeight ?? 0;
-                              const priorTop = scroller?.scrollTop ?? 0;
+                              const restoreAnchor = holdScrollAnchor(container);
                               const rawRemaining = page.earlierEntries ?? 0;
                               const remaining = currentEarlierCount(s, rawRemaining);
                               const split = inheritedTranscript(s, page.entries ?? []);
@@ -897,11 +895,7 @@ export function createChatSurface(
                                   ...chatState.inheritedMessages,
                                 ],
                               );
-                              requestAnimationFrame(() => {
-                                const scrollerNow = container?.querySelector<HTMLElement>(".chat-scroll");
-                                if (!scrollerNow) return;
-                                scrollerNow.scrollTop = priorTop + (scrollerNow.scrollHeight - priorHeight);
-                              });
+                              restoreAnchor();
                             } catch {
                               btn.disabled = false;
                               btn.textContent = "Show earlier messages";
@@ -987,20 +981,14 @@ export function createChatSurface(
           ...entriesToMessages(split.inherited, transcriptModel()),
           ...chatState.inheritedMessages,
         ];
-      const scroller = chatState.host?.querySelector<HTMLElement>(".chat-scroll");
-      const priorHeight = scroller?.scrollHeight ?? 0;
-      const priorTop = scroller?.scrollTop ?? 0;
+      const restoreAnchor = holdScrollAnchor(chatState.host);
       agent.state.messages = [...earlierMessages, ...agent.state.messages];
       const rawRemaining = page.earlierEntries ?? 0;
       chatState.transcriptAnchorSeq = rawRemaining > 0 ? (page.entries?.[0]?.seq ?? null) : null;
       chatState.earlierCount = currentEarlierCount(chatState.forkSession ?? {}, rawRemaining);
       chatState.loadingEarlier = false;
       drawActiveChat(agent);
-      requestAnimationFrame(() => {
-        const scrollerNow = chatState.host?.querySelector<HTMLElement>(".chat-scroll");
-        if (!scrollerNow) return;
-        scrollerNow.scrollTop = priorTop + (scrollerNow.scrollHeight - priorHeight);
-      });
+      restoreAnchor();
     } catch {
       void 0;
     } finally {
@@ -2319,6 +2307,17 @@ export function createChatSurface(
   function scrollToBottom(): void {
     stickToBottom = true;
     scrollTranscript(true);
+  }
+
+  function holdScrollAnchor(root: ParentNode | null | undefined): () => void {
+    const scroller = root?.querySelector<HTMLElement>(".chat-scroll");
+    const priorHeight = scroller?.scrollHeight ?? 0;
+    const priorTop = scroller?.scrollTop ?? 0;
+    return () =>
+      requestAnimationFrame(() => {
+        const now = root?.querySelector<HTMLElement>(".chat-scroll");
+        if (now) now.scrollTop = priorTop + (now.scrollHeight - priorHeight);
+      });
   }
 
   function scrollTranscript(force = false): void {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1260,7 +1260,6 @@ a.chat-row-open {
   overflow-y: auto;
 
   padding: 28px var(--chat-pad) 8px;
-  scroll-behavior: smooth;
 }
 
 .fork-origin-row {

--- a/plugins/web-ui/test/layout-thrash.test.ts
+++ b/plugins/web-ui/test/layout-thrash.test.ts
@@ -45,6 +45,10 @@ test("revealing a transcript re-arms auto-follow; read-only mounts start at the 
 test("programmatic transcript scrolls never animate", () => {
   assert.doesNotMatch(css, /scroll-behavior:\s*smooth/);
   assert.doesNotMatch(chat, /scrollBehavior/);
-  const anchors = chat.match(/scrollerNow\.scrollTop = priorTop \+ \(scrollerNow\.scrollHeight - priorHeight\);/g);
-  assert.equal(anchors?.length, 2);
+});
+
+test("both pagination paths keep the viewport anchored through one helper", () => {
+  assert.match(chat, /function holdScrollAnchor\(root: ParentNode \| null \| undefined\): \(\) => void/);
+  assert.equal(chat.match(/const restoreAnchor = holdScrollAnchor\(/g)?.length, 2);
+  assert.equal(chat.match(/restoreAnchor\(\);/g)?.length, 2);
 });

--- a/plugins/web-ui/test/layout-thrash.test.ts
+++ b/plugins/web-ui/test/layout-thrash.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 
 test("resizeComposer skips the forced-reflow measure pass when the draft value is unchanged", () => {
   const fn = composer.match(/function resizeComposer\(\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
@@ -41,9 +42,9 @@ test("revealing a transcript re-arms auto-follow; read-only mounts start at the 
   assert.match(chat, /const scroller = ctx\.container\(\)\?\.querySelector/);
 });
 
-test("both pagination paths adjust their anchor without smooth scrolling", () => {
-  const anchors = chat.match(
-    /const prev = scrollerNow\.style\.scrollBehavior;\s*scrollerNow\.style\.scrollBehavior = "auto";\s*scrollerNow\.scrollTop = priorTop \+ \(scrollerNow\.scrollHeight - priorHeight\);\s*scrollerNow\.style\.scrollBehavior = prev;/g,
-  );
+test("programmatic transcript scrolls never animate", () => {
+  assert.doesNotMatch(css, /scroll-behavior:\s*smooth/);
+  assert.doesNotMatch(chat, /scrollBehavior/);
+  const anchors = chat.match(/scrollerNow\.scrollTop = priorTop \+ \(scrollerNow\.scrollHeight - priorHeight\);/g);
   assert.equal(anchors?.length, 2);
 });


### PR DESCRIPTION
## Problem

When a run ended with a pending approval, the web-ui transcript visibly scrolled from the top of the conversation all the way to the bottom as an animation.

The transcript scroller (`.chat-scroll`) had `scroll-behavior: smooth`. That property only affects programmatic scrolls (assigning `scrollTop`), never wheel or trackpad input. Every redraw that re-sticks the transcript to the bottom therefore animated, and when the scroller had been rebuilt at the top the animation covered the whole conversation.

## Change

- Remove `scroll-behavior: smooth` from `.chat-scroll`.
- Delete the three call sites that flipped `style.scrollBehavior` to `auto` and back to dodge the animation (forced scroll-to-bottom, and both pagination anchor adjustments). They are now plain `scrollTop` writes.
- The layout test now asserts no smooth scrolling in the transcript CSS and no `scrollBehavior` juggling in `chat.ts`, and still asserts both pagination anchors exist.

Net: 5 insertions, 20 deletions.

## Demo

Behavior-only change: the after state renders pixel-identical to before, the difference is that scroll-to-bottom is now instant instead of animated. No screenshot can show it, so none attached. To see it: open a long conversation, trigger a run that ends in an approval, and observe the transcript snaps to the pending approval instead of animating from the top.

## Verification

- `plugins/web-ui`: `layout-thrash`, `tab-switch-scroll-snap`, `pane-approval-overflow` tests pass.
- `plugins/web-ui` typecheck passes; eslint clean on changed files.

## Not in this PR

The screenshot that prompted this also asked for an "allow always" option on security-screen quarantine releases. Those are deliberately once-only in the orchestrator (server-side guard plus tests). The existing knob is the `security-posture` admin resource (`dangerous` disables content screening). Left unchanged here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791245311&installation_model_id=19911&pr_number=959&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F959&signature=6adead0b6678746c5b3a2f2c479f381309d0472ec63d85b9493745f4af3e8d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->