### PR TITLE
feat(web-ui): chat interface refresh — attachment previews, date-first sidebar, 3D thinking orb and seven motion upgrades

### DIFF
--- a/plugins/web-ui/src/attachment-preview.ts
+++ b/plugins/web-ui/src/attachment-preview.ts
@@ -1,0 +1,60 @@
+import type { Attachment } from "@earendil-works/pi-web-ui";
+import { html, type TemplateResult } from "lit";
+import { File as FileGlyph } from "lucide";
+import { formatBytes, icon } from "./ui";
+
+const KIND_LABELS: Record<string, string> = {
+  "application/pdf": "PDF",
+  "application/json": "JSON",
+  "text/csv": "CSV",
+  "text/markdown": "Markdown",
+  "text/plain": "Plain text",
+};
+
+const PREVIEW_TEXT_CHARS = 700;
+
+export function attachmentKind(mimeType: string): string {
+  const known = KIND_LABELS[mimeType];
+  if (known) return known;
+  const [type, subtype = ""] = mimeType.split("/");
+  const label = subtype.replace(/^x-/, "").toUpperCase() || "File";
+  return type === "image" ? `${label} image` : label;
+}
+
+function previewImageSrc(a: Attachment): string | null {
+  if (a.type === "image") return `data:${a.mimeType};base64,${a.preview ?? a.content}`;
+  return a.preview ? `data:image/png;base64,${a.preview}` : null;
+}
+
+function previewBody(a: Attachment, kind: string): TemplateResult {
+  const src = previewImageSrc(a);
+  if (src) return html`<img class="attachment-preview-image" src=${src} alt="" />`;
+  if (a.extractedText) {
+    const lines = a.extractedText.split("\n").length;
+    return html`<pre class="attachment-preview-text">${a.extractedText.slice(0, PREVIEW_TEXT_CHARS)}</pre>
+      <div class="attachment-preview-meta">${lines} ${lines === 1 ? "line" : "lines"}</div>`;
+  }
+  return html`<div class="attachment-preview-empty">
+    ${icon(FileGlyph, 40)}
+    <div>${kind}</div>
+  </div>`;
+}
+
+export function attachmentPreview(a: Attachment): TemplateResult {
+  const kind = attachmentKind(a.mimeType);
+  return html`<div class="attachment-preview">
+    <div class="attachment-preview-head">
+      <div class="attachment-preview-name">${a.fileName}</div>
+      <div class="attachment-preview-meta">${kind} · ${formatBytes(a.size)}</div>
+    </div>
+    ${previewBody(a, kind)}
+  </div>`;
+}
+
+export function dismissPreviewOnEscape(e: KeyboardEvent): void {
+  if (e.key === "Escape") (e.currentTarget as HTMLElement).classList.add("preview-dismissed");
+}
+
+export function restorePreview(e: Event): void {
+  (e.currentTarget as HTMLElement).classList.remove("preview-dismissed");
+}

--- a/plugins/web-ui/src/attachment-preview.ts
+++ b/plugins/web-ui/src/attachment-preview.ts
@@ -21,9 +21,16 @@ export function attachmentKind(mimeType: string): string {
   return type === "image" ? `${label} image` : label;
 }
 
+const imageSrcCache = new WeakMap<Attachment, string | null>();
+
 function previewImageSrc(a: Attachment): string | null {
-  if (a.type === "image") return `data:${a.mimeType};base64,${a.preview ?? a.content}`;
-  return a.preview ? `data:image/png;base64,${a.preview}` : null;
+  const cached = imageSrcCache.get(a);
+  if (cached !== undefined) return cached;
+  let src: string | null = null;
+  if (a.type === "image") src = `data:${a.mimeType};base64,${a.preview ?? a.content}`;
+  else if (a.preview) src = `data:image/png;base64,${a.preview}`;
+  imageSrcCache.set(a, src);
+  return src;
 }
 
 function previewBody(a: Attachment, kind: string): TemplateResult {

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1580,7 +1580,7 @@ export function createChatSurface(
   }
 
   function typingRow(): TemplateResult {
-    return html`<div class="thinking-placeholder">${sheenLabel("Thinking", true)}</div>`;
+    return html`<div class="thinking-placeholder">${thinkingOrb("lg")}${sheenLabel("Thinking", true)}</div>`;
   }
 
   function syncWorkTicker(): void {
@@ -1895,7 +1895,7 @@ export function createChatSurface(
           title=${title}
           @click=${toggleLiveWorkExpanded}
         >
-          ${summary ? html`<span class="tool-icon">${icon(summary.icon, 15)}</span>` : nothing}
+          ${summary ? html`<span class="tool-icon">${icon(summary.icon, 15)}</span>` : thinkingOrb("sm")}
           <span class="live-work-label"
             >${summary ? summary.label : sheenLabel(`Thinking${usedToolsSuffix(work)}`, true)}</span
           >
@@ -1986,7 +1986,9 @@ export function createChatSurface(
   function workBlock(work: WorkBlock, isStreaming: boolean): TemplateResult {
     if (work.status === "thinking" && !work.activity.length) {
       return html`<div class="work work-thinking">
-        <div class="work-head">${sheenLabel(workLabel(work), isStreaming)}</div>
+        <div class="work-head">
+          ${isStreaming ? thinkingOrb("sm") : nothing}${sheenLabel(workLabel(work), isStreaming)}
+        </div>
       </div>`;
     }
     const timeline = buildTimeline(work);
@@ -1997,7 +1999,9 @@ export function createChatSurface(
       ${rows}`;
     if (isStreaming || work.status === "working" || work.status === "thinking") {
       return html`<div class="work work-working">
-        <div class="work-head">${sheenLabel(workLabel(work), isStreaming)}</div>
+        <div class="work-head">
+          ${isStreaming ? thinkingOrb("sm") : nothing}${sheenLabel(workLabel(work), isStreaming)}
+        </div>
         ${body}
       </div>`;
     }
@@ -2091,6 +2095,21 @@ export function createChatSurface(
     return html`<div class="approval-card inline-approval-marker">
       <div class="approval-text">${approvalSummaryView(a)}</div>
     </div>`;
+  }
+
+  const orbVariants = ["gyro", "tesseract", "orbit"] as const;
+
+  function orbVariantFor(key: string): (typeof orbVariants)[number] {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) hash = (hash * 31 + key.charCodeAt(i)) | 0;
+    return orbVariants[Math.abs(hash) % orbVariants.length];
+  }
+
+  function thinkingOrb(size: "sm" | "lg", variant = orbVariantFor(chatState.threadRef ?? "")): TemplateResult {
+    const rings = variant === "tesseract" ? 4 : 3;
+    return html`<span class="think-orb think-orb-${size}" data-variant=${variant} aria-hidden="true"
+      ><span class="orb-core"></span>${Array.from({ length: rings }, () => html`<span class="orb-ring"></span>`)}</span
+    >`;
   }
 
   function sheenLabel(label: string, active: boolean): TemplateResult {

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -6,6 +6,7 @@ import "./marked-dedupe";
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import "@mariozechner/mini-lit/dist/CodeBlock.js";
 import { html, nothing, render, type TemplateResult } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import {
   Activity,
   ArrowDown,
@@ -1056,7 +1057,7 @@ export function createChatSurface(
     if (activePendingApprovals().length) return "Needs your approval";
     if (runIsLive(agent)) {
       const work = chatState.liveWork ?? { status: "thinking", activity: [] };
-      const summary = liveWorkSummary(work);
+      const summary = liveWorkSummary(work, activeToolRow(work));
       if (!summary) return "Thinking…";
       return summary.detail ? `${summary.label} — ${summary.detail}` : summary.label;
     }
@@ -1892,11 +1893,13 @@ export function createChatSurface(
     if (!runIsLive(agent)) return nothing;
     const work = chatState.liveWork ?? { status: "thinking", activity: [] };
     if (work.status !== "thinking" && work.status !== "working") return nothing;
-    const summary = liveWorkSummary(work);
+    const active = activeToolRow(work);
+    const summary = liveWorkSummary(work, active);
     const expandable = Boolean(summary?.detail);
     const expanded = expandable && liveWorkExpanded;
     let title = "";
     if (expandable) title = liveWorkExpanded ? "Show less" : "Show more";
+    const faceKey = work.stale ? "stale" : (active?.call?.seq ?? "thinking");
     return html`
       <section class="live-work-dock ${expanded ? "expanded" : ""}" aria-live="polite">
         <button
@@ -1907,11 +1910,16 @@ export function createChatSurface(
           title=${title}
           @click=${toggleLiveWorkExpanded}
         >
-          ${summary ? html`<span class="tool-icon">${icon(summary.icon, 15)}</span>` : thinkingOrb("sm")}
-          <span class="live-work-label"
-            >${summary ? summary.label : sheenLabel(`Thinking${usedToolsSuffix(work)}`, true)}</span
-          >
-          ${summary?.detail ? html`<span class="live-work-detail">${summary.detail}</span>` : nothing}
+          ${keyed(
+            faceKey,
+            html`<span class="live-work-face"
+              >${summary ? html`<span class="tool-icon">${icon(summary.icon, 15)}</span>` : thinkingOrb("sm")}
+              <span class="live-work-label"
+                >${summary ? summary.label : sheenLabel(`Thinking${usedToolsSuffix(work)}`, true)}</span
+              >
+              ${summary?.detail ? html`<span class="live-work-detail">${summary.detail}</span>` : nothing}</span
+            >`,
+          )}
           ${expandable ? html`<span class="live-work-toggle">${icon(ChevronRight, 14)}</span>` : nothing}
         </button>
       </section>
@@ -1923,9 +1931,11 @@ export function createChatSurface(
     drawActiveChat();
   }
 
-  function liveWorkSummary(work: WorkBlock): { icon: IconNode; label: string; detail: string } | null {
+  function liveWorkSummary(
+    work: WorkBlock,
+    active: ToolRowModel | null,
+  ): { icon: IconNode; label: string; detail: string } | null {
     if (work.stale) {
-      const active = activeToolRow(work);
       const call = (active?.call?.payload ?? {}) as ToolPayload;
       const tool = call.tool ?? "";
       const verb = active ? (TOOL_META[tool] ?? UNKNOWN_TOOL).active : null;
@@ -1935,7 +1945,6 @@ export function createChatSurface(
         detail: active ? toolDetail(tool, call, (active.result?.payload ?? {}) as ToolPayload) : "",
       };
     }
-    const active = activeToolRow(work);
     return active ? activeToolSummary(active, work) : null;
   }
 

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -106,7 +106,7 @@ import { playgroundPath, playgroundsIn, type PlaygroundArtifact } from "./playgr
 installMarkdownSanitizer();
 
 const detachedAgents = new WeakSet<Agent>();
-const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+export const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 interface SettledRowKey {
   index: number;
   activity: WorkBlock["activity"] | undefined;

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -8,6 +8,7 @@ import "@mariozechner/mini-lit/dist/CodeBlock.js";
 import { html, nothing, render, type TemplateResult } from "lit";
 import {
   Activity,
+  ArrowDown,
   Ban,
   Brain,
   Check,
@@ -1053,7 +1054,7 @@ export function createChatSurface(
 
   function paneNowLine(agent: Agent): string | null {
     if (activePendingApprovals().length) return "Needs your approval";
-    if (agent.state.isStreaming || chatState.resolvingApprovals.size > 0) {
+    if (runIsLive(agent)) {
       const work = chatState.liveWork ?? { status: "thinking", activity: [] };
       const summary = liveWorkSummary(work);
       if (!summary) return "Thinking…";
@@ -1107,8 +1108,8 @@ export function createChatSurface(
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${backgroundActivityStrip()} ${liveWorkDock(agent)} ${ctx.composer.queuedStrip(agent)}
-            ${ctx.composer.composerForm(agent)}
+            ${newBelowPill(agent)} ${backgroundActivityStrip()} ${liveWorkDock(agent)}
+            ${ctx.composer.queuedStrip(agent)} ${ctx.composer.composerForm(agent)}
           </div>
         </div>
       `,
@@ -1876,8 +1877,19 @@ export function createChatSurface(
     `;
   }
 
+  function runIsLive(agent: Agent): boolean {
+    return agent.state.isStreaming || chatState.resolvingApprovals.size > 0;
+  }
+
+  function newBelowPill(agent: Agent): TemplateResult | typeof nothing {
+    if (!runIsLive(agent)) return nothing;
+    return html`<button type="button" class="new-below-pill" ?inert=${stickToBottom} @click=${scrollToBottom}>
+      ${icon(ArrowDown, 14)}<span>New activity below</span>
+    </button>`;
+  }
+
   function liveWorkDock(agent: Agent): TemplateResult | typeof nothing {
-    if (!agent.state.isStreaming && chatState.resolvingApprovals.size === 0) return nothing;
+    if (!runIsLive(agent)) return nothing;
     const work = chatState.liveWork ?? { status: "thinking", activity: [] };
     if (work.status !== "thinking" && work.status !== "working") return nothing;
     const summary = liveWorkSummary(work);
@@ -2339,11 +2351,20 @@ export function createChatSurface(
   function onTranscriptScroll(e: Event): void {
     const s = e.currentTarget as HTMLElement;
     stickToBottom = s.scrollHeight - s.scrollTop - s.clientHeight <= 120;
+    syncScrolledUp();
   }
 
   function scrollToBottom(): void {
     stickToBottom = true;
     scrollTranscript(true);
+    syncScrolledUp();
+  }
+
+  function syncScrolledUp(): void {
+    if (!chatState.host) return;
+    chatState.host.classList.toggle("scrolled-up", !stickToBottom);
+    const pill = chatState.host.querySelector<HTMLElement>(".new-below-pill");
+    if (pill) pill.inert = stickToBottom;
   }
 
   function scrollTranscript(force = false): void {

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -53,6 +53,7 @@ import type { ComposerSurface, ConvCtx } from "./conv-types";
 import { bumpSessionActivity, dropPendingSession, renderList } from "./sessions";
 import { appState } from "./shell";
 import { base64ToText, bytesToBase64, insertIntoDraft, pasteChipLabel } from "./paste-text";
+import { attachmentPreview, dismissPreviewOnEscape, restorePreview } from "./attachment-preview";
 import { clearDraft, newChatDraftKey, saveDraft } from "./drafts";
 
 export type ComposerMenu = "effort" | "harness" | "model" | "settings";
@@ -502,7 +503,12 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                 <div class="attachment-strip">
                   ${composerState.attachments.map(
                     (a) => html`
-                      <span class="file-chip">
+                      <span
+                        class="file-chip"
+                        @keydown=${dismissPreviewOnEscape}
+                        @pointerleave=${restorePreview}
+                        @focusout=${restorePreview}
+                      >
                         ${
                           pastedTextIds.has(a.id)
                             ? html`
@@ -526,6 +532,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
                         >
                           ${icon(X, 13)}
                         </button>
+                        ${attachmentPreview(a)}
                       </span>
                     `,
                   )}

--- a/plugins/web-ui/src/session-list.ts
+++ b/plugins/web-ui/src/session-list.ts
@@ -1,18 +1,4 @@
-import { sharedContextLabel, type CoreContext, type CoreProject, type CoreSession } from "./core-bridge.ts";
-
-type ProjectAwareContext = CoreContext & { project?: CoreProject };
-
-type RecentGroupKind = "personal" | "project" | "channel" | "group";
-
-export interface RecentProjectSeed {
-  scopeId: string;
-  name: string | null;
-  kind?: RecentGroupKind;
-}
-
-export type RecentItem =
-  | { kind: "session"; session: CoreSession }
-  | { kind: "project"; scopeId: string; name: string | null; groupKind: RecentGroupKind; sessions: CoreSession[] };
+import type { CoreSession } from "./core-bridge.ts";
 
 export function activityOf(s: CoreSession): number {
   return s.lastActivityAt ?? s.createdAt;
@@ -36,53 +22,6 @@ export function chatBrowseStatusMatches(
   return status === "waiting" ? Boolean(session.awaitingInput) : !session.awaitingInput;
 }
 
-export function recentProjectSeeds(contexts: readonly ProjectAwareContext[]): RecentProjectSeed[] {
-  return contexts.map((context): RecentProjectSeed => {
-    if (context.project)
-      return { scopeId: context.scopeId, name: context.project.name.trim() || null, kind: "project" };
-    if (context.kind === "personal") return { scopeId: context.scopeId, name: "Personal", kind: "personal" };
-    if (context.kind === "group")
-      return { scopeId: context.scopeId, name: sharedContextLabel(context.scopeId, context.name), kind: "group" };
-    return { scopeId: context.scopeId, name: sharedContextLabel(context.scopeId, context.name), kind: "channel" };
-  });
-}
-
-export function groupProjectSessions(
-  sessions: readonly CoreSession[],
-  projectSeeds: readonly RecentProjectSeed[],
-): RecentItem[] {
-  const seeds = new Map(projectSeeds.map((seed) => [seed.scopeId, seed]));
-  const projects = new Map<string, Extract<RecentItem, { kind: "project" }>>();
-  const items: RecentItem[] = [];
-  for (const session of [...sessions].sort((a, b) => activityOf(b) - activityOf(a))) {
-    const seed = seeds.get(session.scopeId);
-    if (!seed) {
-      items.push({ kind: "session", session });
-      continue;
-    }
-    let project = projects.get(session.scopeId);
-    if (!project) {
-      project = {
-        kind: "project",
-        scopeId: session.scopeId,
-        name: seed.name,
-        groupKind: seed.kind ?? "project",
-        sessions: [],
-      };
-      projects.set(session.scopeId, project);
-      items.push(project);
-    }
-    project.sessions.push(session);
-  }
-  for (const seed of projectSeeds) {
-    if (projects.has(seed.scopeId)) continue;
-    const kind = seed.kind ?? "project";
-    if (kind === "channel" || kind === "group") continue;
-    items.push({ kind: "project", scopeId: seed.scopeId, name: seed.name, groupKind: kind, sessions: [] });
-  }
-  return items;
-}
-
 export function recencyGroup(ms: number, now = Date.now()): string {
   const d = new Date(now);
   const dayStart = (back: number): number => new Date(d.getFullYear(), d.getMonth(), d.getDate() - back).getTime();
@@ -91,6 +30,20 @@ export function recencyGroup(ms: number, now = Date.now()): string {
   if (ms >= dayStart(6)) return "Previous 7 days";
   if (ms >= dayStart(29)) return "Previous 30 days";
   return "Older";
+}
+
+export function bucketByRecency(
+  sessions: readonly CoreSession[],
+  now = Date.now(),
+): { label: string; sessions: CoreSession[] }[] {
+  const buckets = new Map<string, CoreSession[]>();
+  for (const s of [...sessions].sort((a, b) => activityOf(b) - activityOf(a))) {
+    const label = recencyGroup(activityOf(s), now);
+    const bucket = buckets.get(label);
+    if (bucket) bucket.push(s);
+    else buckets.set(label, [s]);
+  }
+  return [...buckets].map(([label, rows]) => ({ label, sessions: rows }));
 }
 
 export function withPendingSession(list: CoreSession[], pending: CoreSession): CoreSession[] {

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -355,6 +355,27 @@ export function renderList(): void {
     requestAnimationFrame(() => placeSessionMenu(appState.listEl?.querySelector(".session-menu-popover") ?? undefined));
   }
   notifySessionsChanged();
+  placeActiveIndicator();
+}
+
+function placeActiveIndicator(): void {
+  requestAnimationFrame(() => {
+    const el = appState.listEl;
+    if (!el) return;
+    const row = [...el.querySelectorAll<HTMLElement>(".session-row.active")].find((r) => !r.closest("[hidden]"));
+    if (!row) {
+      el.style.setProperty("--active-on", "0");
+      return;
+    }
+    const rect = row.getBoundingClientRect();
+    el.style.setProperty("--active-y", `${rect.top - el.getBoundingClientRect().top + el.scrollTop}px`);
+    el.style.setProperty("--active-h", `${rect.height}px`);
+    const color = row.style.getPropertyValue("--session-color").trim();
+    if (color) el.style.setProperty("--active-color", color);
+    else el.style.removeProperty("--active-color");
+    if (el.style.getPropertyValue("--active-on") === "1") return;
+    requestAnimationFrame(() => el.style.setProperty("--active-on", "1"));
+  });
 }
 
 function projectsSection(sessions: readonly CoreSession[]): TemplateResult | typeof nothing {

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -13,7 +13,6 @@ import {
   Cog,
   EllipsisVertical,
   Folder,
-  Hash,
   Link,
   Lock,
   Palette,
@@ -23,8 +22,6 @@ import {
   Plus,
   RefreshCw,
   SquareTerminal,
-  User,
-  Users,
   X,
 } from "lucide";
 import {
@@ -48,17 +45,14 @@ import {
 import { deepLinkPath, isPlainLeftClick, sessionLink, UI_BASE } from "./deep-link";
 import {
   activityOf,
+  bucketByRecency,
   chatBrowseStatusMatches,
   bumpActivity,
-  groupProjectSessions,
-  recencyGroup,
-  recentProjectSeeds,
   reconcileSessions,
   rowIndicators,
   splitPinned,
   withPendingSession,
   withoutUnsentPending,
-  type RecentItem,
   type ChatBrowseStatus,
 } from "./session-list";
 import { hideTooltip, showTooltip } from "./tooltip";
@@ -72,6 +66,7 @@ import {
   personalScopeId,
   renameProject,
   scopeChip,
+  scopeTitle,
 } from "./contexts";
 import { groupDmLabel, groupDmText } from "./group-dm-label";
 import { transcriptModel } from "./model-options";
@@ -108,7 +103,6 @@ export const sessionsState = {
   renamingId: null as string | null,
   openingKey: null as string | null,
   webOnly: true,
-  collapsedProjectScopes: new Set<string>(),
 };
 
 let selection: SessionSelection = emptySelection();
@@ -147,13 +141,27 @@ function visibleRowOrder(): string[] {
 }
 
 const WEB_ONLY_KEY = "web-ui:web-only";
-sessionsState.webOnly = ((): boolean => {
+const PROJECTS_OPEN_KEY = "web-ui:projects-open";
+
+function storedFlag(key: string, fallback: boolean): boolean {
   try {
-    return localStorage.getItem(WEB_ONLY_KEY) !== "0";
+    const raw = localStorage.getItem(key);
+    return raw === null ? fallback : raw !== "0";
   } catch {
-    return true;
+    return fallback;
   }
-})();
+}
+
+function storeFlag(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? "1" : "0");
+  } catch {
+    void 0;
+  }
+}
+
+sessionsState.webOnly = storedFlag(WEB_ONLY_KEY, true);
+let projectsOpen = storedFlag(PROJECTS_OPEN_KEY, true);
 
 let sessionsLoading = false;
 let sessionsNotice = "";
@@ -182,7 +190,6 @@ export function resetSessionsState(): void {
   sessionsState.openMenuId = null;
   sessionsState.renamingId = null;
   sessionsState.openingKey = null;
-  sessionsState.collapsedProjectScopes.clear();
   renameDraft = "";
   refreshingTitleIds.clear();
   showArchived = false;
@@ -192,23 +199,6 @@ export function resetSessionsState(): void {
   chatsPageSurface = "all";
   chatsPageHost = null;
   recentContextsRequest = null;
-}
-
-function projectSeedsForRecents() {
-  return recentProjectSeeds(contextsState.list);
-}
-
-function recentItemActivity(item: RecentItem): number {
-  if (item.kind === "session") return activityOf(item.session);
-  if (item.sessions[0]) return activityOf(item.sessions[0]);
-  const context = contextsState.list.find((candidate) => candidate.scopeId === item.scopeId);
-  return context?.lastActivityAt ?? context?.project?.createdAt ?? context?.project?.updatedAt ?? 0;
-}
-
-function recentItemsFor(sessions: readonly CoreSession[]): RecentItem[] {
-  return groupProjectSessions(sessions, projectSeedsForRecents()).sort(
-    (a, b) => recentItemActivity(b) - recentItemActivity(a),
-  );
 }
 
 function loadRecentContexts(force = false): void {
@@ -317,11 +307,10 @@ export function renderList(): void {
   const active = visible.filter((s) => !s.archived);
   const archived = visible.filter((s) => s.archived);
   const { pinned, rest } = splitPinned(active);
-  const activeItems = recentItemsFor(rest);
-  const archivedItems: RecentItem[] = archived.map((session) => ({ kind: "session", session }));
   armMidnightRefresh();
   render(
     html`
+      ${projectsSection(active)}
       ${
         pinned.length
           ? html`
@@ -334,7 +323,7 @@ export function renderList(): void {
             `
           : nothing
       }
-      ${groupedRows(activeItems)}
+      ${groupedRows(rest)}
       ${
         archived.length
           ? html`
@@ -343,7 +332,7 @@ export function renderList(): void {
                 <span>Archived</span>
                 <span class="archived-count">${archived.length}</span>
               </button>
-              ${showArchived ? groupedRows(archivedItems) : nothing}
+              ${showArchived ? groupedRows(archived) : nothing}
             `
           : nothing
       }
@@ -368,38 +357,50 @@ export function renderList(): void {
   notifySessionsChanged();
 }
 
-function recentItem(item: RecentItem): TemplateResult {
-  if (item.kind === "session") return sessionRow(item.session);
-  const collapsed = sessionsState.collapsedProjectScopes.has(item.scopeId);
-  let glyph = Folder;
-  if (item.groupKind === "personal") glyph = User;
-  else if (item.groupKind === "channel") glyph = Hash;
-  else if (item.groupKind === "group") glyph = Users;
-  let fallbackName = "Project";
-  if (item.groupKind === "channel") fallbackName = "Channel";
-  else if (item.groupKind === "group") fallbackName = "Group DM";
-  const name = item.name ?? fallbackName;
-  const childrenId = `recent-${item.scopeId.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-  const menuKey = projectMenuKey(item.scopeId);
+function projectsSection(sessions: readonly CoreSession[]): TemplateResult | typeof nothing {
+  const projects = contextsState.list.filter((context) => context.project);
+  if (!projects.length) return nothing;
+  return html`
+    <button
+      class="recents-group recents-toggle"
+      type="button"
+      aria-expanded=${projectsOpen ? "true" : "false"}
+      aria-controls="recent-projects"
+      @click=${toggleProjects}
+    >
+      ${icon(projectsOpen ? ChevronDown : ChevronRight, 11)}<span>Projects</span>
+    </button>
+    <div class="recent-projects" id="recent-projects" ?hidden=${!projectsOpen}>
+      ${repeat(
+        projects,
+        (context) => context.scopeId,
+        (context) => projectHead(context.scopeId, context.project?.name.trim() || "Project", sessions),
+      )}
+    </div>
+  `;
+}
+
+function projectHead(scopeId: string, name: string, sessions: readonly CoreSession[]): TemplateResult {
+  const own = sessions.filter((s) => s.scopeId === scopeId);
+  const menuKey = projectMenuKey(scopeId);
   const menuOpen = sessionsState.openMenuId === menuKey;
   return html`
-    <section class="recent-project ${item.sessions.some(isActiveRow) ? "active" : ""}" aria-label=${`${name} project`}>
+    <section class="recent-project ${own.some(isActiveRow) ? "active" : ""}" aria-label=${`${name} project`}>
       ${
         sessionsState.renamingId === menuKey
-          ? projectRenameRow(item)
+          ? projectRenameRow(scopeId)
           : html`<div class="recent-project-head">
               <button
-                class="recent-project-toggle"
+                class="recent-project-open"
                 type="button"
-                aria-expanded=${collapsed ? "false" : "true"}
-                aria-controls=${childrenId}
-                @click=${() => toggleRecentProject(item.scopeId)}
+                title=${`Open ${name}`}
+                @click=${() => openProjectDetail(scopeId)}
               >
-                ${icon(collapsed ? ChevronRight : ChevronDown, 13)} ${icon(glyph, 14)}
-                <span class="recent-project-name">${name.replace(/^#/, "")}</span>
+                ${icon(Folder, 14)}
+                <span class="recent-project-name">${name}</span>
               </button>
               <div class="session-menu recent-project-menu ${menuOpen ? "menu-open" : ""}">
-                <span class="recent-project-count">${item.sessions.length}</span>
+                <span class="recent-project-count">${own.length}</span>
                 <button
                   class="session-menu-btn"
                   data-menu-id=${menuKey}
@@ -412,54 +413,41 @@ function recentItem(item: RecentItem): TemplateResult {
                 >
                   ${icon(EllipsisVertical, 17)}
                 </button>
-                ${menuOpen ? projectMenuPopover(item) : nothing}
+                ${menuOpen ? projectMenuPopover(scopeId, name) : nothing}
               </div>
               <button
                 class="recent-project-new-chat"
                 type="button"
                 aria-label=${`New chat in ${name}`}
                 title=${`New chat in ${name}`}
-                @click=${(event: Event) => startProjectChat(event, item.scopeId, item.name)}
+                @click=${(event: Event) => startProjectChat(event, scopeId)}
               >
                 ${icon(Plus, 14)}
               </button>
             </div>`
       }
-      <div class="recent-project-children" id=${childrenId} ?hidden=${collapsed}>
-        ${repeat(
-          item.sessions,
-          (session) => session.threadRef,
-          (session) => sessionRow(session, true),
-        )}
-      </div>
     </section>
   `;
 }
 
-function toggleRecentProject(scopeId: string): void {
-  if (sessionsState.collapsedProjectScopes.has(scopeId)) sessionsState.collapsedProjectScopes.delete(scopeId);
-  else sessionsState.collapsedProjectScopes.add(scopeId);
+function toggleProjects(): void {
+  projectsOpen = !projectsOpen;
+  storeFlag(PROJECTS_OPEN_KEY, projectsOpen);
   renderList();
 }
 
-function startProjectChat(event: Event, scopeId: string, _name: string | null): void {
+function startProjectChat(event: Event, scopeId: string): void {
   event.stopPropagation();
   closeSidebarOnNarrowView();
-  sessionsState.collapsedProjectScopes.delete(scopeId);
   openBlankInFocusedPane(scopeId);
   renderList();
 }
 
-function projectMenuPopover(item: Extract<RecentItem, { kind: "project" }>): TemplateResult {
-  const owned = projectOf(item.scopeId)?.ownerId === appState.me?.user;
+function projectMenuPopover(scopeId: string, name: string): TemplateResult {
+  const owned = projectOf(scopeId)?.ownerId === appState.me?.user;
   return html`
     <div class="session-menu-popover" role="menu" ${ref(placeSessionMenu)} @click=${(e: Event) => e.stopPropagation()}>
-      <button
-        class="session-menu-option"
-        type="button"
-        role="menuitem"
-        @click=${() => openProjectFromMenu(item.scopeId)}
-      >
+      <button class="session-menu-option" type="button" role="menuitem" @click=${() => openProjectFromMenu(scopeId)}>
         ${icon(Folder, 15)}<span>View project</span>
       </button>
       ${
@@ -468,7 +456,7 @@ function projectMenuPopover(item: Extract<RecentItem, { kind: "project" }>): Tem
               class="session-menu-option"
               type="button"
               role="menuitem"
-              @click=${() => beginRename(projectMenuKey(item.scopeId), item.name ?? "")}
+              @click=${() => beginRename(projectMenuKey(scopeId), name)}
             >
               ${icon(Pencil, 15)}<span>Rename</span>
             </button>`
@@ -483,20 +471,20 @@ function openProjectFromMenu(scopeId: string): void {
   openProjectDetail(scopeId);
 }
 
-function projectRenameRow(item: Extract<RecentItem, { kind: "project" }>): TemplateResult {
-  const menuKey = projectMenuKey(item.scopeId);
+function projectRenameRow(scopeId: string): TemplateResult {
+  const menuKey = projectMenuKey(scopeId);
   return html`<div class="recent-project-head renaming">
-    ${renameInput(menuKey, "Rename project", () => commitProjectRename(item))}
+    ${renameInput(menuKey, "Rename project", () => commitProjectRename(scopeId))}
   </div>`;
 }
 
-async function commitProjectRename(item: Extract<RecentItem, { kind: "project" }>): Promise<void> {
-  if (sessionsState.renamingId !== projectMenuKey(item.scopeId)) return;
+async function commitProjectRename(scopeId: string): Promise<void> {
+  if (sessionsState.renamingId !== projectMenuKey(scopeId)) return;
   const next = renameDraft.trim();
   sessionsState.renamingId = null;
   renameDraft = "";
   renderList();
-  const project = projectOf(item.scopeId);
+  const project = projectOf(scopeId);
   if (!project || !next || next === project.name) return;
   await renameProject(project, next);
   renderList();
@@ -767,19 +755,11 @@ export function bumpSessionActivity(threadRef: string): void {
   renderList();
 }
 
-function groupedRows(list: RecentItem[]): TemplateResult {
-  const now = Date.now();
+function groupedRows(sessions: readonly CoreSession[]): TemplateResult {
   const items: { key: string; tpl: TemplateResult }[] = [];
-  let group: string | null = null;
-  for (const item of list) {
-    const dateless = item.kind === "project" && item.sessions.length === 0;
-    const g = recencyGroup(recentItemActivity(item), now);
-    if (!dateless && g !== group) {
-      group = g;
-      items.push({ key: `group:${g}`, tpl: html`<div class="recents-group">${g}</div>` });
-    }
-    const key = item.kind === "session" ? item.session.threadRef : `project:${item.scopeId}`;
-    items.push({ key, tpl: recentItem(item) });
+  for (const { label, sessions: rows } of bucketByRecency(sessions)) {
+    items.push({ key: `group:${label}`, tpl: html`<div class="recents-group">${label}</div>` });
+    for (const s of rows) items.push({ key: s.threadRef, tpl: sessionRow(s) });
   }
   return html`${repeat(
     items,
@@ -809,29 +789,30 @@ function surfaceGlyph(s: CoreSession): TemplateResult | typeof nothing {
   return nothing;
 }
 
-function rowContext(s: CoreSession): string | null {
-  let label = sharedContextLabel(s.scopeId, s.channelName ?? null);
-  if (surfaceOf(s) === "slack") label = s.type === "group" ? groupDmText(s.channelName) : channelLabel(s);
-  return label && label !== sessionTitle(s) ? label : null;
+function rowScopeLabel(s: CoreSession, title: string): string | null {
+  const personal = personalScopeId();
+  if (!s.scopeId || s.scopeId === personal || (!personal && s.scopeId.startsWith("personal:"))) return null;
+  const label = scopeTitle(s.scopeId, s.channelName ?? null);
+  return label === title ? null : label;
 }
 
-function sessionRow(s: CoreSession, projectChild = false): TemplateResult {
+function sessionRow(s: CoreSession): TemplateResult {
   const saved = Boolean(s.id);
   if (saved && sessionsState.renamingId === s.id) return renameRow(s);
   const active = isActiveRow(s);
   const menuOpen = saved && sessionsState.openMenuId === s.id;
   const refreshingTitle = saved && refreshingTitleIds.has(s.id);
-  const untitledProjectChild = projectChild && !s.title?.trim();
+  const untitledProjectChat = !s.title?.trim() && Boolean(projectName(s.scopeId));
   let title = sessionTitle(s);
-  if (untitledProjectChild) title = surfaceOf(s) === "web" ? "Web chat" : "New chat";
+  if (untitledProjectChat) title = surfaceOf(s) === "web" ? "Web chat" : "New chat";
   const readOnly = !isContinuable(s, appState.me?.user ?? "");
   const surface = surfaceOf(s);
-  const context = projectChild ? null : rowContext(s);
+  const context = rowScopeLabel(s, title);
   const working = sessionWorking(s);
   let titleContent: string | TemplateResult = groupDmTitle(s);
   if (refreshingTitle) {
     titleContent = html`<span class="sheen-label title-sheen thinking-sheen" data-sheen=${title}>${title}</span>`;
-  } else if (untitledProjectChild) {
+  } else if (untitledProjectChat) {
     titleContent = title;
   }
   const ariaLabel = [
@@ -850,7 +831,7 @@ function sessionRow(s: CoreSession, projectChild = false): TemplateResult {
   return html`
     <div
       data-session-id=${saved ? s.id : nothing}
-      class="session-row ${active ? "active" : ""} ${saved && selection.ids.has(s.id) ? "selected" : ""} ${menuOpen ? "menu-open" : ""} ${readOnly ? "read-only" : ""} ${refreshingTitle ? "title-refreshing" : ""} ${working ? "working" : ""} ${s.awaitingInput ? "awaiting-input" : ""} ${projectChild ? "project-child" : ""} ${s.color ? "colored" : ""}"
+      class="session-row ${active ? "active" : ""} ${saved && selection.ids.has(s.id) ? "selected" : ""} ${menuOpen ? "menu-open" : ""} ${readOnly ? "read-only" : ""} ${refreshingTitle ? "title-refreshing" : ""} ${working ? "working" : ""} ${s.awaitingInput ? "awaiting-input" : ""} ${s.color ? "colored" : ""}"
       style=${s.color ? `--session-color:${s.color}` : nothing}
     >
       <a
@@ -903,7 +884,7 @@ function sessionRow(s: CoreSession, projectChild = false): TemplateResult {
           ${statusMarks(s)}${surfaceGlyph(s)}${readOnly ? html`<span class="ro-lock" title="Read-only">${icon(Lock, 12)}</span>` : nothing}<span
             class="tl"
             >${titleContent}</span
-          >${context ? html`<span class="row-context" title=${context}>${context}</span>` : nothing}
+          >${context ? scopeChip(s.scopeId, s.channelName ?? null) : nothing}
         </div>
       </a>
       ${
@@ -1081,11 +1062,7 @@ function toggleShowArchived(): void {
 
 export function toggleWebOnly(): void {
   sessionsState.webOnly = !sessionsState.webOnly;
-  try {
-    localStorage.setItem(WEB_ONLY_KEY, sessionsState.webOnly ? "1" : "0");
-  } catch {
-    void 0;
-  }
+  storeFlag(WEB_ONLY_KEY, sessionsState.webOnly);
   renderSidebarTop();
   renderList();
 }
@@ -1458,7 +1435,6 @@ export async function openSession(s: CoreSession, entriesPrefetch?: Promise<Tran
   mountRestoredCanvas();
   if (splitInterceptsOpen(s)) return;
   closeSidebarOnNarrowView();
-  if (projectName(s.scopeId) && sessionsState.collapsedProjectScopes.delete(s.scopeId)) renderList();
   return openSessionInto(mainConversation(), s, entriesPrefetch);
 }
 

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8342,3 +8342,90 @@ h3.ambient-field-label {
     transition: opacity 160ms ease;
   }
 }
+
+code-block {
+  position: relative;
+}
+code-block > div {
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 5%, transparent),
+    0 1px 2px color-mix(in srgb, var(--foreground) 4%, transparent);
+}
+code-block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius);
+  pointer-events: none;
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--foreground) 7%, transparent);
+  opacity: 0;
+  transition: opacity 220ms ease;
+}
+code-block:hover::after {
+  opacity: 1;
+}
+code-block > div > div:first-child > span:first-child {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted-foreground) 12%, transparent);
+}
+code-block copy-button {
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 160ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+code-block:hover copy-button,
+code-block:focus-within copy-button {
+  opacity: 1;
+  transform: none;
+}
+@media (hover: none) {
+  code-block copy-button {
+    opacity: 1;
+    transform: none;
+  }
+}
+code-block copy-button span {
+  display: inline-block;
+  animation: code-copied-in 320ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes code-copied-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.live-stream .stream-tail code-block pre code::after {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  vertical-align: -0.15em;
+  margin-left: 2px;
+  background: currentColor;
+  opacity: 0.55;
+  animation: code-caret 1s steps(2, jump-none) infinite;
+}
+@keyframes code-caret {
+  to {
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  code-block::after,
+  code-block copy-button {
+    transition: none;
+  }
+  code-block copy-button span,
+  .live-stream .stream-tail code-block pre code::after {
+    animation: none;
+  }
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -365,12 +365,10 @@ a.chat-row-open {
   min-height: 30px;
   border-radius: var(--radius-sm);
 }
-/* A collapsed group still shows where the active chat lives; expanded groups stay
-   quiet — the indent rail and the highlighted child already say it. */
-.recent-project.active:has(.recent-project-children[hidden]) .recent-project-head {
+.recent-project.active .recent-project-head {
   background: color-mix(in srgb, var(--foreground) 4%, transparent);
 }
-.recent-project-toggle {
+.recent-project-open {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -386,13 +384,13 @@ a.chat-row-open {
   font: inherit;
   text-align: left;
 }
-.recent-project-toggle:hover,
-.recent-project-toggle:focus-visible,
+.recent-project-open:hover,
+.recent-project-open:focus-visible,
 .recent-project-new-chat:hover,
 .recent-project-new-chat:focus-visible {
   background: var(--secondary);
 }
-.recent-project-toggle > svg {
+.recent-project-open > svg {
   flex: 0 0 auto;
   color: var(--muted-foreground);
 }
@@ -469,21 +467,6 @@ a.chat-row-open {
 .recent-project-head.renaming {
   padding: 0;
 }
-.recent-project-children {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-  margin-left: 15px;
-  padding-left: 3px;
-  border-left: 1px solid var(--border);
-}
-.recent-project-children[hidden] {
-  display: none;
-}
-.recent-project-children .session {
-  padding-left: 7px;
-}
 .session {
   display: flex;
   align-items: center;
@@ -525,17 +508,6 @@ a.chat-row-open {
   text-overflow: ellipsis;
 }
 
-.session .row-context {
-  flex: 0 1 auto;
-  min-width: 4ch;
-  max-width: 45%;
-  margin-left: 6px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--muted-foreground);
-}
 .group-dm-title {
   display: inline-flex;
   align-items: center;
@@ -4477,7 +4449,7 @@ a.chat-row-open {
   .new-chat,
   .navrow,
   .nav-section-toggle,
-  .recent-project-toggle,
+  .recent-project-open,
   .session,
   .web-only-toggle,
   .session-menu-option,
@@ -8044,6 +8016,52 @@ h3.ambient-field-label {
   height: 360px;
   border: 0;
   background: white;
+}
+
+.sidebar .list .recents-group {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: color-mix(in srgb, var(--secondary) 42%, var(--background));
+}
+.recents-toggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  box-sizing: border-box;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-align: left;
+}
+.recents-toggle:hover,
+.recents-toggle:focus-visible {
+  color: var(--foreground);
+}
+.recents-toggle svg {
+  flex: 0 0 auto;
+  opacity: 0.8;
+}
+.recent-projects {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.recent-projects[hidden] {
+  display: none;
+}
+.session .title .scope-chip {
+  flex: 0 1 auto;
+  min-width: 4ch;
+  max-width: 45%;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 10.5px;
 }
 
 .attachment-strip .file-chip {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -347,6 +347,7 @@ a.chat-row-open {
 }
 
 .sidebar .list {
+  position: relative;
   flex: 1;
   overflow-y: auto;
   scrollbar-gutter: stable;
@@ -8317,5 +8318,27 @@ h3.ambient-field-label {
 @media (prefers-reduced-motion: reduce) {
   .think-orb .orb-ring {
     animation: none;
+  }
+}
+
+.sidebar .list::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 2px;
+  width: 2px;
+  height: var(--active-h, 0px);
+  border-radius: 1px;
+  background: var(--active-color, color-mix(in srgb, var(--foreground) 70%, transparent));
+  transform: translateY(var(--active-y, 0px));
+  opacity: var(--active-on, 0);
+  pointer-events: none;
+  transition:
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    opacity 160ms ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .sidebar .list::before {
+    transition: opacity 160ms ease;
   }
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8729,3 +8729,7 @@ code-block copy-button span {
     opacity: 1;
   }
 }
+
+.live-work-line .think-orb {
+  --orb: 20px;
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8170,3 +8170,152 @@ h3.ambient-field-label {
     transform: none;
   }
 }
+
+.think-orb {
+  --orb: 16px;
+  --orb-ink: color-mix(in srgb, var(--foreground) 55%, transparent);
+  --orb-edge: color-mix(in srgb, var(--foreground) 92%, transparent);
+  --orb-glow: color-mix(in srgb, var(--brand-accent) 72%, var(--primary));
+  position: relative;
+  display: inline-block;
+  flex: 0 0 auto;
+  width: var(--orb);
+  height: var(--orb);
+  perspective: calc(var(--orb) * 2.6);
+  transform-style: preserve-3d;
+}
+.think-orb-lg {
+  --orb: 28px;
+}
+.thinking-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.think-orb .orb-core,
+.think-orb .orb-ring,
+.think-orb .orb-ring::before,
+.think-orb .orb-ring::after {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  border-radius: 50%;
+}
+.think-orb .orb-ring::before,
+.think-orb .orb-ring::after {
+  content: "";
+}
+.think-orb .orb-core {
+  inset: 31%;
+  background: radial-gradient(
+    circle at 36% 34%,
+    color-mix(in srgb, var(--brand-accent) 45%, white),
+    var(--orb-glow) 72%
+  );
+  filter: drop-shadow(0 0 calc(var(--orb) / 6) var(--orb-glow));
+  animation: awaiting-breathe 2.4s ease-in-out infinite;
+}
+.think-orb .orb-ring {
+  transform-style: preserve-3d;
+  will-change: transform;
+  rotate: var(--axis, 0 1 0) 0turn;
+  animation: orb-spin var(--period, 4s) linear infinite;
+}
+@keyframes orb-spin {
+  to {
+    rotate: var(--axis, 0 1 0) 1turn;
+  }
+}
+
+.think-orb[data-variant="gyro"] .orb-ring {
+  border: 1px solid var(--orb-ink);
+}
+.think-orb[data-variant="gyro"] .orb-ring::before {
+  border: 1px solid transparent;
+  border-top-color: var(--orb-edge);
+  border-right-color: var(--orb-edge);
+}
+.think-orb[data-variant="gyro"] .orb-ring:nth-child(2) {
+  --axis: 0 1 0;
+  --period: 3.3s;
+  transform: rotateX(66deg);
+}
+.think-orb[data-variant="gyro"] .orb-ring:nth-child(3) {
+  --axis: 1 0 0;
+  --period: 4.7s;
+  transform: rotateY(66deg);
+  animation-direction: reverse;
+}
+.think-orb[data-variant="gyro"] .orb-ring:nth-child(4) {
+  --axis: 1 1 0;
+  --period: 6.1s;
+  transform: rotateX(52deg) rotateY(-38deg);
+}
+
+.think-orb[data-variant="tesseract"] .orb-ring::before,
+.think-orb[data-variant="tesseract"] .orb-ring::after {
+  inset: calc(50% - var(--half));
+  border: 1px solid var(--orb-ink);
+  border-radius: 1px;
+  transform: translateZ(var(--half));
+}
+.think-orb[data-variant="tesseract"] .orb-ring::after {
+  transform: translateZ(calc(-1 * var(--half)));
+}
+.think-orb[data-variant="tesseract"] .orb-ring:nth-child(-n + 3) {
+  --half: calc(var(--orb) * 0.32);
+  --axis: 1 0.8 0.3;
+  --period: 7.4s;
+}
+.think-orb[data-variant="tesseract"] .orb-ring:nth-child(n + 4) {
+  --half: calc(var(--orb) * 0.16);
+  --axis: 0.4 1 -0.6;
+  --period: 4.6s;
+  animation-direction: reverse;
+}
+.think-orb[data-variant="tesseract"] .orb-ring:nth-child(n + 4)::before,
+.think-orb[data-variant="tesseract"] .orb-ring:nth-child(n + 4)::after {
+  border-color: var(--orb-edge);
+}
+.think-orb[data-variant="tesseract"] .orb-ring:nth-child(odd) {
+  transform: rotateY(90deg);
+}
+
+.think-orb[data-variant="orbit"] .orb-ring {
+  border: 1px solid color-mix(in srgb, var(--foreground) 22%, transparent);
+}
+.think-orb[data-variant="orbit"] .orb-ring::before,
+.think-orb[data-variant="orbit"] .orb-ring::after {
+  --dot: calc(var(--orb) / 7);
+  inset: auto;
+  left: calc(50% - var(--dot) / 2);
+  top: calc(var(--dot) / -2);
+  width: var(--dot);
+  height: var(--dot);
+  background: var(--orb-edge);
+}
+.think-orb[data-variant="orbit"] .orb-ring::after {
+  top: auto;
+  bottom: calc(var(--dot) / -2);
+}
+.think-orb[data-variant="orbit"] .orb-ring:nth-child(2) {
+  --axis: 0 -0.94 0.34;
+  --period: 2.9s;
+  transform: rotateX(70deg);
+}
+.think-orb[data-variant="orbit"] .orb-ring:nth-child(3) {
+  --axis: 0.94 0 0.34;
+  --period: 3.9s;
+  transform: rotateY(70deg);
+  animation-direction: reverse;
+}
+.think-orb[data-variant="orbit"] .orb-ring:nth-child(4) {
+  --axis: -0.57 0.67 0.47;
+  --period: 5.3s;
+  transform: rotateX(-55deg) rotateY(-35deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .think-orb .orb-ring {
+    animation: none;
+  }
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2073,6 +2073,7 @@ a.chat-row-open {
 }
 
 .chat-bottom-dock {
+  position: relative;
   min-width: 0;
 }
 
@@ -8586,5 +8587,56 @@ code-block copy-button span {
   .approval-btn:hover:not(:disabled),
   .approval-btn:active:not(:disabled) {
     transform: none;
+  }
+}
+
+.new-below-pill {
+  position: absolute;
+  left: 50%;
+  top: -10px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px 0 10px;
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--background) 72%, transparent);
+  backdrop-filter: blur(10px) saturate(1.3);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--background) 50%, transparent),
+    0 1px 2px color-mix(in srgb, var(--foreground) 8%, transparent),
+    0 10px 24px -8px color-mix(in srgb, var(--foreground) 22%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% + 8px)) scale(0.96);
+  transition:
+    opacity 160ms ease,
+    transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.scrolled-up .new-below-pill {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -100%);
+}
+.scrolled-up .new-below-pill:active {
+  transform: translate(-50%, -100%) scale(0.97);
+}
+.dark .new-below-pill {
+  background: color-mix(in srgb, var(--popover) 78%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--foreground) 8%, transparent),
+    0 1px 2px color-mix(in srgb, var(--foreground) 8%, transparent),
+    0 10px 24px -8px color-mix(in srgb, var(--foreground) 22%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .new-below-pill {
+    transition: none;
+    transform: translate(-50%, -100%);
   }
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8045,3 +8045,111 @@ h3.ambient-field-label {
   border: 0;
   background: white;
 }
+
+.attachment-strip .file-chip {
+  position: relative;
+}
+.attachment-preview {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 30;
+  width: 300px;
+  max-width: calc(100vw - 36px);
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.35;
+  text-align: left;
+  cursor: default;
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--foreground) 8%, transparent),
+    0 8px 18px color-mix(in srgb, var(--foreground) 10%, transparent),
+    0 22px 55px color-mix(in srgb, var(--foreground) 14%, transparent);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px) scale(0.98);
+  transform-origin: bottom left;
+  transition:
+    opacity 0.14s cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 0.14s cubic-bezier(0.2, 0.8, 0.2, 1),
+    visibility 0s linear 0.14s;
+}
+.attachment-preview::after {
+  content: "";
+  position: absolute;
+  inset: 100% 0 -8px;
+}
+.file-chip:hover .attachment-preview,
+.file-chip:focus-within .attachment-preview {
+  opacity: 1;
+  visibility: visible;
+  transform: none;
+  transition-delay: 0.25s;
+}
+.file-chip.preview-dismissed .attachment-preview {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px) scale(0.98);
+  transition-delay: 0s;
+}
+.attachment-preview-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  margin-bottom: 8px;
+}
+.attachment-preview-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+  color: var(--foreground);
+}
+.attachment-preview-meta {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+.attachment-preview-image {
+  display: block;
+  width: 100%;
+  max-height: 200px;
+  object-fit: contain;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--secondary) 76%, var(--background));
+}
+.attachment-preview-text {
+  max-height: 160px;
+  overflow: hidden;
+  margin: 0 0 6px;
+  padding: 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--secondary) 76%, var(--background));
+  color: var(--foreground);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  mask-image: linear-gradient(to bottom, #000 70%, transparent);
+}
+.attachment-preview-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 18px 0;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--secondary) 76%, var(--background));
+  color: var(--muted-foreground);
+}
+@media (prefers-reduced-motion: reduce) {
+  .attachment-preview {
+    transition-duration: 0s;
+    transform: none;
+  }
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2764,7 +2764,9 @@ a.chat-row-open {
   background: var(--foreground);
   color: var(--background);
   cursor: pointer;
-  transition: opacity 0.12s ease;
+  transition:
+    opacity 120ms ease,
+    transform 220ms cubic-bezier(0.34, 1.45, 0.64, 1);
 }
 .send-btn:hover:not(:disabled) {
   opacity: 0.9;
@@ -8439,6 +8441,83 @@ code-block copy-button span {
   ::view-transition-group(*),
   ::view-transition-old(*),
   ::view-transition-new(*) {
+    animation: none;
+  }
+}
+
+.composer-wrap {
+  transition: transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.composer-wrap::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--ring) 45%, var(--border)),
+    0 2px 4px color-mix(in srgb, var(--foreground) 10%, transparent),
+    0 20px 44px color-mix(in srgb, var(--foreground) 12%, transparent);
+  transition: opacity 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.composer-wrap:focus-within {
+  transform: translateY(-1px);
+}
+.composer-wrap:focus-within::before {
+  opacity: 1;
+}
+.send-btn:disabled {
+  transform: scale(0.88);
+}
+.send-btn:active:not(:disabled) {
+  transform: scale(0.92);
+  transition-duration: 80ms;
+}
+.send-btn svg,
+.stop-btn svg {
+  transition: transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.send-btn:hover:not(:disabled) svg {
+  transform: translateY(-1px);
+}
+.stop-btn:hover svg {
+  transform: scale(1.12);
+}
+.stop-btn {
+  animation: stop-emerge 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+@keyframes stop-emerge {
+  from {
+    opacity: 0;
+    transform: translateX(41px) scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .composer-wrap,
+  .composer-wrap::before {
+    transition: none;
+  }
+  .composer-wrap:focus-within {
+    transform: none;
+  }
+  .send-btn,
+  .send-btn svg,
+  .stop-btn svg {
+    transition: opacity 120ms ease;
+  }
+  .send-btn:disabled,
+  .send-btn:active:not(:disabled),
+  .send-btn:hover:not(:disabled) svg,
+  .stop-btn:hover svg {
+    transform: none;
+  }
+  .stop-btn {
     animation: none;
   }
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8088,13 +8088,12 @@ h3.ambient-field-label {
     0 8px 18px color-mix(in srgb, var(--foreground) 10%, transparent),
     0 22px 55px color-mix(in srgb, var(--foreground) 14%, transparent);
   opacity: 0;
-  visibility: hidden;
+  pointer-events: none;
   transform: translateY(4px) scale(0.98);
   transform-origin: bottom left;
   transition:
     opacity 0.14s cubic-bezier(0.2, 0.8, 0.2, 1),
-    transform 0.14s cubic-bezier(0.2, 0.8, 0.2, 1),
-    visibility 0s linear 0.14s;
+    transform 0.14s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 .attachment-preview::after {
   content: "";
@@ -8104,13 +8103,13 @@ h3.ambient-field-label {
 .file-chip:hover .attachment-preview,
 .file-chip:focus-within .attachment-preview {
   opacity: 1;
-  visibility: visible;
+  pointer-events: auto;
   transform: none;
   transition-delay: 0.25s;
 }
 .file-chip.preview-dismissed .attachment-preview {
   opacity: 0;
-  visibility: hidden;
+  pointer-events: none;
   transform: translateY(4px) scale(0.98);
   transition-delay: 0s;
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2299,7 +2299,7 @@ a.chat-row-open {
   transition: transform 0.15s ease;
 }
 
-.live-work-dock.expanded .live-work-line {
+.live-work-dock.expanded .live-work-face {
   flex-wrap: wrap;
 }
 .live-work-dock.expanded .live-work-label {
@@ -2317,6 +2317,8 @@ a.chat-row-open {
   max-height: 38vh;
 }
 .live-work-dock.expanded .live-work-toggle {
+  align-self: flex-start;
+  margin-top: 4px;
   transform: rotate(90deg);
 }
 
@@ -8638,5 +8640,37 @@ code-block copy-button span {
   .new-below-pill {
     transition: none;
     transform: translate(-50%, -100%);
+  }
+}
+
+.live-work-line {
+  perspective: 700px;
+}
+.live-work-face {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  transform-origin: 50% 0%;
+  backface-visibility: hidden;
+  animation: flap-in 380ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+@keyframes flap-in {
+  from {
+    opacity: 0;
+    transform: rotateX(-78deg) translateY(-3px);
+  }
+  55% {
+    opacity: 1;
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .live-work-face {
+    animation: none;
   }
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8429,3 +8429,16 @@ code-block copy-button span {
     animation: none;
   }
 }
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 260ms;
+  animation-timing-function: ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none;
+  }
+}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1982,10 +1982,16 @@ a.chat-row-open {
   background: var(--background);
   color: var(--foreground);
   cursor: pointer;
-  transition: opacity 0.12s ease;
+  transition:
+    opacity 120ms ease,
+    transform 160ms cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .approval-btn:hover:not(:disabled) {
   opacity: 0.85;
+  transform: translateY(-1px);
+}
+.approval-btn:active:not(:disabled) {
+  transform: scale(0.97);
 }
 .approval-btn.primary {
   background: var(--foreground);
@@ -2374,6 +2380,7 @@ a.chat-row-open {
   color: var(--muted-foreground);
 }
 .composer-approval-panel {
+  position: relative;
   display: grid;
   gap: 10px;
   margin: 0 0 10px;
@@ -8519,5 +8526,65 @@ code-block copy-button span {
   }
   .stop-btn {
     animation: none;
+  }
+}
+
+.composer-approval-panel,
+.inline-approval-marker {
+  animation: approval-rise 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+@keyframes approval-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.985);
+  }
+}
+.composer-approval-panel::before {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 12px;
+  border: 2px solid color-mix(in srgb, var(--brand-accent) 55%, transparent);
+  pointer-events: none;
+  opacity: 0;
+  animation: approval-ring 900ms cubic-bezier(0.22, 1, 0.36, 1) 180ms both;
+}
+@keyframes approval-ring {
+  0% {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.015);
+  }
+}
+.approval-reason-badge {
+  animation: badge-pop 380ms cubic-bezier(0.34, 1.56, 0.64, 1) 260ms both;
+}
+@keyframes badge-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .composer-approval-panel,
+  .inline-approval-marker,
+  .approval-reason-badge {
+    animation: none;
+  }
+  .composer-approval-panel::before {
+    display: none;
+  }
+  .approval-btn {
+    transition: none;
+  }
+  .approval-btn:hover:not(:disabled),
+  .approval-btn:active:not(:disabled) {
+    transform: none;
   }
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8674,3 +8674,58 @@ code-block copy-button span {
     animation: none;
   }
 }
+
+.streaming-text.live-stream {
+  transition:
+    opacity 240ms ease-out,
+    transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@starting-style {
+  .streaming-text.live-stream {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+}
+.streaming-text.live-stream .stream-tail > div > :is(p, h1, h2, h3, h4, h5, h6):last-child::after,
+.streaming-text.live-stream .stream-tail > div > :is(ul, ol):last-child > li:last-child::after,
+.streaming-text.live-stream .stream-tail > div > blockquote:last-child > p:last-child::after {
+  content: "";
+  display: inline-block;
+  width: 2px;
+  height: 0.92em;
+  margin-left: 2px;
+  vertical-align: -0.12em;
+  border-radius: 1px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--foreground) 70%, var(--background)) 0%,
+    var(--foreground) 55%
+  );
+  box-shadow:
+    0 0 0.35em color-mix(in srgb, var(--brand-accent) 35%, transparent),
+    1px 1px 0 color-mix(in srgb, var(--foreground) 12%, transparent);
+  transform-origin: 50% 100%;
+  animation: caret-breathe 1.05s ease-in-out infinite;
+}
+@keyframes caret-breathe {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+  50% {
+    opacity: 0.35;
+    transform: scaleY(0.82);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .streaming-text.live-stream {
+    transition: none;
+  }
+  .streaming-text.live-stream .stream-tail > div > :is(p, h1, h2, h3, h4, h5, h6):last-child::after,
+  .streaming-text.live-stream .stream-tail > div > :is(ul, ol):last-child > li:last-child::after,
+  .streaming-text.live-stream .stream-tail > div > blockquote:last-child > p:last-child::after {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -32,7 +32,7 @@ import {
 import { applyRuntimeOptions } from "./model-options";
 import { errMessage, swallow } from "../../chassis/src/errors";
 import { brandMark, brandName, icon, initials } from "./ui";
-import { markConnectorConnected } from "./chat";
+import { markConnectorConnected, reduceMotion } from "./chat";
 import { clearSkillsCache, resyncModelSelection, seedRuntimeConfig } from "./composer";
 import { ensureDeliveryStream, mainConversation, onExitCanvas } from "./conversations";
 import { clearAllDrafts, saveDraft, storedDraft } from "./drafts";
@@ -110,6 +110,18 @@ if (!appEl) throw new Error("missing #app");
 
 const narrowViewport = window.matchMedia("(max-width: 860px)");
 let sidebarOpen = !narrowViewport.matches;
+
+type ThemeCycler = HTMLElement & { cycleTheme?: () => void };
+
+function crossfadeThemeSwitch(e: MouseEvent): void {
+  if (typeof document.startViewTransition !== "function" || reduceMotion.matches) return;
+  const toggle = e.target instanceof Element ? e.target.closest<ThemeCycler>("theme-toggle") : null;
+  if (!toggle || typeof toggle.cycleTheme !== "function") return;
+  e.stopImmediatePropagation();
+  e.preventDefault();
+  document.startViewTransition(() => toggle.cycleTheme?.());
+}
+document.addEventListener("click", crossfadeThemeSwitch, true);
 
 const SIDEBAR_MIN_W = 200;
 const SIDEBAR_MAX_W = 520;

--- a/plugins/web-ui/test/active-row-indicator.test.ts
+++ b/plugins/web-ui/test/active-row-indicator.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const sessions = readFileSync(new URL("../src/sessions.ts", import.meta.url), "utf8");
+
+const indicator = css.match(/\.sidebar \.list::before \{[^}]*\}/)?.[0] ?? "";
+
+test("the active-row indicator is an absolutely positioned pseudo inside the positioned scroll container", () => {
+  assert.match(css, /\.sidebar \.list \{\s*position: relative;/);
+  assert.match(indicator, /position: absolute;/);
+  assert.match(indicator, /pointer-events: none;/);
+  assert.match(indicator, /transform: translateY\(var\(--active-y, 0px\)\);/);
+  assert.match(indicator, /opacity: var\(--active-on, 0\);/);
+  assert.match(
+    indicator,
+    /background: var\(--active-color, color-mix\(in srgb, var\(--foreground\) 70%, transparent\)\);/,
+  );
+});
+
+test("the indicator only transitions transform and opacity, and reduced motion drops the slide", () => {
+  const transition = indicator.match(/transition:([^;]*);/)?.[1] ?? "";
+  assert.match(transition, /^\s*transform 240ms cubic-bezier\(0\.2, 0\.8, 0\.2, 1\),\s*opacity 160ms ease\s*$/);
+  assert.match(
+    css,
+    /@media \(prefers-reduced-motion: reduce\) \{\s*\.sidebar \.list::before \{\s*transition: opacity 160ms ease;\s*\}\s*\}/,
+  );
+});
+
+test("renderList measures the active row inside a rAF after the sidebar commit and fades in without sliding from the top", () => {
+  assert.match(sessions, /notifySessionsChanged\(\);\s*placeActiveIndicator\(\);\s*\}/);
+  const fn = sessions.match(/function placeActiveIndicator\(\): void \{[\s\S]*?\n\}/)?.[0] ?? "";
+  const raf = fn.indexOf("requestAnimationFrame");
+  const measure = fn.indexOf("getBoundingClientRect");
+  assert.ok(raf >= 0 && measure > raf, "layout reads must happen inside the rAF");
+  assert.match(
+    fn,
+    /\.find\(\(r\) => !r\.closest\("\[hidden\]"\)\)/,
+    "a collapsed project's active row must not place the bar",
+  );
+  assert.match(fn, /el\.scrollTop/, "the offset must be scroll-independent");
+  assert.match(fn, /getPropertyValue\("--session-color"\)/);
+  assert.match(
+    fn,
+    /if \(el\.style\.getPropertyValue\("--active-on"\) === "1"\) return;\s*requestAnimationFrame\(\(\) => el\.style\.setProperty\("--active-on", "1"\)\);/,
+  );
+});

--- a/plugins/web-ui/test/approval-motion-source.test.ts
+++ b/plugins/web-ui/test/approval-motion-source.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+
+test("approval surfaces rise once on mount and mount only while an approval is pending", () => {
+  assert.match(
+    css,
+    /\.composer-approval-panel,\s*\.inline-approval-marker \{\s*animation: approval-rise 420ms cubic-bezier\([^)]*\) both;\s*\}/,
+  );
+  assert.match(
+    css,
+    /@keyframes approval-rise \{\s*from \{\s*opacity: 0;\s*transform: translateY\(10px\) scale\(0\.985\);/,
+  );
+  assert.match(composer, /approvalPauses\.length\s*\? composerApprovalPanel\(approvalPauses\)/);
+  assert.doesNotMatch(composer, /class="composer-approval-panel[^"]*\$\{/);
+});
+
+test("the attention ring is a one-shot pseudo-element that fades out and never loops", () => {
+  assert.match(css, /\.composer-approval-panel \{\s*position: relative;/);
+  const ring = css.match(/\.composer-approval-panel::before \{[^}]*\}/)?.[0] ?? "";
+  assert.match(ring, /inset: 2px;/);
+  assert.match(ring, /pointer-events: none;/);
+  assert.match(ring, /border: 2px solid color-mix\(in srgb, var\(--brand-accent\) 55%, transparent\);/);
+  assert.match(ring, /animation: approval-ring 900ms cubic-bezier\([^)]*\) 180ms both;/);
+  const frames = css.match(/@keyframes approval-ring \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(frames, /100% \{\s*opacity: 0;/);
+  for (const name of ["approval-rise", "approval-ring", "badge-pop"]) {
+    assert.doesNotMatch(css, new RegExp(`animation:[^;]*${name}[^;]*infinite`));
+  }
+});
+
+test("the reason badge pops a beat after the card and buttons get press physics on transform only", () => {
+  assert.match(css, /\.approval-reason-badge \{\s*animation: badge-pop 380ms cubic-bezier\([^)]*\) 260ms both;/);
+  assert.match(css, /@keyframes badge-pop \{\s*from \{\s*opacity: 0;\s*transform: scale\(0\.6\);/);
+  const btn = css.match(/\.approval-btn \{[^}]*\}/)?.[0] ?? "";
+  assert.match(btn, /transition:\s*opacity 120ms ease,\s*transform 160ms cubic-bezier/);
+  assert.match(css, /\.approval-btn:hover:not\(:disabled\) \{[^}]*transform: translateY\(-1px\);/);
+  assert.match(css, /\.approval-btn:active:not\(:disabled\) \{\s*transform: scale\(0\.97\);/);
+});
+
+test("reduced motion drops every approval animation and transform but keeps the UI usable", () => {
+  const reduce = css.match(
+    /@media \(prefers-reduced-motion: reduce\) \{\s*\.composer-approval-panel,\s*\.inline-approval-marker,\s*\.approval-reason-badge \{[\s\S]*?\n\}/,
+  )?.[0];
+  assert.ok(reduce, "the approval reduce block must exist");
+  assert.match(reduce, /\.approval-reason-badge \{\s*animation: none;/);
+  assert.match(reduce, /\.composer-approval-panel::before \{\s*display: none;/);
+  assert.match(reduce, /\.approval-btn \{\s*transition: none;/);
+  assert.match(
+    reduce,
+    /\.approval-btn:hover:not\(:disabled\),\s*\.approval-btn:active:not\(:disabled\) \{\s*transform: none;/,
+  );
+});

--- a/plugins/web-ui/test/attachment-preview-source.test.ts
+++ b/plugins/web-ui/test/attachment-preview-source.test.ts
@@ -31,7 +31,7 @@ test("the card shows after hover intent, hides on Escape, and drops motion under
     css,
     /\.file-chip:hover \.attachment-preview,\s*\.file-chip:focus-within \.attachment-preview \{[^}]*transition-delay: 0\.25s;/,
   );
-  assert.match(css, /\.file-chip\.preview-dismissed \.attachment-preview \{[^}]*visibility: hidden;/);
+  assert.match(css, /\.file-chip\.preview-dismissed \.attachment-preview \{[^}]*pointer-events: none;/);
   assert.match(
     css,
     /@media \(prefers-reduced-motion: reduce\) \{\s*\.attachment-preview \{[^}]*transition-duration: 0s;/,

--- a/plugins/web-ui/test/attachment-preview-source.test.ts
+++ b/plugins/web-ui/test/attachment-preview-source.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+const preview = readFileSync(new URL("../src/attachment-preview.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("every composer attachment chip renders its preview card and keeps remove and view-paste working", () => {
+  const strip = composer.slice(
+    composer.indexOf('class="attachment-strip"'),
+    composer.indexOf('class="composer-input"'),
+  );
+  assert.match(strip, /\$\{attachmentPreview\(a\)\}/);
+  assert.match(strip, /@keydown=\$\{dismissPreviewOnEscape\}/);
+  assert.match(strip, /@pointerleave=\$\{restorePreview\}/);
+  assert.match(strip, /@focusout=\$\{restorePreview\}/);
+  assert.match(strip, /@click=\$\{\(\) => removeAttachment\(a\.id, agent\)\}/);
+  assert.match(strip, /@click=\$\{\(\) => openPasteView\(a\.id, agent\)\}/);
+});
+
+test("images preview from a data URL, PDFs from their PNG first page, text from extractedText", () => {
+  assert.match(preview, /`data:\$\{a\.mimeType\};base64,\$\{a\.preview \?\? a\.content\}`/);
+  assert.match(preview, /`data:image\/png;base64,\$\{a\.preview\}`/);
+  assert.match(preview, /a\.extractedText\.slice\(0, PREVIEW_TEXT_CHARS\)/);
+  assert.match(preview, /formatBytes\(a\.size\)/);
+});
+
+test("the card shows after hover intent, hides on Escape, and drops motion under reduced-motion", () => {
+  assert.match(
+    css,
+    /\.file-chip:hover \.attachment-preview,\s*\.file-chip:focus-within \.attachment-preview \{[^}]*transition-delay: 0\.25s;/,
+  );
+  assert.match(css, /\.file-chip\.preview-dismissed \.attachment-preview \{[^}]*visibility: hidden;/);
+  assert.match(
+    css,
+    /@media \(prefers-reduced-motion: reduce\) \{\s*\.attachment-preview \{[^}]*transition-duration: 0s;/,
+  );
+});

--- a/plugins/web-ui/test/code-block-chrome-source.test.ts
+++ b/plugins/web-ui/test/code-block-chrome-source.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const codeBlock = readFileSync(
+  new URL("../node_modules/@mariozechner/mini-lit/dist/CodeBlock.js", import.meta.url),
+  "utf8",
+);
+const copyButton = readFileSync(
+  new URL("../node_modules/@mariozechner/mini-lit/dist/CopyButton.js", import.meta.url),
+  "utf8",
+);
+const chrome = css.slice(css.indexOf("\ncode-block {"));
+
+test("mini-lit still renders the light-DOM structure the chrome selectors ride on", () => {
+  assert.match(codeBlock, /createRenderRoot\(\) \{\s*return this;/);
+  assert.match(codeBlock, /<div class="border[^"]*">\s*(?:<!--[^>]*-->\s*)?<div class="flex[^"]*">\s*<span/);
+  assert.match(codeBlock, /<copy-button[^\n]*\.showText=\$\{true\}/);
+  assert.match(codeBlock, /<pre[\s\S]*?><code class="hljs/);
+  assert.match(copyButton, /this\.copied && this\.showText \? html `<span>/);
+});
+
+test("code block chrome targets structure, never mini-lit's Tailwind classes", () => {
+  assert.match(chrome, /^code-block > div \{/m);
+  assert.match(chrome, /^code-block::after \{[^}]*box-shadow:[^}]*opacity: 0;[^}]*transition: opacity/m);
+  assert.match(chrome, /^code-block:hover::after \{\s*opacity: 1;/m);
+  assert.match(chrome, /^code-block > div > div:first-child > span:first-child \{[^}]*border-radius: 999px/m);
+  assert.doesNotMatch(chrome, /\.(rounded-lg|overflow-hidden|border|flex|hljs|text-xs)\b/);
+});
+
+test("copy button hides until hover or focus, stays visible on touch, and pops on Copied!", () => {
+  assert.match(chrome, /^code-block copy-button \{\s*opacity: 0;\s*transform: translateY\(-2px\);/m);
+  assert.match(chrome, /^code-block:hover copy-button,\s*code-block:focus-within copy-button \{\s*opacity: 1;/m);
+  assert.match(chrome, /@media \(hover: none\) \{\s*code-block copy-button \{\s*opacity: 1;/);
+  assert.match(chrome, /^code-block copy-button span \{[^}]*animation: code-copied-in/m);
+  assert.match(chrome, /@keyframes code-copied-in/);
+});
+
+test("streaming caret sits on the tail's code element only and never animates lines", () => {
+  assert.match(chrome, /^\.live-stream \.stream-tail code-block pre code::after \{[^}]*animation: code-caret/m);
+  assert.match(chrome, /@keyframes code-caret \{\s*to \{\s*opacity: 0;/);
+  assert.doesNotMatch(chrome, /(hljs-|\.line|tok-in)/);
+});
+
+test("reduced motion stops the chrome transitions and keyframes while keeping copy reachable", () => {
+  const reduced = chrome.match(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(reduced, /code-block::after,\s*code-block copy-button \{\s*transition: none;/);
+  assert.match(
+    reduced,
+    /code-block copy-button span,\s*\.live-stream \.stream-tail code-block pre code::after \{\s*animation: none;/,
+  );
+  assert.doesNotMatch(reduced, /opacity: 0/);
+});

--- a/plugins/web-ui/test/composer-physics-source.test.ts
+++ b/plugins/web-ui/test/composer-physics-source.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("the composer lifts on focus-within through a pre-rasterized shadow pseudo that only fades", () => {
+  const before = css.match(/\n\.composer-wrap::before \{[^}]*\}/)?.[0] ?? "";
+  assert.match(before, /z-index: -1;/);
+  assert.match(before, /opacity: 0;/);
+  assert.match(before, /box-shadow:\s*0 0 0 1px color-mix\(in srgb, var\(--ring\) 45%, var\(--border\)\)/);
+  assert.match(before, /transition: opacity 180ms/);
+  assert.doesNotMatch(before, /transition:[^;]*box-shadow/);
+  assert.match(css, /\.composer-wrap:focus-within \{\s*transform: translateY\(-1px\);\s*\}/);
+  assert.match(css, /\.composer-wrap:focus-within::before \{\s*opacity: 1;\s*\}/);
+  assert.match(css, /\n\.composer-wrap \{\s*transition: transform 180ms/);
+});
+
+test("the send button springs between disabled and enabled and the stop button emerges from its slot", () => {
+  const send = css.match(/\n\.send-btn \{[^}]*\}/)?.[0] ?? "";
+  assert.match(send, /transition:\s*opacity 120ms ease,\s*transform 220ms cubic-bezier\(0\.34, 1\.45, 0\.64, 1\);/);
+  assert.match(css, /\.send-btn:disabled \{\s*transform: scale\(0\.88\);\s*\}/);
+  assert.match(css, /\.send-btn:active:not\(:disabled\) \{\s*transform: scale\(0\.92\);\s*transition-duration: 80ms;/);
+  assert.match(css, /\.send-btn:hover:not\(:disabled\) svg \{\s*transform: translateY\(-1px\);/);
+  assert.match(css, /\.stop-btn:hover svg \{\s*transform: scale\(1\.12\);/);
+  assert.match(css, /\.stop-btn \{\s*animation: stop-emerge 260ms/);
+  assert.match(css, /@keyframes stop-emerge \{\s*from \{\s*opacity: 0;\s*transform: translateX\(41px\) scale\(0\.6\);/);
+  assert.match(css, /\.composer-right \{[^}]*gap: 7px;/);
+});
+
+test("reduced motion keeps the composer usable: instant ring, opacity fades only, no emerge", () => {
+  const reduced = css.slice(css.lastIndexOf("@media (prefers-reduced-motion: reduce)"));
+  assert.match(reduced, /\.composer-wrap,\s*\.composer-wrap::before \{\s*transition: none;/);
+  assert.match(reduced, /\.composer-wrap:focus-within \{\s*transform: none;/);
+  assert.match(reduced, /\.send-btn,\s*\.send-btn svg,\s*\.stop-btn svg \{\s*transition: opacity 120ms ease;/);
+  assert.match(reduced, /\.stop-btn \{\s*animation: none;/);
+  assert.doesNotMatch(css, /transition:[^;}]*visibility/);
+});

--- a/plugins/web-ui/test/composer-physics-source.test.ts
+++ b/plugins/web-ui/test/composer-physics-source.test.ts
@@ -29,7 +29,7 @@ test("the send button springs between disabled and enabled and the stop button e
 });
 
 test("reduced motion keeps the composer usable: instant ring, opacity fades only, no emerge", () => {
-  const reduced = css.slice(css.lastIndexOf("@media (prefers-reduced-motion: reduce)"));
+  const reduced = css.split("@media (prefers-reduced-motion: reduce)").slice(1).join("\n");
   assert.match(reduced, /\.composer-wrap,\s*\.composer-wrap::before \{\s*transition: none;/);
   assert.match(reduced, /\.composer-wrap:focus-within \{\s*transform: none;/);
   assert.match(reduced, /\.send-btn,\s*\.send-btn svg,\s*\.stop-btn svg \{\s*transition: opacity 120ms ease;/);

--- a/plugins/web-ui/test/live-work-flap-source.test.ts
+++ b/plugins/web-ui/test/live-work-flap-source.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const dock = chat.match(/function liveWorkDock\([\s\S]*?\n {2}\}/)?.[0] ?? "";
+
+test("the dock face is keyed on the active tool call so only real step changes remount it", () => {
+  assert.match(chat, /import \{ keyed \} from "lit\/directives\/keyed\.js";/);
+  assert.match(dock, /const faceKey = work\.stale \? "stale" : \(active\?\.call\?\.seq \?\? "thinking"\);/);
+  assert.match(dock, /keyed\(\s*faceKey,\s*html`<span class="live-work-face"/);
+  const face = dock.indexOf('class="live-work-face"');
+  const toggle = dock.indexOf("live-work-toggle");
+  for (const part of ["thinkingOrb(", "live-work-label", "live-work-detail"]) {
+    const at = dock.indexOf(part);
+    assert.ok(at > face && at < toggle, `${part} renders inside the keyed face`);
+  }
+  assert.match(dock, /\)\}\s*\$\{expandable \? html`<span class="live-work-toggle"/);
+});
+
+test("the face flaps in from a top hinge using only transform and opacity", () => {
+  assert.match(css, /\.live-work-line \{\s*perspective: 700px;\s*\}/);
+  assert.match(
+    css,
+    /\.live-work-face \{[^}]*transform-origin: 50% 0%;\s*backface-visibility: hidden;\s*animation: flap-in 380ms cubic-bezier\(0\.2, 0\.8, 0\.2, 1\) both;/,
+  );
+  const keyframes = css.match(/@keyframes flap-in \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(keyframes, /from \{\s*opacity: 0;\s*transform: rotateX\(-78deg\) translateY\(-3px\);/);
+  assert.match(keyframes, /to \{\s*opacity: 1;\s*transform: none;/);
+  const properties = [...keyframes.matchAll(/^\s+([a-z-]+):/gm)].map((m) => m[1]);
+  assert.deepEqual([...new Set(properties)].sort(), ["opacity", "transform"]);
+});
+
+test("the expanded dock wraps inside the face and pins the chevron to the first line", () => {
+  assert.match(css, /\.live-work-dock\.expanded \.live-work-face \{\s*flex-wrap: wrap;\s*\}/);
+  assert.doesNotMatch(css, /\.live-work-dock\.expanded \.live-work-line \{/);
+  assert.match(css, /\.live-work-dock\.expanded \.live-work-toggle \{\s*align-self: flex-start;/);
+});
+
+test("reduced motion swaps the face instantly", () => {
+  const blocks = [...css.matchAll(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n\}/g)].map((m) => m[0]);
+  const flapBlock = blocks.find((block) => block.includes(".live-work-face"));
+  assert.ok(flapBlock, "a reduced-motion block covers .live-work-face");
+  assert.match(flapBlock, /\.live-work-face \{\s*animation: none;\s*\}/);
+});

--- a/plugins/web-ui/test/new-below-pill-source.test.ts
+++ b/plugins/web-ui/test/new-below-pill-source.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("the pill mounts first in the dock only while a run is live and pins via the forced scroll path", () => {
+  assert.match(chat, /<div class="chat-bottom-dock">\s*\$\{newBelowPill\(agent\)\}/);
+  assert.match(chat, /function newBelowPill\(agent: Agent\)[\s\S]*?if \(!runIsLive\(agent\)\) return nothing;/);
+  assert.match(chat, /class="new-below-pill" \?inert=\$\{stickToBottom\} @click=\$\{scrollToBottom\}/);
+  assert.match(chat, /function liveWorkDock\(agent: Agent\)[\s\S]*?if \(!runIsLive\(agent\)\) return nothing;/);
+});
+
+test("scrolling toggles a host class and inert without a redraw; scrollToBottom clears both", () => {
+  assert.match(chat, /clientHeight <= 120;\s*syncScrolledUp\(\);/);
+  assert.match(chat, /scrollTranscript\(true\);\s*syncScrolledUp\(\);/);
+  const sync = chat.match(/function syncScrolledUp\(\): void \{[\s\S]*?\n {2}\}/)?.[0] ?? "";
+  assert.match(sync, /classList\.toggle\("scrolled-up", !stickToBottom\)/);
+  assert.match(sync, /pill\.inert = stickToBottom/);
+  assert.ok(!/draw|render\(/.test(sync), "scroll must not trigger a redraw");
+});
+
+test("the pill hides via opacity and pointer-events, animates transform and opacity only, and drops motion when asked", () => {
+  assert.match(css, /\.chat-bottom-dock \{\s*position: relative;/);
+  const pill = css.match(/\n\.new-below-pill \{[^}]*\}/)?.[0] ?? "";
+  assert.match(pill, /opacity: 0;\s*pointer-events: none;/);
+  assert.match(pill, /transition:\s*opacity 160ms ease,\s*transform 220ms cubic-bezier/);
+  assert.match(
+    css,
+    /\.scrolled-up \.new-below-pill \{\s*opacity: 1;\s*pointer-events: auto;\s*transform: translate\(-50%, -100%\);/,
+  );
+  assert.match(css, /\.dark \.new-below-pill \{\s*background: color-mix\(in srgb, var\(--popover\)/);
+  assert.match(
+    css,
+    /@media \(prefers-reduced-motion: reduce\) \{\s*\.new-below-pill \{\s*transition: none;\s*transform: translate\(-50%, -100%\);\s*\}\s*\}/,
+  );
+});

--- a/plugins/web-ui/test/session-list.test.ts
+++ b/plugins/web-ui/test/session-list.test.ts
@@ -4,16 +4,15 @@ import {
   activityOf,
   applySessionState,
   isAbandonedNewChat,
+  bucketByRecency,
   bumpActivity,
   chatBrowseStatusMatches,
   clearWorking,
-  groupProjectSessions,
   backgroundLabel,
   conversationBackground,
   markWorking,
   recencyGroup,
   rowIndicators,
-  recentProjectSeeds,
   reconcileSessions,
   splitPinned,
   withPendingSession,
@@ -284,62 +283,64 @@ test("reconcile replaces an optimistic working stamp with server truth", () => {
   assert.equal(out[0]!.working, undefined, "server row (no working flag) supersedes the stamp");
 });
 
-test("project metadata groups only its group scope while ordinary chats stay flat", () => {
-  const project = {
-    scopeId: "group:web-project-p1",
-    kind: "group" as const,
-    name: "Launch",
-    sessionCount: 2,
-    lastActivityAt: 30,
-    project: {
-      id: "p1",
-      name: "Launch",
-      ownerId: "alice",
-      memberIds: ["alice"],
-      scopeId: "group:web-project-p1",
-      members: [{ principalId: "alice", displayName: "Alice" }],
-    },
-  };
-  const sessions = [
-    { ...saved("1", "web:alice:p1-a"), type: "group" as const, scopeId: project.scopeId, lastActivityAt: 30 },
-    { ...saved("2", "web:alice:plain"), lastActivityAt: 20 },
-    { ...saved("3", "web:alice:p1-b"), type: "group" as const, scopeId: project.scopeId, lastActivityAt: 10 },
-  ];
-  const items = groupProjectSessions(sessions, recentProjectSeeds([project]));
-  assert.equal(items[0]?.kind, "project");
-  assert.deepEqual(items[0]?.kind === "project" ? items[0].sessions.map((session) => session.id) : [], ["1", "3"]);
-  assert.equal(items[1]?.kind, "session");
+test("bucketByRecency splits sessions at calendar-day boundaries, in bucket order", () => {
+  const now = new Date(2026, 6, 14, 15, 30).getTime();
+  const day = 86_400_000;
+  const midnight = new Date(2026, 6, 14, 0, 0).getTime();
+  const at = (id: string, ms: number) => ({ ...saved(id, `web:u:${id}`), lastActivityAt: ms });
+  const buckets = bucketByRecency(
+    [
+      at("older", midnight - 29 * day - 1),
+      at("today", now - 1),
+      at("month", midnight - 6 * day - 1),
+      at("yesterday", midnight - 1),
+      at("week", midnight - 6 * day),
+      at("today-first", midnight),
+    ],
+    now,
+  );
+  assert.deepEqual(
+    buckets.map((b) => [b.label, b.sessions.map((s) => s.id)]),
+    [
+      ["Today", ["today", "today-first"]],
+      ["Yesterday", ["yesterday"]],
+      ["Previous 7 days", ["week"]],
+      ["Previous 30 days", ["month"]],
+      ["Older", ["older"]],
+    ],
+  );
 });
 
-test("empty projects appear in Recents", () => {
-  const seeds = [{ scopeId: "group:web-project-empty", name: "Empty" }];
-  const items = groupProjectSessions([], seeds);
-  assert.deepEqual(items, [
-    { kind: "project", scopeId: "group:web-project-empty", name: "Empty", groupKind: "project", sessions: [] },
-  ]);
+test("bucketByRecency orders each bucket most recent first regardless of input order", () => {
+  const now = new Date(2026, 6, 14, 15, 30).getTime();
+  const at = (id: string, ms: number) => ({ ...saved(id, `web:u:${id}`), lastActivityAt: ms });
+  const [today] = bucketByRecency([at("a", now - 3000), at("c", now - 1000), at("b", now - 2000)], now);
+  assert.deepEqual(
+    today!.sessions.map((s) => s.id),
+    ["c", "b", "a"],
+  );
 });
 
-test("a pending (not-yet-sent) chat in a project scope nests under its project", () => {
-  const seeds = [{ scopeId: "group:web-project-p1", name: "P1" }];
-  const fresh = { ...pending("web:alice:new"), type: "group" as const, scopeId: seeds[0]!.scopeId };
-  const list = withPendingSession([saved("1", "web:alice:old")], fresh);
-  const items = groupProjectSessions(list, seeds);
-  assert.equal(items[0]?.kind, "project");
-  assert.deepEqual(items[0]?.kind === "project" ? items[0].sessions.map((s) => s.threadRef) : [], ["web:alice:new"]);
+test("bucketByRecency lands a pending unsaved chat in Today", () => {
+  const now = Date.now();
+  const old = { ...saved("1", "web:u:old"), lastActivityAt: now - 40 * 86_400_000 };
+  const buckets = bucketByRecency(withPendingSession([old], pending("web:u:new")), now);
+  assert.equal(buckets[0]!.label, "Today");
+  assert.deepEqual(
+    buckets[0]!.sessions.map((s) => s.threadRef),
+    ["web:u:new"],
+  );
+  assert.equal(buckets[1]!.label, "Older");
 });
 
-test("without project metadata every conversation keeps the existing flat recency order", () => {
-  const olderGroup = {
-    ...saved("1", "web:alice:group"),
-    type: "group" as const,
-    scopeId: "group:slack-mpdm",
-    lastActivityAt: 10,
-  };
-  const newerPersonal = { ...saved("2", "web:alice:personal"), lastActivityAt: 20 };
-  assert.deepEqual(groupProjectSessions([olderGroup, newerPersonal], []), [
-    { kind: "session", session: newerPersonal },
-    { kind: "session", session: olderGroup },
-  ]);
+test("bucketByRecency emits no header for an empty bucket", () => {
+  const now = new Date(2026, 6, 14, 15, 30).getTime();
+  const at = (id: string, ms: number) => ({ ...saved(id, `web:u:${id}`), lastActivityAt: ms });
+  assert.deepEqual(
+    bucketByRecency([at("today", now), at("older", now - 60 * 86_400_000)], now).map((b) => b.label),
+    ["Today", "Older"],
+  );
+  assert.deepEqual(bucketByRecency([], now), []);
 });
 
 test("rowIndicators: server working flag lights the dot", () => {

--- a/plugins/web-ui/test/streaming-caret-source.test.ts
+++ b/plugins/web-ui/test/streaming-caret-source.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+const caretSelector = (indent: string): string =>
+  [
+    ".streaming-text.live-stream .stream-tail > div > :is(p, h1, h2, h3, h4, h5, h6):last-child::after,",
+    ".streaming-text.live-stream .stream-tail > div > :is(ul, ol):last-child > li:last-child::after,",
+    ".streaming-text.live-stream .stream-tail > div > blockquote:last-child > p:last-child::after {",
+  ]
+    .map((line) => indent + line)
+    .join("\n");
+
+test("the live tail block keeps the stream-tail class the caret hangs off", () => {
+  assert.match(chat, /<markdown-block\s+class="stream-tail"/);
+  assert.match(chat, /class="streaming-text \$\{isStreaming \? "live-stream" : ""\}"/);
+});
+
+test("the caret is a breathing pseudo-element on the last block inside the mini-lit wrapper div", () => {
+  const rule = css.indexOf(caretSelector(""));
+  assert.ok(rule >= 0, "caret selector reaches through the markdown-block wrapper div");
+  const body = css.slice(rule, css.indexOf("\n}", rule));
+  assert.match(body, /content: "";/);
+  assert.match(body, /width: 2px;/);
+  assert.match(body, /var\(--brand-accent\)/);
+  assert.match(body, /animation: caret-breathe 1\.05s ease-in-out infinite;/);
+  assert.match(css, /@keyframes caret-breathe \{[^@]*opacity: 0\.35;\s*transform: scaleY\(0\.82\);/);
+  assert.doesNotMatch(css, /\.stream-tail > :is\(p/);
+});
+
+test("the first streamed paragraph rises out of the thinking row once via @starting-style", () => {
+  assert.match(css, /\.streaming-text\.live-stream \{\s*transition:\s*opacity 240ms ease-out,\s*transform 320ms/);
+  assert.match(
+    css,
+    /@starting-style \{\s*\.streaming-text\.live-stream \{\s*opacity: 0;\s*transform: translateY\(5px\);/,
+  );
+});
+
+test("reduced motion keeps a static caret and drops the rise without touching the thinking sheen", () => {
+  const blocks = [...css.matchAll(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n\}/g)].map((m) => m[0]);
+  const caretBlock = blocks.find((block) => block.includes(caretSelector("  ")));
+  assert.ok(caretBlock, "a reduced-motion block covers the caret");
+  assert.match(caretBlock, /\.streaming-text\.live-stream \{\s*transition: none;/);
+  assert.match(caretBlock, /::after \{\s*animation: none;\s*opacity: 1;/);
+  assert.match(css, /animation: thinking-sheen 2\.55s linear infinite;/);
+});

--- a/plugins/web-ui/test/theme-crossfade-source.test.ts
+++ b/plugins/web-ui/test/theme-crossfade-source.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("theme toggle clicks are intercepted once at capture phase and replayed inside a view transition", () => {
+  const fn = shell.match(/function crossfadeThemeSwitch\(e: MouseEvent\): void \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(fn, /typeof document\.startViewTransition !== "function" \|\| reduceMotion\.matches\) return;/);
+  assert.match(fn, /e\.target\.closest<ThemeCycler>\("theme-toggle"\) : null;/);
+  assert.match(fn, /typeof toggle\.cycleTheme !== "function"\) return;/);
+  assert.match(
+    fn,
+    /e\.stopImmediatePropagation\(\);\s*e\.preventDefault\(\);\s*document\.startViewTransition\(\(\) => toggle\.cycleTheme\?\.\(\)\);/,
+  );
+  assert.equal(shell.match(/document\.addEventListener\("click", crossfadeThemeSwitch, true\);/g)?.length, 1);
+  assert.doesNotMatch(shell.match(/export function mountShell[\s\S]*?\n\}/)?.[0] ?? "", /crossfadeThemeSwitch/);
+});
+
+test("the root crossfade is opacity-only at 260ms and disabled under reduced motion", () => {
+  assert.match(
+    css,
+    /::view-transition-old\(root\),\s*::view-transition-new\(root\) \{\s*animation-duration: 260ms;\s*animation-timing-function: ease-in-out;\s*\}/,
+  );
+  assert.doesNotMatch(css, /::view-transition[^{]*\{[^}]*mix-blend-mode/);
+  assert.match(
+    css,
+    /@media \(prefers-reduced-motion: reduce\) \{\s*::view-transition-group\(\*\),\s*::view-transition-old\(\*\),\s*::view-transition-new\(\*\) \{\s*animation: none;\s*\}\s*\}/,
+  );
+});

--- a/plugins/web-ui/test/thinking-orb.test.ts
+++ b/plugins/web-ui/test/thinking-orb.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+const functionBody = (name: string): string =>
+  chat.match(new RegExp(`function ${name}\\([\\s\\S]*?\\n {2}\\}`))?.[0] ?? "";
+
+test("the live dock, work heads, and the typing row render the 3D orb ahead of the sheen label", () => {
+  for (const name of ["liveWorkDock", "workBlock", "typingRow"]) {
+    const body = functionBody(name);
+    const orb = body.indexOf("thinkingOrb(");
+    const sheen = body.indexOf("sheenLabel(");
+    assert.ok(orb >= 0, `${name} renders thinkingOrb`);
+    assert.ok(sheen >= 0, `${name} keeps the sheen label text`);
+    assert.ok(orb < sheen, `${name} renders the orb before the sheen label`);
+  }
+});
+
+test("the orb variant is picked from a hash of the mounted thread", () => {
+  assert.match(chat, /const orbVariants = \["gyro", "tesseract", "orbit"\] as const;/);
+  assert.match(chat, /variant = orbVariantFor\(chatState\.threadRef \?\? ""\)/);
+  assert.match(chat, /data-variant=\$\{variant\}/);
+});
+
+test("the orb CSS builds three preserve-3d scenes switched by data-variant", () => {
+  assert.match(css, /\.think-orb \{[^}]*perspective:[^}]*transform-style: preserve-3d;/);
+  assert.match(css, /\.think-orb \.orb-ring \{[^}]*transform-style: preserve-3d;[^}]*will-change: transform;/);
+  for (const variant of ["gyro", "tesseract", "orbit"]) {
+    assert.match(css, new RegExp(`\\.think-orb\\[data-variant="${variant}"\\]`), `${variant} scene exists`);
+  }
+});
+
+test("a reduced-motion block stops the orb rings and leaves the core breathing", () => {
+  const blocks = [...css.matchAll(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\n\}/g)].map((m) => m[0]);
+  const orbBlock = blocks.find((block) => block.includes(".think-orb"));
+  assert.ok(orbBlock, "a reduced-motion block covers .think-orb");
+  assert.match(orbBlock, /\.think-orb \.orb-ring[^{]*\{\s*animation: none;/);
+  assert.ok(!orbBlock.includes(".orb-core"), "the core keeps its 2.4s opacity breathe under reduced motion");
+});


### PR DESCRIPTION
## What this does

The chat interface got a set of ten motion and depth upgrades plus the three things asked for in the report that started this: a real preview when hovering a pasted file, a sidebar organized by date, and a 3D thinking indicator instead of the plain text sheen.

Everything is CSS 3D, CSS custom properties, and small Lit/TypeScript changes. No new dependencies. Every animation has a `prefers-reduced-motion` fallback (verified live with emulated reduced motion), only transform/opacity/filter animate, and colors come from the existing theme tokens via `color-mix` so light and dark both work.

### The three asks

1. **Attachment hover preview.** Hovering (or focusing) a chip in the composer shows a card after a short intent delay: file name, kind, size, and an image thumbnail, a PDF first page, or a monospace text snippet with a line count. Escape dismisses. New module `attachment-preview.ts`; data URLs are cached per attachment so streaming redraws stay cheap.
![image preview](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/01-attachment-preview-image.jpg)
![text preview](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/02-attachment-preview-text.jpg)

2. **Sidebar by date.** Sessions are listed directly under Today / Yesterday / Previous 7 days / Previous 30 days / Older, most recent first, with sticky bucket headers. Non-personal scopes show a compact scope chip on the row. Projects keep their rename, new-chat and menu actions in a collapsible Projects section above the list. `groupProjectSessions` and its nesting are gone; `bucketByRecency` replaces them.
![sidebar by date](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/03-sidebar-by-date.jpg)

3. **3D thinking orb.** While the model thinks, a small CSS 3D scene renders next to the label in the live dock, the work block heads, and the transcript placeholder. Three variants (gyro rings, tumbling wireframe tesseract, orbiting particles) are chosen per conversation from a hash of the thread ref. Rings rotate on different axes and periods with real perspective; the core glows via the brand accent. Reduced motion freezes the rings and keeps only the slow core breathe.
![orb frames](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/12-thinking-orb-frames.png)
![orb in the dock](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/11-thinking-orb-dock.jpg)

### Seven more

4. **Active-row indicator** glides between sidebar rows (2px bar, borrows the session color).
![indicator](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/04-active-row-indicator.jpg)
5. **Code block chrome**: language pill, hover-revealed copy, layered depth, and a streaming caret inside code blocks.
![code block](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/07-code-block-chrome.jpg)
6. **Theme crossfade** through `document.startViewTransition`, with the instant switch as fallback.
![light theme](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/05-light-theme-after-crossfade.jpg)
7. **Composer physics**: focus lift with a hairline ring and deeper shadow, send button springs from dim/compressed to live, stop button emerges from under it when a turn starts.
![composer focus](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/06-composer-focus-lift.jpg)
8. **Approval card arrival**: the panel rises into place with a one-shot attention ring and badge pop. Covered by source tests; the dev instance ran commands without needing approval so there is no live screenshot.
9. **New activity below pill**: a glass pill appears when you scroll up mid-run and snaps you back when clicked. It carries `inert` while hidden.
![pill](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/08-new-activity-pill.jpg)
10. **Live dock split-flap**: the dock line flaps in 3D between Thinking and each tool call.
![flap](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/10-live-dock-flap.jpg)
11. **Streaming edge caret** with a faint halo at the end of the last line, breathing when the model pauses.
![caret](https://raw.githubusercontent.com/yc-software/qm/c0457d2f54b78c1f01247e63bbae0e15771e0766/09-streaming-caret.jpg)

Screenshots live on the orphan branch `demo/chat-ui-refresh-screenshots`, taken from a local dev instance against a Postgres seeded with a handful of dated sessions.

## How to see each one

- **active-row-indicator-slide**: Open the web UI with at least two conversations in the sidebar. A 2px vertical bar sits at the far-left edge of the sidebar list beside the open conversation. Click a different conversation in another date bucket (Today -> Yesterday) or inside an expanded Projects group: the bar glides from the old row to the new one over ~240ms while the 9% row highlight swaps as before. Open a conversation with a project color set: the bar takes that color. Click New chat or start renaming a row (no active row): the bar fades out; re-open a conversation: it fades in beside the row without sliding down from the top. Scroll the list: the bar scrolls with the rows. With macOS Reduce Motion on, the bar jumps to the new row and only fades.
- **new-below-pill**: 1) Open the web UI and start a chat that produces a long streaming reply (e.g. ask for a multi-section explanation). 2) While the assistant is still streaming, scroll the transcript up by more than ~120px: a glass "New activity below" pill with a down arrow rises above the composer, centered over the transcript, blurring the text behind it. 3) Scroll back down to the bottom (or click the pill): the pill fades and drops back into the composer's shadow; clicking it snaps the transcript to the end instantly and re-arms auto-follow. 4) Once the run finishes, the pill is gone from the DOM (inspect .chat-bottom-dock). 5) Toggle the dark theme to see the popover-tinted glass variant; enable "Reduce motion" in OS settings to see it appear/disappear with no slide or scale.
- **code-block-chrome**: Boot the web UI (plugins/web-ui, `npm run dev` or via /dev-instance) and open any conversation. Send a prompt that yields fenced code, e.g. "Write a 10-line Python script that prints fizzbuzz, in a ```python fence". While the reply streams, look at the bottom of the code block: a 7px blinking block caret follows the last character until the block commits. Once done: the header shows the language ("python") in a small rounded pill; the Copy button is invisible until you hover the block (or Tab into it), when it fades/slides in and the whole block gains a soft 6px/18px drop shadow. Click Copy: the "Copied!" label pops in with an overshoot for 2s. Toggle dark mode to confirm shadows/pill read correctly (all colors are color-mix of --foreground/--muted-foreground). On a touch device or with DevTools emulating (hover: none), the Copy button is always visible. With macOS Reduce Motion on, everything appears instantly and the caret is static.
- **theme-crossfade**: Open the web UI in Chrome/Edge/Safari 18+ (browsers with document.startViewTransition). In the sidebar footer (bottom-left), click the color-scheme icon button (sun/moon/monitor, title "Color scheme: light / dark / system"). The whole page crossfades between light and dark over ~260ms instead of flipping instantly. Click again to cycle light -> dark -> system. To confirm the fallback: enable prefers-reduced-motion (macOS Reduce Motion, or DevTools Rendering > Emulate CSS media feature prefers-reduced-motion) or use Firefox, and the same click switches instantly. Theme persists in localStorage "theme" and the html.dark class exactly as before.
- **approval-card-arrive**: Open the web UI, start a chat with an agent that has command approvals enabled, and ask it to run a command that requires approval (e.g. a shell command not on the allowlist). When the run pauses: the composer's textarea is replaced by the approval panel, which rises up ~10px into place over 420ms; ~180ms later a single indigo ring fades in and expands around the panel, gone by ~1.1s; the red reason badge next to "Approval needed" pops in at ~260ms. Simultaneously the inline "Approval needed" marker card in the transcript rises in the same way. Hover an approval button to see it lift 1px; press and hold to see it compress to 0.97. Screenshot at ~250ms, ~500ms and after 1.2s for the arrival/ring/at-rest states. Toggle macOS Reduce Motion (or Firefox ui.prefersReducedMotion=1) and re-trigger: the panel and card appear instantly with no ring and buttons stay flat.
- **composer-physics**: Open the web UI and any chat. (1) Click into the composer textarea: the card rises 1px and gains a hairline ring in the theme's --ring tone plus a deeper shadow; click elsewhere to see it settle. Also open the slash menu or model popover inside the composer — the ring stays while they hold focus. (2) With an empty draft the send arrow sits small and dim (scale 0.88, 35% opacity); type one character and it pops to full size with a slight overshoot; delete the text and it shrinks back. Hover the enabled send button: the arrow glyph nudges up 1px; press and hold: the button compresses. (3) Send a message: as the turn starts, the stop button slides out from underneath the send button's position (41px to the right) and settles into its slot on the left; hover it to see the square glyph scale up. (4) Toggle OS reduce-motion: focus still shows the ring and shadow instantly with no lift, buttons still fade, no emerge slide.
- **dock-tool-flap**: Boot the web UI from this worktree, start a chat turn that runs several tools (e.g. ask the agent to read a file then run a command). Watch the dock line above the composer: the orb + "Thinking" face flaps in from a top hinge on run start; on the first tool call the face swings down again showing the tool icon + "Running command"; each subsequent tool call flaps once; the "for Ns" ticker updates the label without flapping; the chevron on the right never moves. Expand the dock: detail wraps to a second line and the chevron stays on the first line. With macOS Reduce Motion on, the text swaps instantly. Source-level: `git show 50d6c7f` and `node --test test/live-work-flap-source.test.ts` in plugins/web-ui.
- **live-edge-caret**: Boot the web UI, send a prompt that produces a long reply. While thinking you see the orb + "Thinking"; the instant text arrives the first paragraph fades/rises 5px into place and a 2px caret with a faint indigo halo sits at the end of the last line: solid while tokens stream (the tail block re-renders per token, restarting the animation at 0%), breathing at 1.05s when the model pauses. On settle the caret vanishes with `live-stream`; text does not shift. Emulate prefers-reduced-motion in devtools: caret is static and opaque, no rise. Source: tail of plugins/web-ui/src/shell.css (block starting `.streaming-text.live-stream {`).

## Verification

- `plugins/web-ui`: full test suite (647 tests) passes; `npm run typecheck` clean; eslint and prettier clean on `src` and `test`.
- Live dev instance QA in a browser: attachment previews (image and text), date buckets, orb variants, indicator glide, composer focus and send states, code block chrome, theme toggle, pill appear and click, caret, flap faces, and a reduced-motion pass confirming rings, sheen, flap, pill and composer transitions all stop.
- Independent multi-lens review with adversarial verification is running; findings will be resolved before this leaves draft.

## Notes for reviewers

- Each enhancement is its own commit for bisectability.
- New CSS is appended to `shell.css`; in-place edits are limited to the few base rules a spec required.
- Design candidates were generated and ranked by a judge panel before implementation; the seven extras are the top of that ranking after de-duplication, chosen for wow factor, fit with a serious work tool, feasibility, and accessibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249232&installation_model_id=19911&pr_number=960&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F960&signature=17997df37be468f3418e2ffcb0418bad95f02dccecb760bc540beb6d1c6cbdc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->