### PR TITLE
feat(web-ui): Tidy chats with the auxiliary model

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1465,13 +1465,8 @@ const apiRoutes: readonly WebRoute[] = [
     method: "POST",
     path: "/api/sessions/tidy",
     handle: async (c) => {
-      const { req, res, user } = c;
-      const p = await readJson<{ idleDays?: unknown }>(req, res, false);
-      if (!p) return;
-      if (typeof p.idleDays !== "number" || !Number.isFinite(p.idleDays) || p.idleDays < 0) {
-        return json(res, 400, { error: "bad_request", message: "idleDays must be a non-negative number" });
-      }
-      return relayCore(res, "POST", "/v1/sessions/tidy", JSON.stringify({ principalId: user, idleDays: p.idleDays }));
+      const { res, user } = c;
+      return relayCore(res, "POST", "/v1/sessions/tidy", JSON.stringify({ principalId: user }));
     },
   },
   {

--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1463,6 +1463,19 @@ const apiRoutes: readonly WebRoute[] = [
   },
   {
     method: "POST",
+    path: "/api/sessions/tidy",
+    handle: async (c) => {
+      const { req, res, user } = c;
+      const p = await readJson<{ idleDays?: unknown }>(req, res, false);
+      if (!p) return;
+      if (typeof p.idleDays !== "number" || !Number.isFinite(p.idleDays) || p.idleDays < 0) {
+        return json(res, 400, { error: "bad_request", message: "idleDays must be a non-negative number" });
+      }
+      return relayCore(res, "POST", "/v1/sessions/tidy", JSON.stringify({ principalId: user, idleDays: p.idleDays }));
+    },
+  },
+  {
+    method: "POST",
     path: "/api/sessions/:id",
     handle: async (c) => {
       const { req, res, user } = c;

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -269,8 +269,8 @@ export async function fetchEntry(sessionId: string, seq: number): Promise<Sessio
   return r.entry;
 }
 
-export async function tidySessions(idleDays: number): Promise<{ archived: string[]; considered: number }> {
-  return api(`/api/sessions/tidy`, { method: "POST", body: JSON.stringify({ idleDays }) });
+export async function tidySessions(): Promise<{ archived: string[]; considered: number }> {
+  return api(`/api/sessions/tidy`, { method: "POST", body: "{}" });
 }
 
 export async function regenerateTitle(id: string): Promise<{ title: string | null }> {

--- a/plugins/web-ui/src/core-bridge.ts
+++ b/plugins/web-ui/src/core-bridge.ts
@@ -269,6 +269,10 @@ export async function fetchEntry(sessionId: string, seq: number): Promise<Sessio
   return r.entry;
 }
 
+export async function tidySessions(idleDays: number): Promise<{ archived: string[]; considered: number }> {
+  return api(`/api/sessions/tidy`, { method: "POST", body: JSON.stringify({ idleDays }) });
+}
+
 export async function regenerateTitle(id: string): Promise<{ title: string | null }> {
   return api<{ title: string | null }>(`/api/sessions/${encodeURIComponent(id)}/title`, { method: "POST" });
 }

--- a/plugins/web-ui/src/main.ts
+++ b/plugins/web-ui/src/main.ts
@@ -8,7 +8,6 @@ import {
   clearSessionSelection,
   closeOpenSessionMenu,
   closeSessionSelectionColor,
-  closeTidyMenu,
   renderList,
   sessionsState,
 } from "./sessions";
@@ -35,7 +34,6 @@ document.addEventListener("click", (e) => {
     renderList();
   }
   if (!target?.closest(".multi-select-color")) closeSessionSelectionColor();
-  if (!target?.closest(".tidy-menu")) closeTidyMenu();
   closeDeployMenu(target);
 });
 

--- a/plugins/web-ui/src/main.ts
+++ b/plugins/web-ui/src/main.ts
@@ -8,6 +8,7 @@ import {
   clearSessionSelection,
   closeOpenSessionMenu,
   closeSessionSelectionColor,
+  closeTidyMenu,
   renderList,
   sessionsState,
 } from "./sessions";
@@ -34,6 +35,7 @@ document.addEventListener("click", (e) => {
     renderList();
   }
   if (!target?.closest(".multi-select-color")) closeSessionSelectionColor();
+  if (!target?.closest(".tidy-menu")) closeTidyMenu();
   closeDeployMenu(target);
 });
 

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -150,138 +150,40 @@ function visibleRowOrder(): string[] {
 }
 
 const WEB_ONLY_KEY = "web-ui:web-only";
-const TIDY_KEY = "web-ui:tidy";
-const TIDY_AUTO_INTERVAL_MS = 24 * 60 * 60_000;
-
-export const tidyState: { open: boolean; running: boolean; auto: boolean; idleDays: number; lastRunAt: number } = {
-  open: false,
-  running: false,
-  auto: false,
-  idleDays: 7,
-  lastRunAt: 0,
-  ...((): Partial<{ auto: boolean; idleDays: number; lastRunAt: number }> => {
-    try {
-      const raw: unknown = JSON.parse(localStorage.getItem(TIDY_KEY) ?? "{}");
-      if (!raw || typeof raw !== "object") return {};
-      const r = raw as Record<string, unknown>;
-      return {
-        ...(typeof r.auto === "boolean" ? { auto: r.auto } : {}),
-        ...(typeof r.idleDays === "number" && r.idleDays >= 0 ? { idleDays: r.idleDays } : {}),
-        ...(typeof r.lastRunAt === "number" ? { lastRunAt: r.lastRunAt } : {}),
-      };
-    } catch {
-      return {};
-    }
-  })(),
-};
-
-function saveTidySettings(): void {
-  try {
-    const { auto, idleDays, lastRunAt } = tidyState;
-    localStorage.setItem(TIDY_KEY, JSON.stringify({ auto, idleDays, lastRunAt }));
-  } catch {
-    void 0;
-  }
-}
-
-export function closeTidyMenu(): void {
-  if (!tidyState.open) return;
-  tidyState.open = false;
-  renderSidebarTop();
-}
+let tidyRunning = false;
 
 export async function runTidy(): Promise<void> {
-  if (tidyState.running) return;
-  tidyState.running = true;
+  if (tidyRunning) return;
+  tidyRunning = true;
   renderSidebarTop();
   try {
-    const { archived, considered } = await tidySessions(tidyState.idleDays);
-    tidyState.lastRunAt = Date.now();
-    saveTidySettings();
+    const { archived, considered } = await tidySessions();
     for (const id of archived) closeSessionSurfaces(id);
     sessionsState.list = sessionsState.list.map((s) => (archived.includes(s.id) ? { ...s, archived: true } : s));
     renderList();
     const chats = considered === 1 ? "chat" : "chats";
-    if (archived.length) canvasToast(`Tidied ${archived.length} of ${considered} idle ${chats}`);
-    else if (considered) canvasToast(`Looked at ${considered} idle ${chats}, all still open`);
-    else canvasToast("Nothing idle to tidy");
+    if (archived.length) canvasToast(`Tidied ${archived.length} of ${considered} ${chats}`);
+    else if (considered) canvasToast(`Looked at ${considered} ${chats}, all still open`);
+    else canvasToast("Nothing to tidy");
   } catch (e) {
     canvasToast(errMessage(e, "Tidy failed"));
   } finally {
-    tidyState.running = false;
+    tidyRunning = false;
     renderSidebarTop();
   }
 }
 
-export function maybeAutoTidy(): void {
-  if (!tidyState.auto || Date.now() - tidyState.lastRunAt < TIDY_AUTO_INTERVAL_MS) return;
-  void runTidy();
-}
-
 export function tidyControl(): TemplateResult {
-  const idleLabel = tidyState.idleDays === 1 ? "day" : "days";
-  return html`<span class="tidy-menu">
-    <button
-      class="chat-search-open tidy-open ${tidyState.open ? "on" : ""}"
-      type="button"
-      aria-haspopup="menu"
-      aria-expanded=${tidyState.open ? "true" : "false"}
-      title="Tidy: archive finished chats"
-      @click=${() => {
-        tidyState.open = !tidyState.open;
-        renderSidebarTop();
-      }}
-    >
-      ${icon(Sparkles, 13)}
-    </button>
-    ${
-      tidyState.open
-        ? html`<div class="session-menu-popover tidy-popover" role="menu" @click=${(e: Event) => e.stopPropagation()}>
-            <label class="tidy-field">
-              <span>Consider chats idle for</span>
-              <input
-                type="number"
-                min="0"
-                step="1"
-                .value=${live(String(tidyState.idleDays))}
-                @change=${(e: Event) => {
-                  const v = Number((e.target as HTMLInputElement).value);
-                  tidyState.idleDays = Number.isFinite(v) && v >= 0 ? Math.floor(v) : tidyState.idleDays;
-                  saveTidySettings();
-                  renderSidebarTop();
-                }}
-              />
-              <span>${idleLabel}</span>
-            </label>
-            <label class="tidy-field">
-              <input
-                type="checkbox"
-                .checked=${live(tidyState.auto)}
-                @change=${(e: Event) => {
-                  tidyState.auto = (e.target as HTMLInputElement).checked;
-                  saveTidySettings();
-                  renderSidebarTop();
-                }}
-              />
-              <span>Auto-tidy daily when I open the app</span>
-            </label>
-            <button
-              class="session-menu-option"
-              type="button"
-              role="menuitem"
-              ?disabled=${tidyState.running}
-              @click=${() => void runTidy()}
-            >
-              ${icon(Sparkles, 15)}<span>${tidyState.running ? "Tidying…" : "Tidy now"}</span>
-            </button>
-            <div class="tidy-hint">
-              A small model reads each idle chat and archives the finished ones. Pinned chats are skipped; unarchive
-              anything from the Archived list.
-            </div>
-          </div>`
-        : nothing
-    }
-  </span>`;
+  return html`<button
+    class="chat-search-open tidy-open ${tidyRunning ? "on" : ""}"
+    type="button"
+    ?disabled=${tidyRunning}
+    aria-label="Tidy: archive finished chats"
+    title=${tidyRunning ? "Tidying…" : "Tidy: archive finished chats"}
+    @click=${() => void runTidy()}
+  >
+    ${icon(Sparkles, 13)}
+  </button>`;
 }
 sessionsState.webOnly = ((): boolean => {
   try {
@@ -1565,10 +1467,8 @@ async function runSessionsRefresh(
     if (seq !== sessionRefreshSeq) return sessionsState.loaded || ((await newerRun()) ?? false);
     if (patchEpoch !== sessionPatchEpoch) return false;
     sessionsState.list = reconcileSessions(r.sessions ?? [], sessionsState.list);
-    const firstLoad = !sessionsState.loaded;
     sessionsState.loaded = true;
     sessionsNotice = "";
-    if (firstLoad) maybeAutoTidy();
     return true;
   } catch (e) {
     if (seq !== sessionRefreshSeq) return sessionsState.loaded || ((await newerRun()) ?? false);

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -22,6 +22,7 @@ import {
   PinOff,
   Plus,
   RefreshCw,
+  Sparkles,
   SquareTerminal,
   User,
   Users,
@@ -40,6 +41,7 @@ import {
   slackThreadUrl,
   TAIL_TURNS,
   type TranscriptPage,
+  tidySessions,
   updateSession,
   type PendingApproval,
   type CoreProject,
@@ -87,6 +89,7 @@ import { allConversations, mainConversation } from "./conversations";
 import type { Conversation } from "./conv-types";
 import {
   beginSessionDrag,
+  canvasToast,
   endSessionDrag,
   notifySessionsChanged,
   closeSessionSurfaces,
@@ -147,6 +150,139 @@ function visibleRowOrder(): string[] {
 }
 
 const WEB_ONLY_KEY = "web-ui:web-only";
+const TIDY_KEY = "web-ui:tidy";
+const TIDY_AUTO_INTERVAL_MS = 24 * 60 * 60_000;
+
+export const tidyState: { open: boolean; running: boolean; auto: boolean; idleDays: number; lastRunAt: number } = {
+  open: false,
+  running: false,
+  auto: false,
+  idleDays: 7,
+  lastRunAt: 0,
+  ...((): Partial<{ auto: boolean; idleDays: number; lastRunAt: number }> => {
+    try {
+      const raw: unknown = JSON.parse(localStorage.getItem(TIDY_KEY) ?? "{}");
+      if (!raw || typeof raw !== "object") return {};
+      const r = raw as Record<string, unknown>;
+      return {
+        ...(typeof r.auto === "boolean" ? { auto: r.auto } : {}),
+        ...(typeof r.idleDays === "number" && r.idleDays >= 0 ? { idleDays: r.idleDays } : {}),
+        ...(typeof r.lastRunAt === "number" ? { lastRunAt: r.lastRunAt } : {}),
+      };
+    } catch {
+      return {};
+    }
+  })(),
+};
+
+function saveTidySettings(): void {
+  try {
+    const { auto, idleDays, lastRunAt } = tidyState;
+    localStorage.setItem(TIDY_KEY, JSON.stringify({ auto, idleDays, lastRunAt }));
+  } catch {
+    void 0;
+  }
+}
+
+export function closeTidyMenu(): void {
+  if (!tidyState.open) return;
+  tidyState.open = false;
+  renderSidebarTop();
+}
+
+export async function runTidy(): Promise<void> {
+  if (tidyState.running) return;
+  tidyState.running = true;
+  renderSidebarTop();
+  try {
+    const { archived, considered } = await tidySessions(tidyState.idleDays);
+    tidyState.lastRunAt = Date.now();
+    saveTidySettings();
+    for (const id of archived) closeSessionSurfaces(id);
+    sessionsState.list = sessionsState.list.map((s) => (archived.includes(s.id) ? { ...s, archived: true } : s));
+    renderList();
+    const chats = considered === 1 ? "chat" : "chats";
+    if (archived.length) canvasToast(`Tidied ${archived.length} of ${considered} idle ${chats}`);
+    else if (considered) canvasToast(`Looked at ${considered} idle ${chats}, all still open`);
+    else canvasToast("Nothing idle to tidy");
+  } catch (e) {
+    canvasToast(errMessage(e, "Tidy failed"));
+  } finally {
+    tidyState.running = false;
+    renderSidebarTop();
+  }
+}
+
+export function maybeAutoTidy(): void {
+  if (!tidyState.auto || Date.now() - tidyState.lastRunAt < TIDY_AUTO_INTERVAL_MS) return;
+  void runTidy();
+}
+
+export function tidyControl(): TemplateResult {
+  const idleLabel = tidyState.idleDays === 1 ? "day" : "days";
+  return html`<span class="tidy-menu">
+    <button
+      class="chat-search-open tidy-open ${tidyState.open ? "on" : ""}"
+      type="button"
+      aria-haspopup="menu"
+      aria-expanded=${tidyState.open ? "true" : "false"}
+      title="Tidy: archive finished chats"
+      @click=${() => {
+        tidyState.open = !tidyState.open;
+        renderSidebarTop();
+      }}
+    >
+      ${icon(Sparkles, 13)}
+    </button>
+    ${
+      tidyState.open
+        ? html`<div class="session-menu-popover tidy-popover" role="menu" @click=${(e: Event) => e.stopPropagation()}>
+            <label class="tidy-field">
+              <span>Consider chats idle for</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                .value=${live(String(tidyState.idleDays))}
+                @change=${(e: Event) => {
+                  const v = Number((e.target as HTMLInputElement).value);
+                  tidyState.idleDays = Number.isFinite(v) && v >= 0 ? Math.floor(v) : tidyState.idleDays;
+                  saveTidySettings();
+                  renderSidebarTop();
+                }}
+              />
+              <span>${idleLabel}</span>
+            </label>
+            <label class="tidy-field">
+              <input
+                type="checkbox"
+                .checked=${live(tidyState.auto)}
+                @change=${(e: Event) => {
+                  tidyState.auto = (e.target as HTMLInputElement).checked;
+                  saveTidySettings();
+                  renderSidebarTop();
+                }}
+              />
+              <span>Auto-tidy daily when I open the app</span>
+            </label>
+            <button
+              class="session-menu-option"
+              type="button"
+              role="menuitem"
+              ?disabled=${tidyState.running}
+              @click=${() => void runTidy()}
+            >
+              ${icon(Sparkles, 15)}<span>${tidyState.running ? "Tidying…" : "Tidy now"}</span>
+            </button>
+            <div class="tidy-hint">
+              A small model reads each idle chat and archives the finished ones. Pinned chats are skipped; unarchive
+              anything from the Archived list.
+            </div>
+          </div>`
+        : nothing
+    }
+  </span>`;
+}
 sessionsState.webOnly = ((): boolean => {
   try {
     return localStorage.getItem(WEB_ONLY_KEY) !== "0";
@@ -1429,8 +1565,10 @@ async function runSessionsRefresh(
     if (seq !== sessionRefreshSeq) return sessionsState.loaded || ((await newerRun()) ?? false);
     if (patchEpoch !== sessionPatchEpoch) return false;
     sessionsState.list = reconcileSessions(r.sessions ?? [], sessionsState.list);
+    const firstLoad = !sessionsState.loaded;
     sessionsState.loaded = true;
     sessionsNotice = "";
+    if (firstLoad) maybeAutoTidy();
     return true;
   } catch (e) {
     if (seq !== sessionRefreshSeq) return sessionsState.loaded || ((await newerRun()) ?? false);

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -295,7 +295,6 @@ a.chat-row-open {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  position: relative;
   scrollbar-gutter: stable;
 }
 .web-only-toggle {
@@ -7433,42 +7432,8 @@ h3.ambient-field-label {
   background: color-mix(in srgb, var(--foreground) 8%, transparent);
   color: var(--foreground);
 }
-.tidy-menu {
-  display: inline-flex;
-}
-.chat-search-open.on {
-  background: color-mix(in srgb, var(--foreground) 8%, transparent);
-  color: var(--foreground);
-}
-.tidy-popover {
-  right: 11px;
-  width: 250px;
-  gap: 6px;
-  padding: 10px;
-  text-transform: none;
-  letter-spacing: normal;
-  font-size: 13px;
-  font-weight: 400;
-}
-.tidy-field {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--foreground);
-}
-.tidy-field input[type="number"] {
-  width: 48px;
-  padding: 3px 6px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--background);
-  color: inherit;
-  font: inherit;
-}
-.tidy-hint {
-  color: var(--muted-foreground);
-  font-size: 12px;
-  line-height: 1.4;
+.tidy-open:disabled {
+  cursor: progress;
 }
 .chat-search-overlay {
   position: fixed;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -295,9 +295,6 @@ a.chat-row-open {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  /* Match the list's reserved scrollbar gutter so the Web-only toggle shares a
-     right edge with the session rows below. */
-  overflow-x: hidden;
   scrollbar-gutter: stable;
 }
 .web-only-toggle {
@@ -7434,6 +7431,43 @@ h3.ambient-field-label {
 .chat-search-open:focus-visible {
   background: color-mix(in srgb, var(--foreground) 8%, transparent);
   color: var(--foreground);
+}
+.tidy-menu {
+  position: relative;
+  display: inline-flex;
+}
+.chat-search-open.on {
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+  color: var(--foreground);
+}
+.tidy-popover {
+  width: 250px;
+  gap: 6px;
+  padding: 10px;
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 13px;
+  font-weight: 400;
+}
+.tidy-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--foreground);
+}
+.tidy-field input[type="number"] {
+  width: 48px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--background);
+  color: inherit;
+  font: inherit;
+}
+.tidy-hint {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.4;
 }
 .chat-search-overlay {
   position: fixed;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -295,6 +295,7 @@ a.chat-row-open {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+  position: relative;
   scrollbar-gutter: stable;
 }
 .web-only-toggle {
@@ -7433,7 +7434,6 @@ h3.ambient-field-label {
   color: var(--foreground);
 }
 .tidy-menu {
-  position: relative;
   display: inline-flex;
 }
 .chat-search-open.on {
@@ -7441,6 +7441,7 @@ h3.ambient-field-label {
   color: var(--foreground);
 }
 .tidy-popover {
+  right: 11px;
   width: 250px;
   gap: 6px;
   padding: 10px;

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -60,6 +60,7 @@ import {
   resetSessionsState,
   sessionTitle,
   sessionsState,
+  tidyControl,
   toggleWebOnly,
   sessionSelectionBar,
 } from "./sessions";
@@ -583,6 +584,7 @@ export function renderSidebarTop(): void {
             >
               ${icon(Search, 13)}
             </button>
+            ${tidyControl()}
             <button
               class="web-only-toggle ${sessionsState.webOnly ? "on" : ""}"
               type="button"

--- a/plugins/web-ui/test/tidy-source.test.ts
+++ b/plugins/web-ui/test/tidy-source.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (f: string): string => readFileSync(new URL(`../${f}`, import.meta.url), "utf8");
+const sessions = read("src/sessions.ts");
+const server = read("server/index.ts");
+
+const fn = (src: string, name: string): string => {
+  const body = src.match(new RegExp(`^(?:export )?(?:async )?function ${name}\\([\\s\\S]*?\\n\\}`, "m"))?.[0] ?? "";
+  assert.ok(body, `${name} not found`);
+  return body;
+};
+
+test("tidy closes archived panes before the list redraws and reports via toast", () => {
+  const run = fn(sessions, "runTidy");
+  assert.match(run, /for \(const id of archived\) closeSessionSurfaces\(id\);/);
+  assert.match(run, /archived\.includes\(s\.id\) \? \{ \.\.\.s, archived: true \}/);
+  assert.match(run, /canvasToast\(/);
+  assert.match(run, /saveTidySettings\(\)/, "lastRunAt must persist so auto-tidy stays daily");
+});
+
+test("auto-tidy runs once per day and only on the first sessions load", () => {
+  const auto = fn(sessions, "maybeAutoTidy");
+  assert.match(auto, /!tidyState\.auto \|\| Date\.now\(\) - tidyState\.lastRunAt < TIDY_AUTO_INTERVAL_MS/);
+  assert.match(sessions, /const firstLoad = !sessionsState\.loaded;[\s\S]*?if \(firstLoad\) maybeAutoTidy\(\);/);
+});
+
+test("the tidy relay validates idleDays and registers before the session patch route", () => {
+  const tidy = server.indexOf('path: "/api/sessions/tidy"');
+  const patch = server.indexOf('method: "POST",\n    path: "/api/sessions/:id"');
+  assert.ok(tidy > 0 && patch > 0 && tidy < patch);
+  assert.match(server, /idleDays must be a non-negative number/);
+});

--- a/plugins/web-ui/test/tidy-source.test.ts
+++ b/plugins/web-ui/test/tidy-source.test.ts
@@ -17,18 +17,10 @@ test("tidy closes archived panes before the list redraws and reports via toast",
   assert.match(run, /for \(const id of archived\) closeSessionSurfaces\(id\);/);
   assert.match(run, /archived\.includes\(s\.id\) \? \{ \.\.\.s, archived: true \}/);
   assert.match(run, /canvasToast\(/);
-  assert.match(run, /saveTidySettings\(\)/, "lastRunAt must persist so auto-tidy stays daily");
 });
 
-test("auto-tidy runs once per day and only on the first sessions load", () => {
-  const auto = fn(sessions, "maybeAutoTidy");
-  assert.match(auto, /!tidyState\.auto \|\| Date\.now\(\) - tidyState\.lastRunAt < TIDY_AUTO_INTERVAL_MS/);
-  assert.match(sessions, /const firstLoad = !sessionsState\.loaded;[\s\S]*?if \(firstLoad\) maybeAutoTidy\(\);/);
-});
-
-test("the tidy relay validates idleDays and registers before the session patch route", () => {
+test("the tidy relay registers before the session patch route", () => {
   const tidy = server.indexOf('path: "/api/sessions/tidy"');
   const patch = server.indexOf('method: "POST",\n    path: "/api/sessions/:id"');
   assert.ok(tidy > 0 && patch > 0 && tidy < patch);
-  assert.match(server, /idleDays must be a non-negative number/);
 });

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -46,6 +46,7 @@ export function createSessionMethods(
   | "authorizesCapabilityScope"
   | "updateSession"
   | "regenerateTitle"
+  | "tidySessions"
   | "spawnSession"
   | "discardSession"
   | "forkSession"
@@ -512,6 +513,26 @@ export function createSessionMethods(
       const parsed = parseScopeId(session.scopeId);
       const projectMembers = parsed.kind === "group" ? await deps.projects?.members(parsed.ref) : undefined;
       return deps.orchestrator.regenerateTitle(sessionId, principalId, projectMembers);
+    },
+
+    async tidySessions(principalId, { idleMs }) {
+      const cutoff = Date.now() - idleMs;
+      const candidates = (await this.listSessions(principalId))
+        .filter(
+          (s) =>
+            !s.archived &&
+            !s.pinned &&
+            !s.working &&
+            !s.awaitingInput &&
+            !s.crons &&
+            !s.watches &&
+            !s.backgroundJobs &&
+            (s.lastActivityAt ?? s.createdAt) <= cutoff,
+        )
+        .sort((a, b) => (a.lastActivityAt ?? a.createdAt) - (b.lastActivityAt ?? b.createdAt));
+      const { archived, judged } = await deps.orchestrator.judgeConcluded(principalId, candidates);
+      for (const id of archived) await deps.sessions.updateParticipantView(id, principalId, { archived: true });
+      return { archived, considered: judged };
     },
 
     async forkSession(sessionId, principalId, opts) {

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -515,19 +515,11 @@ export function createSessionMethods(
       return deps.orchestrator.regenerateTitle(sessionId, principalId, projectMembers);
     },
 
-    async tidySessions(principalId, { idleMs }) {
-      const cutoff = Date.now() - idleMs;
+    async tidySessions(principalId) {
       const candidates = (await this.listSessions(principalId))
         .filter(
           (s) =>
-            !s.archived &&
-            !s.pinned &&
-            !s.working &&
-            !s.awaitingInput &&
-            !s.crons &&
-            !s.watches &&
-            !s.backgroundJobs &&
-            (s.lastActivityAt ?? s.createdAt) <= cutoff,
+            !s.archived && !s.pinned && !s.working && !s.awaitingInput && !s.crons && !s.watches && !s.backgroundJobs,
         )
         .sort((a, b) => (a.lastActivityAt ?? a.createdAt) - (b.lastActivityAt ?? b.createdAt));
       const { archived, judged } = await deps.orchestrator.judgeConcluded(principalId, candidates);

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -315,7 +315,7 @@ export interface App {
     patch: { title?: string | null; archived?: boolean; pinned?: boolean; color?: string | null },
   ): Promise<Session | null>;
   regenerateTitle(sessionId: string, principalId: string): Promise<{ title: string | null } | null>;
-  tidySessions(principalId: string, opts: { idleMs: number }): Promise<{ archived: string[]; considered: number }>;
+  tidySessions(principalId: string): Promise<{ archived: string[]; considered: number }>;
   spawnSession(principalId: string, opts: { scopeId: ScopeId; title?: string }): Promise<{ session: Session } | null>;
   discardSession(sessionId: string, principalId: string): Promise<boolean>;
   forkSession(

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -315,6 +315,7 @@ export interface App {
     patch: { title?: string | null; archived?: boolean; pinned?: boolean; color?: string | null },
   ): Promise<Session | null>;
   regenerateTitle(sessionId: string, principalId: string): Promise<{ title: string | null } | null>;
+  tidySessions(principalId: string, opts: { idleMs: number }): Promise<{ archived: string[]; considered: number }>;
   spawnSession(principalId: string, opts: { scopeId: ScopeId; title?: string }): Promise<{ session: Session } | null>;
   discardSession(sessionId: string, principalId: string): Promise<boolean>;
   forkSession(

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -74,14 +74,11 @@ async function regenerateSessionTitle(ctx: ApiCtx): Promise<void> {
 
 async function tidySessions(ctx: ApiCtx): Promise<void> {
   const { res, app, body } = ctx;
-  const b = body as { principalId?: unknown; idleDays?: unknown };
-  if (typeof b.principalId !== "string" || !b.principalId) {
+  const principalId = (body as { principalId?: unknown }).principalId;
+  if (typeof principalId !== "string" || !principalId) {
     return sendJson(res, 400, { error: "bad_request", message: "principalId required" });
   }
-  if (typeof b.idleDays !== "number" || !Number.isFinite(b.idleDays) || b.idleDays < 0) {
-    return sendJson(res, 400, { error: "bad_request", message: "idleDays must be a non-negative number" });
-  }
-  return sendJson(res, 200, await app.tidySessions(b.principalId, { idleMs: b.idleDays * 86_400_000 }));
+  return sendJson(res, 200, await app.tidySessions(principalId));
 }
 
 async function forkSession(ctx: ApiCtx): Promise<void> {

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -72,6 +72,18 @@ async function regenerateSessionTitle(ctx: ApiCtx): Promise<void> {
   return sendJson(res, 200, out);
 }
 
+async function tidySessions(ctx: ApiCtx): Promise<void> {
+  const { res, app, body } = ctx;
+  const b = body as { principalId?: unknown; idleDays?: unknown };
+  if (typeof b.principalId !== "string" || !b.principalId) {
+    return sendJson(res, 400, { error: "bad_request", message: "principalId required" });
+  }
+  if (typeof b.idleDays !== "number" || !Number.isFinite(b.idleDays) || b.idleDays < 0) {
+    return sendJson(res, 400, { error: "bad_request", message: "idleDays must be a non-negative number" });
+  }
+  return sendJson(res, 200, await app.tidySessions(b.principalId, { idleMs: b.idleDays * 86_400_000 }));
+}
+
 async function forkSession(ctx: ApiCtx): Promise<void> {
   const { res, app, body } = ctx;
   const id = ctx.params.id!;
@@ -1397,6 +1409,7 @@ export async function postSoul(ctx: ApiCtx): Promise<void> {
 export const surfaceRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "POST", path: "/v1/session-cap", auth: "source", handle: sessionCapability },
   { method: "GET", path: "/v1/sessions/search", auth: "source", handle: searchSessions },
+  { method: "POST", path: "/v1/sessions/tidy", auth: "source", handle: tidySessions },
   { method: "POST", path: "/v1/sessions/:id/title", auth: "source", handle: regenerateSessionTitle },
   { method: "POST", path: "/v1/sessions/:id/fork", auth: "source", handle: forkSession },
   { method: "GET", path: "/v1/sessions/:id/approvals", auth: "source", handle: listSessionApprovals },

--- a/src/api/user-scoped-routes.ts
+++ b/src/api/user-scoped-routes.ts
@@ -18,6 +18,7 @@ const USER_SCOPED: Rule[] = [
   pat("GET", "/v1/files/:id/content", { in: "query", name: "viewer" }),
   pat("GET", "/v1/files", { in: "query", name: "viewer" }),
   pat("POST", "/v1/files/upload", { in: "body", name: "principalId" }),
+  pat("POST", "/v1/sessions/tidy", { in: "body", name: "principalId" }),
   pat("POST", "/v1/sessions/:id", { in: "body", name: "principalId" }),
   pat("POST", "/v1/sessions/:id/title", { in: "body", name: "principalId" }),
   pat("POST", "/v1/sessions/:id/fork", { in: "body", name: "principalId" }),

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -196,6 +196,15 @@ const CONNECTOR_HOSTS = Object.values(PROVIDERS).flatMap((p) => p.hosts);
 const INSTANCE_CACHE_MAX_ENTRIES = 5_000;
 const DIRECTORY_INDEX_CACHE_MAX_ENTRIES = 100;
 
+const TIDY_MAX_CANDIDATES = 40;
+
+export const TIDY_JUDGE_PROMPT = [
+  "You tidy a chat sidebar. Each card below is one conversation: its id in brackets, title, days idle, and the tail of its transcript.",
+  "Pick the conversations that are finished: the ask was answered, the task completed, or the thread is a one-off that nobody will return to.",
+  "Keep anything open-ended, awaiting a reply, mid-task, or that reads like a long-running reference thread.",
+  'Reply with ONLY JSON: {"archive": ["<id>", ...]}. Use the ids exactly as given. Empty list if nothing is finished.',
+].join("\n");
+
 export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
   const skillMaterializer = createSkillMaterializer(deps.advisoryLock);
   const residentAuthConnectors = (): ResidentAuthConnector[] =>
@@ -396,6 +405,39 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         participantIds?.length ? principalId : undefined,
       );
       return { title: title ?? (participantIds ? null : (session.title ?? null)) };
+    },
+
+    async judgeConcluded(principalId, candidates) {
+      if (!deps.harness.models.judge || candidates.length === 0) return { archived: [], judged: 0 };
+      const now = Date.now();
+      const tails = await Promise.all(
+        candidates.slice(0, TIDY_MAX_CANDIDATES).map(async (s) => {
+          const entries = await deps.sessions.visibleEntries(s.id, principalId);
+          return {
+            s,
+            tail: renderTitleTranscript(entries.slice(-4))
+              .replace(/\n\n---\n\n/g, " ")
+              .slice(0, 1200),
+          };
+        }),
+      );
+      const judged = tails.filter(({ tail }) => tail);
+      if (judged.length === 0) return { archived: [], judged: 0 };
+      const cards = judged.map(({ s, tail }) => {
+        const idleDays = Math.floor((now - (s.lastActivityAt ?? s.createdAt)) / 86_400_000);
+        return `[${s.id}] ${s.title ?? "(untitled)"} · idle ${idleDays}d\n${tail}`;
+      });
+      const raw = await deps.harness.models.judge(TIDY_JUDGE_PROMPT, cards.join("\n\n---\n\n"));
+      const allowed = new Set(judged.map(({ s }) => s.id));
+      try {
+        const parsed = JSON.parse(/\{[\s\S]*\}/.exec(raw ?? "")?.[0] ?? "{}") as { archive?: unknown };
+        const archived = Array.isArray(parsed.archive)
+          ? parsed.archive.filter((id): id is string => typeof id === "string" && allowed.has(id))
+          : [];
+        return { archived, judged: judged.length };
+      } catch {
+        return { archived: [], judged: judged.length };
+      }
     },
 
     async handleTurn(input: OrchestratorInput): Promise<TurnResult> {

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -198,7 +198,7 @@ const DIRECTORY_INDEX_CACHE_MAX_ENTRIES = 100;
 
 const TIDY_MAX_CANDIDATES = 40;
 
-export const TIDY_JUDGE_PROMPT = [
+const TIDY_JUDGE_PROMPT = [
   "You tidy a chat sidebar. Each card below is one conversation: its id in brackets, title, days idle, and the tail of its transcript.",
   "Pick the conversations that are finished: the ask was answered, the task completed, or the thread is a one-off that nobody will return to.",
   "Keep anything open-ended, awaiting a reply, mid-task, or that reads like a long-running reference thread.",
@@ -410,17 +410,16 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
     async judgeConcluded(principalId, candidates) {
       if (!deps.harness.models.judge || candidates.length === 0) return { archived: [], judged: 0 };
       const now = Date.now();
-      const tails = await Promise.all(
-        candidates.slice(0, TIDY_MAX_CANDIDATES).map(async (s) => {
-          const entries = await deps.sessions.visibleEntries(s.id, principalId);
-          return {
-            s,
-            tail: renderTitleTranscript(entries.slice(-4))
-              .replace(/\n\n---\n\n/g, " ")
-              .slice(0, 1200),
-          };
-        }),
-      );
+      const tails = [];
+      for (const s of candidates.slice(0, TIDY_MAX_CANDIDATES)) {
+        const entries = await deps.sessions.visibleEntries(s.id, principalId);
+        tails.push({
+          s,
+          tail: renderTitleTranscript(entries.slice(-4))
+            .replace(/\n\n---\n\n/g, " ")
+            .slice(0, 1200),
+        });
+      }
       const judged = tails.filter(({ tail }) => tail);
       if (judged.length === 0) return { archived: [], judged: 0 };
       const cards = judged.map(({ s, tail }) => {

--- a/src/core/orchestrator/types.ts
+++ b/src/core/orchestrator/types.ts
@@ -3,6 +3,7 @@ import type {
   Conversation,
   Principal,
   PendingApprovalRecord,
+  Session,
   SurfaceContextQuery,
   SurfaceContextResult,
   TurnRequest,
@@ -214,4 +215,5 @@ export interface Orchestrator {
     principalId: string,
     participantIds?: readonly string[],
   ): Promise<{ title: string | null } | null>;
+  judgeConcluded(principalId: string, candidates: readonly Session[]): Promise<{ archived: string[]; judged: number }>;
 }

--- a/src/harness/mock-harness.ts
+++ b/src/harness/mock-harness.ts
@@ -762,7 +762,15 @@ export function createMockHarness(): Harness {
         return Promise.resolve(`mock one-shot reply to: ${prompt.slice(0, 200)}`);
       },
 
-      judge(_systemPrompt: string, prompt: string): Promise<string | undefined> {
+      judge(systemPrompt: string, prompt: string): Promise<string | undefined> {
+        if (systemPrompt.startsWith("You tidy a chat sidebar.")) {
+          const done = prompt
+            .split("\n\n---\n\n")
+            .filter((card) => /!done\b/.test(card))
+            .map((card) => /^\[([^\]]+)\]/.exec(card)?.[1])
+            .filter((id): id is string => Boolean(id));
+          return Promise.resolve(JSON.stringify({ archive: done }));
+        }
         const asked = /!engage-asked\b[:\s]*(.*)/i.exec(prompt);
         if (asked) {
           const id = /^\[([^\]]+)\]/m.exec(prompt)?.[1];

--- a/test/process-run.test.ts
+++ b/test/process-run.test.ts
@@ -24,6 +24,9 @@ function fakeOrchestrator(handle: (input: OrchestratorInput) => Promise<TurnResu
     async regenerateTitle() {
       return null;
     },
+    async judgeConcluded() {
+      return { archived: [], judged: 0 };
+    },
   };
 }
 

--- a/test/session-tidy.test.ts
+++ b/test/session-tidy.test.ts
@@ -1,0 +1,37 @@
+import "./support/auto-fake-sprites.ts";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+import type { TurnRequest } from "../src/types.ts";
+
+const actor = { externalId: "U1" };
+function dm(text: string, thread: string): TurnRequest {
+  return { surface: "test", actor, conversation: { kind: "dm", threadRef: thread }, text };
+}
+
+test("tidy archives only the idle conversations the judge marks finished", async () => {
+  const { app } = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "ap-tidy-")) }));
+  const done = (await app.turn(dm("Reset my password !done", "web:U1:done"))).sessionId!;
+  const open = (await app.turn(dm("Plan the Q3 roadmap with me", "web:U1:open"))).sessionId!;
+  const pinnedDone = (await app.turn(dm("Quick one !done", "web:U1:pinned"))).sessionId!;
+  await app.updateSession(pinnedDone, "U1", { pinned: true });
+
+  const fresh = await app.tidySessions("U1", { idleMs: 60 * 60_000 });
+  assert.deepEqual(fresh, { archived: [], considered: 0 }, "nothing idle long enough is even considered");
+
+  const out = await app.tidySessions("U1", { idleMs: 0 });
+  assert.deepEqual(out.archived, [done]);
+  assert.equal(out.considered, 2, "pinned chats are never candidates");
+  const after = new Map((await app.listSessions("U1")).map((s) => [s.id, s]));
+  assert.equal(after.get(done)?.archived, true);
+  assert.equal(after.get(open)?.archived, undefined);
+  assert.equal(after.get(pinnedDone)?.archived, undefined);
+
+  assert.deepEqual(await app.tidySessions("U1", { idleMs: 0 }), { archived: [], considered: 1 });
+  assert.deepEqual(await app.tidySessions("stranger", { idleMs: 0 }), { archived: [], considered: 0 });
+});

--- a/test/session-tidy.test.ts
+++ b/test/session-tidy.test.ts
@@ -14,17 +14,14 @@ function dm(text: string, thread: string): TurnRequest {
   return { surface: "test", actor, conversation: { kind: "dm", threadRef: thread }, text };
 }
 
-test("tidy archives only the idle conversations the judge marks finished", async () => {
+test("tidy archives only the conversations the judge marks finished", async () => {
   const { app } = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "ap-tidy-")) }));
   const done = (await app.turn(dm("Reset my password !done", "web:U1:done"))).sessionId!;
   const open = (await app.turn(dm("Plan the Q3 roadmap with me", "web:U1:open"))).sessionId!;
   const pinnedDone = (await app.turn(dm("Quick one !done", "web:U1:pinned"))).sessionId!;
   await app.updateSession(pinnedDone, "U1", { pinned: true });
 
-  const fresh = await app.tidySessions("U1", { idleMs: 60 * 60_000 });
-  assert.deepEqual(fresh, { archived: [], considered: 0 }, "nothing idle long enough is even considered");
-
-  const out = await app.tidySessions("U1", { idleMs: 0 });
+  const out = await app.tidySessions("U1");
   assert.deepEqual(out.archived, [done]);
   assert.equal(out.considered, 2, "pinned chats are never candidates");
   const after = new Map((await app.listSessions("U1")).map((s) => [s.id, s]));
@@ -32,6 +29,6 @@ test("tidy archives only the idle conversations the judge marks finished", async
   assert.equal(after.get(open)?.archived, undefined);
   assert.equal(after.get(pinnedDone)?.archived, undefined);
 
-  assert.deepEqual(await app.tidySessions("U1", { idleMs: 0 }), { archived: [], considered: 1 });
-  assert.deepEqual(await app.tidySessions("stranger", { idleMs: 0 }), { archived: [], considered: 0 });
+  assert.deepEqual(await app.tidySessions("U1"), { archived: [], considered: 1 });
+  assert.deepEqual(await app.tidySessions("stranger"), { archived: [], considered: 0 });
 });


### PR DESCRIPTION
## What

A **Tidy** button (sparkle icon) next to **Sessions** in the sidebar. One click sends the viewer's active, unpinned, non-working chats to the auxiliary judge model in a single batched prompt and archives, in the viewer's own view, the ones the model marks finished. A toast reports the outcome. Archiving is per participant view and reversible from the Archived list.

No settings: live QA showed a settings popover was more friction than help, so the idle-days threshold and daily auto-tidy from the first revision were removed.

## How

- Core: `POST /v1/sessions/tidy` (source auth, user-scoped on `principalId`). `app.tidySessions` builds candidates from `listSessions` so working, awaiting-input, cron, watch, and background-job sessions are never touched. The 40 most idle go to `orchestrator.judgeConcluded`, which reads the last four turns of each sequentially, asks `harness.models.judge` (auxiliary model) for JSON, and only accepts ids from the candidate set. Transcript text cannot forge card boundaries.
- Web UI server relays `POST /api/sessions/tidy` with the signed-in user as principal.
- Mock harness dispatches on the tidy system prompt so the flow is testable (`!done` marks a finished chat).

## Demo (dev instance, real Haiku judge)

Chats: a one-word France question, a NYC weather check, a flight search, a Stripe balance check, and an open Stripe migration plan. Tidy archived the France and weather chats and kept the rest. Toast: "Tidied 1 of 4 chats" on the second pass.

![after](https://raw.githubusercontent.com/yc-software/qm/qa-screenshots/ai-chat-tidy/tidy-after.png)

Screenshot lives on the `qa-screenshots/ai-chat-tidy` branch; nothing is mocked.

## Tests

- `test/session-tidy.test.ts`: pinned exclusion, judge result applied, stranger gets nothing.
- `plugins/web-ui/test/tidy-source.test.ts`: panes closed before redraw, relay route order.
- Typecheck + lint for both packages, plus process-run, portal-identity-gate, route-table, agent-api-parity.

## Review

Independent review pass found and I fixed: missing user-scoped route registration, cron/watch/approval sessions eligible for archive, unbounded per-candidate reads, over-reported "considered" count, mock judge matching on user text, prompt-boundary forgery, prose-wrapped JSON, duplicated CSS.