### PR TITLE
fix(portal): ask the identity provider for the account chooser and hint the tenant domain

### DIFF
--- a/cli/src/services.ts
+++ b/cli/src/services.ts
@@ -261,6 +261,7 @@ const CATALOG: Record<ServiceName, ServiceDef> = {
         "OIDC_JWKS_URI",
         "OIDC_SCOPES",
         "OIDC_PRINCIPAL_CLAIM",
+        "OIDC_PROMPT",
         "AUTH_BROKER_UPSTREAM",
         "AUTH_BROKER_PREFIX",
       ],

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -27,6 +27,7 @@ import {
   verifyIdToken,
   type OidcConfig,
   type PrincipalRule,
+  hostedDomainHint,
 } from "./oidc.ts";
 import {
   proxyToSurface,
@@ -145,6 +146,8 @@ const OIDC: OidcConfig = {
   issuer: process.env.OIDC_ISSUER ?? "https://slack.com",
   jwksUri: process.env.OIDC_JWKS_URI ?? "https://slack.com/openid/connect/keys",
   expectedTeamId: process.env.PORTAL_EXPECTED_TEAM_ID || undefined,
+  prompt: process.env.OIDC_PROMPT || undefined,
+  hostedDomain: hostedDomainHint(process.env.OIDC_ISSUER ?? "https://slack.com", process.env.OIDC_ALLOWED_EMAIL_DOMAIN),
 };
 const OIDC_JWKS_CONFIGURED = Boolean(process.env.OIDC_JWKS_URI?.trim());
 

--- a/plugins/portal/src/oidc.ts
+++ b/plugins/portal/src/oidc.ts
@@ -18,7 +18,7 @@ export interface OidcConfig {
   hostedDomain?: string;
 }
 
-export const GOOGLE_ISSUER = "https://accounts.google.com";
+const GOOGLE_ISSUER = "https://accounts.google.com";
 
 export function hostedDomainHint(issuer: string, allowedEmailDomain: string | undefined): string | undefined {
   return issuer === GOOGLE_ISSUER && allowedEmailDomain ? allowedEmailDomain : undefined;

--- a/plugins/portal/src/oidc.ts
+++ b/plugins/portal/src/oidc.ts
@@ -14,6 +14,14 @@ export interface OidcConfig {
   issuer: string;
   jwksUri: string;
   expectedTeamId?: string;
+  prompt?: string;
+  hostedDomain?: string;
+}
+
+export const GOOGLE_ISSUER = "https://accounts.google.com";
+
+export function hostedDomainHint(issuer: string, allowedEmailDomain: string | undefined): string | undefined {
+  return issuer === GOOGLE_ISSUER && allowedEmailDomain ? allowedEmailDomain : undefined;
 }
 
 export function pkcePair(): { verifier: string; challenge: string } {
@@ -32,6 +40,8 @@ export function buildAuthorizeUrl(cfg: OidcConfig, args: { state: string; nonce:
   u.searchParams.set("nonce", args.nonce);
   u.searchParams.set("code_challenge", args.challenge);
   u.searchParams.set("code_challenge_method", "S256");
+  if (cfg.prompt) u.searchParams.set("prompt", cfg.prompt);
+  if (cfg.hostedDomain) u.searchParams.set("hd", cfg.hostedDomain);
   return u.toString();
 }
 

--- a/plugins/portal/test/oidc.test.ts
+++ b/plugins/portal/test/oidc.test.ts
@@ -7,6 +7,7 @@ import {
   buildAuthorizeUrl,
   exchangeCode,
   fetchUserinfo,
+  hostedDomainHint,
   resolvePrincipal,
   verifyIdToken,
   type OidcConfig,
@@ -46,6 +47,29 @@ test("buildAuthorizeUrl carries code+PKCE+state+nonce", () => {
   assert.equal(u.searchParams.get("nonce"), "NO");
   assert.equal(u.searchParams.get("code_challenge"), "CH");
   assert.equal(u.searchParams.get("code_challenge_method"), "S256");
+  assert.equal(u.searchParams.get("prompt"), null);
+  assert.equal(u.searchParams.get("hd"), null);
+});
+
+test("buildAuthorizeUrl forwards prompt and hosted-domain hints when configured", () => {
+  const google: OidcConfig = {
+    ...cfg,
+    authEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+    issuer: "https://accounts.google.com",
+    prompt: "select_account",
+    hostedDomain: "example.com",
+  };
+  const u = new URL(buildAuthorizeUrl(google, { state: "ST", nonce: "NO", challenge: "CH" }));
+  assert.equal(u.origin + u.pathname, "https://accounts.google.com/o/oauth2/v2/auth");
+  assert.equal(u.searchParams.get("prompt"), "select_account");
+  assert.equal(u.searchParams.get("hd"), "example.com");
+});
+
+test("hostedDomainHint applies only to the Google issuer with a domain gate", () => {
+  assert.equal(hostedDomainHint("https://accounts.google.com", "example.com"), "example.com");
+  assert.equal(hostedDomainHint("https://accounts.google.com", undefined), undefined);
+  assert.equal(hostedDomainHint("https://accounts.google.com", ""), undefined);
+  assert.equal(hostedDomainHint("https://slack.com", "example.com"), undefined);
 });
 
 test("exchangeCode posts client_secret_basic + PKCE verifier and parses the token", async () => {


### PR DESCRIPTION
## Problem

When the portal runs against Google as the OIDC issuer, the authorize request carries neither `prompt` nor `hd`. Google therefore reuses whichever account the browser is already signed into. If that account is outside `OIDC_ALLOWED_EMAIL_DOMAIN`, the user is refused after the round trip with no way to pick a different account, and every retry repeats the same auto-selection.

## Change

- `plugins/portal/src/oidc.ts`: `OidcConfig` gains optional `prompt` and `hostedDomain`. `buildAuthorizeUrl` forwards them as `prompt=` and `hd=` only when set. New `hostedDomainHint(issuer, allowedEmailDomain)` returns the hint only for the Google issuer with a domain gate configured.
- `plugins/portal/src/index.ts`: `prompt` comes from a new optional `OIDC_PROMPT` env var; `hostedDomain` comes from `hostedDomainHint`.
- `cli/src/services.ts`: `OIDC_PROMPT` added to the portal's Fly stack keys so a stack can set it.
- Tests: the default authorize URL carries neither parameter; a Google configuration carries both; `hostedDomainHint` covers Google with a domain, Google without a domain, and a non-Google issuer with a domain.

Both hints are opt-in and absent by default, so the Slack issuer and existing deployments are unchanged. `hd` is a chooser hint only; server-side domain enforcement is untouched.

## Verification

`plugins/portal`: 116/116 tests pass; `plugins/portal` and `cli` typechecks pass. No rendered surface changes; the only user-visible effect is Google's own account chooser appearing when `OIDC_PROMPT=select_account` is configured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791318899&installation_model_id=19911&pr_number=962&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F962&signature=2a3b764fe71908013871b3814912ffa1614046af90eb7ded11c5f23ea4c1cce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->