### PR TITLE
Fix sticky prompts, scrolling, and chat status placement

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -130,6 +130,8 @@ import { tip } from "./tooltip";
 import { workSeconds, workedLabel } from "./work-duration";
 import { decorateTextCodeBlocks, normalizePlainTextFences } from "./text-code";
 
+import { createTranscriptViewport } from "./transcript-viewport";
+
 installMarkdownSanitizer();
 
 const detachedAgents = new WeakSet<Agent>();
@@ -188,6 +190,7 @@ export function createChatSurface(
   dependencies: { fetchTranscript?: typeof fetchTranscript; openSession?: typeof openSession } = {},
 ): ChatSurface {
   const runSlot = createRunSlot();
+  const transcriptViewport = createTranscriptViewport();
   const transcriptFetcher = dependencies.fetchTranscript ?? fetchTranscript;
   const sessionOpener = dependencies.openSession ?? openSession;
 
@@ -281,6 +284,7 @@ export function createChatSurface(
   let readOnlyView: { id: string; threadRef: string; session: CoreSession; anchorSeq: number | null } | null = null;
 
   function teardownActiveChat(): void {
+    transcriptViewport.dispose();
     forkOriginController.invalidateRefresh();
     readOnlyView = null;
     preserveOutgoingWorkingDot(null);
@@ -467,7 +471,6 @@ export function createChatSurface(
       });
     });
 
-    stickToBottom = true;
     container.replaceChildren(chatState.host);
     const opening = startProactiveOpenerIfNew(agent, threadRef, normalStreamFn, onWork, sessionId, scopeId, messages);
     drawActiveChat(agent, { forceScroll: true });
@@ -1024,7 +1027,10 @@ export function createChatSurface(
         `,
         host,
       );
-      requestAnimationFrame(() => decorateTextCodeBlocks(host));
+      requestAnimationFrame(() => {
+        decorateTextCodeBlocks(host);
+        if (host.isConnected) transcriptViewport.sync(host.querySelector<HTMLElement>(".chat-scroll"));
+      });
     };
     readonlyRedraw = draw;
     draw();
@@ -1263,7 +1269,7 @@ export function createChatSurface(
           }
           ${glanceTier || ctx.pane ? nothing : sessionTopbar()}
           ${glanceTier ? paneGlance(agent, messages, glanceTier) : nothing}
-          <section class="chat-scroll" @scroll=${onTranscriptScroll}>
+          <section class="chat-scroll">
             ${pinnedStrip()}
             <div class="message-stack ${emptyChat ? "empty-stack" : ""}">
               ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing} ${messageContent}
@@ -2657,34 +2663,13 @@ export function createChatSurface(
     return fileChip(file.name, file.sizeBytes, href);
   }
 
-  let stickToBottom = true;
-
-  function onTranscriptScroll(e: Event): void {
-    const s = e.currentTarget as HTMLElement;
-    stickToBottom = s.scrollHeight - s.scrollTop - s.clientHeight <= 120;
-  }
-
   function scrollToBottom(): void {
-    stickToBottom = true;
     scrollTranscript(true);
   }
 
   function scrollTranscript(force = false): void {
-    const scroller = ctx.container()?.querySelector<HTMLElement>(".chat-scroll");
-    if (!scroller) return;
-    if (!force && !stickToBottom) return;
-    requestAnimationFrame(() => {
-      if (force) {
-        const prev = scroller.style.scrollBehavior;
-        scroller.style.scrollBehavior = "auto";
-        scroller.scrollTop = scroller.scrollHeight;
-        requestAnimationFrame(() => {
-          scroller.style.scrollBehavior = prev;
-        });
-        return;
-      }
-      scroller.scrollTop = scroller.scrollHeight;
-    });
+    transcriptViewport.sync(ctx.container()?.querySelector<HTMLElement>(".chat-scroll") ?? null);
+    transcriptViewport.follow(force);
   }
 
   redrawHooks.add(redrawForConnector);

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1278,8 +1278,8 @@ export function createChatSurface(
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${backgroundActivityStrip()} ${goalStrip(agent)} ${liveWorkDock(agent)} ${ctx.composer.queuedStrip(agent)}
-            ${ctx.composer.composerForm(agent)}
+            ${goalStrip(agent)} ${liveWorkDock(agent)} ${ctx.composer.queuedStrip(agent)}
+            ${ctx.composer.composerForm(agent, backgroundActivityStrip())}
           </div>
         </div>
       `,

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1273,12 +1273,12 @@ export function createChatSurface(
             ${pinnedStrip()}
             <div class="message-stack ${emptyChat ? "empty-stack" : ""}">
               ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing} ${messageContent}
-              ${emptyChat ? html`<h1 class="chat-cta">${chatCta()}</h1>` : nothing}
+              ${emptyChat ? html`<h1 class="chat-cta">${chatCta()}</h1>` : nothing} ${liveWorkStatus(agent)}
               ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${goalStrip(agent)} ${liveWorkDock(agent)} ${ctx.composer.queuedStrip(agent)}
+            ${goalStrip(agent)} ${ctx.composer.queuedStrip(agent)}
             ${ctx.composer.composerForm(agent, backgroundActivityStrip())}
           </div>
         </div>
@@ -2120,7 +2120,7 @@ export function createChatSurface(
     `;
   }
 
-  function liveWorkDock(agent: Agent): TemplateResult | typeof nothing {
+  function liveWorkStatus(agent: Agent): TemplateResult | typeof nothing {
     if (!agent.state.isStreaming && chatState.resolvingApprovals.size === 0) return nothing;
     const work = chatState.liveWork ?? { status: "thinking", activity: [] };
     if (work.status !== "thinking" && work.status !== "working") return nothing;
@@ -2130,7 +2130,7 @@ export function createChatSurface(
     let title = "";
     if (expandable) title = liveWorkExpanded ? "Show less" : "Show more";
     return html`
-      <section class="live-work-dock ${expanded ? "expanded" : ""}" aria-live="polite">
+      <section class="live-work-status ${expanded ? "expanded" : ""}" aria-live="polite">
         <button
           type="button"
           class="live-work-line ${expandable ? "" : "static"}"

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -379,7 +379,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     ctx.chat.drawActiveChat(agent);
   }
 
-  function composerForm(agent: Agent): TemplateResult {
+  function composerForm(agent: Agent, header: TemplateResult | typeof nothing = nothing): TemplateResult {
     const selectedModel = currentModelOption();
     if (!selectedModel) {
       const selected =
@@ -516,7 +516,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
         `;
     return html`
       <form class="composer-wrap ${compact ? "compact" : ""}" @submit=${(e: Event) => submitComposer(e, agent)}>
-        ${slashMenu(agent)}
+        ${header} ${slashMenu(agent)}
         ${
           activeRuntimeConfig?.upgradeAvailable
             ? html`<div class="runtime-upgrade">

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -1869,10 +1869,14 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
       }
       if (ta.value === autosizedValue) return;
       autosizedValue = ta.value;
+      const wrap = ta.closest<HTMLElement>(".composer-wrap");
+      const wrapHeight = wrap?.style.height ?? "";
+      if (wrap) wrap.style.height = `${wrap.getBoundingClientRect().height}px`;
       ta.style.height = "auto";
       const cap = parseFloat(getComputedStyle(ta).maxHeight) || 180;
       const content = ta.scrollHeight;
       ta.style.height = `${Math.min(cap, Math.max(ctx.pane ? 0 : 48, content))}px`;
+      if (wrap) wrap.style.height = wrapHeight;
       if (content > cap) {
         ta.style.overflowY = "auto";
       } else {

--- a/plugins/web-ui/src/conv-types.ts
+++ b/plugins/web-ui/src/conv-types.ts
@@ -1,5 +1,5 @@
 import type { Agent } from "@earendil-works/pi-agent-core";
-import type { TemplateResult } from "lit";
+import type { TemplateResult, nothing } from "lit";
 import type { DensityTier } from "./density";
 import type { Attachment } from "@earendil-works/pi-web-ui";
 import type {
@@ -119,7 +119,7 @@ interface ComposerState {
 export interface ComposerSurface {
   restageAttachments(attachments: Attachment[], note: string): void;
   state: ComposerState;
-  composerForm(agent: Agent): TemplateResult;
+  composerForm(agent: Agent, header?: TemplateResult | typeof nothing): TemplateResult;
   queuedStrip(agent: Agent): TemplateResult | typeof import("lit").nothing;
   queuedRunsFor(threadRef: string | null): QueuedRun[];
   setQueuedRuns(threadRef: string, runs: QueuedRun[]): void;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2611,9 +2611,10 @@ a.chat-row-open {
   max-height: 30vh;
 }
 
-.live-work-dock {
-  width: min(var(--content-w), calc(100% - 32px));
-  margin: 0 auto 8px;
+.live-work-status {
+  width: 100%;
+  min-width: 0;
+  margin: 8px 0 0;
   color: var(--muted-foreground);
 }
 .live-work-line {
@@ -2676,15 +2677,15 @@ a.chat-row-open {
   transition: transform 0.15s ease;
 }
 
-.live-work-dock.expanded .live-work-line {
+.live-work-status.expanded .live-work-line {
   flex-wrap: wrap;
 }
-.live-work-dock.expanded .live-work-label {
+.live-work-status.expanded .live-work-label {
   white-space: normal;
   overflow: visible;
   text-overflow: clip;
 }
-.live-work-dock.expanded .live-work-detail {
+.live-work-status.expanded .live-work-detail {
   order: 1;
   flex-basis: 100%;
   margin-top: 4px;
@@ -2693,7 +2694,7 @@ a.chat-row-open {
   text-overflow: clip;
   max-height: 38vh;
 }
-.live-work-dock.expanded .live-work-toggle {
+.live-work-status.expanded .live-work-toggle {
   transform: rotate(90deg);
 }
 
@@ -7245,8 +7246,7 @@ h3.ambient-field-label {
   /* Mid-width surfaces: the floating composer/dock hug the full-width column with 16px
      side margins, but must still clear the device safe areas — the 10px variant below
      only kicks in at <=470px, so the insets need a floor here too. */
-  .composer-wrap,
-  .live-work-dock {
+  .composer-wrap {
     width: auto;
     margin-right: max(16px, calc(10px + env(safe-area-inset-right)));
     margin-left: max(16px, calc(10px + env(safe-area-inset-left)));
@@ -7278,10 +7278,6 @@ h3.ambient-field-label {
     margin-right: calc(22px + env(safe-area-inset-right));
     margin-left: calc(22px + env(safe-area-inset-left));
   }
-  .live-work-dock {
-    margin-right: calc(10px + env(safe-area-inset-right));
-    margin-left: calc(10px + env(safe-area-inset-left));
-  }
   .goal-strip {
     margin-right: calc(18px + env(safe-area-inset-right));
     margin-left: calc(18px + env(safe-area-inset-left));
@@ -7289,8 +7285,8 @@ h3.ambient-field-label {
 }
 [data-density="card"] .context-banner,
 [data-density="strip"] .context-banner,
-[data-density="card"] .live-work-dock,
-[data-density="strip"] .live-work-dock,
+[data-density="card"] .live-work-status,
+[data-density="strip"] .live-work-status,
 [data-density="card"] .goal-strip,
 [data-density="strip"] .goal-strip {
   display: none;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1310,7 +1310,7 @@ a.chat-row-open {
 }
 .chat-scroll {
   isolation: isolate;
-  --chat-scroll-pad-top: 28px;
+  --chat-scroll-pad-top: 8px;
   container-type: size;
 
   --chat-edge-space: 24px;
@@ -1381,7 +1381,7 @@ a.chat-row-open {
   top: 0;
   z-index: 6;
   width: min(var(--content-w), 100%);
-  margin: 0 auto 10px;
+  margin: 0 auto 8px;
   border: 1px solid var(--border, #d0d0d0);
   border-radius: 10px;
   background: var(--background, #fff);
@@ -1532,9 +1532,9 @@ a.chat-row-open {
   position: sticky;
   top: var(--chat-sticky-top, 0px);
   z-index: 3;
-  padding-top: 14px;
-  margin-top: -14px;
-  margin-bottom: var(--chat-edge-space);
+  padding-top: 8px;
+  margin-top: -8px;
+  margin-bottom: 12px;
   background: transparent;
   pointer-events: none;
 }
@@ -2471,6 +2471,19 @@ a.chat-row-open {
   color: var(--muted-foreground);
   font-size: 12.5px;
 }
+.composer-wrap > .bg-activity {
+  flex: 0 0 calc(100% + var(--composer-pad-inline) + var(--composer-pad-end));
+  width: auto;
+  min-width: 0;
+  margin: calc(-1 * var(--composer-pad-block)) calc(-1 * var(--composer-pad-end)) 8px
+    calc(-1 * var(--composer-pad-inline));
+  padding: 8px var(--composer-pad-end) 8px var(--composer-pad-inline);
+  border-radius: inherit;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--secondary) 40%, var(--background));
+}
 .readonly-chat .bg-activity {
   margin-top: 8px;
 }
@@ -2792,11 +2805,14 @@ a.chat-row-open {
 }
 
 .composer-wrap {
+  --composer-pad-block: 12px;
+  --composer-pad-inline: 12px;
+  --composer-pad-end: var(--composer-pad-inline);
   position: relative;
   z-index: 1;
   width: min(var(--content-w), calc(100% - 32px));
   margin: 0 auto max(18px, calc(10px + env(safe-area-inset-bottom)));
-  padding: 12px;
+  padding: var(--composer-pad-block) var(--composer-pad-end) var(--composer-pad-block) var(--composer-pad-inline);
   border: 1px solid var(--border);
   border-radius: 24px;
   background: var(--background);
@@ -3305,7 +3321,7 @@ a.chat-row-open {
   text-underline-offset: 2px;
 }
 .readonly-scroll {
-  --chat-scroll-pad-top: 20px;
+  --chat-scroll-pad-top: 8px;
 }
 .chat-loading {
   flex: 1;
@@ -7205,7 +7221,7 @@ h3.ambient-field-label {
 }
 
 [data-density="compact"] .chat-scroll {
-  --chat-scroll-pad-top: 14px;
+  --chat-scroll-pad-top: 8px;
   --chat-edge-space: 14px;
   padding: var(--chat-scroll-pad-top) var(--chat-pad) var(--chat-scroll-pad-bottom);
 }
@@ -7284,6 +7300,8 @@ h3.ambient-field-label {
 }
 
 [data-density] .composer-wrap {
+  --composer-pad-block: 6px;
+  --composer-pad-inline: 8px;
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
@@ -7292,7 +7310,7 @@ h3.ambient-field-label {
      the surface's own width — a pane that fills a wide window centres the composer on the
      transcript column instead of stretching across it, and a narrow one still runs full-bleed. */
   margin-bottom: 10px;
-  padding: 6px 8px;
+  padding: var(--composer-pad-block) var(--composer-pad-end) var(--composer-pad-block) var(--composer-pad-inline);
   border-radius: 16px;
 }
 [data-density] .composer-input {
@@ -8735,7 +8753,7 @@ h3.ambient-field-label {
   min-height: 0;
 }
 .mini-convo-body .chat-scroll {
-  --chat-scroll-pad-top: 12px;
+  --chat-scroll-pad-top: 8px;
   --chat-edge-space: 12px;
   --chat-pad: 12px;
   container-type: normal;
@@ -9358,7 +9376,10 @@ h3.ambient-field-label {
   .composer-wrap {
     width: calc(100% - 16px);
     margin: 0 auto calc(8px + env(safe-area-inset-bottom));
-    padding: 8px 8px 8px 10px;
+    --composer-pad-block: 8px;
+    --composer-pad-inline: 10px;
+    --composer-pad-end: 8px;
+    padding: var(--composer-pad-block) var(--composer-pad-end) var(--composer-pad-block) var(--composer-pad-inline);
     border-radius: 22px;
   }
   .composer-input {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1320,7 +1320,7 @@ a.chat-row-open {
   scrollbar-gutter: stable;
 
   padding: var(--chat-scroll-pad-top) var(--chat-pad) var(--chat-scroll-pad-bottom);
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
 }
 
 .fork-origin-row {
@@ -1393,7 +1393,7 @@ a.chat-row-open {
 }
 .pinned-strip.expanded {
   padding: 6px 10px;
-  max-height: min(38vh, 240px);
+  max-height: min(38cqh, 240px);
   overflow-y: auto;
 }
 .pinned-strip-head {
@@ -1530,7 +1530,7 @@ a.chat-row-open {
 }
 .message-stack .user-row:not(:has(~ .user-row)) {
   position: sticky;
-  top: calc(-1 * var(--chat-scroll-pad-top, 0px));
+  top: var(--chat-sticky-top, 0px);
   z-index: 3;
   padding-top: 14px;
   margin-top: -14px;
@@ -1539,9 +1539,24 @@ a.chat-row-open {
   pointer-events: none;
 }
 
+.message-stack .user-row.sticky-disabled {
+  position: relative;
+  top: auto;
+}
+
 .message-stack .user-row:not(:has(~ .user-row)) > .user-bubble {
   pointer-events: auto;
+  transition: box-shadow 120ms ease;
+}
+
+.message-stack .user-row.stuck > .user-bubble {
   box-shadow: var(--chat-surface-shadow);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message-stack .user-row > .user-bubble {
+    transition: none;
+  }
 }
 
 .assistant-row + .user-row {

--- a/plugins/web-ui/src/transcript-viewport.ts
+++ b/plugins/web-ui/src/transcript-viewport.ts
@@ -1,0 +1,136 @@
+export function createTranscriptViewport() {
+  let scroller: HTMLElement | null = null;
+  let pins: HTMLElement | null = null;
+  let prompt: HTMLElement | null = null;
+  let stack: HTMLElement | null = null;
+  let lastTop = 0;
+  let observer: ResizeObserver | null = null;
+  let following = false;
+  let frame: number | null = null;
+
+  function setFollowing(value: boolean): void {
+    following = value;
+    if (scroller) scroller.style.overflowAnchor = value ? "none" : "";
+  }
+
+  function cancelFollow(): void {
+    setFollowing(false);
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = null;
+  }
+
+  function syncSticky(): void {
+    if (!scroller) return;
+    const top = pins?.getBoundingClientRect().height ?? 0;
+    scroller.style.setProperty("--chat-sticky-top", `${top}px`);
+    const style = getComputedStyle(scroller);
+    const paddingTop = parseFloat(style.paddingTop) || 0;
+    const paddingBottom = parseFloat(style.paddingBottom) || 0;
+    const promptMargin = prompt ? parseFloat(getComputedStyle(prompt).marginBottom) || 0 : 0;
+    const canStick =
+      !!prompt &&
+      prompt.getBoundingClientRect().height + promptMargin + top + paddingTop + paddingBottom <= scroller.clientHeight;
+    prompt?.classList.toggle("sticky-disabled", !canStick);
+    prompt?.classList.toggle(
+      "stuck",
+      canStick &&
+        scroller.scrollTop > 0 &&
+        prompt.getBoundingClientRect().top <=
+          scroller.getBoundingClientRect().top + scroller.clientTop + paddingTop + top + 0.5,
+    );
+  }
+
+  function onScroll(): void {
+    if (!scroller) return;
+    const atBottom = scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop <= 1;
+    if (atBottom) setFollowing(true);
+    else if (scroller.scrollTop < lastTop) cancelFollow();
+    lastTop = scroller.scrollTop;
+    syncSticky();
+  }
+
+  function onWheel(event: WheelEvent): void {
+    if (event.deltaY < 0) cancelFollow();
+  }
+
+  function dispose(): void {
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = null;
+    observer?.disconnect();
+    observer = null;
+    scroller?.removeEventListener("scroll", onScroll);
+    scroller?.removeEventListener("wheel", onWheel);
+    scroller?.style.removeProperty("--chat-sticky-top");
+    scroller?.style.removeProperty("overflow-anchor");
+    prompt?.classList.remove("stuck", "sticky-disabled");
+    scroller = pins = prompt = stack = null;
+    lastTop = 0;
+    following = false;
+  }
+
+  function sync(element: HTMLElement | null): void {
+    let changed = false;
+    if (scroller !== element) {
+      changed = true;
+      dispose();
+      scroller = element;
+      lastTop = scroller?.scrollTop ?? 0;
+      setFollowing(false);
+      scroller?.addEventListener("scroll", onScroll, { passive: true });
+      scroller?.addEventListener("wheel", onWheel, { passive: true });
+      if (typeof ResizeObserver !== "undefined") {
+        observer = new ResizeObserver(() => {
+          syncSticky();
+          follow();
+        });
+        if (scroller) observer.observe(scroller);
+      }
+    }
+    const nextStack = scroller?.querySelector<HTMLElement>(".message-stack") ?? null;
+    if (stack !== nextStack) {
+      changed = true;
+      if (stack) observer?.unobserve(stack);
+      stack = nextStack;
+      if (stack) observer?.observe(stack);
+    }
+    const nextPins = scroller?.querySelector<HTMLElement>(".pinned-strip") ?? null;
+    const nextPrompt = scroller?.querySelector<HTMLElement>(".message-stack .user-row:not(:has(~ .user-row))") ?? null;
+    if (pins !== nextPins) {
+      changed = true;
+      if (pins) observer?.unobserve(pins);
+      pins = nextPins;
+      if (pins) observer?.observe(pins);
+    }
+    if (prompt !== nextPrompt) {
+      changed = true;
+      prompt?.classList.remove("stuck", "sticky-disabled");
+      if (prompt) observer?.unobserve(prompt);
+      prompt = nextPrompt;
+      if (prompt) observer?.observe(prompt);
+    }
+    if (changed) syncSticky();
+  }
+
+  function follow(force = false): void {
+    if (force) {
+      setFollowing(true);
+      lastTop = scroller?.scrollTop ?? 0;
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = null;
+    }
+    if (!scroller || !following || frame !== null) return;
+    const element = scroller;
+    const priorTop = element.scrollTop;
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      if (element !== scroller || !element.isConnected || !following) return;
+      if (element.scrollTop < priorTop && element.scrollHeight - element.clientHeight - element.scrollTop > 1)
+        return cancelFollow();
+      element.scrollTop = element.scrollHeight;
+      lastTop = scroller?.scrollTop ?? 0;
+      syncSticky();
+    });
+  }
+
+  return { sync, follow, dispose };
+}

--- a/plugins/web-ui/test/chat-elevation.test.ts
+++ b/plugins/web-ui/test/chat-elevation.test.ts
@@ -11,18 +11,17 @@ test("transcript edges do not blur or mask the response", () => {
 });
 
 test("the pinned prompt and composer have elevated solid surfaces", () => {
-  const pinned =
-    css.match(/\.message-stack \.user-row:not\(:has\(~ \.user-row\)\) > \.user-bubble \{[^}]*\}/)?.[0] ?? "";
+  const pinned = css.match(/\.message-stack \.user-row\.stuck > \.user-bubble \{[^}]*\}/)?.[0] ?? "";
   const composer = css.match(/^\.composer-wrap \{[^}]*\}/m)?.[0] ?? "";
   assert.match(pinned, /box-shadow: var\(--chat-surface-shadow\);/);
   assert.match(composer, /background: var\(--background\);/);
   assert.match(composer, /box-shadow: var\(--chat-surface-shadow\);/);
 });
 
-test("prompt elevation is shared by every transcript without scroll-handler state", () => {
+test("prompt elevation uses the shared surface shadow only while stuck", () => {
   const root = css.match(/:root \{[^}]*\}/)?.[0] ?? "";
   const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
   assert.match(root, /--chat-surface-shadow:/);
-  assert.doesNotMatch(css, /\.user-row\.stuck/);
+  assert.match(css, /\.user-row\.stuck/);
   assert.doesNotMatch(chat, /markStuckUserRow/);
 });

--- a/plugins/web-ui/test/css-vars.test.ts
+++ b/plugins/web-ui/test/css-vars.test.ts
@@ -33,11 +33,7 @@ test("every drop zone the canvas renders has a positioning rule in shell.css", (
 });
 
 test("only the elevated chat surfaces paint a shadow", () => {
-  const elevated = [
-    ".pinned-strip",
-    ".message-stack .user-row.stuck > .user-bubble",
-    ".composer-wrap",
-  ];
+  const elevated = [".pinned-strip", ".message-stack .user-row.stuck > .user-bubble", ".composer-wrap"];
   const rules = shellCss.replace(/\/\*[\s\S]*?\*\//g, "");
   const painted = [...rules.matchAll(/([^{}]+)\{([^{}]*)\}/g)].flatMap((rule) =>
     [...rule[2].matchAll(/(box|text)-shadow\s*:\s*([^;}]+)/g)]

--- a/plugins/web-ui/test/css-vars.test.ts
+++ b/plugins/web-ui/test/css-vars.test.ts
@@ -35,7 +35,7 @@ test("every drop zone the canvas renders has a positioning rule in shell.css", (
 test("only the elevated chat surfaces paint a shadow", () => {
   const elevated = [
     ".pinned-strip",
-    ".message-stack .user-row:not(:has(~ .user-row)) > .user-bubble",
+    ".message-stack .user-row.stuck > .user-bubble",
     ".composer-wrap",
   ];
   const rules = shellCss.replace(/\/\*[\s\S]*?\*\//g, "");

--- a/plugins/web-ui/test/layout-thrash.test.ts
+++ b/plugins/web-ui/test/layout-thrash.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+const viewport = readFileSync(new URL("../src/transcript-viewport.ts", import.meta.url), "utf8");
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 
 test("resizeComposer skips the forced-reflow measure pass when the draft value is unchanged", () => {
@@ -20,25 +21,32 @@ test("a box-size change re-arms the composer measure via ResizeObserver (fires a
   assert.match(composer, /autosizeObserver\.unobserve\(autosizedTa\)/, "the replaced input must be unobserved");
 });
 
-test("scrollTranscript's skip path performs zero layout reads", () => {
-  const fn = chat.match(/function scrollTranscript\(force = false\): void \{[\s\S]*?\n\}/)?.[0] ?? "";
-  const beforeRaf = fn.slice(0, fn.indexOf("requestAnimationFrame"));
-  for (const read of ["scrollHeight", "clientHeight", "scrollTop -", "getBoundingClientRect"]) {
-    assert.ok(!beforeRaf.includes(read), `no sync layout read before the rAF: found ${read}`);
-  }
-  assert.match(fn, /if \(!force && !stickToBottom\) return;/);
+test("bottom-follow's skip path performs zero layout reads", () => {
+  const fn = viewport.slice(viewport.indexOf("  function follow("));
+  const skip = fn.indexOf("if (!scroller || !following || frame !== null) return;");
+  const firstRead = fn.indexOf("const priorTop = element.scrollTop;");
+  assert.ok(skip >= 0 && skip < firstRead);
+  assert.match(viewport, /if \(changed\) syncSticky\(\);/);
 });
 
-test("bottom-stickiness is tracked by the scroller's own scroll listener, and a fresh mount starts pinned", () => {
-  assert.match(chat, /class="chat-scroll" @scroll=\$\{onTranscriptScroll\}/);
-  assert.match(chat, /stickToBottom = s\.scrollHeight - s\.scrollTop - s\.clientHeight <= 120;/);
-  assert.match(chat, /let stickToBottom = true;/);
+test("bottom-follow belongs to each scroller, and fresh mounts start pinned", () => {
+  assert.match(viewport, /addEventListener\("scroll", onScroll/);
+  assert.match(viewport, /const atBottom = scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop <= 1;/);
+  assert.match(viewport, /if \(force\) \{\s*setFollowing\(true\);/);
 });
 
-test("revealing a transcript re-arms auto-follow; read-only mounts start at the end except pagination", () => {
-  assert.match(chat, /function scrollToBottom\(\): void \{\s*stickToBottom = true;\s*scrollTranscript\(true\);/);
+test("revealing a transcript re-arms follow; read-only mounts start at the end except pagination", () => {
+  assert.match(chat, /function scrollToBottom\(\): void \{\s*scrollTranscript\(true\);/);
   assert.match(chat, /if \(!sameSession\) scrollToBottom\(\);/);
-  assert.match(chat, /const scroller = ctx\.container\(\)\?\.querySelector/);
+  assert.match(chat, /transcriptViewport.follow\(force\);/);
+});
+
+test("composer measurement holds its outer height instead of temporarily resizing the transcript", () => {
+  const fn = composer.slice(composer.indexOf("  function resizeComposer("));
+  const lock = fn.indexOf("wrap.style.height = `${wrap.getBoundingClientRect().height}px`");
+  const measure = fn.indexOf('ta.style.height = "auto"');
+  const release = fn.indexOf("wrap.style.height = wrapHeight");
+  assert.ok(lock >= 0 && lock < measure && release > measure);
 });
 
 test("both pagination paths adjust their anchor without smooth scrolling", () => {

--- a/plugins/web-ui/test/pinned-composer-polish.test.ts
+++ b/plugins/web-ui/test/pinned-composer-polish.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+
+test("transcript top spacing and prompt gap stay compact at every density", () => {
+  const values = [...css.matchAll(/--chat-scroll-pad-top: (\d+)px/g)].map((m) => Number(m[1]));
+  assert.ok(values.length >= 3 && values.every((v) => v === 8));
+  const prompt = css.match(/\.message-stack \.user-row:not\(:has\(~ \.user-row\)\) \{[^}]*\}/)?.[0] ?? "";
+  assert.match(prompt, /padding-top: 8px;/);
+  assert.match(prompt, /margin-top: -8px;/);
+  assert.match(prompt, /margin-bottom: 12px;/);
+});
+
+test("editable background activity is rendered inside the composer surface", () => {
+  assert.match(chat, /composerForm\(agent, backgroundActivityStrip\(\)\)/);
+  assert.match(composer, /<form class="composer-wrap[^]*?\$\{header\}/);
+  assert.match(
+    css,
+    /\.composer-wrap > \.bg-activity \{[^}]*background: color-mix\(in srgb, var\(--secondary\) 40%, var\(--background\)\);/,
+  );
+});

--- a/plugins/web-ui/test/queue-by-default.test.ts
+++ b/plugins/web-ui/test/queue-by-default.test.ts
@@ -184,7 +184,10 @@ test("the strip renders core's queue, refreshed from the same read that names th
 });
 
 test("the queued strip sits behind and outside the composer form", () => {
-  assert.match(chat, /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent\)/);
+  assert.match(
+    chat,
+    /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent, backgroundActivityStrip\(\)\)/,
+  );
   const composerMarkup = composer.slice(composer.indexOf('<form class="composer-wrap"'), composer.indexOf("</form>"));
   assert.doesNotMatch(composerMarkup, /queuedStrip\(agent\)/);
   const queuedRule = shell.match(/(?:^|\n)\.queued-strip \{[^}]*\}/)?.[0] ?? "";

--- a/plugins/web-ui/test/responsive-source.test.ts
+++ b/plugins/web-ui/test/responsive-source.test.ts
@@ -130,14 +130,10 @@ test("touch layouts expose row actions and preserve readable composer choices", 
   assert.match(compactCss, /margin: 0 auto max\(18px, calc\(10px \+ env\(safe-area-inset-bottom\)\)\)/);
   assert.match(
     compactCss,
-    /\.composer-wrap,\s*\.live-work-dock \{\s*width: auto;\s*margin-right: max\(16px, calc\(10px \+ env\(safe-area-inset-right\)\)\);\s*margin-left: max\(16px, calc\(10px \+ env\(safe-area-inset-left\)\)\)/,
+    /\.composer-wrap \{\s*width: auto;\s*margin-right: max\(16px, calc\(10px \+ env\(safe-area-inset-right\)\)\);\s*margin-left: max\(16px, calc\(10px \+ env\(safe-area-inset-left\)\)\)/,
   );
   assert.match(
     compactCss,
     /\.composer-wrap \{\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-bottom: calc\(10px \+ env\(safe-area-inset-bottom\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
-  );
-  assert.match(
-    compactCss,
-    /\.live-work-dock \{\s*margin-right: calc\(10px \+ env\(safe-area-inset-right\)\);\s*margin-left: calc\(10px \+ env\(safe-area-inset-left\)\)/,
   );
 });

--- a/plugins/web-ui/test/thinking-placement.test.ts
+++ b/plugins/web-ui/test/thinking-placement.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("live thinking and tool activity belong to the transcript, not the composer dock", () => {
+  const draw = chat.slice(
+    chat.indexOf("  function drawActiveChat("),
+    chat.indexOf("  function decorateStreamingTail("),
+  );
+  const transcript = draw.slice(
+    draw.indexOf('<section class="chat-scroll">'),
+    draw.indexOf('<div class="chat-bottom-dock">'),
+  );
+  const dock = draw.slice(draw.indexOf('<div class="chat-bottom-dock">'));
+  assert.match(transcript, /\$\{liveWorkStatus\(agent\)\}/);
+  assert.doesNotMatch(dock, /liveWork(?:Dock|Status)\(agent\)/);
+  assert.match(dock, /composerForm\(agent, backgroundActivityStrip\(\)\)/);
+});
+
+test("the live-work row aligns with the message column rather than composer gutters", () => {
+  const rule = css.match(/\.live-work-status \{[^}]*\}/)?.[0] ?? "";
+  assert.match(rule, /width: 100%;/);
+  assert.match(rule, /margin: 8px 0 0;/);
+  assert.doesNotMatch(css, /live-work-dock/);
+});

--- a/plugins/web-ui/test/transcript-viewport.test.ts
+++ b/plugins/web-ui/test/transcript-viewport.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+
+test("only an actually stuck prompt gets elevation", () => {
+  const normal =
+    css.match(/\.message-stack \.user-row:not\(:has\(~ \.user-row\)\) > \.user-bubble \{[^}]*\}/)?.[0] ?? "";
+  assert.doesNotMatch(normal, /box-shadow: var/);
+  assert.match(css, /\.user-row\.stuck > \.user-bubble/);
+});
+
+test("prompt offset reserves the pane's measured pins height", () => {
+  assert.match(css, /top: var\(--chat-sticky-top, 0px\)/);
+  assert.match(css, /max-height: min\(38cqh, 240px\)/);
+});
+
+test("stream following never uses smooth scrolling or a near-bottom zone", () => {
+  const scroller = css.match(/\.chat-scroll \{[^}]*\}/)?.[0] ?? "";
+  assert.doesNotMatch(scroller, /scroll-behavior: smooth/);
+  assert.doesNotMatch(chat, /<= 120/);
+});
+
+import { JSDOM } from "jsdom";
+import { createTranscriptViewport } from "../src/transcript-viewport.ts";
+
+function fixture() {
+  const dom = new JSDOM(
+    '<section><div class="pinned-strip"></div><div class="message-stack"><article class="user-row"></article></div></section>',
+  );
+  const s = dom.window.document.querySelector("section")!;
+  const pins = s.querySelector<HTMLElement>(".pinned-strip")!;
+  const prompt = s.querySelector<HTMLElement>(".user-row")!;
+  let height = 1000;
+  let pinsHeight = 30;
+  let promptTop = 50;
+  Object.defineProperties(s, { scrollHeight: { get: () => height }, clientHeight: { value: 200 } });
+  s.scrollTop = 800;
+  s.getBoundingClientRect = () => ({ top: 20 }) as DOMRect;
+  pins.getBoundingClientRect = () => ({ height: pinsHeight }) as DOMRect;
+  prompt.getBoundingClientRect = () => ({ top: promptTop, height: 50 }) as DOMRect;
+  const writes: number[] = [];
+  let top = s.scrollTop;
+  Object.defineProperty(s, "scrollTop", {
+    get: () => top,
+    set: (value: number) => {
+      writes.push(value);
+      top = Math.min(value, height - 200);
+    },
+  });
+  const frames = new Map<number, FrameRequestCallback>();
+  let id = 0;
+  let resize = () => {};
+  const restore = ["requestAnimationFrame", "cancelAnimationFrame", "ResizeObserver", "getComputedStyle"].map(
+    (key) => [key, Object.getOwnPropertyDescriptor(globalThis, key)] as const,
+  );
+  Object.assign(globalThis, {
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+    requestAnimationFrame: (cb: FrameRequestCallback) => {
+      frames.set(++id, cb);
+      return id;
+    },
+    cancelAnimationFrame: (n: number) => frames.delete(n),
+    ResizeObserver: class {
+      constructor(cb: () => void) {
+        resize = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  });
+  const viewport = createTranscriptViewport();
+  viewport.sync(s);
+  viewport.follow(true);
+  for (const cb of frames.values()) cb(0);
+  frames.clear();
+  writes.length = 0;
+  return {
+    s,
+    prompt,
+    viewport,
+    writes,
+    resize: (pinHeight: number, top: number) => {
+      pinsHeight = pinHeight;
+      promptTop = top;
+      resize();
+    },
+    grow: () => {
+      height += 100;
+    },
+    scroll: (top: number) => {
+      s.scrollTop = top;
+      s.dispatchEvent(new dom.window.Event("scroll"));
+    },
+    wheelUp: () => s.dispatchEvent(new dom.window.WheelEvent("wheel", { deltaY: -1 })),
+    flush: () => {
+      const pending = [...frames.values()];
+      frames.clear();
+      for (const cb of pending) cb(0);
+    },
+    close: () => {
+      viewport.dispose();
+      dom.window.close();
+      for (const [key, descriptor] of restore) {
+        if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+        else Reflect.deleteProperty(globalThis, key);
+      }
+    },
+  };
+}
+
+test("a bottom-pinned stream follows growth instantly and coalesces frames", () => {
+  const f = fixture();
+  try {
+    f.grow();
+    f.viewport.follow();
+    f.viewport.follow();
+    f.flush();
+    assert.equal(f.s.scrollTop, 900);
+    assert.deepEqual(f.writes, [1100]);
+  } finally {
+    f.close();
+  }
+});
+
+test("even a small upward scroll stops following; returning to the bottom resumes it", () => {
+  const f = fixture();
+  try {
+    f.scroll(798);
+    f.grow();
+    f.viewport.follow();
+    f.flush();
+    assert.equal(f.s.scrollTop, 798);
+    assert.deepEqual(f.writes, [798]);
+    f.scroll(900);
+    f.grow();
+    f.viewport.follow();
+    f.flush();
+    assert.equal(f.s.scrollTop, 1000);
+  } finally {
+    f.close();
+  }
+});
+
+test("an upward wheel cancels a queued follow before its scroll event arrives", () => {
+  const f = fixture();
+  try {
+    f.grow();
+    f.viewport.follow();
+    f.wheelUp();
+    f.flush();
+    assert.equal(f.writes.length, 0);
+  } finally {
+    f.close();
+  }
+});
+
+test("scrolling between scheduling and painting cannot be overwritten", () => {
+  const f = fixture();
+  try {
+    f.grow();
+    f.viewport.follow();
+    f.s.scrollTop -= 10;
+    f.flush();
+    assert.deepEqual(f.writes, [790]);
+  } finally {
+    f.close();
+  }
+});
+
+test("only reaching the sticky edge elevates the prompt; pin resizes update the edge", () => {
+  const f = fixture();
+  try {
+    f.resize(30, 200);
+    assert.equal(f.prompt.classList.contains("stuck"), false);
+    f.resize(30, 50);
+    assert.equal(f.prompt.classList.contains("stuck"), true);
+    f.resize(90, 110);
+    assert.equal(f.s.style.getPropertyValue("--chat-sticky-top"), "90px");
+    assert.equal(f.prompt.classList.contains("stuck"), true);
+    f.scroll(0);
+    assert.equal(f.prompt.classList.contains("stuck"), false);
+  } finally {
+    f.close();
+  }
+});
+
+test("disposing cancels queued work and clears sticky presentation", () => {
+  const f = fixture();
+  try {
+    f.viewport.follow();
+    f.viewport.dispose();
+    f.flush();
+    assert.equal(f.writes.length, 0);
+    assert.equal(f.prompt.classList.contains("stuck"), false);
+    assert.equal(f.s.style.getPropertyValue("--chat-sticky-top"), "");
+  } finally {
+    f.close();
+  }
+});
+
+test("native scroll anchoring is restored when the reader leaves the bottom", () => {
+  const f = fixture();
+  try {
+    assert.equal(f.s.style.overflowAnchor, "none");
+    f.scroll(700);
+    assert.equal(f.s.style.overflowAnchor, "");
+    f.scroll(800);
+    assert.equal(f.s.style.overflowAnchor, "none");
+  } finally {
+    f.close();
+  }
+});
+
+test("replacing a scroller does not arm follow without an explicit fresh-session jump", () => {
+  const f = fixture();
+  try {
+    f.viewport.dispose();
+    f.viewport.sync(f.s);
+    f.viewport.follow();
+    f.flush();
+    assert.equal(f.writes.length, 0);
+    f.viewport.follow(true);
+    f.flush();
+    assert.equal(f.writes.length, 1);
+  } finally {
+    f.close();
+  }
+});
+
+test("redrawing unchanged nodes while reading performs no layout reads", () => {
+  const f = fixture();
+  try {
+    f.scroll(600);
+    f.s.getBoundingClientRect = () => {
+      throw new Error("unexpected layout read");
+    };
+    f.viewport.sync(f.s);
+    f.viewport.follow();
+    f.flush();
+    assert.deepEqual(f.writes, [600]);
+  } finally {
+    f.close();
+  }
+});
+
+test("a prompt stays in flow when pins leave too little room, and can stick again after resizing", () => {
+  const f = fixture();
+  try {
+    f.resize(160, 180);
+    assert.equal(f.prompt.classList.contains("sticky-disabled"), true);
+    assert.equal(f.prompt.classList.contains("stuck"), false);
+    f.resize(30, 50);
+    assert.equal(f.prompt.classList.contains("sticky-disabled"), false);
+    assert.equal(f.prompt.classList.contains("stuck"), true);
+  } finally {
+    f.close();
+  }
+});


### PR DESCRIPTION
Tightens sticky prompt positioning, keeps live thinking in the transcript, and integrates background status with the composer without overriding manual scrolling.

- Conditional elevation and collision-free pin positioning, including undersized panes.
- Verified desktop, split, and phone layouts with synthetic streaming data.
- Web UI tests: 956 passed.
- Web UI typechecks, build, changed-file lint, and formatting pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791434375&installation_model_id=19911&pr_number=972&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F972&signature=8cfe17ad7f495f36b4fc767d0aa5b09b4fe9098921f0d2df40367699de12251f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->