### PR TITLE
fix: clarify agent computer egress warning

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -5335,8 +5335,10 @@
                   <div class="body">
                     <div class="governance-capability" id="egress-capability" role="status">
                       <div>
-                        <strong>Egress policy unavailable</strong
-                        ><span>The deployment backend cannot enforce outbound host policy.</span>
+                        <strong>Agent computer egress policy unavailable</strong
+                        ><span
+                          >The agent computer provider cannot enforce host restrictions on all outbound traffic.</span
+                        >
                       </div>
                     </div>
                     <div class="egress-empty-state">
@@ -7646,13 +7648,15 @@
         );
         const capability = $("egress-capability");
         capability.classList.toggle("hidden", !!enforcement.active);
-        let enforcementTitle = "Egress policy unavailable";
+        let enforcementTitle = "Agent computer egress policy unavailable";
         if (enforcement.reason === "control_plane_unconfigured") enforcementTitle = "Enforcement is not activated";
         capability.querySelector("strong").textContent = enforcementTitle;
         let enforcementSummary =
-          "This deployment’s " + titleCase(enforcement.backend) + " backend cannot enforce outbound host policy.";
+          "Agent computers use " +
+          titleCase(enforcement.backend) +
+          ", which cannot enforce host restrictions on all outbound traffic. A configured egress proxy still applies policy to traffic sent through it.";
         if (enforcement.reason === "control_plane_unconfigured") {
-          enforcementSummary = "Egress enforcement has not been activated for this deployment.";
+          enforcementSummary = "Egress enforcement has not been activated for agent computers.";
         }
         capability.querySelector("span").textContent = enforcementSummary;
         const egressCard = $("card-egress");

--- a/plugins/admin/test/default-view.test.ts
+++ b/plugins/admin/test/default-view.test.ts
@@ -285,7 +285,7 @@ test("governance reviews high-impact changes in product and preserves drafts", (
   assert.doesNotMatch(html, /confirm\("Enable Dangerous/);
 });
 
-test("governance disables egress controls when the deployment cannot enforce them", () => {
+test("governance disables egress controls when agent computers cannot enforce them", () => {
   assert.match(html, /id="egress-capability"/);
   assert.doesNotMatch(html, /View deployment/);
   assert.match(html, /id="egress-deny-editor"/);
@@ -298,11 +298,16 @@ test("governance disables egress controls when the deployment cannot enforce the
   assert.match(html, /capability\.classList\.toggle\("hidden", !!enforcement\.active\)/);
   assert.match(html, /control\.disabled = !enforcement\.active/);
   assert.match(html, /enforcement\.reason === "control_plane_unconfigured"/);
-  assert.match(html, /Egress enforcement has not been activated for this deployment/);
+  assert.match(html, /Egress enforcement has not been activated for agent computers/);
   assert.match(html, /Backend supports policy; control plane inactive/);
   assert.match(html, /Backend cannot enforce host policy/);
   assert.doesNotMatch(html, /fidelity, which cannot enforce outbound host policy/);
   assert.doesNotMatch(html, /Agents still have open outbound access/);
+  assert.match(html, /Agent computer egress policy unavailable/);
+  assert.match(html, /"Agent computers use "\s*\+\s*titleCase\(enforcement.backend\)/);
+  assert.match(html, /cannot enforce host restrictions on all outbound traffic/);
+  assert.match(html, /A configured egress proxy still applies policy to traffic sent through it/);
+  assert.doesNotMatch(html, /This deployment’s|The deployment backend cannot enforce/);
 });
 
 test("governance keeps effective-state summaries synchronized after focused saves", () => {


### PR DESCRIPTION
Clarifies that egress enforcement depends on agent computers, while a configured proxy still applies policy to traffic sent through it; no behavior changes.

- Verification: 113 admin tests and 54 egress/sandbox tests pass; full typecheck, lint, and changed-file formatting pass.
- Browser verification: real admin UI with mocked API data, desktop/mobile, unsupported/unconfigured/enforced states; before/after screenshots captured.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791435581&installation_model_id=19911&pr_number=973&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F973&signature=686f35f3b985adce38f7c6c4d0d2bdfff20ba7b4c34d24e2e4e0d2b0f05d341e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->