### PR TITLE
Use inline link icons for session sharing

### DIFF
--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -1,4 +1,3 @@
-import { openSessionShare } from "./session-share";
 import { html, nothing, type TemplateResult } from "lit";
 import { Box, Brain, Clock3, Ellipsis, Files, GitFork, KeyRound, Rocket } from "lucide";
 import { api } from "./core-bridge";
@@ -173,7 +172,6 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
             </button>`
           : html`<div class="session-heading">${heading}</div>`
       }
-      ${o.sessionId ? html`<button type="button" class="session-share-button" @click=${() => void openSessionShare(o.sessionId!)}>Share</button>` : nothing}
       <div class="topbar-actions session-tools">
         ${tool("crons", Clock3, "Crons")} ${tool("files", Files, "Files")} ${tool("apps", Rocket, "Apps")}
         ${tool("skills", Box, "Skills")} ${tool("memory", Brain, "Memory")}

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -1,3 +1,4 @@
+import { openSessionShare } from "./session-share";
 import { html, nothing, render, type TemplateResult } from "lit";
 import { live } from "lit/directives/live.js";
 import { ref } from "lit/directives/ref.js";
@@ -729,15 +730,6 @@ function chatPageRow(s: CoreSession): TemplateResult {
               <button
                 class="icon-btn"
                 type="button"
-                ${tip("Copy link")}
-                aria-label=${`Copy link to ${sessionTitle(s)}`}
-                @click=${() => void copyText(sessionLink(location.origin, UI_BASE, s.id))}
-              >
-                ${icon(Link, 13.5)}
-              </button>
-              <button
-                class="icon-btn"
-                type="button"
                 ${tip(s.pinned ? "Unpin" : "Pin")}
                 aria-label=${`${s.pinned ? "Unpin" : "Pin"} ${sessionTitle(s)}`}
                 @click=${() => {
@@ -746,6 +738,15 @@ function chatPageRow(s: CoreSession): TemplateResult {
                 }}
               >
                 ${s.pinned ? icon(PinOff, 13.5) : icon(Pin, 13.5)}
+              </button>
+              <button
+                class="icon-btn"
+                type="button"
+                ${tip("Share conversation")}
+                aria-label=${`Share ${sessionTitle(s)}`}
+                @click=${() => void openSessionShare(s.id)}
+              >
+                ${icon(Link, 13.5)}
               </button>
               <button
                 class="icon-btn"
@@ -937,6 +938,18 @@ function sessionRow(s: CoreSession, projectChild = false): TemplateResult {
       ${
         saved
           ? html`<div class="session-menu">
+              <button
+                class="session-menu-btn session-share-btn"
+                type="button"
+                ${tip("Share conversation")}
+                aria-label=${`Share ${sessionTitle(s)}`}
+                @click=${(e: Event) => {
+                  e.stopPropagation();
+                  void openSessionShare(s.id);
+                }}
+              >
+                ${icon(Link, 13.5)}
+              </button>
               <button
                 class="session-menu-btn session-archive-btn"
                 type="button"

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -498,7 +498,7 @@ a.chat-row-open {
 .session-row:hover .session,
 .session-row:focus-within .session,
 .session-row.menu-open .session {
-  padding-right: 62px;
+  padding-right: 90px;
 }
 .session:hover {
   background: color-mix(in srgb, var(--foreground) 4%, transparent);
@@ -784,6 +784,7 @@ a.chat-row-open {
     color 0.12s ease;
 }
 .session-row:hover .session-menu-btn,
+.session-row:focus-within .session-menu-btn,
 .session-row.menu-open .session-menu-btn,
 .session-menu-btn:focus-visible {
   opacity: 1;
@@ -4558,7 +4559,7 @@ a.chat-row-open {
   .session-row:hover .session,
   .session-row:focus-within .session,
   .session-row.menu-open .session {
-    padding-right: 92px;
+    padding-right: 136px;
   }
   .session-menu {
     right: 0;
@@ -6819,9 +6820,11 @@ h3.ambient-field-label {
   display: none;
 }
 
-/* …but archive has no group-level counterpart (the header's X closes the pane, it doesn't
-   archive), so a lone tab keeps its archive button. */
-.dockview-theme-qm .dv-single-tab .split-tab-archive {
+.split-group-session-action {
+  display: none;
+}
+
+.dockview-theme-qm .dv-single-tab .split-group-session-action {
   display: inline-flex;
 }
 
@@ -6929,9 +6932,7 @@ h3.ambient-field-label {
     min-width 0.12s ease;
 }
 
-/* When the archive button is present it takes the auto margin; the close button that
-   follows sits snug beside it instead of splitting the leftover space. */
-.split-tab-archive + .split-tab-close {
+.split-tab-close + .split-tab-close {
   margin-left: 2px;
 }
 
@@ -6945,6 +6946,7 @@ h3.ambient-field-label {
 }
 
 .dv-tab:hover .split-tab-close,
+.dv-tab:focus-within .split-tab-close,
 .split-tab-close:focus-visible {
   opacity: 0.8;
 }
@@ -9501,6 +9503,7 @@ h3.ambient-field-label {
     margin-bottom: 0;
   }
 
+  .sidebar .session-share-btn,
   .sidebar .session-archive-btn {
     display: none;
   }
@@ -9731,16 +9734,6 @@ h3.ambient-field-label {
   }
 }
 
-.session-share-button {
-  flex-shrink: 0;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: transparent;
-  color: inherit;
-  padding: 4px 9px;
-  font-size: 12px;
-  cursor: pointer;
-}
 .session-share-dialog {
   width: min(480px, calc(var(--share-dialog-space, 100vw) - 40px));
 }

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -11,6 +11,7 @@ import {
   Expand,
   Files,
   KeyRound,
+  Link,
   Maximize2,
   MoreHorizontal,
   Plus,
@@ -903,6 +904,7 @@ export function notifyPanesChanged(): void {
 function refreshHeaders(): void {
   headerSignature = computeHeaderSignature();
   for (const t of paneTabs) t.draw();
+  for (const a of groupActions) a.draw();
   for (const c of paneContents.values()) c.syncTitle();
   syncDocumentTitle();
 }
@@ -1145,6 +1147,40 @@ class PaneContent implements IContentRenderer {
   }
 }
 
+function sessionActions(sessionId: string, inTab: boolean): TemplateResult {
+  const cls = inTab ? "split-tab-close" : "split-group-session-action";
+  return html`<button
+      type="button"
+      class="icon-btn subtle ${cls} split-tab-share"
+      ${tip("Share conversation")}
+      aria-label="Share conversation"
+      @pointerdown=${(e: Event) => {
+        if (inTab) e.stopPropagation();
+      }}
+      @click=${(e: Event) => {
+        if (inTab) e.stopPropagation();
+        void openSessionShare(sessionId);
+      }}
+    >
+      ${icon(Link, 13)}
+    </button>
+    <button
+      class="icon-btn subtle ${cls} split-tab-archive"
+      type="button"
+      title="Archive session"
+      aria-label="Archive session"
+      @pointerdown=${(e: Event) => {
+        if (inTab) e.stopPropagation();
+      }}
+      @click=${(e: Event) => {
+        if (inTab) e.stopPropagation();
+        archiveSessionById(sessionId);
+      }}
+    >
+      ${icon(Archive, 13)}
+    </button>`;
+}
+
 class PaneTab implements ITabRenderer {
   readonly element: HTMLElement;
   private panelId = "";
@@ -1228,39 +1264,7 @@ class PaneTab implements ITabRenderer {
             : nothing
         }
         <span class="split-pane-title-text" dir="auto">${title}</span>
-        ${
-          sessionId
-            ? html`<button
-                type="button"
-                class="session-share-button"
-                aria-label="Share conversation"
-                @pointerdown=${(e: Event) => e.stopPropagation()}
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  void openSessionShare(sessionId);
-                }}
-              >
-                Share
-              </button>`
-            : nothing
-        }
-        ${
-          this.inStrip && sessionId
-            ? html`<button
-                class="icon-btn subtle split-tab-close split-tab-archive"
-                type="button"
-                title="Archive session"
-                aria-label="Archive session"
-                @pointerdown=${(e: Event) => e.stopPropagation()}
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  archiveSessionById(sessionId);
-                }}
-              >
-                ${icon(Archive, 13)}
-              </button>`
-            : nothing
-        }
+        ${this.inStrip && sessionId ? sessionActions(sessionId, true) : nothing}
         ${
           this.inStrip
             ? html`<button
@@ -1346,7 +1350,8 @@ class GroupActions implements IHeaderActionsRenderer {
 
   private readonly onDocClick = (e: Event): void => {
     if (!this.menuOpen) return;
-    if (this.element.querySelector(".split-tools")?.contains(e.target as Node)) return;
+    const tools = this.element.querySelector(".split-tools");
+    if (tools && e.composedPath().includes(tools)) return;
     this.menuOpen = false;
     this.draw();
   };
@@ -1368,6 +1373,9 @@ class GroupActions implements IHeaderActionsRenderer {
       const g = dockApi?.groups.find((x) => x.id === props.group.id);
       return g?.activePanel ?? g?.panels[0] ?? null;
     };
+    const panel = activePanel();
+    const sessionId =
+      panel && !paneKindEntry(panelParams(panel)) ? (panelParams(panel).sessionId ?? paneSession(panel)?.id) : null;
     const maximized = props.api.isMaximized();
     const runTool = (tool: SessionTool): void => {
       this.menuOpen = false;
@@ -1454,6 +1462,7 @@ class GroupActions implements IHeaderActionsRenderer {
           </button>
           ${menu}
         </span>
+        ${sessionId ? sessionActions(sessionId, false) : nothing}
         ${buttons.map(
           (b) =>
             html`<button

--- a/plugins/web-ui/test/session-share-actions.test.ts
+++ b/plugins/web-ui/test/session-share-actions.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (name: string) => readFileSync(new URL(`../src/${name}`, import.meta.url), "utf8");
+const split = read("split.ts");
+const sessions = read("sessions.ts");
+const css = read("shell.css");
+
+test("tab and header sharing use the same session actions", () => {
+  assert.match(split, /this\.inStrip && sessionId \? sessionActions\(sessionId, true\) : nothing/);
+  const actions = split.slice(split.indexOf("function sessionActions"), split.indexOf("class PaneTab"));
+  assert.match(actions, /split-tab-share[\s\S]*?openSessionShare\(sessionId\)[\s\S]*?icon\(Link, 13\)/);
+  assert.match(actions, /split-tab-archive[\s\S]*?archiveSessionById\(sessionId\)/);
+  assert.doesNotMatch(split, /session-share-button/);
+});
+
+test("a lone header orders tools before sharing and archive", () => {
+  const group = split.slice(split.indexOf("class GroupActions"), split.indexOf("function notePaneSession"));
+  const render = group.slice(group.indexOf("    render("));
+  assert.match(render, /split-tools[\s\S]*?sessionActions\(sessionId, false\)[\s\S]*?buttons\.map/);
+  assert.match(css, /\.dv-single-tab \.split-tab-close\s*\{\s*display: none/);
+  assert.match(css, /\.split-group-session-action\s*\{\s*display: none/);
+  assert.match(css, /\.dv-single-tab \.split-group-session-action\s*\{\s*display: inline-flex/);
+});
+
+test("session lists open sharing inline beside archive", () => {
+  assert.match(
+    sessions,
+    /class="session-menu-btn session-share-btn"[\s\S]*?openSessionShare\(s.id\)[\s\S]*?session-archive-btn/,
+  );
+  const row = sessions.slice(
+    sessions.indexOf("function chatPageRow"),
+    sessions.indexOf("export function addPendingSession"),
+  );
+  assert.match(row, /openSessionShare\(s.id\)[\s\S]*?tip\(s.archived/);
+  assert.doesNotMatch(row, /Copy link/);
+  assert.match(css, /\.sidebar \.session-share-btn,\s*\.sidebar \.session-archive-btn\s*\{\s*display: none/);
+});
+
+test("a topbar without archive does not offer a separate share button", () => {
+  assert.doesNotMatch(read("session-scope.ts"), /session-share-button|openSessionShare/);
+  assert.doesNotMatch(css, /\.session-share-button\s*\{/);
+});

--- a/plugins/web-ui/test/split-single-header.test.ts
+++ b/plugins/web-ui/test/split-single-header.test.ts
@@ -32,7 +32,7 @@ test("project tools live behind the header overflow menu, left of the split butt
 
 test("the tools menu closes on any click outside the \u22ef control \u2014 sibling buttons included", () => {
   const cls = split.slice(split.indexOf("class GroupActions"), split.indexOf("function notePaneSession"));
-  assert.match(cls, /querySelector\("\.split-tools"\)\?\.contains\(e\.target as Node\)/);
+  assert.match(cls, /e\.composedPath\(\)\.includes\(tools\)/);
   // the toggle must not swallow the click, or another pane's open menu never hears it
   const toggle = cls.slice(cls.indexOf('class="icon-btn subtle split-tools-btn'), cls.indexOf("MoreHorizontal"));
   assert.doesNotMatch(toggle, /stopPropagation/);

--- a/plugins/web-ui/test/tab-archive-button.test.ts
+++ b/plugins/web-ui/test/tab-archive-button.test.ts
@@ -13,15 +13,11 @@ const fn = (src: string, name: string): string => {
 };
 
 test("a tab offers an archive button beside close, for real sessions only", () => {
-  const btn = split.match(/this\.inStrip && sessionId[\s\S]*?split-tab-archive[\s\S]*?<\/button>`/)?.[0] ?? "";
-  assert.ok(btn, "archive button must render only in the tab strip and only when the pane shows a session");
-  assert.match(btn, /archiveSessionById\(sessionId\)/, "click archives the pane's session");
-  assert.match(btn, /e\.stopPropagation\(\)/, "click must not also activate the tab");
-  assert.match(
-    btn,
-    /@pointerdown=\$\{\(e: Event\) => e\.stopPropagation\(\)\}/,
-    "pointerdown must not activate an inactive tab before the archive click lands",
-  );
+  assert.match(split, /this\.inStrip && sessionId \? sessionActions\(sessionId, true\)/);
+  const btn = fn(split, "sessionActions");
+  assert.match(btn, /archiveSessionById\(sessionId\)/);
+  assert.match(btn, /@pointerdown=[\s\S]*?if \(inTab\) e\.stopPropagation\(\)/);
+  assert.match(btn, /@click=[\s\S]*?if \(inTab\) e\.stopPropagation\(\)/);
   const archiveAt = split.indexOf("split-tab-archive");
   assert.ok(
     archiveAt !== -1 && split.indexOf('tip("Close pane")', archiveAt) !== -1,
@@ -42,12 +38,9 @@ test("archiveSessionById routes through setArchived so surfaces close and Recent
   );
 });
 
-test("a lone tab keeps its archive button even though its close yields to the group header", () => {
-  const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
-  const hide = css.indexOf(".dv-single-tab .split-tab-close");
-  const keep = css.indexOf(".dv-single-tab .split-tab-archive");
-  assert.ok(hide !== -1 && keep !== -1, "both single-tab rules exist");
-  assert.ok(keep > hide, "the archive exemption must come after (and defeat) the hide rule");
-  const rule = css.slice(keep, css.indexOf("}", keep));
-  assert.match(rule, /display: inline-flex/);
+test("a lone session keeps archive in the group header instead of the tab", () => {
+  const css = read("shell.css");
+  assert.match(css, /\.dv-single-tab \.split-tab-close\s*\{\s*display: none/);
+  assert.match(css, /\.dv-single-tab \.split-group-session-action\s*\{\s*display: inline-flex/);
+  assert.match(split, /sessionId \? sessionActions\(sessionId, false\) : nothing/);
 });


### PR DESCRIPTION
Replace text sharing controls with link icons beside archive, add inline session-list sharing, and keep the single-session header ordered Tools → Share → Archive.

- 64 focused tests, typecheck, lint, formatting, and build pass.
- Browser checks cover visibility, keyboard interaction, correct session targets, header ordering, and tab-close transitions.
- Synthetic interactive preview shared privately; sending and attachments are disabled there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791436773&installation_model_id=19911&pr_number=975&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F975&signature=06a3321b7ece72e290232373f4c6db5ef407be6f324eca87bb35616f75101189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->