### PR TITLE
web-ui: a bare arrow marks a link that leaves the app

### DIFF
--- a/plugins/web-ui/src/deploys.ts
+++ b/plugins/web-ui/src/deploys.ts
@@ -1,6 +1,6 @@
 import { html, nothing, render, type TemplateResult } from "lit";
 import { live } from "lit/directives/live.js";
-import { Archive, Check, Copy, ExternalLink, Pencil, RotateCcw, X } from "lucide";
+import { Archive, ArrowUpRight, Check, Copy, Pencil, RotateCcw, X } from "lucide";
 import { api, withBase } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
 import { copyText, icon, relTime } from "./ui";
@@ -266,7 +266,7 @@ function drawDeployDetail(d: DeploymentView, loading = false): void {
             <div class="deploy-detail-url">/d/${deploymentSlug(d)}/</div>
           </div>
           <div class="actions">
-            ${running && d.webUrl ? html`<a class="btn primary" href=${withBase(d.webUrl)} target="_blank" rel="noreferrer">Open app ${icon(ExternalLink, 14)}</a>` : nothing}
+            ${running && d.webUrl ? html`<a class="btn primary" href=${withBase(d.webUrl)} target="_blank" rel="noreferrer">Open app ${icon(ArrowUpRight, 14)}</a>` : nothing}
             ${running && canManage(d) ? html`<button class="btn" type="button" @click=${(event: Event) => void openLiveEdit(d, event.currentTarget as HTMLButtonElement)}>${icon(Pencil, 14)}<span>Edit live</span></button>` : nothing}
             ${d.webUrl ? html`<button class="btn" type="button" @click=${(event: Event) => void copyText(new URL(withBase(d.webUrl!), window.location.href).href, event.currentTarget as HTMLButtonElement)}>${icon(Copy, 14)}<span>Copy URL</span></button>` : nothing}
           </div>

--- a/plugins/web-ui/src/settings.ts
+++ b/plugins/web-ui/src/settings.ts
@@ -1,5 +1,5 @@
 import { html, nothing, render, type TemplateResult } from "lit";
-import { BookOpen, ExternalLink, LogOut, Monitor, Moon, ShieldUser, Sun, Trash2, Upload, type IconNode } from "lucide";
+import { ArrowUpRight, BookOpen, LogOut, Monitor, Moon, ShieldUser, Sun, Trash2, Upload, type IconNode } from "lucide";
 import { icon } from "./ui";
 import { ADMIN_HOME_URL, appState, can, signOut } from "./shell";
 import { sessionsState, setWebOnly } from "./sessions";
@@ -242,7 +242,7 @@ function adminRow(): TemplateResult {
         <div class="settings-row-note">Org settings, people, and policy.</div>
       </div>
       <a class="btn settings-row-action" href=${ADMIN_HOME_URL}>
-        ${icon(ShieldUser, 15)}<span>Open admin</span>${icon(ExternalLink, 14)}
+        ${icon(ShieldUser, 15)}<span>Open admin</span>${icon(ArrowUpRight, 14)}
       </a>
     </div>
   `;
@@ -258,7 +258,7 @@ function aboutRow(): TemplateResult {
         </div>
       </div>
       <a class="btn settings-row-action" href=${QM_ABOUT_URL} target="_blank" rel="noreferrer noopener">
-        ${icon(BookOpen, 15)}<span>Read the announcement</span>${icon(ExternalLink, 14)}
+        ${icon(BookOpen, 15)}<span>Read the announcement</span>${icon(ArrowUpRight, 14)}
       </a>
     </div>
   `;


### PR DESCRIPTION
Swaps the boxed `ExternalLink` glyph for `ArrowUpRight` on every link that opens outside the app.

- Settings → **Open admin**: boxed arrow becomes a plain top-right arrow
- Settings → **Read the announcement**: same
- Deployments → **Open app**: same, so the signifier is consistent app-wide
- `ExternalLink` is no longer imported anywhere in `plugins/web-ui/src`

`ArrowUpRight` is already what the inbox uses for *Open in Slack* and the agent-session link, so this leaves one mark for "this leaves the app" instead of two.

Before / after (Settings):

| before | after |
|---|---|
| boxed arrow | bare arrow |

web-ui 939/939, typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791442121&installation_model_id=19911&pr_number=977&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F977&signature=0e81fa1970b3661e988f390d47199651aaf2f48370b31186613a77e9b46fa0ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->