### PR TITLE
web-ui: an email draft folds its To and Subject away

### DIFF
--- a/plugins/web-ui/src/inbox.ts
+++ b/plugins/web-ui/src/inbox.ts
@@ -387,6 +387,17 @@ function notify(msg: string | null): void {
   }
 }
 
+function draftSubject(item: InboxItem, draft: InboxDraft): string {
+  if (draft.subject !== undefined) return draft.subject;
+  return item.gmail?.subject ? `Re: ${item.gmail.subject.replace(/^re:\s*/i, "")}` : "";
+}
+
+function headerPeek(item: InboxItem, draft: InboxDraft): string {
+  const to = (draft.to ?? []).join(", ");
+  const subject = draftSubject(item, draft);
+  return [to, subject].filter(Boolean).join(" · ") || "Recipients and subject";
+}
+
 function effectiveDraft(item: InboxItem): InboxDraft {
   const edited = draftEdits.get(item.id);
   if (edited) {
@@ -852,17 +863,19 @@ export function draftEditorTpl(item: InboxItem, opts: { chat?: boolean } = {}): 
       ${
         gmail
           ? html`
-              <label class="inbox-field">
-                <span>To</span>
-                <input
-                  type="text"
-                  .value=${(draft.to ?? []).join(", ")}
-                  placeholder="who@example.com"
-                  @input=${(e: Event) => editDraft(item, { to: splitAddresses((e.currentTarget as HTMLInputElement).value) })}
-                  @blur=${() => void persistDraft(item)}
-                />
-              </label>
-              ${
+              <details class="inbox-draft-headers">
+                <summary><span class="inbox-draft-headers-peek">${headerPeek(item, draft)}</span></summary>
+                <label class="inbox-field">
+                  <span>To</span>
+                  <input
+                    type="text"
+                    .value=${(draft.to ?? []).join(", ")}
+                    placeholder="who@example.com"
+                    @input=${(e: Event) => editDraft(item, { to: splitAddresses((e.currentTarget as HTMLInputElement).value) })}
+                    @blur=${() => void persistDraft(item)}
+                  />
+                </label>
+                ${
                 showCc
                   ? html`<label class="inbox-field">
                       <span>Cc</span>
@@ -875,15 +888,16 @@ export function draftEditorTpl(item: InboxItem, opts: { chat?: boolean } = {}): 
                     </label>`
                   : nothing
               }
-              <label class="inbox-field">
-                <span>Subject</span>
-                <input
-                  type="text"
-                  .value=${draft.subject ?? (item.gmail?.subject ? `Re: ${item.gmail.subject.replace(/^re:\s*/i, "")}` : "")}
-                  @input=${(e: Event) => editDraft(item, { subject: (e.currentTarget as HTMLInputElement).value })}
-                  @blur=${() => void persistDraft(item)}
-                />
-              </label>
+                <label class="inbox-field">
+                  <span>Subject</span>
+                  <input
+                    type="text"
+                    .value=${draftSubject(item, draft)}
+                    @input=${(e: Event) => editDraft(item, { subject: (e.currentTarget as HTMLInputElement).value })}
+                    @blur=${() => void persistDraft(item)}
+                  />
+                </label>
+              </details>
             `
           : nothing
       }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -8170,6 +8170,48 @@ h3.ambient-field-label {
   margin-left: auto;
   font-size: 11px;
 }
+.inbox-draft-headers {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.inbox-draft-headers > summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 2px 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  cursor: pointer;
+  list-style: none;
+}
+.inbox-draft-headers > summary::-webkit-details-marker {
+  display: none;
+}
+.inbox-draft-headers > summary::before {
+  content: "";
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 0.12s ease;
+}
+.inbox-draft-headers[open] > summary::before {
+  transform: rotate(45deg);
+}
+.inbox-draft-headers > summary:hover {
+  color: var(--foreground);
+}
+.inbox-draft-headers-peek {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .inbox-field {
   display: flex;
   align-items: center;


### PR DESCRIPTION
On an email inbox item, the draft's **To**, **Cc** and **Subject** fields sat open above the body. You almost never edit them — the agent fills them from the thread — so they pushed the actual draft down the page for nothing.

- The three fields are now inside a `<details>`, **collapsed by default**
- The summary line still shows the recipient and subject, so nothing is hidden — just unstacked
- One click opens them when a reply really does need a different address or subject
- `<details>` keeps its own open state, so a redraw mid-edit won't snap it shut, and no state has to be tracked
- Pulled the default `Re: …` subject out of the input's value binding into `draftSubject()`, so the summary and the field can't drift apart

Slack drafts are untouched — they never had these fields.

web-ui 939/939, typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791442978&installation_model_id=19911&pr_number=979&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F979&signature=8078686b2ce4d5233c2d27e56d681557da15bd235e49d8148df2da839712a32f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->