### PR TITLE
fix: accept custom models the web picker already offers

### DIFF
--- a/src/api/app-turn.ts
+++ b/src/api/app-turn.ts
@@ -19,7 +19,7 @@ import {
   modelUnavailableReason,
   resolveModel,
 } from "../model/pi-models.ts";
-import { selectableCatalogForHarness, selectableModelCatalog } from "../model/model-catalog.ts";
+import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../model/model-catalog.ts";
 import { resolveRuntimeChoiceDurable } from "../harness/harness-router.ts";
 import { swallow, swallowAs } from "../util/errors.ts";
 import { sleep } from "../util/async.ts";
@@ -204,13 +204,13 @@ export function createTurnMethods(
             enabledWebuiModels = configuredWebuiModels.length
               ? [...new Set([...configuredWebuiModels, orgRuntime.modelId])]
               : [];
-          } else if (providers?.openrouter) {
+          } else {
+            const catalog = providers?.openrouter
+              ? await selectableModelCatalog(deps.modelCredentialFetch)
+              : builtInModelCatalog();
             enabledWebuiModels = [
               ...new Set([
-                ...selectableCatalogForHarness(
-                  await selectableModelCatalog(deps.modelCredentialFetch),
-                  runtime.harnessId,
-                )
+                ...selectableCatalogForHarness(catalog, runtime.harnessId)
                   .filter((model) => modelOfferedInWebui(model.id))
                   .map((model) => model.id),
                 ...(orgRuntime.harnessId === runtime.harnessId ? [orgRuntime.modelId] : []),

--- a/src/model/pi-models.ts
+++ b/src/model/pi-models.ts
@@ -2,7 +2,7 @@ import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { parseModelOverlay, type ModelOverlay } from "./model-overlay.ts";
 import { providerBaseUrl } from "./provider-endpoints.ts";
-import { isCustomModelId, resolveCustomModel } from "./custom-providers.ts";
+import { isCustomModelId, resolveCustomModel, customModelCatalog } from "./custom-providers.ts";
 
 const getModel = getBuiltinModel as unknown as (provider: string, id: string) => Model<Api> | undefined;
 
@@ -282,7 +282,11 @@ export function overlayModelCatalog(): Array<{ id: string; name: string; provide
 }
 
 export function defaultWebuiModelIds(): readonly string[] {
-  return [...DEFAULT_WEBUI_MODEL_IDS, ...[...overlays.values()].filter((m) => m.webui).map((m) => m.id)];
+  return [
+    ...DEFAULT_WEBUI_MODEL_IDS,
+    ...[...overlays.values()].filter((m) => m.webui).map((m) => m.id),
+    ...customModelCatalog().map((m) => m.id),
+  ];
 }
 
 export function fastModeModelIds(): readonly string[] {

--- a/test/custom-provider-route.test.ts
+++ b/test/custom-provider-route.test.ts
@@ -22,9 +22,14 @@ function start(modelCredentialFetch: typeof fetch = async () => new Response(nul
   built: BuiltApp;
   close: () => Promise<void>;
 } {
-  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "custom-provider-route-")) }), {
-    modelCredentialFetch,
-  });
+  const built = buildApp(
+    testConfig({
+      dataDir: mkdtempSync(join(tmpdir(), "custom-provider-route-")),
+      openaiApiKey: undefined,
+      openrouterApiKey: undefined,
+    }),
+    { modelCredentialFetch },
+  );
   const server = createInsecureTestServer(built.app, {
     config: built.config,
     modelCredentials: built.modelCredentials,
@@ -92,6 +97,47 @@ test("custom provider lifecycle: register, list, resolve, delete — admin only,
     });
     assert.equal(del.status, 200);
     assert.equal(resolveModel("acme-large"), undefined);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a custom model the picker offers is accepted on web turns when no allowlist is set", async () => {
+  const srv = start(async () => new Response(null, { status: 200 }));
+  try {
+    const put = await fetch(`${srv.base}/v1/admin/custom-providers/acme-gateway`, {
+      method: "PUT",
+      headers: ADMIN,
+      body: JSON.stringify({ ...BODY, validate: false }),
+    });
+    assert.equal(put.status, 200);
+
+    const surface = await fetch(`${srv.base}/v1/surface-config`);
+    assert.equal(surface.status, 200);
+    const surfaceBody = (await surface.json()) as { webuiModels: string[] };
+    assert.ok(surfaceBody.webuiModels.includes("acme-large"), "picker offers the custom model");
+
+    const accepted = await srv.built.app.turn({
+      surface: "web",
+      actor: { externalId: "alice" },
+      conversation: { kind: "dm", threadRef: "web:alice:custom-no-allowlist" },
+      text: "hello",
+      model: "acme-large",
+      async: true,
+    });
+    assert.equal(accepted.status, "queued", JSON.stringify(accepted));
+
+    srv.built.config.setWebuiModels("org:default-org", ["claude-opus-4-8"]);
+    const refused = await srv.built.app.turn({
+      surface: "web",
+      actor: { externalId: "alice" },
+      conversation: { kind: "dm", threadRef: "web:alice:custom-allowlist-miss" },
+      text: "hello",
+      model: "acme-large",
+      async: true,
+    });
+    assert.equal(refused.status, "refused");
+    assert.equal(refused.reason, "that model is not enabled for the web UI");
   } finally {
     await srv.close();
   }

--- a/test/custom-providers.test.ts
+++ b/test/custom-providers.test.ts
@@ -9,7 +9,12 @@ import {
 } from "../src/model/custom-providers.ts";
 import { builtInModelCatalog } from "../src/model/model-catalog.ts";
 import { createCustomProviderStore } from "../src/model/custom-provider-store.ts";
-import { modelSupportedByHarness, modelServiceable, resolveModel } from "../src/model/pi-models.ts";
+import {
+  defaultWebuiModelIds,
+  modelSupportedByHarness,
+  modelServiceable,
+  resolveModel,
+} from "../src/model/pi-models.ts";
 import { createMemoryMap } from "../src/persistence/durable-map.ts";
 import type { StoredCustomProvider } from "../src/model/custom-provider-store.ts";
 
@@ -75,9 +80,11 @@ test("a registered custom model is serviceable regardless of built-in key availa
 test("catalog lists custom models; clearing the registry removes them", () => {
   setCustomProviders([GATEWAY]);
   assert.deepEqual(customModelCatalog(), [{ id: "acme-large", name: "Acme Large", provider: "acme-gateway" }]);
+  assert.ok(defaultWebuiModelIds().includes("acme-large"), "custom models join the default web-UI picker set");
   setCustomProviders([]);
   assert.equal(isCustomModelId("acme-large"), false);
   assert.equal(resolveModel("acme-large"), undefined);
+  assert.ok(!defaultWebuiModelIds().includes("acme-large"));
 });
 
 test("spec validation rejects reserved ids, bad slugs, bad URLs, and empty model lists", () => {

--- a/test/turn-options.test.ts
+++ b/test/turn-options.test.ts
@@ -1,4 +1,4 @@
-import { test } from "node:test";
+import { afterEach, test } from "node:test";
 import assert from "node:assert/strict";
 import {
   NON_INTERACTIVE_FAST_MODE,
@@ -6,6 +6,10 @@ import {
   turnModelOptions,
   validateWebTurnModelOptions,
 } from "../src/core/turn-options.ts";
+import { defaultWebuiModelIds } from "../src/model/pi-models.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
+
+afterEach(() => setCustomProviders([]));
 
 test("triggered turns default to extra-high thinking and non-fast mode", () => {
   assert.deepEqual(turnModelOptions({ triggered: true }), {
@@ -32,6 +36,24 @@ test("web model controls are bounded by admin configuration", () => {
 
 test("interactive turns do not force model options", () => {
   assert.deepEqual(turnModelOptions({}), {});
+});
+
+test("the web-turn fallback allowlist includes live custom-provider models", () => {
+  setCustomProviders([
+    {
+      id: "acme-gateway",
+      name: "Acme Gateway",
+      protocol: "openai",
+      baseUrl: "https://llm.acme.internal/v1",
+      models: [{ id: "acme-large", name: "Acme Large" }],
+    },
+  ]);
+  assert.ok(defaultWebuiModelIds().includes("acme-large"));
+  assert.equal(validateWebTurnModelOptions({ model: "acme-large" }, null), null);
+  assert.equal(
+    validateWebTurnModelOptions({ model: "acme-large" }, ["claude-opus-4-8"]),
+    "that model is not enabled for the web UI",
+  );
 });
 
 test("a triggered turn with an explicit low thinking level overrides the xhigh trigger default", () => {


### PR DESCRIPTION
## Why

With no web-UI allowlist and no OpenRouter key, `GET /v1/surface-config` still lists admin-registered custom models (from `builtInModelCatalog()`). Sending a turn on one of those models was refused: `validateWebTurnModelOptions` fell back to `DEFAULT_WEBUI_MODEL_IDS`, which never includes custom ids. `postTurn` maps that refusal to HTTP 403.

That is the documented custom-provider path. The picker and the gate disagreed.

Fixes #952

## What

- Default web-UI model ids now include the live custom catalog, matching overlays.
- When no allowlist is configured, web-turn validation uses the same catalog as the picker (`builtInModelCatalog`, or the OpenRouter catalog when that key is present) instead of leaving the allowlist `null`.
- An explicit Governance allowlist still refuses custom models that are not on it.

## Tests

- Unit: fallback allowlist includes a registered custom model; an explicit allowlist still refuses it.
- Integration: register a custom provider with no OpenRouter/OpenAI env key, confirm the picker lists it, a web turn queues, then an allowlist that omits it refuses with `that model is not enabled for the web UI`.
- Focused suites: `test/turn-options.test.ts`, `test/custom-providers.test.ts`, `test/custom-provider-route.test.ts`, `test/model-registry.test.ts` — 33 passed.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791470342&installation_model_id=19911&pr_number=980&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F980&signature=21840cf2806e658b541c98372bbee57580b2294645f71ccda196e0ad5a7da86f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->