### PR TITLE
fix: add tabs instead of automatically splitting a fourth tile

### DIFF
--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -620,7 +620,7 @@ export function startNewChatInCanvas(scopeId?: string, threadRef?: string): Conv
   const target = dockApi.activePanel ?? dockApi.panels[0];
   if (!target) return null;
   const replace = dockApi.panels.length === 1 || dockApi.panels.length >= MAX_PANES;
-  const tile = !replace && dockApi.groups.length > 1 && dockApi.groups.length < MAX_TILES;
+  const tile = !replace && dockApi.groups.length === 2;
   const { width, height } = target.group.element.getBoundingClientRect();
   const direction = width >= height ? "right" : "below";
   const fresh = addPane(

--- a/plugins/web-ui/test/new-chat-placement.test.ts
+++ b/plugins/web-ui/test/new-chat-placement.test.ts
@@ -7,6 +7,9 @@ interface Canvas {
   panes: () => number;
   tiles: () => number;
   newChat: () => boolean;
+  tabCounts: () => number[];
+  focusTile: (index: number) => void;
+  splitTile: (index: number) => void;
   seededChat: (threadRef?: string) => { state: { threadRef: string | null; agent: unknown } } | null;
   split: () => void;
   switchAway: () => void;
@@ -112,6 +115,22 @@ async function withCanvas(run: (canvas: Canvas) => void | Promise<void>, stacked
     }
     await run({
       panes: () => document.querySelectorAll(".dv-tab").length,
+      tabCounts: () =>
+        Array.from(document.querySelectorAll(".dv-groupview"), (g) => g.querySelectorAll(".dv-tab").length),
+      focusTile: (index) => {
+        document
+          .querySelectorAll(".dv-groupview")
+          .item(index)!
+          .querySelector(".dv-tab")!
+          .dispatchEvent(new dom.window.MouseEvent("pointerdown", { bubbles: true }));
+      },
+      splitTile: (index) => {
+        document
+          .querySelectorAll(".dv-groupview")
+          .item(index)!
+          .querySelector<HTMLButtonElement>('[aria-label="Split this pane with a new session"]')!
+          .click();
+      },
       tiles: () => document.querySelectorAll(".dv-groupview").length,
       newChat: () => sessions.startNewChat() !== null,
       seededChat: (threadRef) => sessions.startNewChat(null, null, threadRef),
@@ -132,7 +151,7 @@ async function withCanvas(run: (canvas: Canvas) => void | Promise<void>, stacked
   }
 }
 
-test("New chat replaces one pane, then joins the arrangement the viewer built", async () => {
+test("New chat stops splitting after three tiles and adds tabs to the selected pane", async () => {
   await withCanvas((canvas) => {
     assert.deepEqual([canvas.panes(), canvas.tiles()], [0, 0]);
 
@@ -146,10 +165,18 @@ test("New chat replaces one pane, then joins the arrangement the viewer built", 
     assert.deepEqual([canvas.panes(), canvas.tiles()], [3, 3], "split screen: New chat adds a window");
 
     assert.equal(canvas.newChat(), true);
-    assert.deepEqual([canvas.panes(), canvas.tiles()], [4, 4]);
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [4, 3], "three tiles: New chat adds a tab");
 
     assert.equal(canvas.newChat(), true);
-    assert.deepEqual([canvas.panes(), canvas.tiles()], [5, 4], "at the window limit: New chat adds a tab");
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [5, 3], "further sessions also add tabs");
+    assert.deepEqual(canvas.tabCounts(), [1, 1, 3]);
+    canvas.focusTile(0);
+    assert.equal(canvas.newChat(), true);
+    assert.deepEqual(canvas.tabCounts(), [2, 1, 3], "the new tab follows the selected pane");
+    canvas.splitTile(2);
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [7, 4], "explicit splitting still creates a fourth tile");
+    assert.equal(canvas.newChat(), true);
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [8, 4], "four tiles: New chat still adds a tab");
   });
 });
 
@@ -185,9 +212,9 @@ test("new chat replaces the focused conversation at capacity without dropping th
   await withCanvas((canvas) => {
     canvas.split();
     for (let i = 2; i < 12; i++) assert.equal(canvas.newChat(), true);
-    assert.deepEqual([canvas.panes(), canvas.tiles()], [12, 4]);
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [12, 3]);
     assert.ok(canvas.seededChat()?.state.agent);
-    assert.deepEqual([canvas.panes(), canvas.tiles()], [12, 4]);
+    assert.deepEqual([canvas.panes(), canvas.tiles()], [12, 3]);
   });
 });
 

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -22,7 +22,7 @@ test("every new-chat affordance follows the shared placement rule", () => {
   const placed = fn(split, "startNewChatInCanvas");
   assert.match(placed, /dockApi\.panels\.length >= MAX_PANES/);
   assert.match(placed, /dockApi\.removePanel\(target\)/);
-  assert.match(placed, /dockApi\.groups\.length > 1 && dockApi\.groups\.length < MAX_TILES/);
+  assert.match(placed, /dockApi\.groups\.length === 2/);
   const start = fn(sessions, "startNewChat");
   assert.match(start, /if \(splitState\.active\) return startNewChatInCanvas/);
   assert.match(start, /addPendingSession\(conv\.newChat/);


### PR DESCRIPTION
New sessions add a tab to the selected pane once three tiles are open, while explicit pane splitting remains available.

- Verification: 960 web tests passed; web typechecks and changed-file lint passed.
- Browser: reproduced before fix; verified selected-pane targeting, repeated tabs, explicit fourth-tile splitting, and four-tile fallback afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791486679&installation_model_id=19911&pr_number=984&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F984&signature=c3b40fe63df67ba0ae463a997566addd39369452845d25eb785117f3e0836717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->