### PR TITLE
fix: keep tab widths stable on hover

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6816,7 +6816,7 @@ h3.ambient-field-label {
   box-sizing: border-box;
 }
 
-.dockview-theme-qm .dv-single-tab .split-tab-close {
+.dockview-theme-qm .dv-single-tab .split-tab-actions {
   display: none;
 }
 
@@ -6919,36 +6919,42 @@ h3.ambient-field-label {
   background: var(--secondary);
 }
 
-.split-tab-close {
-  width: 18px;
-  height: 18px;
-  min-width: 18px;
-  margin-left: auto;
+.split-tab-actions {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-left: 10px;
   border-radius: 5px;
+  background: linear-gradient(to right, transparent, color-mix(in srgb, var(--background) 96%, transparent) 10px);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;
 }
 
-.split-tab-close + .split-tab-close {
-  margin-left: 2px;
+.dv-tab.dv-active-tab .split-tab-actions,
+.dv-tab:hover .split-tab-actions,
+.dv-tab:focus-within .split-tab-actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 
-.dv-tab.dv-active-tab .split-tab-close {
+.split-tab-close {
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  border-radius: 5px;
   opacity: 0.55;
-  pointer-events: auto;
 }
 
 .dv-tab:hover .split-tab-close,
-.dv-tab:focus-within .split-tab-close,
-.split-tab-close:focus-visible {
+.dv-tab:focus-within .split-tab-close {
   opacity: 0.8;
-  pointer-events: auto;
 }
 
-/* The old pane-header title — verbatim; tabs host it now. The title is the tab's only
-   child, so it has to span the chip for the close button's `margin-left: auto` to have
-   slack to push into. */
 .split-pane-title {
   display: flex;
   align-items: center;
@@ -6959,12 +6965,10 @@ h3.ambient-field-label {
 }
 
 .dv-tab .split-pane-title {
+  position: relative;
   flex: 1 1 auto;
 }
 
-/* The gap the close's own margin used to hold open, now that the margin is doing the
-   floating: it belongs to the text it separates, so a title long enough to ellipsize
-   still clears the close. */
 .split-pane-title-text {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6926,29 +6926,24 @@ h3.ambient-field-label {
   margin-left: auto;
   border-radius: 5px;
   opacity: 0;
-  transition:
-    opacity 0.12s ease,
-    width 0.12s ease,
-    min-width 0.12s ease;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
 }
 
 .split-tab-close + .split-tab-close {
   margin-left: 2px;
 }
 
-.dv-tab:not(.dv-active-tab):not(:hover):not(:focus-within) .split-tab-close {
-  width: 0;
-  min-width: 0;
-}
-
 .dv-tab.dv-active-tab .split-tab-close {
   opacity: 0.55;
+  pointer-events: auto;
 }
 
 .dv-tab:hover .split-tab-close,
 .dv-tab:focus-within .split-tab-close,
 .split-tab-close:focus-visible {
   opacity: 0.8;
+  pointer-events: auto;
 }
 
 /* The old pane-header title — verbatim; tabs host it now. The title is the tab's only

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6929,7 +6929,7 @@ h3.ambient-field-label {
   gap: 2px;
   padding-left: 10px;
   border-radius: 5px;
-  background: linear-gradient(to right, transparent, color-mix(in srgb, var(--background) 96%, transparent) 10px);
+  background: color-mix(in srgb, var(--background) 96%, transparent);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.12s ease;

--- a/plugins/web-ui/src/split.ts
+++ b/plugins/web-ui/src/split.ts
@@ -1219,18 +1219,20 @@ class PaneTab implements ITabRenderer {
           ${count > 0 ? html`<span class="pane-kind-count" title=${`${count} waiting on you`}>${count}</span>` : nothing}
           ${
             this.inStrip
-              ? html`<button
-                  class="icon-btn subtle split-tab-close"
-                  type="button"
-                  ${tip("Close pane")}
-                  aria-label="Close pane"
-                  @click=${(e: Event) => {
-                    e.stopPropagation();
-                    closePanels([panel]);
-                  }}
-                >
-                  ${icon(X, 13)}
-                </button>`
+              ? html`<span class="split-tab-actions"
+                  ><button
+                    class="icon-btn subtle split-tab-close"
+                    type="button"
+                    ${tip("Close pane")}
+                    aria-label="Close pane"
+                    @click=${(e: Event) => {
+                      e.stopPropagation();
+                      closePanels([panel]);
+                    }}
+                  >
+                    ${icon(X, 13)}
+                  </button></span
+                >`
               : nothing
           }
         `,
@@ -1264,21 +1266,23 @@ class PaneTab implements ITabRenderer {
             : nothing
         }
         <span class="split-pane-title-text" dir="auto">${title}</span>
-        ${this.inStrip && sessionId ? sessionActions(sessionId, true) : nothing}
         ${
           this.inStrip
-            ? html`<button
-                class="icon-btn subtle split-tab-close"
-                type="button"
-                ${tip("Close pane")}
-                aria-label="Close pane"
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  closePanels([panel]);
-                }}
-              >
-                ${icon(X, 13)}
-              </button>`
+            ? html`<span class="split-tab-actions">
+                ${sessionId ? sessionActions(sessionId, true) : nothing}
+                <button
+                  class="icon-btn subtle split-tab-close"
+                  type="button"
+                  ${tip("Close pane")}
+                  aria-label="Close pane"
+                  @click=${(e: Event) => {
+                    e.stopPropagation();
+                    closePanels([panel]);
+                  }}
+                >
+                  ${icon(X, 13)}
+                </button></span
+              >`
             : nothing
         }
       `,

--- a/plugins/web-ui/test/session-share-actions.test.ts
+++ b/plugins/web-ui/test/session-share-actions.test.ts
@@ -8,7 +8,10 @@ const sessions = read("sessions.ts");
 const css = read("shell.css");
 
 test("tab and header sharing use the same session actions", () => {
-  assert.match(split, /this\.inStrip && sessionId \? sessionActions\(sessionId, true\) : nothing/);
+  assert.match(
+    split,
+    /this\.inStrip[\s\S]*?split-tab-actions[\s\S]*?sessionId \? sessionActions\(sessionId, true\) : nothing/,
+  );
   const actions = split.slice(split.indexOf("function sessionActions"), split.indexOf("class PaneTab"));
   assert.match(actions, /split-tab-share[\s\S]*?openSessionShare\(sessionId\)[\s\S]*?icon\(Link, 13\)/);
   assert.match(actions, /split-tab-archive[\s\S]*?archiveSessionById\(sessionId\)/);
@@ -19,7 +22,7 @@ test("a lone header orders tools before sharing and archive", () => {
   const group = split.slice(split.indexOf("class GroupActions"), split.indexOf("function notePaneSession"));
   const render = group.slice(group.indexOf("    render("));
   assert.match(render, /split-tools[\s\S]*?sessionActions\(sessionId, false\)[\s\S]*?buttons\.map/);
-  assert.match(css, /\.dv-single-tab \.split-tab-close\s*\{\s*display: none/);
+  assert.match(css, /\.dv-single-tab \.split-tab-actions\s*\{\s*display: none/);
   assert.match(css, /\.split-group-session-action\s*\{\s*display: none/);
   assert.match(css, /\.dv-single-tab \.split-group-session-action\s*\{\s*display: inline-flex/);
 });

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -93,9 +93,6 @@ test("the per-tab close floats to the end of the tab", () => {
   assert.match(close, /margin-left: auto;/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*flex: 1 1 auto;/);
   assert.match(css, /\.split-pane-title-text \{[^}]*margin-right: 6px;/);
-  const collapsed = css.match(/:not\(:hover\):not\(:focus-within\) \.split-tab-close \{[^}]*\}/)?.[0] ?? "";
-  assert.ok(collapsed, "the collapsed-slot rule not found");
-  assert.doesNotMatch(collapsed, /margin-left:/);
 });
 
 test("the tab overflow menu is lifted above the panes and styled", () => {
@@ -120,4 +117,20 @@ test("a pane tab carries the conversation's background chip, from the sidebar's 
   // Only the sidebar's chip opens the inspector; the tab's is a mark on a tab that is
   // itself the control, so the clickable affordance hangs off the clickable one.
   assert.match(css, /\.bg-chip\[role="button"\] \{[^}]*cursor: pointer;/);
+});
+
+test("tab actions reserve their space and only fade on hover or keyboard focus", () => {
+  const close = css.match(/^\.split-tab-close \{[^}]*\}/m)?.[0] ?? "";
+  assert.match(close, /width: 18px;/);
+  assert.match(close, /min-width: 18px;/);
+  assert.match(close, /transition: opacity 0\.12s ease;/);
+  assert.match(close, /pointer-events: none;/);
+  const states = [...css.matchAll(/([^{}]*\.split-tab-close[^{}]*)\{([^{}]*)\}/g)].filter(([, selector]) =>
+    /:(?:not|hover|focus|focus-within|focus-visible)|\.dv-active-tab/.test(selector),
+  );
+  assert.ok(states.length > 0);
+  for (const [, selector, declarations] of states) {
+    assert.doesNotMatch(declarations, /(?:width|margin|padding|display|flex|gap)\s*:/, selector);
+    assert.match(declarations, /pointer-events: auto;/, selector);
+  }
 });

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -92,7 +92,8 @@ test("tab actions overlay the title instead of reserving title space", () => {
   const actions = css.match(/^\.split-tab-actions \{[^}]*\}/m)?.[0] ?? "";
   assert.match(actions, /position: absolute;/);
   assert.match(actions, /right: 0;/);
-  assert.match(actions, /background: linear-gradient\([^;]*96%/);
+  assert.match(actions, /background: color-mix\(in srgb, var\(--background\) 96%, transparent\);/);
+  assert.doesNotMatch(actions, /gradient|blur/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*position: relative;/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*flex: 1 1 auto;/);
   const draw = split.slice(split.indexOf("class PaneTab"), split.indexOf("class StripDrop"));

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -88,11 +88,15 @@ test("tabs share the strip evenly down to a legible floor", () => {
   assert.match(multi, /max-width: 220px;/);
 });
 
-test("the per-tab close floats to the end of the tab", () => {
-  const close = css.match(/^\.split-tab-close \{[^}]*\}/m)?.[0] ?? "";
-  assert.match(close, /margin-left: auto;/);
+test("tab actions overlay the title instead of reserving title space", () => {
+  const actions = css.match(/^\.split-tab-actions \{[^}]*\}/m)?.[0] ?? "";
+  assert.match(actions, /position: absolute;/);
+  assert.match(actions, /right: 0;/);
+  assert.match(actions, /background: linear-gradient\([^;]*96%/);
+  assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*position: relative;/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*flex: 1 1 auto;/);
-  assert.match(css, /\.split-pane-title-text \{[^}]*margin-right: 6px;/);
+  const draw = split.slice(split.indexOf("class PaneTab"), split.indexOf("class StripDrop"));
+  assert.equal((draw.match(/class="split-tab-actions"/g) ?? []).length, 2);
 });
 
 test("the tab overflow menu is lifted above the panes and styled", () => {
@@ -119,18 +123,17 @@ test("a pane tab carries the conversation's background chip, from the sidebar's 
   assert.match(css, /\.bg-chip\[role="button"\] \{[^}]*cursor: pointer;/);
 });
 
-test("tab actions reserve their space and only fade on hover or keyboard focus", () => {
-  const close = css.match(/^\.split-tab-close \{[^}]*\}/m)?.[0] ?? "";
-  assert.match(close, /width: 18px;/);
-  assert.match(close, /min-width: 18px;/);
-  assert.match(close, /transition: opacity 0\.12s ease;/);
-  assert.match(close, /pointer-events: none;/);
-  const states = [...css.matchAll(/([^{}]*\.split-tab-close[^{}]*)\{([^{}]*)\}/g)].filter(([, selector]) =>
+test("tab action overlays only fade on hover or keyboard focus", () => {
+  const actions = css.match(/^\.split-tab-actions \{[^}]*\}/m)?.[0] ?? "";
+  assert.match(actions, /transition: opacity 0\.12s ease;/);
+  assert.match(actions, /opacity: 0;/);
+  assert.match(actions, /pointer-events: none;/);
+  const states = [...css.matchAll(/([^{}]*\.split-tab-(?:actions|close)[^{}]*)\{([^{}]*)\}/g)].filter(([, selector]) =>
     /:(?:not|hover|focus|focus-within|focus-visible)|\.dv-active-tab/.test(selector),
   );
   assert.ok(states.length > 0);
   for (const [, selector, declarations] of states) {
     assert.doesNotMatch(declarations, /(?:width|margin|padding|display|flex|gap)\s*:/, selector);
-    assert.match(declarations, /pointer-events: auto;/, selector);
   }
+  assert.match(css, /\.dv-tab:focus-within \.split-tab-actions \{[^}]*pointer-events: auto;/);
 });

--- a/plugins/web-ui/test/tab-archive-button.test.ts
+++ b/plugins/web-ui/test/tab-archive-button.test.ts
@@ -13,7 +13,7 @@ const fn = (src: string, name: string): string => {
 };
 
 test("a tab offers an archive button beside close, for real sessions only", () => {
-  assert.match(split, /this\.inStrip && sessionId \? sessionActions\(sessionId, true\)/);
+  assert.match(split, /this\.inStrip[\s\S]*?split-tab-actions[\s\S]*?sessionId \? sessionActions\(sessionId, true\)/);
   const btn = fn(split, "sessionActions");
   assert.match(btn, /archiveSessionById\(sessionId\)/);
   assert.match(btn, /@pointerdown=[\s\S]*?if \(inTab\) e\.stopPropagation\(\)/);
@@ -40,7 +40,7 @@ test("archiveSessionById routes through setArchived so surfaces close and Recent
 
 test("a lone session keeps archive in the group header instead of the tab", () => {
   const css = read("shell.css");
-  assert.match(css, /\.dv-single-tab \.split-tab-close\s*\{\s*display: none/);
+  assert.match(css, /\.dv-single-tab \.split-tab-actions\s*\{\s*display: none/);
   assert.match(css, /\.dv-single-tab \.split-group-session-action\s*\{\s*display: inline-flex/);
   assert.match(split, /sessionId \? sessionActions\(sessionId, false\) : nothing/);
 });


### PR DESCRIPTION
Overlay tab actions on a mostly opaque background so controls reveal without resizing tabs or reserving title space.

- 46 focused split, share, and archive tests pass.
- Web typechecks, lint, and formatting pass.
- 59 browser checks pass, including recovered title space, frame-by-frame geometry, narrow panes, keyboard sharing, and lone-tab controls.
- Six additional short/long-title and light/dark-theme cases pass.
- Synthetic-data preview checked under isolated browser restrictions.
