### PR TITLE
Fix /d/ published-app links in the direct web UI proxy

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -2884,10 +2884,11 @@ const routeRequest = async (req: IncomingMessage, res: ServerResponse) => {
     return found.route.handle({ req, res, url, user, params: found.params });
   }
 
-  if (method === "GET" && path.startsWith("/deployments/")) {
+  const deploymentPrefix = ["/deployments/", "/d/"].find((prefix) => path.startsWith(prefix));
+  if (method === "GET" && deploymentPrefix) {
     const user = cookieUser(req);
     if (!user) return unauthorized(res, req);
-    const rest = path.slice("/deployments/".length);
+    const rest = path.slice(deploymentPrefix.length);
     const slash = rest.indexOf("/");
     const id = decodeURIComponent(slash === -1 ? rest : rest.slice(0, slash));
     const subPath = slash === -1 ? "/" : rest.slice(slash);

--- a/plugins/web-ui/test/deploy-open-proxy.test.ts
+++ b/plugins/web-ui/test/deploy-open-proxy.test.ts
@@ -1,23 +1,35 @@
-import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
+import { mintPortalIdentity, verifyPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../chassis/src/portal-identity.ts";
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { createServer, get as httpGet, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import { gzipSync } from "node:zlib";
 
+const SECRET = "deploy-open-test-secret";
+const IDENTITY_SECRET = "deploy-open-identity-test-secret";
 const PAGE = "<!doctype html><h1>deployed app</h1>";
-let lastCoreRequest: { url: string; principal: string } | null = null;
+const ASSET = Buffer.from([0, 1, 127, 128, 255]);
+const coreRequests: Array<{ url: string; method: string; headers: IncomingMessage["headers"] }> = [];
 
 const core = createServer((req: IncomingMessage, res) => {
   const u = req.url ?? "";
-  lastCoreRequest = { url: u, principal: String(req.headers["x-as-principal"] ?? "") };
   if (!u.startsWith("/d/")) {
     res.writeHead(404, { "content-type": "application/json" });
     return void res.end(JSON.stringify({ error: "not_found" }));
   }
-  if (u.startsWith("/d/redirecting-app/")) {
+  coreRequests.push({ url: u, method: req.method ?? "GET", headers: req.headers });
+  if (u === "/d/redirecting-app/") {
     res.writeHead(302, { location: "/d/redirecting-app/home" });
     return void res.end();
+  }
+  if (u === "/d/forbidden-app/") {
+    res.writeHead(403, { "content-type": "application/json" });
+    return void res.end(JSON.stringify({ error: "forbidden" }));
+  }
+  if (u === "/d/app1/assets/file.bin?v=2") {
+    res.writeHead(200, { "content-type": "application/octet-stream" });
+    return void res.end(ASSET);
   }
   if (/\bgzip\b/.test(String(req.headers["accept-encoding"] ?? ""))) {
     const z = gzipSync(Buffer.from(PAGE));
@@ -31,9 +43,10 @@ await new Promise<void>((r) => core.listen(0, r));
 const coreUrl = `http://localhost:${(core.address() as AddressInfo).port}`;
 
 process.env.CORE_API_URL = coreUrl;
-const SECRET = "deploy-open-test-secret";
 process.env.CORE_SIGNING_SECRET = SECRET;
+process.env.PORTAL_IDENTITY_SECRET = IDENTITY_SECRET;
 process.env.WEB_UI_PRINCIPALS = "alice";
+process.env.ALLOW_UNSIGNED_TEST_IDENTITY = "0";
 
 const { handler } = await import("../server/index.ts");
 
@@ -47,8 +60,7 @@ test.after(() => {
 });
 
 const IDENTITY = {
-  cookie: "webuiuser=alice",
-  [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "alice", exp: Date.now() + 60_000 }, SECRET),
+  [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "alice", exp: Date.now() + 600_000 }, IDENTITY_SECRET),
 };
 
 function rawGet(
@@ -65,25 +77,149 @@ function rawGet(
   });
 }
 
-test("GET /deployments/:id/ relays a gzip-serving app as a decodable response", async () => {
-  const r = await rawGet("/deployments/app1/", { ...IDENTITY, "accept-encoding": "gzip" });
-  assert.equal(r.status, 200);
-  assert.equal(r.headers["content-encoding"], undefined, "no stale content-encoding on the decompressed body");
-  if (r.headers["content-length"] !== undefined) {
-    assert.equal(Number(r.headers["content-length"]), r.body.length, "content-length matches the bytes actually sent");
+function assertAuthenticatedRequest(index: number, url: string): void {
+  const request = coreRequests[index];
+  assert.ok(request, "the app request reaches core");
+  assert.equal(request.url, url);
+  assert.equal(request.method, "GET");
+  assert.equal(request.headers["x-as-principal"], "alice");
+  assert.equal(request.headers[PORTAL_IDENTITY_HEADER], IDENTITY[PORTAL_IDENTITY_HEADER]);
+  assert.equal(
+    verifyPortalIdentity(String(request.headers[PORTAL_IDENTITY_HEADER]), IDENTITY_SECRET, Date.now())?.p,
+    "alice",
+  );
+  const expected = createHmac("sha256", SECRET)
+    .update(`v0:${request.headers["x-timestamp"]}:GET\n${url}\nalice`)
+    .digest("hex");
+  assert.equal(request.headers["x-signature"], `v0=${expected}`, "signature binds the core path, query, and principal");
+  assert.equal(request.headers.cookie, undefined, "browser cookies are not forwarded to apps");
+}
+
+for (const prefix of ["/deployments", "/d"]) {
+  test(`GET ${prefix}/:id/ relays a gzip-serving app as a decodable response`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(`${prefix}/app1/`, { ...IDENTITY, "accept-encoding": "gzip" });
+    assert.equal(r.status, 200);
+    assert.equal(r.headers["content-encoding"], undefined, "no stale content-encoding on the decompressed body");
+    if (r.headers["content-length"] !== undefined) {
+      assert.equal(
+        Number(r.headers["content-length"]),
+        r.body.length,
+        "content-length matches the bytes actually sent",
+      );
+    }
+    assert.equal(r.body.toString(), PAGE, "the body reaches the browser decodable as declared");
+    assert.equal(
+      r.headers["content-security-policy"],
+      "sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads",
+    );
+    assert.equal(r.headers["x-content-type-options"], "nosniff");
+    assert.equal(coreRequests.length, before + 1);
+    assertAuthenticatedRequest(before, "/d/app1/");
+  });
+
+  for (const [suffix, corePath] of [
+    ["/app1", "/d/app1/"],
+    ["/%61pp1/nested/page?x=1&x=2&next=%2Fd%2Fother%2F", "/d/app1/nested/page?x=1&x=2&next=%2Fd%2Fother%2F"],
+  ]) {
+    test(`GET ${prefix}${suffix} preserves the normalized id, subpath, and query`, async () => {
+      const before = coreRequests.length;
+      const r = await rawGet(`${prefix}${suffix}`, IDENTITY);
+      assert.equal(r.status, 200);
+      assert.equal(r.body.toString(), PAGE);
+      assert.equal(coreRequests.length, before + 1);
+      assertAuthenticatedRequest(before, corePath);
+    });
   }
-  assert.equal(r.body.toString(), PAGE, "the body reaches the browser decodable as declared");
-  assert.equal(lastCoreRequest?.url, "/d/app1/", "the id maps onto core's /d/ path");
-  assert.equal(lastCoreRequest?.principal, "alice", "the signed-in user rides as the principal");
-});
 
-test("GET /deployments/:id/ passes an app redirect through without following it", async () => {
-  const r = await rawGet("/deployments/redirecting-app/", { ...IDENTITY, "accept-encoding": "identity" });
-  assert.equal(r.status, 302, "the 3xx reaches the browser, which follows it itself");
-  assert.equal(r.headers.location, "/d/redirecting-app/home");
-});
+  test(`GET ${prefix}/:id/assets/file.bin preserves binary bytes`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(`${prefix}/app1/assets/file.bin?v=2`, IDENTITY);
+    assert.equal(r.status, 200);
+    assert.equal(r.headers["content-type"], "application/octet-stream");
+    assert.deepEqual(r.body, ASSET);
+    assert.equal(coreRequests.length, before + 1);
+    assertAuthenticatedRequest(before, "/d/app1/assets/file.bin?v=2");
+  });
 
-test("GET /deployments/:id/ requires a signed-in user", async () => {
-  const r = await rawGet("/deployments/app1/", {});
-  assert.equal(r.status, 401);
-});
+  test(`GET ${prefix}/:id/ passes an app redirect through without following it`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(`${prefix}/redirecting-app/`, { ...IDENTITY, "accept-encoding": "identity" });
+    assert.equal(r.status, 302, "the 3xx reaches the browser, which follows it itself");
+    assert.equal(r.headers.location, "/d/redirecting-app/home");
+    assert.equal(coreRequests.length, before + 1);
+    assertAuthenticatedRequest(before, "/d/redirecting-app/");
+  });
+
+  test(`GET ${prefix}/:id/ still reaches the app after following a /d/ redirect`, async () => {
+    const before = coreRequests.length;
+    const r = await fetch(`${base}${prefix}/redirecting-app/`, { headers: IDENTITY });
+    assert.equal(r.status, 200);
+    assert.equal(await r.text(), PAGE);
+    assert.equal(coreRequests.length, before + 2);
+    assertAuthenticatedRequest(before, "/d/redirecting-app/");
+    assertAuthenticatedRequest(before + 1, "/d/redirecting-app/home");
+  });
+
+  test(`GET ${prefix}/:id/ preserves a core authorization denial`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(`${prefix}/forbidden-app/`, IDENTITY);
+    assert.equal(r.status, 403);
+    assert.deepEqual(JSON.parse(r.body.toString()), { error: "forbidden" });
+    assert.equal(coreRequests.length, before + 1);
+    assertAuthenticatedRequest(before, "/d/forbidden-app/");
+  });
+
+  const invalidIdentities: Array<[string, Record<string, string>]> = [
+    ["no identity", {}],
+    ["cookie and forged principal", { cookie: "webuiuser=alice", "x-as-principal": "alice" }],
+    ["invalid portal token", { [PORTAL_IDENTITY_HEADER]: "invalid", cookie: "webuiuser=alice" }],
+    [
+      "expired portal token",
+      { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "alice", exp: Date.now() - 60_000 }, IDENTITY_SECRET) },
+    ],
+    [
+      "disallowed principal",
+      { [PORTAL_IDENTITY_HEADER]: mintPortalIdentity({ p: "mallory", exp: Date.now() + 600_000 }, IDENTITY_SECRET) },
+    ],
+  ];
+  for (const [label, headers] of invalidIdentities) {
+    test(`GET ${prefix}/:id/ refuses ${label} before reaching core`, async () => {
+      const before = coreRequests.length;
+      const r = await rawGet(`${prefix}/app1/`, headers);
+      assert.equal(r.status, 401);
+      assert.equal(coreRequests.length, before);
+    });
+  }
+
+  test(`GET ${prefix}/:id/ binds the verified principal rather than client headers`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(`${prefix}/app1/`, {
+      ...IDENTITY,
+      "x-as-principal": "mallory",
+      cookie: "webuiuser=mallory; private=not-for-apps",
+    });
+    assert.equal(r.status, 200);
+    assert.equal(coreRequests.length, before + 1);
+    assertAuthenticatedRequest(before, "/d/app1/");
+  });
+
+  for (const method of ["HEAD", "POST"]) {
+    test(`${method} ${prefix}/:id/ remains outside the GET-only proxy`, async () => {
+      const before = coreRequests.length;
+      const r = await fetch(`${base}${prefix}/app1/`, { method, headers: IDENTITY });
+      await r.arrayBuffer();
+      assert.equal(r.status, 404);
+      assert.equal(coreRequests.length, before);
+    });
+  }
+}
+
+for (const path of ["/d-other/app1/issue-923.js", "/deployments-other/app1/issue-923.js"]) {
+  test(`GET ${path} is not mistaken for a deployment alias`, async () => {
+    const before = coreRequests.length;
+    const r = await rawGet(path, IDENTITY);
+    assert.equal(r.status, 404);
+    assert.equal(coreRequests.length, before);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #923.

Route both `/deployments/:id/...` and `/d/:id/...` through the existing authenticated GET deployment proxy in the standalone Node web-UI server. Keep principal verification, source-request signing, portal-identity forwarding, response handling, and core authorization unchanged.

The portal already handles both prefixes directly, so this fixes direct web-UI access rather than the normal portal-fronted path.

## Reproduction

Against the unmodified public main (`c0f8c97f9f94dc7541db729aa6696d8a4e32e1c6`), using the real web-UI handler and a local synthetic app backend:

| Direct web-UI request | Before | After |
| --- | --- | --- |
| `/deployments/app1/` | App HTML | App HTML |
| `/d/app1/` | QM shell fallback instead of app HTML | App HTML |
| `/d/app1/assets/file.bin?v=2` | 404; app never reached | Correct binary asset |
| `/deployments/redirecting-app/` followed by `/d/redirecting-app/home` | QM shell fallback | App HTML |

For extensionless paths the old fallback returns the QM shell when built, or 503 when unbuilt. Neither reaches the app. There is no demonstrated published-app authorization bypass.

## Changes

- Match either prefix and slice the matched prefix before entering the existing proxy code.
- Expand the existing `deploy-open-proxy.test.ts` to cover both aliases: signed requests and verified identities, decoded IDs, nested paths and query strings, gzip decoding, binary data, redirects (including following them), upstream authorization denial, forged/expired/disallowed identities, cookie isolation, and prefix/method boundaries.
- Keep the regression tests independent of a frontend build or portal installation. No production code outside the web-UI prefix handling changes.

## Validation

- Focused regression tests on old source: **18 passed / 14 failed**.
- Focused regression tests with the fix: **32 passed**, including without `dist-web`.
- Affected web-UI tests on the clean PR checkout: **65 passed** (includes the 32 focused tests).
- Existing portal router, proxy-error, and frame-policy tests: **50 passed**.
- Web-UI server TypeScript check and focused regression-test TypeScript check: passed.
- Repository ESLint rules and Prettier on both changed files: passed.
- Separate local HTTP integration reproduction through the real web UI and portal: **24/24 passed** with signed identities and **24/24 passed** with dev sign-in cookies. Portal controls confirm both aliases bypass the web-UI server and go directly to core.

The app/core responses and identities in these checks are synthetic. No production deployment or production traffic was exercised. Full CI and a browser/live-dev-instance check are not claimed; this PR is kept in draft pending those checks and review.

### Focused test command

```sh
cd plugins/web-ui
npm ci --ignore-scripts --no-audit --no-fund
NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --test test/deploy-open-proxy.test.ts
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791490242&installation_model_id=19911&pr_number=987&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F987&signature=bb9e9ff1efbd7589bb144a3ad0802245f9a470a3265283d38d628da6d2b6164a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->