### PR TITLE
Make private and shared chat destinations explicit

### DIFF
--- a/plugins/web-ui/README.md
+++ b/plugins/web-ui/README.md
@@ -71,7 +71,9 @@ the CSS media queries, the composer, and the split canvas.
   transcript, bottom composer, inline **model selector** (the models core reports as
   serviceable for the approved harnesses),
   explicit **effort selector** (`low|medium|high|xhigh|max|ultracode|auto`), **Fast mode**
-  toggle, attachments, streaming partials, and a theme picker. Settings → Theme takes
+  toggle, attachments, streaming partials, and a theme picker. The main **Create New Chat**
+  action opens a context chooser so private chats and shared project chats have an explicit destination.
+  Settings → Theme takes
   light, dark, or system, or an imported palette: drop in an iTerm2 `.itermcolors` preset or
   a VS Code color theme `.json` and the app repaints from it (background, text, sidebar,
   buttons, links, text selection, status badges, and code highlighting, mapped from the

--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -207,7 +207,7 @@ function contextMeta(c: CoreContext): { title: string; sub: string; glyph: IconN
     };
   }
   if (c.kind === "personal") {
-    return { title: "Personal", sub: "Just you. Your web chats and DMs with the agent live here.", glyph: User };
+    return { title: "My chats", sub: "Private to you. Your web chats and DMs with the agent live here.", glyph: User };
   }
   if (c.kind === "group") {
     return {
@@ -259,7 +259,7 @@ function metaForScope(scopeId: string | null, fallbackName?: string | null): { t
   if (shared) return { title: shared, glyph: scopeId?.startsWith("group:") ? Users : Hash };
   if (scopeId?.startsWith("personal:") && scopeId !== personalScopeId())
     return { title: "Shared personal space", glyph: User };
-  return { title: fallbackName?.trim() || "Personal", glyph: User };
+  return { title: fallbackName?.trim() || "My chats", glyph: User };
 }
 
 export function scopeTitle(scopeId: string | null, fallbackName?: string | null): string {
@@ -346,8 +346,8 @@ function gridTpl(): TemplateResult {
     return context.project ? "web" : "slack";
   };
   const groups = [
-    { key: "personal", label: "Personal" },
-    { key: "web", label: "Web" },
+    { key: "personal", label: "My chats" },
+    { key: "web", label: "Shared projects" },
     { key: "slack", label: "Slack" },
   ]
     .map((g) => ({ ...g, items: projects.filter((context) => groupOf(context) === g.key) }))

--- a/plugins/web-ui/src/deploys.ts
+++ b/plugins/web-ui/src/deploys.ts
@@ -97,7 +97,7 @@ function ownerLabel(d: DeploymentView): string {
   const me = appState.me?.user;
   if (d.ownerScopeId === `personal:${me}`) return "Your personal context";
   if (d.ownerScopeId?.startsWith("personal:"))
-    return `${friendlyPrincipal(d.ownerScopeId.slice("personal:".length))} · Personal`;
+    return `${friendlyPrincipal(d.ownerScopeId.slice("personal:".length))} · My chats`;
   if (d.ownerScopeId?.startsWith("org:")) return "Organization";
   return d.createdBy ? `Shared context · created by ${friendlyPrincipal(d.createdBy)}` : "Shared context";
 }

--- a/plugins/web-ui/src/main.ts
+++ b/plugins/web-ui/src/main.ts
@@ -1,6 +1,6 @@
 import "dockview-core/dist/styles/dockview.css";
 import "./shell.css";
-import { bootSafely, closeUserMenu } from "./shell";
+import { bootSafely, closeNewChatMenu, closeUserMenu } from "./shell";
 import "./draft-review";
 import { registerChatSearchHotkey } from "./search";
 import { registerSessionJumpHotkeys } from "./session-jump";
@@ -37,6 +37,7 @@ document.addEventListener("click", (e) => {
   }
   if (!target?.closest(".multi-select-color")) closeSessionSelectionColor();
   if (!target?.closest(".user-menu")) closeUserMenu();
+  if (!target?.closest(".new-chat-menu")) closeNewChatMenu();
 });
 
 document.addEventListener("keydown", (e) => {
@@ -46,6 +47,7 @@ document.addEventListener("keydown", (e) => {
   clearSessionSelection();
   closeFormMenus();
   closeUserMenu();
+  closeNewChatMenu();
 });
 
 onPhoneChange(() => {
@@ -66,6 +68,7 @@ document.addEventListener(
     closeFormMenus();
     closeOpenSessionMenu();
     closeUserMenu();
+    closeNewChatMenu();
   },
   true,
 );
@@ -75,6 +78,7 @@ document.addEventListener("qm:close-overlays", () => {
   closeFormMenus();
   closeOpenSessionMenu();
   closeUserMenu();
+  closeNewChatMenu();
 });
 
 let sheetSwipe: { y: number; el: HTMLElement } | null = null;

--- a/plugins/web-ui/src/session-list.ts
+++ b/plugins/web-ui/src/session-list.ts
@@ -41,7 +41,7 @@ export function recentProjectSeeds(contexts: readonly ProjectAwareContext[]): Re
   return contexts.map((context): RecentProjectSeed => {
     if (context.project)
       return { scopeId: context.scopeId, name: context.project.name.trim() || null, kind: "project" };
-    if (context.kind === "personal") return { scopeId: context.scopeId, name: "Personal", kind: "personal" };
+    if (context.kind === "personal") return { scopeId: context.scopeId, name: "My chats", kind: "personal" };
     if (context.kind === "group")
       return { scopeId: context.scopeId, name: sharedContextLabel(context.scopeId, context.name), kind: "group" };
     return { scopeId: context.scopeId, name: sharedContextLabel(context.scopeId, context.name), kind: "channel" };

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -632,7 +632,7 @@ export function drawChatsPage(): void {
 }
 
 function chatMatches(s: CoreSession, q: string): boolean {
-  const context = sharedContextLabel(s.scopeId, s.channelName ?? null) ?? "Personal";
+  const context = sharedContextLabel(s.scopeId, s.channelName ?? null) ?? "My chats";
   return [sessionTitle(s), s.channelName ?? "", context].join(" ").toLowerCase().includes(q);
 }
 

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -255,6 +255,53 @@ body.resizing-sidebar {
 .new-chat-nav {
   margin-top: 4px;
 }
+.new-chat-menu {
+  position: relative;
+}
+.new-chat-menu-toggle {
+  justify-content: flex-start;
+}
+.new-chat-menu-toggle > svg:last-child {
+  margin-left: auto;
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
+}
+.new-chat-context-menu {
+  top: calc(100% + 5px);
+  right: 0;
+  left: 0;
+  min-width: 240px;
+}
+.new-chat-context-heading {
+  padding: 5px 9px 7px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+.new-chat-context-option {
+  justify-content: space-between;
+}
+.new-chat-context-copy {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 10px;
+}
+.new-chat-context-copy > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.new-chat-context-detail {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+.new-chat-context-loading {
+  padding: 8px 9px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
 a.navrow,
 a.session,
 a.chat-row-open {

--- a/plugins/web-ui/src/shell.ts
+++ b/plugins/web-ui/src/shell.ts
@@ -3,6 +3,7 @@ import { html, nothing, render, type TemplateResult } from "lit";
 import {
   Box,
   Brain,
+  ChevronDown,
   Clock,
   Files,
   Folder,
@@ -70,7 +71,6 @@ import {
   sessionsState,
   sessionSelectionBar,
   revealSessionSurface,
-  startNewChatInLastScope,
   startNewChat,
 } from "./sessions";
 import { openCronById, renderCronsPage, resetActiveCron, routeCronsHistory } from "./crons";
@@ -101,6 +101,7 @@ import { activeSessionForDocumentTitle, updateDocumentTitle } from "./document-t
 export { appState, can, type Me, type View } from "./shell-state";
 
 let userMenuOpen = false;
+let newChatMenuOpen = false;
 let footerEl: HTMLElement | null = null;
 
 applyTheme();
@@ -116,6 +117,67 @@ export function closeUserMenu(): void {
   if (!userMenuOpen) return;
   userMenuOpen = false;
   renderSidebarFooter();
+}
+
+export function closeNewChatMenu(): void {
+  if (!newChatMenuOpen) return;
+  newChatMenuOpen = false;
+  renderSidebarTop();
+}
+
+function newChatContextName(context: (typeof contextsState.list)[number]): string {
+  if (context.project?.name) return context.project.name;
+  if (context.kind === "personal") return "My chats";
+  return context.name?.trim() || "Shared context";
+}
+
+function toggleNewChatMenu(e: Event): void {
+  e.stopPropagation();
+  newChatMenuOpen = !newChatMenuOpen;
+  renderSidebarTop();
+  if (!newChatMenuOpen) return;
+  void ensureContexts().then(() => {
+    if (newChatMenuOpen) renderSidebarTop();
+  });
+}
+
+function startNewChatInContext(context: (typeof contextsState.list)[number]): void {
+  newChatMenuOpen = false;
+  renderSidebarTop();
+  if (context.kind === "personal") startNewChat();
+  else startNewChat(context.scopeId, newChatContextName(context));
+}
+
+function newChatContextMenu(): TemplateResult {
+  const contexts = [...contextsState.list].sort((a, b) => {
+    if (a.kind === "personal") return -1;
+    if (b.kind === "personal") return 1;
+    return newChatContextName(a).localeCompare(newChatContextName(b));
+  });
+  return html`
+    <div class="session-menu-popover new-chat-context-menu" role="menu" @click=${(e: Event) => e.stopPropagation()}>
+      <div class="new-chat-context-heading">Choose where this chat lives</div>
+      ${
+        contexts.length
+          ? contexts.map(
+              (context) =>
+                html`<button
+                  class="session-menu-option new-chat-context-option"
+                  type="button"
+                  role="menuitem"
+                  @click=${() => startNewChatInContext(context)}
+                >
+                  <span class="new-chat-context-copy">
+                    ${icon(context.kind === "personal" ? MessageSquare : context.project ? Folder : MessageSquare, 15)}
+                    <span>${newChatContextName(context)}</span>
+                  </span>
+                  <span class="new-chat-context-detail">${context.kind === "personal" ? "Private" : "Shared"}</span>
+                </button>`,
+            )
+          : html`<div class="new-chat-context-loading">Loading contexts…</div>`
+      }
+    </div>
+  `;
 }
 
 function signOutFromMenu(): void {
@@ -225,6 +287,7 @@ export async function signOut(): Promise<void> {
     }
   }
   appState.me = null;
+  newChatMenuOpen = false;
   closeBrowse();
   resetInboxState();
   clearAllDrafts();
@@ -621,10 +684,20 @@ export function renderSidebarTop(): void {
         })}
       </nav>
       <div class="nav new-chat-nav">
-        ${actionRow(ICON.newChat, newChatLabel, () => {
-          hideTooltip();
-          startNewChatInLastScope();
-        })}
+        <div class="new-chat-menu ${newChatMenuOpen ? "menu-open" : ""}">
+          <button
+            class="navrow new-chat-menu-toggle"
+            type="button"
+            aria-label=${newChatLabel}
+            aria-haspopup="menu"
+            aria-expanded=${newChatMenuOpen ? "true" : "false"}
+            ${tip(sidebarOpen ? "Choose a chat context" : newChatLabel)}
+            @click=${toggleNewChatMenu}
+          >
+            ${icon(ICON.newChat, 17)}<span>${newChatLabel}</span>${icon(ChevronDown, 14)}
+          </button>
+          ${newChatMenuOpen ? newChatContextMenu() : nothing}
+        </div>
       </div>
       ${sessionSelectionBar() ?? html` <div class="section-label recents-label"><span>Sessions</span></div> `}
     `,

--- a/plugins/web-ui/src/skills.ts
+++ b/plugins/web-ui/src/skills.ts
@@ -619,7 +619,7 @@ function drawSkills(loading = false): void {
                 },
                 options: [
                   html`<option value="all">All scopes</option>`,
-                  html`<option value="personal">Personal</option>`,
+                  html`<option value="personal">My chats</option>`,
                   html`<option value="channel">Channel</option>`,
                   html`<option value="group">Project / group</option>`,
                   html`<option value="team">Team</option>`,
@@ -893,7 +893,7 @@ export async function renderSkills(): Promise<void> {
     skillRows = (r.skills ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
     const personal = appState.me ? `personal:${appState.me.user}` : "";
     createScopes = [
-      { scopeId: personal, name: "Personal (only you)" },
+      { scopeId: personal, name: "My chats (only you)" },
       ...(contexts.contexts ?? [])
         .filter(
           (context) =>

--- a/plugins/web-ui/test/project-interactions.test.ts
+++ b/plugins/web-ui/test/project-interactions.test.ts
@@ -50,7 +50,7 @@ test("project interactions preserve focus and successful local mutations", async
   const personal = {
     scopeId: "personal:owner",
     kind: "personal",
-    name: "Personal",
+    name: "My chats",
     sessionCount: 0,
     lastActivityAt: null,
   } as const;

--- a/plugins/web-ui/test/responsive-source.test.ts
+++ b/plugins/web-ui/test/responsive-source.test.ts
@@ -18,7 +18,8 @@ test("mobile shell follows the visual viewport and device safe areas", () => {
 });
 
 test("mobile sidebar is modal, dismissible, and sized for touch", () => {
-  assert.match(shell, /actionRow\(ICON\.newChat[\s\S]{0,200}startNewChatInLastScope\(\);/);
+  assert.match(shell, /new-chat-menu-toggle[\s\S]{0,500}toggleNewChatMenu/);
+  assert.match(shell, /newChatContextMenu\(\)/);
   assert.match(sessions, /export function startNewChat\([^)]*\)[^{]*\{\s*closeSidebarOnNarrowView\(\);/);
   assert.match(shell, /class="sidebar-scrim"[^>]+aria-label="Close sidebar"[^>]+@click=\$\{toggleSidebar\}/);
   assert.match(shell, /main\.inert = modal/);
@@ -65,6 +66,13 @@ test("the sidebar's quick actions share the navrow treatment", () => {
   assert.doesNotMatch(css, /split-new-session/);
 });
 
+test("new chats make private and shared scope choices explicit", () => {
+  assert.match(shell, /new-chat-context-heading">Choose where this chat lives/);
+  assert.match(shell, /if \(context\.kind === "personal"\) return "My chats"/);
+  assert.match(shell, /context\.kind === "personal" \? "Private" : "Shared"/);
+  assert.match(shell, /startNewChat\(context\.scopeId, newChatContextName\(context\)\)/);
+});
+
 test("the quick nav is home, search, browse; create sits under the divider with the sessions it starts", () => {
   assert.match(
     shell,
@@ -77,7 +85,7 @@ test("the quick nav is home, search, browse; create sits under the divider with 
   );
   assert.match(
     shell,
-    /<div class="nav new-chat-nav">[\s\S]*?actionRow\(ICON\.newChat[\s\S]*?<\/div>[\s\S]*?section-label recents-label/,
+    /<div class="nav new-chat-nav">[\s\S]*?new-chat-menu-toggle[\s\S]*?newChatContextMenu\(\)[\s\S]*?section-label recents-label/,
     "create sits between the divider and the Sessions header",
   );
   assert.doesNotMatch(shell, /navRow\("chats", ICON\.chats/);

--- a/plugins/web-ui/test/split-canvas-entry.test.ts
+++ b/plugins/web-ui/test/split-canvas-entry.test.ts
@@ -26,7 +26,7 @@ test("every new-chat affordance follows the shared placement rule", () => {
   const start = fn(sessions, "startNewChat");
   assert.match(start, /if \(splitState\.active\) return startNewChatInCanvas/);
   assert.match(start, /addPendingSession\(conv\.newChat/);
-  assert.match(shell, /startNewChatInLastScope\(\);/);
+  assert.match(shell, /new-chat-menu-toggle[\s\S]*toggleNewChatMenu/);
   assert.match(fn(sessions, "startProjectChat"), /startNewChat\(scopeId, name\);/);
   assert.match(fn(sessions, "startNewChatInLastScope"), /startNewChat\(/);
   assert.match(fn(shell, "openAppEditChat"), /startNewChat\(null, null, threadRef\)/);


### PR DESCRIPTION
## Problem
The primary new-chat action did not show where a conversation would be stored, so users could mistake private chats for shared project work.

## Change
- Add a context chooser to the main new-chat action.
- Make the private destination explicit as `My chats` / `Private`.
- Show shared projects and connected shared contexts as `Shared` destinations.
- Use the same wording in context lists, session grouping, search, deployments, and skill scope filters.
- Preserve existing scope boundaries and existing conversations; this does not migrate or expose private chats.

## Validation
- `npm run build`
- `node --test test/new-chat-placement.test.ts test/project-interactions.test.ts test/responsive-source.test.ts test/contexts-source.test.ts test/session-list.test.ts` (69 passed)
- Full web UI suite: 961 passed
- `npx tsc -p tsconfig.json --noEmit`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791491485&installation_model_id=19911&pr_number=989&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F989&signature=90221e8356b37e07d619573985f365c44e27b09c2c0af2e5ce31c81b2994d481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->