### PR TITLE
Tape parity: limited-read comparison uses the snapshot window

### DIFF
--- a/scripts/lib/tape-retirement.ts
+++ b/scripts/lib/tape-retirement.ts
@@ -334,10 +334,13 @@ export async function limitedSessionParity(
     latestEntrySeq: (id) => store.latestEntrySeq(id),
     participantWindowsOf: (id) => store.participantWindowsOf(id),
   };
-  const served = (await createTranscriptSource(recording).forRender(sessionId, { limit })).entries;
+  const servedRead = (await createTranscriptSource(recording).forRender(sessionId, { limit })).entries;
   if (fellBack) return { status: "fallback" };
+  const covered = projectTapeEntries(sessionId, rows)?.coveredSeq ?? -1;
+  const snapshotLatest = entries.length ? entries[entries.length - 1]!.seq : -1;
+  const served = servedRead.filter((e) => e.seq <= snapshotLatest);
   const floor = served[0]?.seq ?? Number.MAX_SAFE_INTEGER;
-  const expected = entries.filter((e) => e.seq >= floor);
+  const expected = entries.filter((e) => e.seq >= floor && e.seq <= covered);
   return {
     status: "projected",
     report: classifyDivergences(expected, served, { coarse: coarseTape(rows) }),

--- a/scripts/lib/tape-retirement.ts
+++ b/scripts/lib/tape-retirement.ts
@@ -338,6 +338,7 @@ export async function limitedSessionParity(
   if (fellBack) return { status: "fallback" };
   const covered = projectTapeEntries(sessionId, rows)?.coveredSeq ?? -1;
   const snapshotLatest = entries.length ? entries[entries.length - 1]!.seq : -1;
+  if (covered < snapshotLatest) return { status: "fallback" };
   const served = servedRead.filter((e) => e.seq <= snapshotLatest);
   const floor = served[0]?.seq ?? Number.MAX_SAFE_INTEGER;
   const expected = entries.filter((e) => e.seq >= floor && e.seq <= covered);

--- a/test/tape-retirement.test.ts
+++ b/test/tape-retirement.test.ts
@@ -675,4 +675,12 @@ test("limitedSessionParity exercises the bounded read path and detects fallback"
   assert.equal(limited.status, "projected");
   assert.ok(limited.status === "projected");
   assert.deepEqual(limited.report.real, []);
+
+  const staleEntries = await sim.store.getEntries(sim.session.id);
+  const staleRows = await sim.store.getTape(sim.session.id);
+  await simLiveTurn(sim, { input: "one more thing", ts: "1720000000.000300", reply: "Done." });
+  const raced = await limitedSessionParity(sim.store, sim.session.id, staleEntries, staleRows, 3);
+  assert.equal(raced.status, "projected");
+  assert.ok(raced.status === "projected");
+  assert.deepEqual(raced.report.real, [], "a turn landing between the snapshot and the serving read is not a mismatch");
 });


### PR DESCRIPTION
The full-corpus parity check compares a session's entries and tape from one snapshot, but the limited-read comparison calls the live transcript source, which re-reads the store — so a turn landing between the script's snapshot and the serving read makes the served view newer than the expected list, and the trailing rows count as real mismatches. On an active fleet this produces a steady band of false reals per run (reproducibly, since the settle-recheck races the same ongoing activity).

Fix: compare only the intersection window — served rows clamped to the snapshot's latest seq, expected entries clamped to the tape's covered seq. A race-faithful pinning test (snapshot, then a live turn, then the limited comparison with the stale snapshot) is red on the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791496362&installation_model_id=19911&pr_number=994&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F994&signature=8359224fffb54e0249e4707ac3d28ab133cde4939b1d0bae8582870f145376c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->