### PR TITLE
fix: attribute shared-harness security calls as auxiliary

### DIFF
--- a/src/harness/harness-shared.ts
+++ b/src/harness/harness-shared.ts
@@ -1,10 +1,14 @@
 import { randomBytes } from "node:crypto";
 import type { McpToolDescriptor } from "../mcp/mcp-tool-service.ts";
-import { parseSecurityScreenVerdict, SECURITY_SCREEN_SYSTEM_PROMPT } from "../security/security-posture.ts";
+import {
+  parseSecurityScreenVerdict,
+  SECURITY_SCREEN_STEP,
+  SECURITY_SCREEN_SYSTEM_PROMPT,
+} from "../security/security-posture.ts";
 import type { TaskStatus, TaskStore } from "../tasks/task-store.ts";
 import type { ScopeId, SessionEntry } from "../types.ts";
 import { createAgentTools, type AgentToolsOptions, type ToolContextRef } from "./agent-tools.ts";
-import type { HarnessModelUtilities, HarnessTurnInput, HarnessTurnResult } from "./harness.ts";
+import type { HarnessLlmRequestRecord, HarnessModelUtilities, HarnessTurnInput, HarnessTurnResult } from "./harness.ts";
 import { sanitizeTitle, TITLE_GENERATION_PROMPT, titleUserPrompt } from "./pi-harness.ts";
 import { tapeCheckpointPayload, tapeEntryMirrorRecord } from "../sessions/session-store.ts";
 import { swallow } from "../util/errors.ts";
@@ -159,7 +163,12 @@ export function oneShotRunner(runPrompt: (turn: HarnessTurnInput) => Promise<Har
         return saved;
       },
       recordModelCall: observe?.recordModelCall ?? (() => {}),
-      ...(observe?.recordLlmRequest ? { recordLlmRequest: observe.recordLlmRequest } : {}),
+      ...(observe?.recordLlmRequest
+        ? {
+            recordLlmRequest: (rec: HarnessLlmRequestRecord, requestSignal?: AbortSignal) =>
+              observe.recordLlmRequest!({ ...rec, turnSeq: null }, requestSignal),
+          }
+        : {}),
     });
     return result.reply || undefined;
   };
@@ -176,7 +185,12 @@ export function oneShotModelUtilities(
       parseSecurityScreenVerdict(
         await single(SECURITY_SCREEN_SYSTEM_PROMPT, payload, signal, {
           recordModelCall,
-          ...(recordLlmRequest ? { recordLlmRequest } : {}),
+          ...(recordLlmRequest
+            ? {
+                recordLlmRequest: (rec, requestSignal) =>
+                  recordLlmRequest({ ...rec, step: SECURITY_SCREEN_STEP }, requestSignal),
+              }
+            : {}),
         }),
       ),
     generateTitle: async (transcript) =>

--- a/test/harness-shared.test.ts
+++ b/test/harness-shared.test.ts
@@ -1,8 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { harnessToolContext, oneShotModelUtilities, oneShotRunner } from "../src/harness/harness-shared.ts";
-import { SECURITY_SCREEN_SYSTEM_PROMPT } from "../src/security/security-posture.ts";
-import type { HarnessTurnInput, HarnessTurnResult } from "../src/harness/harness.ts";
+import { SECURITY_SCREEN_STEP, SECURITY_SCREEN_SYSTEM_PROMPT } from "../src/security/security-posture.ts";
+import type { HarnessLlmRequestRecord, HarnessTurnInput, HarnessTurnResult } from "../src/harness/harness.ts";
 
 function capturingRunPrompt(reply = "one-shot reply"): {
   turns: HarnessTurnInput[];
@@ -57,8 +57,26 @@ test("the one-shot runner plumbs signal, instrumentation, and model override pos
   const turn = turns[0]!;
   assert.equal(turn.cancel, cancel);
   assert.equal(turn.recordModelCall, recordModelCall);
-  assert.equal(turn.recordLlmRequest, recordLlmRequest);
+  assert.notEqual(turn.recordLlmRequest, undefined);
   assert.deepEqual(turn.runtime, { modelId: "judge-model-1" });
+});
+
+test("one-shot LLM records do not inherit synthetic turn coordinates", async () => {
+  const recorded: HarnessLlmRequestRecord[] = [];
+  const runPrompt = async (turn: HarnessTurnInput): Promise<HarnessTurnResult> => {
+    await turn.recordLlmRequest?.({ turnSeq: 3, step: 2, model: "m", truncated: false });
+    return { reply: "ok" };
+  };
+  const single = oneShotRunner(runPrompt);
+  await single("s", "p", undefined, {
+    recordModelCall: () => {},
+    recordLlmRequest: (rec) => {
+      recorded.push(rec);
+    },
+  });
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0]!.turnSeq, null);
+  assert.equal(recorded[0]!.step, 2);
 });
 
 test("judge overrides the model while oneShot keeps the harness default", async () => {
@@ -95,4 +113,26 @@ test("security screening passes the abort signal and instrumentation through the
   assert.equal(turn.input, "suspicious payload");
   assert.equal(turn.cancel, controller.signal);
   assert.equal(turn.recordModelCall, recordModelCall);
+});
+
+test("shared harness security screens use auxiliary coordinates", async () => {
+  const recorded: HarnessLlmRequestRecord[] = [];
+  const runPrompt = async (turn: HarnessTurnInput): Promise<HarnessTurnResult> => {
+    await turn.recordLlmRequest?.({ turnSeq: 7, step: 0, model: "claude-oneshot", truncated: false });
+    return { reply: '{"decision":"auto"}' };
+  };
+  const utilities = oneShotModelUtilities(oneShotRunner(runPrompt));
+  const verdict = await utilities.screenSecurity!({
+    payload: "suspicious payload",
+    signal: new AbortController().signal,
+    recordModelCall: () => {},
+    recordLlmRequest: (rec) => {
+      recorded.push(rec);
+    },
+  });
+  assert.deepEqual(verdict, { decision: "auto" });
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0]!.turnSeq, null);
+  assert.equal(recorded[0]!.step, SECURITY_SCREEN_STEP);
+  assert.equal(recorded[0]!.model, "claude-oneshot");
 });


### PR DESCRIPTION
Fixes #889. Reported by @ianTPE from a running QM deployment.

The shared one-shot runner fabricated turn 1 and forwarded its LLM recorder unchanged. Security screens in the Claude, Codex, and OpenCode harnesses consequently appeared as steps of the real conversation's first turn, and were absent from the security-screen replay corpus.

This fixes the shared path once:
- One-shot request records get `turnSeq: null`.
- Only `screenSecurity` stamps the existing `SECURITY_SCREEN_STEP`, matching Pi and the mock harness.
- Records, usage fields, errors, and request cancellation are preserved. No calls are deduplicated or discarded; no schema change or historical-data rewrite.

### Validation
- Regression tests failed before the fix and pass afterward.
- Affected harness sweep: 123 passed, 1 existing skip, 0 failed.
- Harness-shared, auto-flagger, and admin-observability suites: 38 passed, 0 failed.
- Core typecheck, full ESLint, and full Oxlint passed.
- Independent fresh-context review accepted the patch; the request-signal naming nit was addressed.

The new tests cover both generic one-shot attribution and screening-specific coordinates. The production change is confined to the shared harness helper.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791499889&installation_model_id=19911&pr_number=996&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F996&signature=d1df9bff3ad7ba1790fe686e77d8e37a02656a3ebe4cc6561626846f09dbd404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->