### PR TITLE
fix: record metrics for ambient gate declines

### DIFF
--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1902,6 +1902,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           detectMs = Date.now() - detectStart;
           if (!decision.respond) {
             const reactions = decision.reactions?.length ? decision.reactions : undefined;
+            const declineStatus = reactions ? "react" : "silent";
             deps.auditLog.record({
               at: Date.now(),
               principalId: actor.id,
@@ -1914,6 +1915,15 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               `[orchestrator] turn.${reactions ? "react" : "silent"} (detection ${reactions ? `acknowledged emoji=${reactions.join(",")}` : "declined"}) thread=${conversation.threadRef}` +
                 (decision.reason ? ` reason=${JSON.stringify(decision.reason)}` : ""),
             );
+            deps.metrics?.record({
+              totalMs: 0,
+              sessionId: session.id,
+              ...(input.runId ? { runId: input.runId } : {}),
+              ingressMs: Math.max(0, Date.now() - coreReceivedAt),
+              detectMs,
+              status: declineStatus,
+              scopeLabel: scopeId,
+            });
             return reactions
               ? { status: "react", sessionId: session.id, reactions }
               : { status: "silent", sessionId: session.id };

--- a/test/orchestrator.test.ts
+++ b/test/orchestrator.test.ts
@@ -1715,6 +1715,49 @@ test("on a surface without reactions, the same acknowledgement just stays silent
   );
 });
 
+test("an ambient decline that goes silent records exactly one metric row tied to the run", async () => {
+  const { app, metrics } = freshApp();
+  const res = await app.turn(channel("ok sounds good to me", { unprompted: true }));
+  assert.equal(res.status, "silent");
+  const samples = (await metrics.list()).filter((s) => s.status !== "capture");
+  assert.equal(samples.length, 1, "the decline must produce exactly one metric row, not zero");
+  const sample = samples[0]!;
+  assert.equal(sample.status, "silent");
+  assert.equal(sample.sessionId, res.sessionId);
+  assert.ok(typeof sample.detectMs === "number" && sample.detectMs >= 0, "the detection latency must be captured");
+  assert.equal(sample.totalMs, 0, "no harness run happened — totalMs must not claim harness work time");
+  assert.ok(
+    typeof sample.ingressMs === "number" && sample.ingressMs >= sample.detectMs!,
+    "ingressMs covers admission through the decline decision, so it must be at least the detection latency",
+  );
+});
+
+test("an ambient decline that reacts records exactly one metric row tied to the run", async () => {
+  const { app, metrics } = freshApp();
+  const res = await app.turn(channel("thanks, that's perfect", { unprompted: true }));
+  assert.equal(res.status, "react");
+  const samples = (await metrics.list()).filter((s) => s.status !== "capture");
+  assert.equal(samples.length, 1, "the decline must produce exactly one metric row, not zero");
+  const sample = samples[0]!;
+  assert.equal(sample.status, "react");
+  assert.equal(sample.sessionId, res.sessionId);
+  assert.ok(typeof sample.detectMs === "number" && sample.detectMs >= 0, "the detection latency must be captured");
+  assert.equal(sample.totalMs, 0, "no harness run happened — totalMs must not claim harness work time");
+  assert.ok(
+    typeof sample.ingressMs === "number" && sample.ingressMs >= sample.detectMs!,
+    "ingressMs covers admission through the decline decision, so it must be at least the detection latency",
+  );
+});
+
+test("a normal answered turn still records exactly one 'ok' metric row, unchanged by the ambient-decline fix", async () => {
+  const { app, metrics } = freshApp();
+  const res = await app.turn(channel("what does everyone think about the rollout?", { unprompted: true }));
+  assert.equal(res.status, "ok");
+  const samples = (await metrics.list()).filter((s) => s.status !== "capture");
+  assert.equal(samples.length, 1, "a normal answered turn must still record exactly one metric row");
+  assert.equal(samples[0]!.status, "ok");
+});
+
 test("an unprompted thread question gets a reply (turn detection chimes in)", async () => {
   const { app } = freshApp();
   const res = await app.turn(channel("what does everyone think about the rollout?", { unprompted: true }));


### PR DESCRIPTION
Addresses the missing ambient-gate metrics in #609, reported by @ianTPE from a running QM deployment. This intentionally does not close the broader issue.

When the ambient reply gate chose silence or an emoji reaction, the orchestrator returned before writing a turn metric. Record one metric at that existing decision point, with the actual status, session, scope, optional run ID, and detection duration.

No answer harness runs on this path, so `totalMs` is zero. Admission-to-decision time is recorded in the existing `ingressMs` field; `detectMs` remains its detection-phase subset. This preserves the meaning of completed-turn timing fields instead of mixing two time bases.

### Scope
- 10 production lines in the existing decline branch.
- No new metric fields, schema changes, public status changes, dashboard redesign, or changes to the gate's decision.
- Other early-return paths and the broader delivered-vs-silent ambiguity in #609 remain separate work.

### Validation
- Silent and reaction regressions failed with zero rows before the fix and pass afterward.
- Tests assert exactly one main metric, correct run/session/scope, zero harness duration, and ingress duration covering detection. A normal answered-turn control is unchanged.
- Orchestrator suite: 150 passed.
- Admin metrics, metrics sink, and turn-metrics route suites: 11 passed.
- Core typecheck, full ESLint, Oxlint, formatting, and Knip passed.
- Independent review caught the initial timing-basis mismatch; it was corrected and re-reviewed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500133&installation_model_id=19911&pr_number=997&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F997&signature=e100c0d9e15ae735eb9312db6453e73a5254c93c594eac4aa5f48e04b07ef118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->