### PR TITLE
fix: list one authorized document per project across turns

### DIFF
--- a/src/api/app-helpers.ts
+++ b/src/api/app-helpers.ts
@@ -336,20 +336,19 @@ export function createAppHelpers(deps: AppDeps, app: App) {
     inScope?: ScopeId,
   ): Promise<FileListPage> {
     const myScopes = await currentResourceScopesForViewer(principalId);
-    const owned = await deps.files.listOwnedByScopes(myScopes, {
-      ...opts,
-      ...(inScope ? { createdInScope: inScope } : {}),
-    });
     const handles = await deps.acl.handlesFor(myScopes);
-    const refs = handles.map((h) => ({ ownerScopeId: h.ownerScopeId, path: h.ownerPath }));
-    const sharedRows = await deps.files.resolveByOwnerPaths(refs);
-    const shared = sharedRows
-      .filter((f) => !myScopes.includes(f.ownerScopeId) && (!inScope || f.createdInScope === inScope))
-      .sort((a, b) => b.updatedAt - a.updatedAt);
+    const page = await deps.files.listDocuments(
+      myScopes,
+      handles.map((h) => ({ ownerScopeId: h.ownerScopeId, path: h.ownerPath })),
+      {
+        ...opts,
+        ...(inScope ? { createdInScope: inScope } : {}),
+      },
+    );
     return {
-      owned: owned.files.map(toFileItem),
-      shared: shared.map(toFileItem),
-      ...(owned.nextCursor ? { nextCursor: owned.nextCursor } : {}),
+      owned: page.files.filter((f) => myScopes.includes(f.ownerScopeId)).map(toFileItem),
+      shared: page.files.filter((f) => !myScopes.includes(f.ownerScopeId)).map(toFileItem),
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
     };
   }
 

--- a/src/api/app-search.ts
+++ b/src/api/app-search.ts
@@ -5,6 +5,7 @@ import { matchesSearchTerms, searchSnippet, searchTerms } from "../sessions/entr
 import type { Principal } from "../types.ts";
 import { collectBytes } from "../util/bytes.ts";
 import type { App, AppDeps } from "./app-types.ts";
+import type { AppHelpers } from "./app-helpers.ts";
 
 function conversationBackend(app: App): SearchBackend {
   return createIntersectionBackend({
@@ -36,15 +37,30 @@ function searchableFile(mimetype: string, name: string): boolean {
     /\.(?:txt|md|markdown|json|jsonl|csv|tsv|xml|ya?ml)$/i.test(name)
   );
 }
-function fileBackend(app: App): SearchBackend {
+function fileBackend(deps: AppDeps, app: App, helpers: AppHelpers): SearchBackend {
   return {
     name: "files",
     async search(request) {
-      const libraries = await Promise.all(request.principals.map((p) => app.listFilesForViewer(p.id, { limit: 200 })));
+      const libraries = await Promise.all(
+        request.principals.map(async (p) => {
+          const scopes = await helpers.currentResourceScopesForViewer(p.id);
+          const [owned, handles] = await Promise.all([
+            deps.files.listOwnedByScopes(scopes, { limit: 200 }),
+            deps.acl.handlesFor(scopes),
+          ]);
+          const shared = await deps.files.resolveByOwnerPaths(
+            handles.map((h) => ({ ownerScopeId: h.ownerScopeId, path: h.ownerPath })),
+          );
+          return [
+            ...owned.files,
+            ...shared.filter((f) => !scopes.includes(f.ownerScopeId)).sort((a, b) => b.updatedAt - a.updatedAt),
+          ];
+        }),
+      );
       const [first, ...rest] = libraries;
       if (!first) return [];
-      const common = rest.map((page) => new Set([...page.owned, ...page.shared].map((file) => file.id)));
-      const files = [...first.owned, ...first.shared].filter((file) => common.every((ids) => ids.has(file.id)));
+      const common = rest.map((files) => new Set(files.map((file) => file.id)));
+      const files = first.filter((file) => common.every((ids) => ids.has(file.id)));
       const terms = searchTerms(request.query);
       const hits: BackendSearchHit[] = [];
       for (const file of files) {
@@ -110,15 +126,18 @@ function slackBackend(deps: AppDeps, app: App): SearchBackend | null {
     },
   };
 }
-export function createSearchMethods(deps: AppDeps, app: App): Pick<App, "search"> {
+export function createSearchMethods(deps: AppDeps, app: App, helpers: AppHelpers): Pick<App, "search"> {
   const slack = slackBackend(deps, app);
-  const core = createCoreSearch([conversationBackend(app), ...(slack ? [slack] : []), fileBackend(app)], {
-    onBackendError: (backend, error) =>
-      console.error(
-        "%s",
-        `[search] backend ${backend} failed:`,
-        error instanceof Error ? error.message : String(error),
-      ),
-  });
+  const core = createCoreSearch(
+    [conversationBackend(app), ...(slack ? [slack] : []), fileBackend(deps, app, helpers)],
+    {
+      onBackendError: (backend, error) =>
+        console.error(
+          "%s",
+          `[search] backend ${backend} failed:`,
+          error instanceof Error ? error.message : String(error),
+        ),
+    },
+  );
   return { search: (query, principals, limit) => core.search({ query, principals, limit }) };
 }

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -669,7 +669,14 @@ export function createSessionMethods(
         deps.deploy.listDeployments(),
         deps.skills.list(),
       ]);
-      const files = [...page.owned, ...page.shared].sort((a, b) => b.createdAt - a.createdAt);
+      const files = [...page.owned, ...page.shared];
+      let cursor = page.nextCursor;
+      while (cursor) {
+        const next = await filesForViewer(principalId, { limit: 200, cursor }, scope);
+        files.push(...next.owned, ...next.shared);
+        cursor = next.nextCursor;
+      }
+      files.sort((a, b) => b.createdAt - a.createdAt);
       const deployments = (
         await Promise.all(
           allDeployments

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -24,5 +24,5 @@ export function createApp(deps: AppDeps): App {
     ...createSkillMethods(deps, helpers),
   };
   Object.assign(app, methods);
-  return Object.assign(app, createSearchMethods(deps, app));
+  return Object.assign(app, createSearchMethods(deps, app, helpers));
 }

--- a/src/files/file-artifact-store.ts
+++ b/src/files/file-artifact-store.ts
@@ -57,6 +57,8 @@ export interface ListOwnedOptions {
   nameQuery?: string;
 }
 
+export type FileArtifactRef = Pick<FileArtifact, "ownerScopeId" | "path">;
+
 export interface FileArtifactStore {
   put(input: PutFileInput): Promise<{ artifact: FileArtifact; created: boolean }>;
 
@@ -66,7 +68,13 @@ export interface FileArtifactStore {
 
   listOwnedByScopes(scopes: readonly ScopeId[], opts?: ListOwnedOptions): Promise<FilePage>;
 
-  resolveByOwnerPaths(refs: ReadonlyArray<{ ownerScopeId: ScopeId; path: string }>): Promise<FileArtifact[]>;
+  listDocuments(
+    scopes: readonly ScopeId[],
+    sharedRefs: readonly FileArtifactRef[],
+    opts?: ListOwnedOptions,
+  ): Promise<FilePage>;
+
+  resolveByOwnerPaths(refs: readonly FileArtifactRef[]): Promise<FileArtifact[]>;
 
   setEnabled(id: string, enabled: boolean): Promise<void>;
 
@@ -120,6 +128,46 @@ export function clampLimit(limit?: number): number {
 export function createMemoryFileArtifactStore(byteStore: DurableByteStore): FileArtifactStore {
   const rows = new Map<string, FileArtifact>();
 
+  async function listFiles(
+    scopes: readonly ScopeId[],
+    opts?: ListOwnedOptions,
+    sharedRefs?: readonly FileArtifactRef[],
+  ): Promise<FilePage> {
+    const owners = new Set(scopes);
+    const shared = new Set(sharedRefs?.map((r) => JSON.stringify([r.ownerScopeId, r.path])));
+    const limit = clampLimit(opts?.limit);
+    const cursor = opts?.cursor ? decodeCursor(opts.cursor) : null;
+    const nameQuery = opts?.nameQuery?.toLowerCase();
+    let all = [...rows.values()]
+      .filter(
+        (r) =>
+          (owners.has(r.ownerScopeId) && (opts?.includeDisabled || r.enabled)) ||
+          (r.enabled && shared.has(JSON.stringify([r.ownerScopeId, r.path]))),
+      )
+      .filter((r) => opts?.createdInScope == null || r.createdInScope === opts.createdInScope)
+      .filter((r) => nameQuery == null || r.name.toLowerCase().includes(nameQuery));
+    if (sharedRefs !== undefined) {
+      all.sort(
+        (a, b) =>
+          Number(owners.has(b.ownerScopeId)) - Number(owners.has(a.ownerScopeId)) ||
+          a.createdAt - b.createdAt ||
+          idOrderDesc(b.id, a.id),
+      );
+      const documents = new Map<string, FileArtifact>();
+      for (const row of all) {
+        const key = JSON.stringify([row.createdInScope ?? row.ownerScopeId, row.sha256 ?? "id:" + row.id]);
+        if (!documents.has(key)) documents.set(key, row);
+      }
+      all = [...documents.values()];
+    }
+    all = all
+      .filter((r) => !cursor || afterCursor(r, cursor))
+      .sort((a, b) => b.createdAt - a.createdAt || idOrderDesc(a.id, b.id));
+    const files = all.slice(0, limit);
+    const nextCursor = all.length > limit && files.length > 0 ? encodeCursor(files[files.length - 1]!) : undefined;
+    return { files, ...(nextCursor ? { nextCursor } : {}) };
+  }
+
   return {
     async put(input) {
       const existing = rows.get(input.id);
@@ -165,21 +213,9 @@ export function createMemoryFileArtifactStore(byteStore: DurableByteStore): File
       return { artifact: r, sizeBytes: bytes.sizeBytes, stream: bytes.stream };
     },
 
-    async listOwnedByScopes(scopes, opts) {
-      const set = new Set(scopes);
-      const limit = clampLimit(opts?.limit);
-      const cursor = opts?.cursor ? decodeCursor(opts.cursor) : null;
-      const nameQuery = opts?.nameQuery?.toLowerCase();
-      const all = [...rows.values()]
-        .filter((r) => set.has(r.ownerScopeId) && (opts?.includeDisabled || r.enabled))
-        .filter((r) => opts?.createdInScope == null || r.createdInScope === opts.createdInScope)
-        .filter((r) => nameQuery == null || r.name.toLowerCase().includes(nameQuery))
-        .filter((r) => (cursor ? afterCursor(r, cursor) : true))
-        .sort((a, b) => b.createdAt - a.createdAt || idOrderDesc(a.id, b.id));
-      const page = all.slice(0, limit);
-      const nextCursor = all.length > limit && page.length > 0 ? encodeCursor(page[page.length - 1]!) : undefined;
-      return { files: page, ...(nextCursor ? { nextCursor } : {}) };
-    },
+    listOwnedByScopes: (scopes, opts) => listFiles(scopes, opts),
+
+    listDocuments: (scopes, sharedRefs, opts) => listFiles(scopes, opts, sharedRefs),
 
     async resolveByOwnerPaths(refs) {
       if (refs.length === 0) return [];

--- a/src/files/postgres-file-artifact-store.ts
+++ b/src/files/postgres-file-artifact-store.ts
@@ -6,6 +6,7 @@ import {
   decodeCursor,
   encodeCursor,
   type FileArtifact,
+  type FileArtifactRef,
   type FileArtifactStore,
   type FileDirection,
   type FilePage,
@@ -71,6 +72,59 @@ export function createPostgresFileArtifactStore(
     return rows.length ? rowToArtifact(rows[0]!) : null;
   }
 
+  async function listFiles(
+    scopes: readonly ScopeId[],
+    opts?: ListOwnedOptions,
+    sharedRefs?: readonly FileArtifactRef[],
+  ): Promise<FilePage> {
+    if (scopes.length === 0 && !sharedRefs?.length) return { files: [] };
+    const limit = clampLimit(opts?.limit);
+    const cursor = opts?.cursor ? decodeCursor(opts.cursor) : null;
+    const params: unknown[] = [scopes as string[]];
+    let access = "owner_scope_id = ANY($1::text[])";
+    if (sharedRefs !== undefined) {
+      params.push(
+        sharedRefs.map((r) => r.ownerScopeId),
+        sharedRefs.map((r) => r.path),
+      );
+      access = `(${access} OR (enabled = TRUE AND (owner_scope_id, path) IN (SELECT * FROM unnest($2::text[], $3::text[]))))`;
+    }
+    const filters = [access];
+    if (!opts?.includeDisabled) filters.push("enabled = TRUE");
+    if (opts?.createdInScope != null) {
+      params.push(opts.createdInScope);
+      filters.push(`created_in_scope = $${params.length}::text`);
+    }
+    if (opts?.nameQuery != null) {
+      params.push(`%${opts.nameQuery.replace(/[\\%_]/g, (c) => `\\${c}`)}%`);
+      filters.push(`name ILIKE $${params.length}::text`);
+    }
+    const visible = `SELECT * FROM file_artifacts WHERE ${filters.join(" AND ")}`;
+    const documents =
+      sharedRefs === undefined
+        ? visible
+        : `
+      SELECT DISTINCT ON (COALESCE(created_in_scope, owner_scope_id), COALESCE(sha256, 'id:' || id)) *
+      FROM (${visible}) visible
+      ORDER BY COALESCE(created_in_scope, owner_scope_id), COALESCE(sha256, 'id:' || id),
+               (owner_scope_id = ANY($1::text[])) DESC, created_at ASC, id ASC`;
+    let pageFilter = "";
+    if (cursor) {
+      params.push(cursor.createdAt, cursor.id);
+      pageFilter = `WHERE (created_at, id) < ($${params.length - 1}::bigint, $${params.length}::text)`;
+    }
+    params.push(limit + 1);
+    const rows = await q(
+      `SELECT * FROM (${documents}) documents ${pageFilter}
+      ORDER BY created_at DESC, id DESC LIMIT $${params.length}`,
+      params,
+    );
+    const all = rows.map(rowToArtifact);
+    const files = all.slice(0, limit);
+    const nextCursor = all.length > limit && files.length > 0 ? encodeCursor(files[files.length - 1]!) : undefined;
+    return { files, ...(nextCursor ? { nextCursor } : {}) };
+  }
+
   return {
     async put(input) {
       const existing = await getRow(input.id);
@@ -121,38 +175,9 @@ export function createPostgresFileArtifactStore(
       return { artifact: r, sizeBytes: bytes.sizeBytes, stream: bytes.stream };
     },
 
-    async listOwnedByScopes(scopes: readonly ScopeId[], opts?: ListOwnedOptions): Promise<FilePage> {
-      if (scopes.length === 0) return { files: [] };
-      const limit = clampLimit(opts?.limit);
-      const cursor = opts?.cursor ? decodeCursor(opts.cursor) : null;
-      const params: unknown[] = [scopes as string[]];
-      const filters = ["owner_scope_id = ANY($1::text[])"];
-      if (!opts?.includeDisabled) filters.push("enabled = TRUE");
-      if (opts?.createdInScope != null) {
-        params.push(opts.createdInScope);
-        filters.push(`created_in_scope = $${params.length}::text`);
-      }
-      if (opts?.nameQuery != null) {
-        params.push(`%${opts.nameQuery.replace(/[\\%_]/g, (c) => `\\${c}`)}%`);
-        filters.push(`name ILIKE $${params.length}::text`);
-      }
-      if (cursor) {
-        params.push(cursor.createdAt, cursor.id);
-        filters.push(`(created_at, id) < ($${params.length - 1}::bigint, $${params.length}::text)`);
-      }
-      params.push(limit + 1);
-      const rows = await q(
-        `SELECT * FROM file_artifacts
-           WHERE ${filters.join(" AND ")}
-           ORDER BY created_at DESC, id DESC
-           LIMIT $${params.length}`,
-        params,
-      );
-      const all = rows.map(rowToArtifact);
-      const page = all.slice(0, limit);
-      const nextCursor = all.length > limit && page.length > 0 ? encodeCursor(page[page.length - 1]!) : undefined;
-      return { files: page, ...(nextCursor ? { nextCursor } : {}) };
-    },
+    listOwnedByScopes: (scopes, opts) => listFiles(scopes, opts),
+
+    listDocuments: (scopes, sharedRefs, opts) => listFiles(scopes, opts, sharedRefs),
 
     async resolveByOwnerPaths(refs) {
       if (refs.length === 0) return [];

--- a/test/core-search.test.ts
+++ b/test/core-search.test.ts
@@ -166,3 +166,89 @@ test("slack backend intersects private-channel visibility across all principals"
     ["C-SHARED:1"],
   );
 });
+
+test("file search retains common artifact identities when viewers own different copies", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "search-copies-")) }));
+  const project = scopeId("group", "search-copy-project");
+  const ids = ["shared-copy-alice", "shared-copy-bob"];
+  for (const [index, author] of principals.entries()) {
+    const id = ids[index]!;
+    const ownerScopeId = scopeId("personal", author.id);
+    await built.files.put({
+      id,
+      ownerScopeId,
+      createdBy: author.id,
+      createdInScope: project,
+      name: "pelican.txt",
+      path: id,
+      mimetype: "text/plain",
+      data: Buffer.from("pelican launch"),
+      direction: "in",
+      createdAt: index + 1,
+    });
+    await built.acl.grant({
+      ownerScopeId,
+      ref: id,
+      granteeScopeId: scopeId("personal", principals[1 - index]!.id),
+      permission: "read",
+      grantedBy: author.id,
+    });
+  }
+  const alice = await built.app.listFilesForViewer(principals[0]!.id);
+  const bob = await built.app.listFilesForViewer(principals[1]!.id);
+  assert.deepEqual(
+    alice.owned.map((f) => f.id),
+    [ids[0]],
+  );
+  assert.deepEqual(
+    bob.owned.map((f) => f.id),
+    [ids[1]],
+  );
+  const result = await built.app.search("pelican", principals);
+  assert.deepEqual(
+    result.hits
+      .filter((hit) => hit.backend === "files")
+      .map((hit) => hit.id)
+      .sort(),
+    ids,
+  );
+});
+
+test("file search still reaches shared artifacts outside the first document page", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "search-shared-pages-")) }));
+  const ownerScopeId = scopeId("personal", "carol@example.com");
+  for (let n = 0; n < 205; n++) {
+    const id = "shared-search-" + n;
+    await built.files.put({
+      id,
+      path: id,
+      ownerScopeId,
+      createdBy: "carol@example.com",
+      name: "note.txt",
+      mimetype: "text/plain",
+      data: Buffer.from(n === 0 ? "pelican milestone" : "unrelated " + n),
+      direction: "out",
+      createdAt: n,
+    });
+    for (const person of principals)
+      await built.acl.grant({
+        ownerScopeId,
+        ref: id,
+        granteeScopeId: scopeId("personal", person.id),
+        permission: "read",
+        grantedBy: "carol@example.com",
+      });
+  }
+  const page = await built.app.listFilesForViewer(principals[0]!.id, { limit: 200 });
+  assert.equal(page.shared.length, 200);
+  assert.ok(page.nextCursor);
+  assert.equal(
+    page.shared.some((file) => file.id === "shared-search-0"),
+    false,
+  );
+  const result = await built.app.search("pelican", principals);
+  assert.deepEqual(
+    result.hits.filter((hit) => hit.backend === "files").map((hit) => hit.id),
+    ["shared-search-0"],
+  );
+});

--- a/test/file-artifact-store.test.ts
+++ b/test/file-artifact-store.test.ts
@@ -1,3 +1,4 @@
+import { assertDocumentListing } from "./support/file-document-listing.ts";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readdir, rm } from "node:fs/promises";
@@ -210,4 +211,20 @@ test("delete removes the ROW only — bytes shared with another row stay openabl
   assert.equal(await store.get("out"), null, "row gone");
   const back = await drain(store, "in");
   assert.deepEqual(back, PNG, "the surviving row's bytes are intact (no inline byte delete)");
+});
+
+test("document listing groups authorized copies before pagination", async () => {
+  await assertDocumentListing(createMemoryFileArtifactStore(createMemoryDurableByteStore()));
+});
+
+test("document listing keeps unknown hashes separate and picks deterministic representatives", async () => {
+  const store = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  for (const id of ["b", "a", "unknown-1", "unknown-2"]) {
+    const { artifact } = await store.put(put({ id, path: id, createdAt: 100 }));
+    if (id.startsWith("unknown")) artifact.sha256 = null;
+  }
+  assert.deepEqual(
+    (await store.listDocuments([owner], [])).files.map((f) => f.id),
+    ["unknown-2", "unknown-1", "a"],
+  );
 });

--- a/test/files-http.test.ts
+++ b/test/files-http.test.ts
@@ -270,3 +270,88 @@ test("scoped file listing pages within the requested context", async () => {
   );
   assert.equal(page.nextCursor, undefined, "unrelated files do not create a misleading next page");
 });
+
+test("project files collapse across contributors and turns before paging owned and shared documents", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const acl = createAclStore();
+  const app = makeUploadApp(files, acl);
+  const ledger: string[] = [];
+  for (const [turn, author, documents] of [
+    [1, "U1", [1, 2]],
+    [2, "U2", [1, 2, 3, 4]],
+    [3, "U2", [1, 2, 3, 4]],
+  ] as const) {
+    for (const document of documents) {
+      const id = fileArtifactId(`turn-${turn}`, "out", document);
+      const ownerScopeId = scopeId("personal", author);
+      const path = `artifacts/${id}/document-${document}.txt`;
+      await files.put({
+        id,
+        ownerScopeId,
+        createdBy: author,
+        path,
+        name: `document-${document}.txt`,
+        mimetype: "text/plain",
+        data: Buffer.from(`document ${document}`),
+        direction: "out",
+        createdInScope: channel,
+        createdAt: turn * 100,
+      });
+      await acl.grant({ ownerScopeId, ref: path, granteeScopeId: channel, permission: "read", grantedBy: author });
+      ledger.push(id);
+    }
+  }
+  for (const viewer of ["U1", "U2"]) {
+    const pages = [];
+    let cursor: string | undefined;
+    do {
+      const page = await app.listFilesForViewer(viewer, { limit: 2, ...(cursor ? { cursor } : {}) }, channel);
+      assert.ok(page.owned.length + page.shared.length <= 2, "the page limit applies to the combined document list");
+      pages.push(page);
+      cursor = page.nextCursor;
+      assert.ok(pages.length <= 2, "four documents require only two pages");
+    } while (cursor);
+    const owned = pages.flatMap((p) => p.owned);
+    const all = pages.flatMap((p) => [...p.owned, ...p.shared]);
+    assert.equal(all.length, 4);
+    assert.equal(new Set(all.map((f) => f.name)).size, 4);
+    assert.equal(owned.length, viewer === "U1" ? 2 : 4, "owned copies remain owned in the grouped listing");
+    for (const file of all) assert.ok(await app.openFileForViewer(file.id, viewer));
+  }
+  for (const id of ledger) assert.ok(await files.get(id), "deduplication does not delete the artifact ledger");
+  const stranger = await app.listFilesForViewer("U3", undefined, channel);
+  assert.deepEqual([...stranger.owned, ...stranger.shared], []);
+});
+
+for (const authors of [["U1"], ["U2"], ["U1", "U2"]]) {
+  test("scope resources drain file pages for " + authors.join(" and "), async () => {
+    const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+    const acl = createAclStore();
+    const app = makeUploadApp(files, acl);
+    for (let n = 0; n < 55; n++) {
+      for (const [index, author] of authors.entries()) {
+        const ownerScopeId = scopeId("personal", author);
+        const id = fileArtifactId("many-" + author, "out", n);
+        const path = "artifacts/" + id + "/file.txt";
+        await files.put({
+          id,
+          path,
+          ownerScopeId,
+          createdBy: author,
+          name: "file.txt",
+          mimetype: "text/plain",
+          data: Buffer.from(author + ":" + n),
+          direction: "out",
+          createdInScope: channel,
+          createdAt: n * 2 + index,
+        });
+        await acl.grant({ ownerScopeId, ref: path, granteeScopeId: channel, permission: "read", grantedBy: author });
+      }
+    }
+    const resources = await app.listScopeResources("U1", channel);
+    assert.equal(resources?.files.length, 55 * authors.length);
+    assert.equal(new Set(resources?.files.map((file) => file.id)).size, 55 * authors.length);
+    for (const author of authors)
+      assert.equal(resources?.files.filter((file) => file.ownerScopeId === scopeId("personal", author)).length, 55);
+  });
+}

--- a/test/postgres-file-artifact-store.test.ts
+++ b/test/postgres-file-artifact-store.test.ts
@@ -1,3 +1,4 @@
+import { assertDocumentListing } from "./support/file-document-listing.ts";
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts";
@@ -183,3 +184,29 @@ test("pg rows survive across store instances (no per-process cache to diverge)",
   const reader = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
   assert.ok(await reader.get("across"));
 });
+
+test("pg document listing groups authorized copies before pagination", { skip }, async () => {
+  await assertDocumentListing(createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore()));
+});
+
+test(
+  "pg document listing keeps unknown hashes separate and picks deterministic representatives",
+  { skip },
+  async () => {
+    const store = createPostgresFileArtifactStore(URL!, createMemoryDurableByteStore());
+    for (const id of ["b", "a", "unknown-1", "unknown-2"]) await store.put(put({ id, path: id, createdAt: 100 }));
+    const pg = (await import("pg")).default;
+    const raw = new pg.Pool({ connectionString: URL });
+    try {
+      await raw.query("UPDATE file_artifacts SET sha256 = NULL WHERE id = ANY($1::text[])", [
+        ["unknown-1", "unknown-2"],
+      ]);
+      assert.deepEqual(
+        (await store.listDocuments([owner], [])).files.map((f) => f.id),
+        ["unknown-2", "unknown-1", "a"],
+      );
+    } finally {
+      await raw.end();
+    }
+  },
+);

--- a/test/support/file-document-listing.ts
+++ b/test/support/file-document-listing.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import type { FileArtifactStore, PutFileInput } from "../../src/files/file-artifact-store.ts";
+import { scopeId } from "../../src/types.ts";
+
+export async function assertDocumentListing(store: FileArtifactStore): Promise<void> {
+  const mine = scopeId("personal", "documents-owner");
+  const teammate = scopeId("personal", "documents-teammate");
+  const project = scopeId("group", "documents-project");
+  const elsewhere = scopeId("group", "documents-elsewhere");
+  const put = (id: string, text: string, at: number, extra: Partial<PutFileInput> = {}) =>
+    store.put({
+      id,
+      name: "report.txt",
+      path: `artifacts/${id}/report.txt`,
+      ownerScopeId: mine,
+      createdBy: "documents-owner",
+      createdInScope: project,
+      direction: "out",
+      mimetype: "text/plain",
+      data: Buffer.from(text),
+      createdAt: at,
+      ...extra,
+    });
+  const hidden = (await put("hidden", "same", 1, { ownerScopeId: teammate })).artifact;
+  const shared = (await put("shared", "same", 2, { ownerScopeId: teammate })).artifact;
+  await put("owned", "same", 3);
+  await put("owned-copy", "same", 9);
+  const second = (await put("second", "different", 4, { ownerScopeId: teammate })).artifact;
+  await put("second-copy", "different", 8, { ownerScopeId: teammate });
+  const disabled = (await put("disabled", "same", 0)).artifact;
+  await store.setEnabled(disabled.id, false);
+  await put("other-scope", "same", 5, { createdInScope: elsewhere });
+  const refs = [shared, second].map(({ ownerScopeId, path }) => ({ ownerScopeId, path }));
+  assert.deepEqual((await store.listDocuments([], [], { limit: 1 })).files, []);
+  assert.deepEqual(
+    (await store.listDocuments([], refs, { createdInScope: project })).files.map((f) => f.id),
+    ["second", "shared"],
+  );
+  const first = await store.listDocuments([mine], refs, { createdInScope: project, limit: 1 });
+  assert.deepEqual(
+    first.files.map((f) => f.id),
+    ["second"],
+  );
+  assert.ok(first.nextCursor);
+  await put("second-later-copy", "different", 100, { ownerScopeId: teammate });
+  const next = await store.listDocuments(
+    [mine],
+    [...refs, { ownerScopeId: teammate, path: "artifacts/second-later-copy/report.txt" }],
+    {
+      createdInScope: project,
+      limit: 1,
+      cursor: first.nextCursor,
+    },
+  );
+  assert.deepEqual(
+    next.files.map((f) => f.id),
+    ["owned"],
+    "an owned copy wins over a shared copy even on a later page",
+  );
+  assert.equal(next.nextCursor, undefined, "new duplicate turns neither repeat nor displace documents across pages");
+  assert.equal((await store.listDocuments([mine], refs)).files.length, 3, "different scopes remain separate documents");
+  assert.equal(
+    (await store.listOwnedByScopes([mine])).files.length,
+    3,
+    "raw artifact listing keeps the per-turn ledger",
+  );
+  assert.deepEqual(
+    (await store.resolveByOwnerPaths([shared, hidden])).map((f) => f.id).sort(),
+    ["hidden", "shared"],
+    "exact handle lookups do not collapse",
+  );
+  assert.ok(await store.open("owned-copy"), "original artifact links keep working");
+  await store.setEnabled("shared", false);
+  assert.deepEqual(
+    (await store.listDocuments([], refs, { includeDisabled: true })).files.map((f) => f.id),
+    ["second"],
+    "a shared grant does not expose a disabled artifact",
+  );
+
+  const firstName = (await put("first-name", "renamed", 20, { name: "original.txt", ownerScopeId: teammate })).artifact;
+  const searchedName = (await put("searched-name", "renamed", 21, { name: "100%_Report.txt", ownerScopeId: teammate }))
+    .artifact;
+  const named = [firstName, searchedName];
+  assert.deepEqual(
+    (await store.listDocuments([], named, { nameQuery: "%_REPORT" })).files.map((f) => f.id),
+    ["searched-name"],
+    "name filtering precedes grouping and applies to shared documents too",
+  );
+  const scoped = await store.listDocuments([mine], refs, { createdInScope: elsewhere, limit: 1 });
+  assert.deepEqual(
+    scoped.files.map((f) => f.id),
+    ["other-scope"],
+  );
+  assert.equal(scoped.nextCursor, undefined);
+}


### PR DESCRIPTION
Fixes #601. Reported by @ianTPE from a multi-user QM deployment.

A project's Files view was displaying the artifact ledger: each upload or agent reattachment created another row for the same document. Keep that ledger, but return one authorized document per scope/content hash in the viewer's file list.

### Change
- Combine owned artifacts and exact ACL-granted artifacts, apply visibility/name/scope filters, then group before cursor pagination.
- Prefer an owned copy when present, then the earliest artifact with a deterministic ID tie-break. Unknown hashes stay separate.
- Keep raw artifact listing, original IDs/paths, downloads, grants, attribution, and stored bytes unchanged. No migration, dependency, speculative index, or new UI.
- Drain pages for the unpaginated context-resources response.
- Keep search on raw authorized artifact identities. Per-viewer document representatives must not change cross-principal file-ID intersection or truncate previously-searchable shared files.

### Validation
- The multi-contributor regression failed before the fix: the combined file page exceeded its limit and repeated documents.
- Final affected file/permission/API/search suites: **105 passed**, no failures/skips.
- Real PostgreSQL 16 artifact-store suite: **10 passed**, no failures/skips. The same document-listing contract runs against memory and PostgreSQL.
- Covers multi-contributor echoes, owned/shared overlap across pages, later duplicate inserts, scope isolation, disabled grants, name filters, null hashes, deterministic ties, original download handles, 55/55/110-document context listings, and search beyond 200 shared files.
- Typecheck, full ESLint, Oxlint, formatting, and Knip passed.
- Two independent review passes accepted the final patch after the context-pagination and exact-search-identity regressions were corrected.

### Local behavior check
Booted the real core with a synthetic four-document dataset and exercised `GET /v1/scope-resources` before and after:

| | Before | After |
|---|---:|---:|
| Listed artifact/document rows | 10 | 4 |
| Unique documents preserved | 4 | 4 |

No production data, credentials, or LLM calls were used for this check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500220&installation_model_id=19911&pr_number=998&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F998&signature=545549ee88eeaeefc9e0a9d97bab4faf0ddcedc9b2cc9113f6b5b82fd15831bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->