### PR TITLE
Update Hono to unblock production dependency audits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7542,9 +7542,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.10",
-    "hono": "4.12.34",
+    "hono": "4.13.5",
     "@fastify/ajv-compiler": {
       "fast-uri": "3.1.7"
     },

--- a/test/pi-dependency-security.test.ts
+++ b/test/pi-dependency-security.test.ts
@@ -47,7 +47,7 @@ test("Pi and MCP security overrides are materialized by the root lockfile", () =
 
   assert.deepEqual(lockedVersions(packages, "brace-expansion"), ["5.0.9"]);
   assert.deepEqual(lockedVersions(packages, "fast-uri").sort(), ["3.1.7", "4.1.4"]);
-  assert.deepEqual(lockedVersions(packages, "hono"), ["4.12.34"]);
+  assert.deepEqual(lockedVersions(packages, "hono"), ["4.13.5"]);
   assert.deepEqual(lockedVersions(packages, "protobufjs"), ["7.6.5"]);
   assert.deepEqual(lockedVersions(packages, "undici"), ["8.9.0"]);
   assert.deepEqual(lockedVersions(packages, "@hono/node-server"), ["2.0.10"]);


### PR DESCRIPTION
Core container builds fail their production dependency audit because the Hono override is below the patched version for three advisories. Update the override and its lockfile entry to 4.13.5, and update the existing dependency-security assertion. All other locked packages remain unchanged.

The [4.13.5 release notes](https://github.com/honojs/hono/releases/tag/v4.13.5) identify fixes for GHSA-gqvv-2mrq-wpjv, GHSA-g6gw-c38x-mqfc, and GHSA-crvj-82cr-hjcx.

Validated with a clean install, zero production audit vulnerabilities, the existing dependency-security/MCP HTTP tests, typecheck, lint, and a successful ARM64 core Docker build including its production audit. Independent review also exercised successful MCP initialization, tools/list, and tools/call through the updated HTTP adapter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500612&installation_model_id=19911&pr_number=999&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F999&signature=332ecfce8ecc85891aa20a2bde8fe1d6238201edceb8abcdcdb099feb0049e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->