### PR TITLE
fix: anchor thinking above the composer

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1273,12 +1273,12 @@ export function createChatSurface(
             ${pinnedStrip()}
             <div class="message-stack ${emptyChat ? "empty-stack" : ""}">
               ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing} ${messageContent}
-              ${emptyChat ? html`<h1 class="chat-cta">${chatCta()}</h1>` : nothing} ${liveWorkStatus(agent)}
+              ${emptyChat ? html`<h1 class="chat-cta">${chatCta()}</h1>` : nothing}
               ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${goalStrip(agent)} ${ctx.composer.queuedStrip(agent)}
+            ${goalStrip(agent)} ${ctx.composer.queuedStrip(agent)} ${liveWorkStatus(agent)}
             ${ctx.composer.composerForm(agent, backgroundActivityStrip())}
           </div>
         </div>

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2613,9 +2613,10 @@ a.chat-row-open {
 }
 
 .live-work-status {
-  width: 100%;
+  width: min(var(--content-w), calc(100% - 32px));
   min-width: 0;
-  margin: 8px 0 0;
+  margin: 0 auto 8px;
+  padding: 0 12px;
   color: var(--muted-foreground);
 }
 .live-work-line {
@@ -7248,6 +7249,7 @@ h3.ambient-field-label {
   /* Mid-width surfaces: the floating composer/dock hug the full-width column with 16px
      side margins, but must still clear the device safe areas — the 10px variant below
      only kicks in at <=470px, so the insets need a floor here too. */
+  .live-work-status,
   .composer-wrap {
     width: auto;
     margin-right: max(16px, calc(10px + env(safe-area-inset-right)));
@@ -7270,6 +7272,10 @@ h3.ambient-field-label {
   }
   /* The floating composer/dock margins pair with the full-bleed 14px chat pad and must
      follow the surface's width too, or a window resize misaligns them with the column. */
+  .live-work-status {
+    margin-right: calc(10px + env(safe-area-inset-right));
+    margin-left: calc(10px + env(safe-area-inset-left));
+  }
   .composer-wrap {
     margin-right: calc(10px + env(safe-area-inset-right));
     margin-bottom: calc(10px + env(safe-area-inset-bottom));
@@ -9371,6 +9377,11 @@ h3.ambient-field-label {
     max-width: 86%;
   }
 
+  .live-work-status {
+    width: calc(100% - 16px);
+    margin-right: auto;
+    margin-left: auto;
+  }
   .composer-wrap {
     width: calc(100% - 16px);
     margin: 0 auto calc(8px + env(safe-area-inset-bottom));

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1778,6 +1778,9 @@ a.chat-row-open {
   width: min(calc(var(--content-w) - 24px), calc(100% - 56px));
   margin: 0 auto -10px;
 }
+.queued-strip:has(+ .live-work-status) {
+  margin-bottom: 6px;
+}
 .queued-chip {
   display: flex;
   align-items: center;

--- a/plugins/web-ui/test/thinking-placement.test.ts
+++ b/plugins/web-ui/test/thinking-placement.test.ts
@@ -26,3 +26,13 @@ test("the live-work row uses the floating composer column", () => {
   assert.match(rule, /margin: 0 auto 8px;/);
   assert.doesNotMatch(css, /live-work-dock/);
 });
+
+test("goal and queued messages precede thinking without the queue's composer overlap", () => {
+  const dock = chat.slice(chat.indexOf('<div class="chat-bottom-dock">'));
+  const goal = dock.indexOf("goalStrip(agent)");
+  const queue = dock.indexOf("ctx.composer.queuedStrip(agent)");
+  const thinking = dock.indexOf("liveWorkStatus(agent)");
+  assert.ok(goal >= 0 && goal < queue && queue < thinking);
+  const spacing = css.match(/\.queued-strip:has\(\+ \.live-work-status\) \{[^}]*\}/)?.[0] ?? "";
+  assert.match(spacing, /margin-bottom: 6px;/);
+});

--- a/plugins/web-ui/test/thinking-placement.test.ts
+++ b/plugins/web-ui/test/thinking-placement.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 
-test("live thinking and tool activity belong to the transcript, not the composer dock", () => {
+test("live thinking and tool activity stay above the composer and background tasks", () => {
   const draw = chat.slice(
     chat.indexOf("  function drawActiveChat("),
     chat.indexOf("  function decorateStreamingTail("),
@@ -14,14 +14,15 @@ test("live thinking and tool activity belong to the transcript, not the composer
     draw.indexOf('<div class="chat-bottom-dock">'),
   );
   const dock = draw.slice(draw.indexOf('<div class="chat-bottom-dock">'));
-  assert.match(transcript, /\$\{liveWorkStatus\(agent\)\}/);
-  assert.doesNotMatch(dock, /liveWork(?:Dock|Status)\(agent\)/);
+  assert.doesNotMatch(transcript, /liveWorkStatus\(agent\)/);
+  assert.match(dock, /\$\{liveWorkStatus\(agent\)\}/);
+  assert.ok(dock.indexOf("liveWorkStatus(agent)") < dock.indexOf("composerForm(agent, backgroundActivityStrip())"));
   assert.match(dock, /composerForm\(agent, backgroundActivityStrip\(\)\)/);
 });
 
-test("the live-work row aligns with the message column rather than composer gutters", () => {
+test("the live-work row uses the floating composer column", () => {
   const rule = css.match(/\.live-work-status \{[^}]*\}/)?.[0] ?? "";
-  assert.match(rule, /width: 100%;/);
-  assert.match(rule, /margin: 8px 0 0;/);
+  assert.match(rule, /width: min\(var\(--content-w\), calc\(100% - 32px\)\);/);
+  assert.match(rule, /margin: 0 auto 8px;/);
   assert.doesNotMatch(css, /live-work-dock/);
 });


### PR DESCRIPTION
Anchor live thinking and tool activity above the composer and background tasks, keeping goals and queued messages separate.

- 961 web UI tests passed.
- 65 browser checks passed across desktop, mobile, and split layouts, including goal states, queues, expanded tasks, and scrolling.
- Typecheck, lint, formatting, and build passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791503993&installation_model_id=19911&pr_number=1004&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1004&signature=815e5a339c26ea7c82f36b94e09c6a9634f4da34b30b14e8ca045e06a7b2cda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->