### PR TITLE
fix: refresh expiring Linear OAuth tokens

### DIFF
--- a/src/connectors/oauth.ts
+++ b/src/connectors/oauth.ts
@@ -344,7 +344,6 @@ export const PROVIDERS: Record<string, OAuthProviderConfig> = {
     redirectPath: "linear/callback",
     consentMode: "standard",
     egressRule: ["api.linear.app"],
-    refresh: null,
     setupGuide: {
       console: "Linear → Settings → API → OAuth applications",
       url: "https://linear.app/settings/api/applications",

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -28,6 +28,8 @@ const env = {
   NOTION_OAUTH_CLIENT_SECRET: "nsecret",
   GITHUB_OAUTH_CLIENT_ID: "ghid",
   GITHUB_OAUTH_CLIENT_SECRET: "ghsecret",
+  LINEAR_OAUTH_CLIENT_ID: "linear-id",
+  LINEAR_OAUTH_CLIENT_SECRET: "linear-secret",
   X_OAUTH_CLIENT_ID: "xid",
   X_OAUTH_CLIENT_SECRET: "xsecret",
 } as NodeJS.ProcessEnv;
@@ -504,4 +506,37 @@ test("oauth flow store — a short opaque state resolves once, then expires", as
   const stale = createOAuthFlowStore(createMemoryMap<OAuthState>(), { now: () => 1_000, ttlMs: 10 });
   const staleId = await stale.start({ provider: "x", principalId: "U1", redirectUri: "https://example.test/cb" }, 0);
   assert.equal(await stale.finish(staleId), null, "expired");
+});
+
+test("Linear refresh exchanges and retains rotated tokens with their expiry", async () => {
+  const refresh = makeRefresh({
+    resolveClient: resolve,
+    now: () => 2_000,
+    fetchImpl: async (url, init) => {
+      assert.equal(url, "https://api.linear.app/oauth/token");
+      assert.equal(init.method, "POST");
+      assert.equal(init.headers["content-type"], "application/x-www-form-urlencoded");
+      assert.deepEqual(Object.fromEntries(new URLSearchParams(init.body)), {
+        grant_type: "refresh_token",
+        refresh_token: "old-refresh",
+        client_id: "linear-id",
+        client_secret: "linear-secret",
+      });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "renewed",
+          refresh_token: "rotated",
+          expires_in: 86399,
+          scope: "read write",
+        }),
+      };
+    },
+  });
+  const token = await refresh("api.linear.app", { accessToken: "expired", refreshToken: "old-refresh", expiresAt: 0 });
+  assert.equal(token.accessToken, "renewed");
+  assert.equal(token.refreshToken, "rotated");
+  assert.equal(token.expiresAt, 2_000 + 86399_000);
+  assert.deepEqual(token.grantedScopes, ["read", "write"]);
 });


### PR DESCRIPTION
Linear access tokens expire, but its provider override disables refresh. Once a token expires, linked accounts lose API access even when QM has a refresh token and the configured OAuth client.

Remove that override so Linear uses the existing OAuth refresh implementation, including client authentication, rotated refresh-token persistence, and expiry handling. Linear documents that all OAuth apps migrated to expiring access tokens on April 1, 2026: https://linear.app/developers/oauth-2-0-authentication.

Validation: 41 OAuth/connector tests, TypeScript, and affected-file lint pass. The new regression test exercises Linear refresh through the shared implementation and verifies the replacement token and expiry. Independent review found no blockers. Live validation of the identical provider patch passed: native keychain early renewal made one real token request, persisted a different refresh token, preserved the standing grant, and successfully queried the same Linear identity before and after a fresh credential read. Tokens stayed inside the runtime; only boolean/status receipts were captured. A separate real background agent run successfully called both GitHub and Linear identity endpoints.
