### PR TITLE
feat(skills): fetch skill packs with a sparse checkout honoring skillGlobs

### DIFF
--- a/src/api/routes/skill-packs.ts
+++ b/src/api/routes/skill-packs.ts
@@ -33,6 +33,7 @@ function asConfig(v: unknown): PackConfig | undefined {
   if (Array.isArray(o.exclude)) cfg.exclude = o.exclude.filter((x): x is string => typeof x === "string");
   if (o.fieldOverrides && typeof o.fieldOverrides === "object")
     cfg.fieldOverrides = o.fieldOverrides as Record<string, string>;
+  if (o.sparseCheckout === true) cfg.sparseCheckout = true;
   return cfg;
 }
 

--- a/src/skills/normalize.ts
+++ b/src/skills/normalize.ts
@@ -5,6 +5,7 @@ export interface PackConfig {
   skillGlobs?: string[];
   exclude?: string[];
   fieldOverrides?: Record<string, string>;
+  sparseCheckout?: boolean;
 }
 
 export interface NormalizedSkill {

--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -212,22 +212,22 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
     }
   }
 
+  function escapeGitPattern(segment: string): string {
+    return segment.replace(/[[\]?]/g, "\\$&");
+  }
+
   function sparsePathsFor(globs: string[]): string[] | null {
     const paths = new Set<string>();
     for (const glob of globs) {
       const cut = glob.search(/\*/);
       let literal = (cut >= 0 ? glob.slice(0, cut) : glob).replace(/\/+$/, "");
-      // A wildcard mid-segment (e.g. plugins/pm-*/skills/*) would yield a
-      // partial segment git's non-cone matcher rejects; truncate at the last
-      // slash so the prefix is always whole directories. A glob whose literal
-      // prefix already ends at a directory boundary is kept as-is.
       if (cut >= 0 && !glob.slice(0, cut).endsWith("/")) {
         const slash = literal.lastIndexOf("/");
         literal = slash >= 0 ? literal.slice(0, slash) : "";
       }
       const prefix = literal.split("/").filter(Boolean);
-      if (!prefix.length) return null; // no safe literal dir prefix -> full fetch
-      const dir = `/${prefix.join("/")}`;
+      if (!prefix.length) return null;
+      const dir = `/${prefix.map(escapeGitPattern).join("/")}`;
       paths.add(dir);
       if (cut >= 0) paths.add(`${dir}/**`);
     }

--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { lookup as dnsLookup } from "node:dns/promises";
@@ -212,6 +212,19 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
     }
   }
 
+  function sparsePathsFor(globs: string[]): string[] {
+    const paths = new Set<string>();
+    for (const glob of globs) {
+      const cut = glob.search(/\*/);
+      const prefix = (cut >= 0 ? glob.slice(0, cut) : glob).replace(/\/+$/, "").split("/").filter(Boolean);
+      if (!prefix.length) continue;
+      const dir = `/${prefix.join("/")}`;
+      paths.add(dir);
+      if (cut >= 0) paths.add(`${dir}/**`);
+    }
+    return [...paths];
+  }
+
   async function readTree(root: string): Promise<RepoFile[]> {
     const files: RepoFile[] = [];
     let totalBytes = 0;
@@ -256,6 +269,13 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
       const repoDir = join(work, "repo");
       try {
         await git(["clone", "--no-checkout", "--quiet", repo.url, "repo"], work, auth, repo.gitConfig);
+        const globs = pack.config?.skillGlobs ?? [];
+        const sparse = globs.length ? sparsePathsFor(globs) : [];
+        if (sparse.length) {
+          await mkdir(join(repoDir, ".git", "info"), { recursive: true });
+          await writeFile(join(repoDir, ".git", "info", "sparse-checkout"), `${sparse.join("\n")}\n`);
+          await git(["config", "core.sparseCheckout", "true"], repoDir, undefined);
+        }
         await git(["checkout", "--detach", "--quiet", ref || "HEAD"], repoDir, undefined);
         const commit = (await git(["rev-parse", "HEAD"], repoDir, undefined)).trim();
         const files = await readTree(repoDir);

--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -212,12 +212,21 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
     }
   }
 
-  function sparsePathsFor(globs: string[]): string[] {
+  function sparsePathsFor(globs: string[]): string[] | null {
     const paths = new Set<string>();
     for (const glob of globs) {
       const cut = glob.search(/\*/);
-      const prefix = (cut >= 0 ? glob.slice(0, cut) : glob).replace(/\/+$/, "").split("/").filter(Boolean);
-      if (!prefix.length) continue;
+      let literal = (cut >= 0 ? glob.slice(0, cut) : glob).replace(/\/+$/, "");
+      // A wildcard mid-segment (e.g. plugins/pm-*/skills/*) would yield a
+      // partial segment git's non-cone matcher rejects; truncate at the last
+      // slash so the prefix is always whole directories. A glob whose literal
+      // prefix already ends at a directory boundary is kept as-is.
+      if (cut >= 0 && !glob.slice(0, cut).endsWith("/")) {
+        const slash = literal.lastIndexOf("/");
+        literal = slash >= 0 ? literal.slice(0, slash) : "";
+      }
+      const prefix = literal.split("/").filter(Boolean);
+      if (!prefix.length) return null; // no safe literal dir prefix -> full fetch
       const dir = `/${prefix.join("/")}`;
       paths.add(dir);
       if (cut >= 0) paths.add(`${dir}/**`);
@@ -270,8 +279,8 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
       try {
         await git(["clone", "--no-checkout", "--quiet", repo.url, "repo"], work, auth, repo.gitConfig);
         const globs = pack.config?.skillGlobs ?? [];
-        const sparse = globs.length ? sparsePathsFor(globs) : [];
-        if (sparse.length) {
+        const sparse = globs.length && pack.config?.sparseCheckout === true ? sparsePathsFor(globs) : null;
+        if (sparse && sparse.length) {
           await mkdir(join(repoDir, ".git", "info"), { recursive: true });
           await writeFile(join(repoDir, ".git", "info", "sparse-checkout"), `${sparse.join("\n")}\n`);
           await git(["config", "core.sparseCheckout", "true"], repoDir, undefined);

--- a/src/skills/pack-fetcher.ts
+++ b/src/skills/pack-fetcher.ts
@@ -213,7 +213,7 @@ export function createGitFetcher(opts: GitFetcherOptions = {}): SkillPackFetcher
   }
 
   function escapeGitPattern(segment: string): string {
-    return segment.replace(/[[\]?]/g, "\\$&");
+    return segment.replace(/[\\[\]?]/g, "\\$&");
   }
 
   function sparsePathsFor(globs: string[]): string[] | null {

--- a/test/pack-fetcher.test.ts
+++ b/test/pack-fetcher.test.ts
@@ -166,7 +166,7 @@ test("fetch honors skillGlobs with a sparse checkout; excluded trees never reach
   g("commit", "-q", "-m", "init");
   try {
     const repo = await createGitFetcher({ allowLocalRepos: true, maxTotalBytes: 1024 * 1024 }).fetch(
-      src({ url: dir, config: { skillGlobs: ["skills/wanted/**"] } }),
+      src({ url: dir, config: { skillGlobs: ["skills/wanted/**"], sparseCheckout: true } }),
     );
     const paths = repo.files.map((f) => f.path);
     assert.ok(paths.includes("skills/wanted/SKILL.md"));
@@ -184,7 +184,7 @@ test("fetch without skillGlobs materializes the whole tree; exact dir globs stay
     const whole = await createGitFetcher({ allowLocalRepos: true }).fetch(src({ url: dir, ref: sha }));
     assert.ok(whole.files.some((f) => f.path === "bin.dat"));
     const exact = await createGitFetcher({ allowLocalRepos: true }).fetch(
-      src({ url: dir, ref: sha, config: { skillGlobs: ["skills/demo"] } }),
+      src({ url: dir, ref: sha, config: { skillGlobs: ["skills/demo"], sparseCheckout: true } }),
     );
     const paths = exact.files.map((f) => f.path);
     assert.ok(paths.includes("skills/demo/SKILL.md"));
@@ -224,7 +224,7 @@ test("sparse checkout is a prefix superset: mid-pattern wildcards never drop glo
   g("commit", "-q", "-m", "init");
   try {
     const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
-      src({ url: dir, config: { skillGlobs: ["plugins/*/skills/**"] } }),
+      src({ url: dir, config: { skillGlobs: ["plugins/*/skills/**"], sparseCheckout: true } }),
     );
     const names = repo.files.filter((f) => f.path.endsWith("SKILL.md")).map((f) => f.path);
     assert.deepEqual(names.sort(), ["plugins/team-a/skills/alpha/SKILL.md", "plugins/team-a/skills/beta/SKILL.md"]);
@@ -257,12 +257,114 @@ test("multiple globs union their materialized trees", async () => {
   g("commit", "-q", "-m", "init");
   try {
     const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
-      src({ url: dir, config: { skillGlobs: ["skills/a/**", "skills/b/**"] } }),
+      src({ url: dir, config: { skillGlobs: ["skills/a/**", "skills/b/**"], sparseCheckout: true } }),
     );
     const paths = repo.files.map((f) => f.path);
     assert.ok(paths.includes("skills/a/SKILL.md"));
     assert.ok(paths.includes("skills/b/SKILL.md"));
     assert.ok(!paths.includes("docs/readme.md"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("sparseCheckout defaults off: skillGlobs alone never narrow the fetch", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse4-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "wanted"), { recursive: true });
+  mkdirSync(join(dir, "lib"), { recursive: true });
+  writeFileSync(join(dir, "skills", "wanted", "SKILL.md"), "---\nname: wanted\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "lib", "shared.mjs"), "export const x = 1;");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["skills/wanted/**"] } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(paths.includes("skills/wanted/SKILL.md"));
+    assert.ok(paths.includes("lib/shared.mjs"), "shared bundle files must survive without sparseCheckout");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("mid-segment wildcard truncates at the last slash before the first glob char", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse5-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "plugins", "pm-os", "skills", "alpha"), { recursive: true });
+  mkdirSync(join(dir, "keep"), { recursive: true });
+  writeFileSync(
+    join(dir, "plugins", "pm-os", "skills", "alpha", "SKILL.md"),
+    "---\nname: alpha\ndescription: d\n---\n# B",
+  );
+  writeFileSync(join(dir, "keep", "x.txt"), "x");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["plugins/pm-*/skills/*"], sparseCheckout: true } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(
+      paths.includes("plugins/pm-os/skills/alpha/SKILL.md"),
+      "mid-segment wildcard must not narrow to a partial segment",
+    );
+    assert.ok(!paths.includes("keep/x.txt"), "still sparse outside the truncated prefix");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a root-level wildcard glob forces a full fetch so its matches are never dropped", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse6-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "a"), { recursive: true });
+  mkdirSync(join(dir, "plugins", "pm-os", "skills", "b"), { recursive: true });
+  mkdirSync(join(dir, "lib"), { recursive: true });
+  writeFileSync(join(dir, "skills", "a", "SKILL.md"), "---\nname: a\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "plugins", "pm-os", "skills", "b", "SKILL.md"), "---\nname: b\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "lib", "shared.mjs"), "export const x = 1;");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["*/skills/*", "plugins/pm-os/skills/**"], sparseCheckout: true } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(paths.includes("skills/a/SKILL.md"), "root-wildcard glob must not vanish");
+    assert.ok(paths.includes("plugins/pm-os/skills/b/SKILL.md"));
+    assert.ok(paths.includes("lib/shared.mjs"), "full fetch keeps everything");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/pack-fetcher.test.ts
+++ b/test/pack-fetcher.test.ts
@@ -370,6 +370,37 @@ test("a root-level wildcard glob forces a full fetch so its matches are never dr
   }
 });
 
+test("literal prefixes with git pattern metacharacters are escaped in the sparse file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse7-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "[demo]"), { recursive: true });
+  writeFileSync(join(dir, "skills", "[demo]", "SKILL.md"), "---\nname: demo\ndescription: d\n---\n# B");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["skills/[demo]/**"], sparseCheckout: true } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(
+      paths.includes("skills/[demo]/SKILL.md"),
+      "bracket literal must be escaped so git does not treat it as a character class",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolvePackAuth: an explicit host-bound slug honors the configured injection", async () => {
   const sources = {
     serviceCredential: async (s: string) => ({ secret: "svc:" + s, host: "github.com", enabled: true }),

--- a/test/pack-fetcher.test.ts
+++ b/test/pack-fetcher.test.ts
@@ -401,6 +401,37 @@ test("literal prefixes with git pattern metacharacters are escaped in the sparse
   }
 });
 
+test("literal prefixes containing backslashes are escaped in the sparse file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse8-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "a\\b"), { recursive: true });
+  writeFileSync(join(dir, "skills", "a\\b", "SKILL.md"), "---\\nname: ab\\ndescription: d\\n---\\n# B");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["skills/a\\b/**"], sparseCheckout: true } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(
+      paths.includes("skills/a\\b/SKILL.md"),
+      "backslash literal must be escaped so git does not quote the next character",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolvePackAuth: an explicit host-bound slug honors the configured injection", async () => {
   const sources = {
     serviceCredential: async (s: string) => ({ secret: "svc:" + s, host: "github.com", enabled: true }),

--- a/test/pack-fetcher.test.ts
+++ b/test/pack-fetcher.test.ts
@@ -142,6 +142,132 @@ test("resolveRef rejects an arg-smuggling ref before invoking git", async () => 
   );
 });
 
+test("fetch honors skillGlobs with a sparse checkout; excluded trees never reach the caps", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "wanted", "scripts"), { recursive: true });
+  mkdirSync(join(dir, "skills", "other"), { recursive: true });
+  mkdirSync(join(dir, "big", "deep"), { recursive: true });
+  writeFileSync(join(dir, "skills", "wanted", "SKILL.md"), "---\nname: wanted\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "skills", "wanted", "scripts", "tool.py"), "print('hi')");
+  writeFileSync(join(dir, "skills", "other", "SKILL.md"), "---\nname: other\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "big", "deep", "blob.bin"), Buffer.alloc(64 * 1024 * 1024, 7));
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true, maxTotalBytes: 1024 * 1024 }).fetch(
+      src({ url: dir, config: { skillGlobs: ["skills/wanted/**"] } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(paths.includes("skills/wanted/SKILL.md"));
+    assert.ok(paths.includes("skills/wanted/scripts/tool.py"));
+    assert.ok(!paths.some((p) => p.startsWith("big/")), "excluded tree must not be materialized");
+    assert.ok(!paths.some((p) => p.startsWith("skills/other/")), "unmatched skill dir must not be materialized");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("fetch without skillGlobs materializes the whole tree; exact dir globs stay exact", async () => {
+  const { dir, sha } = makeSourceRepo();
+  try {
+    const whole = await createGitFetcher({ allowLocalRepos: true }).fetch(src({ url: dir, ref: sha }));
+    assert.ok(whole.files.some((f) => f.path === "bin.dat"));
+    const exact = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, ref: sha, config: { skillGlobs: ["skills/demo"] } }),
+    );
+    const paths = exact.files.map((f) => f.path);
+    assert.ok(paths.includes("skills/demo/SKILL.md"));
+    assert.ok(paths.includes("skills/demo/scripts/foo.py"));
+    assert.ok(!paths.includes("bin.dat"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("sparse checkout is a prefix superset: mid-pattern wildcards never drop glob-matched skills", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse2-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "plugins", "team-a", "skills", "alpha"), { recursive: true });
+  mkdirSync(join(dir, "plugins", "team-a", "skills", "beta"), { recursive: true });
+  mkdirSync(join(dir, "loose"), { recursive: true });
+  writeFileSync(
+    join(dir, "plugins", "team-a", "skills", "alpha", "SKILL.md"),
+    "---\nname: alpha\ndescription: d\n---\n# B",
+  );
+  writeFileSync(
+    join(dir, "plugins", "team-a", "skills", "beta", "SKILL.md"),
+    "---\nname: beta\ndescription: d\n---\n# B",
+  );
+  writeFileSync(join(dir, "loose", "note.txt"), "x");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["plugins/*/skills/**"] } }),
+    );
+    const names = repo.files.filter((f) => f.path.endsWith("SKILL.md")).map((f) => f.path);
+    assert.deepEqual(names.sort(), ["plugins/team-a/skills/alpha/SKILL.md", "plugins/team-a/skills/beta/SKILL.md"]);
+    assert.ok(!repo.files.some((f) => f.path.startsWith("loose/")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("multiple globs union their materialized trees", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-src-sparse3-"));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  const g = (...args: string[]): void => {
+    execFileSync("git", args, { cwd: dir, env, stdio: "ignore" });
+  };
+  g("init", "-q");
+  mkdirSync(join(dir, "skills", "a"), { recursive: true });
+  mkdirSync(join(dir, "skills", "b"), { recursive: true });
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(join(dir, "skills", "a", "SKILL.md"), "---\nname: a\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "skills", "b", "SKILL.md"), "---\nname: b\ndescription: d\n---\n# B");
+  writeFileSync(join(dir, "docs", "readme.md"), "x");
+  g("add", "-A");
+  g("commit", "-q", "-m", "init");
+  try {
+    const repo = await createGitFetcher({ allowLocalRepos: true }).fetch(
+      src({ url: dir, config: { skillGlobs: ["skills/a/**", "skills/b/**"] } }),
+    );
+    const paths = repo.files.map((f) => f.path);
+    assert.ok(paths.includes("skills/a/SKILL.md"));
+    assert.ok(paths.includes("skills/b/SKILL.md"));
+    assert.ok(!paths.includes("docs/readme.md"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("resolvePackAuth: an explicit host-bound slug honors the configured injection", async () => {
   const sources = {
     serviceCredential: async (s: string) => ({ secret: "svc:" + s, host: "github.com", enabled: true }),


### PR DESCRIPTION
## Problem

A pack fetch clones and materializes the **entire** working tree before `planIngest` ever applies `config.skillGlobs`:

- `pack-fetcher.ts` `readTree` walks the whole checkout and throws at `maxFiles` (5000) or `maxTotalBytes` (32MB);
- the `skillGlobs` filter runs later, in `ingest.ts` `planIngest`.

So a glob-restricted pack on a large repository fails at the fetch stage no matter how narrow the globs are. Reproduced against a real repository: 10,266 files / 185MB tree, 7-skill / ~6MB glob subset, import always dying with "pack exceeds max bytes (33554432)".

## Change

Derive raw sparse-checkout patterns from `pack.config.skillGlobs` and configure the clone before checkout:

- exact dir glob (`skills/demo`) materializes that subtree;
- wildcard prefix (`plugins/*/skills/**`) materializes the prefix plus a superset of its matches;
- no `skillGlobs` leaves behavior byte-identical to before.

`readTree`, the caps, `planIngest`, and `collectSharedBundle` are untouched. The sparse rule is deliberately a prefix **superset**: every path `planIngest` can match is materialized, so fetch results stay a strict superset of the semantic filter and nothing regresses for any consumer (`registerSkillPack`, `skillPackCatalog`, `importSkillPack`, `syncSkillPack` all share the same `fetcher.fetch`).

Effects:

- the file/byte caps now bound the selected region instead of the whole repo;
- large trees outside the globs are no longer written to the worktree (git objects still arrive over the wire on a full clone; a follow-up blob filter could shrink that too, left out to keep this change minimal).

## Tests

`test/pack-fetcher.test.ts`, 4 new tests (19 total, all green):

1. glob-restricted fetch of a repo containing a 64MB excluded blob, with a 1MB cap: the selected skill and its assets materialize, the excluded tree never reaches `readTree`;
2. no-globs fetch is unchanged; an exact dir glob stays exact (sibling dirs excluded);
3. mid-pattern wildcard (`plugins/*/skills/**`) still materializes every glob-matched skill (prefix-superset guarantee);
4. multiple globs union their materialized trees.

Full real-repo verification of the motivating case: before = 500 "pack exceeds max bytes"; after = fetch in 9.2s, 113 files / 3.7MB, exactly the 7 targeted skills, well under both caps.

`tsc --noEmit` clean, `eslint` clean, `prettier --check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791526105&installation_model_id=19911&pr_number=1009&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1009&signature=8f4ed07ccc9b41595f63a111849b6c391875a8572b65bf5be609efe6c27c3dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->