### PR TITLE
test: cover deep-linked session recovery

### DIFF
--- a/plugins/web-ui/test/shell-session-deep-link.test.ts
+++ b/plugins/web-ui/test/shell-session-deep-link.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
+
+test("a deep-linked session absent from the sidebar is recovered only through the authorized transcript", () => {
+  const branch = source.slice(
+    source.indexOf("if (wantedSession && !viewIntent && wanted !== \"app-edit\")"),
+    source.indexOf("if (wanted === \"app-edit\")"),
+  );
+
+  assert.match(branch, /fetchTranscript\(wantedSession, \{ tailTurns: TAIL_TURNS \}\)\.catch\(\(\) => null\)/);
+  assert.match(branch, /const linked = \(await transcript\)\?\.session;/);
+  assert.match(branch, /await openSession\(linked, transcript, approvalsPrefetch \?\? undefined\);/);
+  assert.ok(branch.indexOf("if (linked)") < branch.indexOf("That conversation wasn't found"));
+});


### PR DESCRIPTION
## Summary

Adds a regression test for opening a deep-linked conversation that is not present in the initially loaded sidebar list.

The test asserts that the UI recovers the session only from the transcript endpoint, preserving server-side authorization as the source of truth.

## Validation

- `node --test plugins/web-ui/test/shell-session-deep-link.test.ts`
- `npm run typecheck`
- `npx eslint plugins/web-ui/test/shell-session-deep-link.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791528474&installation_model_id=19911&pr_number=1012&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1012&signature=74601b29a3251036aa8bbc4dca8aea06a16ff1a9cc6c4e66848d041a78e67946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->