### PR TITLE
fix: honor request capture opt-out during Pi screening

### DIFF
--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -2396,13 +2396,15 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
             inputTokens: countTokens(systemPrompt) + countTokens(payload),
             entryCount: 1,
           });
-          await recordLlmRequest?.({
-            turnSeq: null,
-            step: SECURITY_SCREEN_STEP,
-            model: modelId,
-            promptEnvelope: { system: systemPrompt, messages: [{ role: "user", content: payload }] },
-            truncated: false,
-          });
+          if (captureRequests) {
+            await recordLlmRequest?.({
+              turnSeq: null,
+              step: SECURITY_SCREEN_STEP,
+              model: modelId,
+              promptEnvelope: { system: systemPrompt, messages: [{ role: "user", content: payload }] },
+              truncated: false,
+            });
+          }
           return parseSecurityScreenVerdict(
             await oneShot("pi-security-screen", model, providerKeys, systemPrompt, payload, {
               signal,

--- a/test/pi-harness-oneshot.test.ts
+++ b/test/pi-harness-oneshot.test.ts
@@ -736,3 +736,28 @@ test("resolveConfiguredModelId: an unresolvable default is rejected too, so auxi
     getRequiredModel(auxiliaryModelFor(resolveConfiguredModelId(undefined, "anthropic/claude-sonnet-4-5"))),
   );
 });
+
+test("Pi screening honors request capture opt-out while retaining model-call metadata", async () => {
+  for (const captureRequests of [false, true]) {
+    const requests: unknown[] = [];
+    const modelCalls: unknown[] = [];
+    const harness = createPiHarness({
+      detectModelId: "claude-haiku-4-5",
+      captureRequests,
+      resolveProviderKeys: async () => ({ anthropic: "test-key" }),
+    });
+    await harness.models.screenSecurity!({
+      payload: "screening-source-sentinel",
+      signal: AbortSignal.abort(),
+      recordModelCall: (call) => {
+        modelCalls.push(call);
+      },
+      recordLlmRequest: async (request) => {
+        requests.push(request);
+      },
+    });
+    assert.equal(modelCalls.length, 1);
+    assert.equal(requests.length, captureRequests ? 1 : 0);
+    assert.equal(JSON.stringify(modelCalls).includes("screening-source-sentinel"), false);
+  }
+});


### PR DESCRIPTION
## Summary

- Pi security screening recorded full prompt envelopes even when request capture was disabled. Apply the existing capture setting to this path while preserving model-call metadata and screening behavior.
- Add a regression covering capture enabled and disabled with a synthetic source sentinel and an already-aborted inference signal. No live provider request is needed for this recording boundary.

## Verification

- Regression failed before the fix (one captured request with capture disabled), then passed.
- 57 affected Pi one-shot, shared-harness and security-screener tests passed on Node24.15.0; typecheck and lint passed.
- The change is a capture predicate only. Live provider, browser and persistent-database checks were not run; no UI changed.

## Notes / Risks

- Capture-enabled behavior remains unchanged. This does not erase previously captured data or disable screening.
- Draft pending independent review. No merge requested.

Upstream CI is currently awaiting maintainer approval for this fork contribution; no hosted job has run.
