### PR TITLE
fix: recognize custom providers in Pi readiness

### DIFF
--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1073,6 +1073,9 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
   const managedKeys = deps.modelCredentials ? await deps.modelCredentials.availability() : null;
   const configuredKeys = deps.providerKeys ?? managedKeys;
   const providerStatus = harnessId === "pi" && managedKeys ? managedKeys : configuredKeys;
+  const customProviderConfigured =
+    harnessId === "pi" &&
+    (await deps.customProviders?.statuses())?.some((provider) => !provider.disabled && provider.hasKey);
   const catalog = managedKeys?.openrouter
     ? await selectableModelCatalog(deps.modelCredentialFetch)
     : builtInModelCatalog();
@@ -1093,12 +1096,13 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
     webuiModels: webuiModels != null ? configuredPicker : allowed,
     baseModel: resolvedBase,
     harnessId,
-    ...(providerStatus && {
+    ...((providerStatus || customProviderConfigured) && {
       modelProviderConfigured: Boolean(
-        providerStatus.anthropic ||
-        providerStatus.openai ||
-        providerStatus.openrouter ||
-        providerStatus.modelIds?.size ||
+        providerStatus?.anthropic ||
+        providerStatus?.openai ||
+        providerStatus?.openrouter ||
+        providerStatus?.modelIds?.size ||
+        customProviderConfigured ||
         deps.harnessCarriedModelAuth,
       ),
     }),

--- a/test/custom-provider-boot-wiring.test.ts
+++ b/test/custom-provider-boot-wiring.test.ts
@@ -37,6 +37,25 @@ test("serverDeps wires the custom-provider store and resolves a custom boot defa
     const list = await fetch(`${base}/v1/admin/custom-providers`, { headers: ADMIN });
     assert.equal(list.status, 200);
 
+    const readiness = async () => {
+      const response = await fetch(`${base}/v1/surface-config`, { headers: ADMIN });
+      assert.equal(response.status, 200);
+      return ((await response.json()) as { modelProviderConfigured: boolean }).modelProviderConfigured;
+    };
+    assert.equal(await readiness(), false);
+    await built.customProviders.upsert(
+      {
+        id: "keyless",
+        name: "Keyless",
+        protocol: "openai",
+        baseUrl: "https://llm.example.test/v1",
+        models: [{ id: "keyless-model", name: "Keyless Model" }],
+      },
+      undefined,
+      "admin-alice@default-org",
+    );
+    assert.equal(await readiness(), false);
+
     const put = await fetch(`${base}/v1/admin/custom-providers/acme-gateway`, {
       method: "PUT",
       headers: ADMIN,
@@ -50,6 +69,19 @@ test("serverDeps wires the custom-provider store and resolves a custom boot defa
       }),
     });
     assert.equal(put.status, 200);
+    assert.equal(await readiness(), true);
+    const otherHarness = createInsecureTestServer(built.app, { ...deps, harnessId: "codex" });
+    otherHarness.listen(0);
+    try {
+      const response = await fetch(
+        `http://localhost:${(otherHarness.address() as AddressInfo).port}/v1/surface-config`,
+        { headers: ADMIN },
+      );
+      assert.equal(response.status, 200);
+      assert.equal(((await response.json()) as { modelProviderConfigured: boolean }).modelProviderConfigured, false);
+    } finally {
+      await new Promise<void>((resolve) => otherHarness.close(() => resolve()));
+    }
 
     assert.equal(defaultModelForHarness("pi", deps.baseModelDefault), "acme-large");
 
@@ -66,6 +98,8 @@ test("serverDeps wires the custom-provider store and resolves a custom boot defa
     assert.equal(body.effective.modelId, "acme-large");
     assert.ok(body.modelsByHarness.pi?.includes("acme-large"));
     assert.equal(body.modelCatalog["acme-large"]?.provider, "acme-gateway");
+    await built.customProviders.delete("acme-gateway", "admin-alice@default-org");
+    assert.equal(await readiness(), false);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }


### PR DESCRIPTION
## Summary

- A Pi deployment with only a registered custom provider reported modelProviderConfigured=false, leaving the Portal readiness gate closed despite having a usable model catalog.
- Include enabled custom providers with stored keys in the existing surface readiness predicate. Missing keys, disabled providers and other harnesses do not gain readiness from this check; built-in credential behavior is preserved.

## Verification

- The existing boot-wiring API regression failed before the fix and passed after it. It exercises absent, keyless, configured, disabled and non-Pi cases against real local HTTP servers with synthetic data and mocked key validation.
- 20 affected custom-provider boot, lifecycle, protocol and store tests passed on Node24.15.0; typecheck and lint passed.
- No rendered UI changed. Browser onboarding and a live external model were not exercised by this configuration-predicate change; readiness does not prove live inference or credential validity.

## Notes / Risks

- Reuse the existing secret-free provider statuses; no keys are returned or decrypted by the readiness route.
- Draft pending independent review and upstream CI. Manual maintainer merge only.

Upstream CI is currently awaiting maintainer approval for this fork contribution; no hosted job has run.
