### PR TITLE
Fix ChatGPT subscription logins expiring silently after the first access token

### DIFF
--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -459,6 +459,18 @@ function expired(rec: { expiresAt?: number }, now: number): boolean {
   return typeof rec.expiresAt === "number" && rec.expiresAt < now;
 }
 
+/** Epoch ms of a JWT access token's exp claim; undefined for opaque tokens. */
+function jwtExpiryMs(token: string | null): number | undefined {
+  if (!token || token.split(".").length !== 3) return undefined;
+  try {
+    const payload = JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8")) as unknown;
+    const exp = (payload as { exp?: unknown } | null)?.exp;
+    return typeof exp === "number" ? exp * 1000 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function credExpired(rec: { kind: CredentialKind; expiresAt?: number }, now: number): boolean {
   return rec.kind !== "file" && expired(rec, now);
 }
@@ -772,7 +784,14 @@ export function createKeychain(deps: {
   async function connectorTokenForRecord(rec: KeychainCredential): Promise<string | null> {
     const t = now();
     const refreshable = rec.refresh?.refreshTokenEnc && deps.refreshConnector && rec.host ? rec.host : null;
-    if (refreshable && rec.expiresAt !== undefined && t >= rec.expiresAt - oauthRefreshMargin) {
+    const secret = tryDecrypt(rec, (r) => decryptSecret(r.secretEnc, deps.key));
+    // A record stored without its expiry (a login flow that predates expiry
+    // capture) would otherwise never refresh and hand out a long-dead token
+    // forever. When the access token is itself a JWT its exp claim is the
+    // authoritative expiry, so fall back to it; one successful refresh then
+    // persists a real expiresAt and the record is healed.
+    const expiresAt = rec.expiresAt ?? jwtExpiryMs(secret);
+    if (refreshable && expiresAt !== undefined && t >= expiresAt - oauthRefreshMargin) {
       let pending = inflightRefreshes.get(rec.id);
       if (!pending) {
         pending = refreshAndStore(refreshable, rec.ownerId, rec.refresh?.accountType, rec);
@@ -781,8 +800,8 @@ export function createKeychain(deps: {
       }
       return pending;
     }
-    if (oauthExpired(rec, t) && !refreshable) return null;
-    return tryDecrypt(rec, (r) => decryptSecret(r.secretEnc, deps.key));
+    if (expiresAt !== undefined && t >= expiresAt - oauthSkew && !refreshable) return null;
+    return secret;
   }
 
   function connectorMeta(rec: KeychainCredentialMeta, t: number): ConnectorMeta {

--- a/src/harness/codex-auth-store.ts
+++ b/src/harness/codex-auth-store.ts
@@ -81,6 +81,11 @@ export function childCodexAuthFromDerived(derived: {
 }): JsonObject | null {
   const auth: JsonObject = {
     auth_mode: "chatgpt",
+    // The Codex CLI reads a missing last_refresh as "refresh immediately",
+    // which the child cannot do (its refresh_token is the empty placeholder) —
+    // the turn then dies on "Failed to refresh token". The material here was
+    // centrally validated or refreshed moments ago, so stamp it as fresh.
+    last_refresh: new Date().toISOString(),
     tokens: {
       access_token: derived.accessToken,
       refresh_token: "",
@@ -94,6 +99,11 @@ export function childCodexAuthFromDerived(derived: {
 
 export function childCodexOAuthAuth(auth: JsonObject): JsonObject {
   const sanitized = sanitizedCodexOAuthAuth(auth);
+  // Same CLI behavior as above: a store record that never carried last_refresh
+  // must not reach the child without one.
+  if (typeof sanitized.last_refresh !== "string" || !sanitized.last_refresh) {
+    sanitized.last_refresh = new Date().toISOString();
+  }
   const tokens = asObject(sanitized.tokens);
   if (tokens) {
     const { refresh_token: _refresh, ...rest } = tokens;

--- a/src/model/codex-device-login.ts
+++ b/src/model/codex-device-login.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { CodexAppServer } from "../harness/codex-app-server.ts";
-import { codexOAuthAuthFromValue } from "../harness/codex-auth-store.ts";
+import { codexOAuthAccessTokenExpiresAt, codexOAuthAuthFromValue } from "../harness/codex-auth-store.ts";
 import { asObject, codexOAuthJwtAccountId, type JsonObject } from "../harness/codex-auth-file.ts";
 import type { UserOAuthTokens } from "./user-model-credential-store.ts";
 import type { ChatGPTDevicePrompt } from "./subscription-oauth.ts";
@@ -27,11 +27,17 @@ function tokensFromAuthJson(home: string): UserOAuthTokens {
   const accessToken = tokens.access_token as string;
   const idToken = typeof tokens.id_token === "string" ? tokens.id_token : undefined;
   const accountId = codexOAuthJwtAccountId(auth) ?? undefined;
+  // Carry the access token's own expiry into the keychain record: the central
+  // refresh triggers off the stored expiresAt, and a record without one is
+  // never refreshed — children then receive a long-expired token they cannot
+  // refresh themselves (they hold no refresh token).
+  const expiresAt = codexOAuthAccessTokenExpiresAt(auth);
   return {
     accessToken,
     refreshToken: tokens.refresh_token as string,
     ...(idToken ? { idToken } : {}),
     ...(accountId ? { accountId } : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
   };
 }
 

--- a/test/codex-auth-store.test.ts
+++ b/test/codex-auth-store.test.ts
@@ -5,6 +5,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  childCodexAuthFromDerived,
   childCodexOAuthAuth,
   codexOAuthAccessTokenExpiresAt,
   codexOAuthAuthFromValue,
@@ -100,6 +101,27 @@ test("child auth material never includes the refresh token", () => {
   assert.equal(tokens.access_token, (auth.tokens as Record<string, unknown>).access_token);
   assert.equal(tokens.id_token, (auth.tokens as Record<string, unknown>).id_token);
   assert.equal(child.auth_mode, "chatgpt");
+});
+
+test("child auth material always carries a last_refresh stamp", () => {
+  // The Codex CLI reads a missing last_refresh as "refresh immediately", and
+  // the child holds only the empty refresh-token placeholder — so a child
+  // auth.json without the stamp fails every turn on "Failed to refresh token".
+  const passedThrough = authJson("acct", FRESH_EXP);
+  passedThrough.last_refresh = "2026-01-02T03:04:05.000Z";
+  assert.equal(childCodexOAuthAuth(passedThrough).last_refresh, "2026-01-02T03:04:05.000Z");
+
+  const stamped = childCodexOAuthAuth(authJson("acct", FRESH_EXP));
+  assert.ok(typeof stamped.last_refresh === "string" && !Number.isNaN(Date.parse(stamped.last_refresh)));
+
+  const derived = childCodexAuthFromDerived({
+    accessToken: accessToken("acct", FRESH_EXP),
+    idToken: idToken("acct"),
+    accountId: "acct",
+  });
+  assert.ok(derived);
+  assert.ok(typeof derived.last_refresh === "string" && !Number.isNaN(Date.parse(derived.last_refresh)));
+  assert.equal((derived.tokens as Record<string, unknown>).refresh_token, "");
 });
 
 test("codexOAuthAuthFromValue validates shape and account binding", () => {

--- a/test/codex-device-login.test.ts
+++ b/test/codex-device-login.test.ts
@@ -10,6 +10,13 @@ function idToken(accountId: string): string {
   return `${seg({ alg: "RS256", typ: "JWT" })}.${seg({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } })}.sig`;
 }
 
+const ACCESS_EXP_SEC = 2_000_000_000;
+
+function accessToken(): string {
+  const seg = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${seg({ alg: "RS256", typ: "JWT" })}.${seg({ exp: ACCESS_EXP_SEC })}.sig`;
+}
+
 /** Fake `codex app-server` that serves the device-login RPCs and writes auth.json on approval. */
 function loginBinary(dir: string, opts: { succeed: boolean; delayMs?: number }): string {
   const path = join(dir, `codex-login-${opts.succeed ? "ok" : "fail"}`);
@@ -31,7 +38,7 @@ rl.on("line", (line) => {
       if (${JSON.stringify(opts.succeed)}) {
         fs.writeFileSync(path.join(process.env.CODEX_HOME, "auth.json"), JSON.stringify({
           auth_mode: "chatgpt",
-          tokens: { access_token: "acc-1", refresh_token: "ref-1", id_token: ${JSON.stringify(idToken("acct_9"))}, account_id: "acct_9" },
+          tokens: { access_token: ${JSON.stringify(accessToken())}, refresh_token: "ref-1", id_token: ${JSON.stringify(idToken("acct_9"))}, account_id: "acct_9" },
         }));
         send({ method: "account/login/completed", params: { loginId: "login-1", success: true, error: null } });
       } else {
@@ -61,9 +68,12 @@ test("device login: start returns the prompt, poll is pending then yields tokens
   const tokens = await login.poll(prompt.deviceAuthId);
   assert.notEqual(tokens, "pending");
   if (tokens === "pending") return;
-  assert.equal(tokens.accessToken, "acc-1");
+  assert.equal(tokens.accessToken, accessToken());
   assert.equal(tokens.refreshToken, "ref-1");
   assert.equal(tokens.accountId, "acct_9");
+  // The harvest carries the access token's exp claim: the keychain's central
+  // refresh keys off the stored expiry, so a record without one never refreshes.
+  assert.equal(tokens.expiresAt, ACCESS_EXP_SEC * 1000);
   // The login is one-shot: after harvest it is gone.
   await assert.rejects(() => login.poll(prompt.deviceAuthId), /expired or unknown/);
 });

--- a/test/keychain.test.ts
+++ b/test/keychain.test.ts
@@ -366,6 +366,42 @@ describe("connectors are grantable like any keychain record", () => {
     await assert.rejects(k2.materialize(g2.id, G1, "carol@x"), (e: KeychainError) => e.status === 410);
   });
 
+  it("a record stored without expiresAt refreshes off its JWT access token's exp claim; opaque tokens stay reused", async () => {
+    const seg = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const expiredJwt = `${seg({ alg: "RS256" })}.${seg({ exp: Math.floor((Date.now() - 60_000) / 1000) })}.sig`;
+    const k = kcWithRefresh("ya29.fresh");
+    // No expiresAt on the record: the login flow that stored it dropped the
+    // expiry. The token's own exp claim must still drive the central refresh.
+    await k.setConnectorToken(GMAIL, "alex@x", { accessToken: expiredJwt, refreshToken: "rt" });
+    const g = await k.createGrant({
+      credentialId: await cidOf(k, "alex@x"),
+      ownerId: "alex@x",
+      audienceScopeId: G1,
+      mode: "standing",
+      purpose: "p",
+    });
+    const m = await k.materialize(g.id, G1, "member@example.com");
+    assert.deepEqual(m.kind === "env" ? m.env : null, [
+      { key: "VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM", value: "ya29.fresh" },
+    ]);
+
+    // An opaque token without expiresAt carries no readable expiry: unchanged
+    // behavior, handed out as stored with no refresh attempt.
+    const k2 = kcWithRefresh("ya29.fresh");
+    await k2.setConnectorToken(GMAIL, "bob@x", { accessToken: "ya29.opaque", refreshToken: "rt" });
+    const g2 = await k2.createGrant({
+      credentialId: await cidOf(k2, "bob@x"),
+      ownerId: "bob@x",
+      audienceScopeId: G1,
+      mode: "standing",
+      purpose: "p",
+    });
+    const m2 = await k2.materialize(g2.id, G1, "member@example.com");
+    assert.deepEqual(m2.kind === "env" ? m2.env : null, [
+      { key: "VAULT_TOKEN_GMAIL_GOOGLEAPIS_COM", value: "ya29.opaque" },
+    ]);
+  });
+
   it("a still-valid token within the refresh margin is refreshed; one with ample life is reused", async () => {
     const k = kcWithRefresh("ya29.fresh");
     await k.setConnectorToken(GMAIL, "alex@x", {


### PR DESCRIPTION
## Problem

A ChatGPT-subscription connection made through the device-code login works until its first
access token expires, then every turn on that connection fails hard. The failure is silent
until then, so it looks like the feature broke days after it was set up.

Mechanism:

- `tokensFromAuthJson` (the device-login harvest) returns the tokens without an
  `expiresAt`, so the keychain record is stored with no expiry.
- The keychain's central refresh (`connectorTokenForRecord`) only engages when the stored
  record carries `expiresAt`; with none, the original access token is handed out forever.
- The Codex child jail deliberately receives no usable refresh token
  (`refresh_token: ""`), so once the access token ages out the CLI's own refresh attempt
  fails with "Failed to refresh token: … got an empty string instead" and the turn dies.

Reconnecting only resets the clock: the fresh harvest also stores no expiry.

## Fix

- The login harvest now carries the access token's own `exp` claim (via
  `codexOAuthAccessTokenExpiresAt`) into the stored tokens, so the central refresh engages
  before expiry and rotated tokens persist normally from then on.
- `connectorTokenForRecord` falls back to the access token's `exp` claim when the record
  has no stored expiry. This heals records created before this fix on their next use: the
  stale token triggers a central refresh, and the refreshed record carries a real
  `expiresAt`. Opaque (non-JWT) access tokens — Google, Slack, and similar connectors —
  read no expiry from the fallback and behave exactly as before.

## Tests

- `test/codex-device-login.test.ts`: the fake login now writes a JWT access token and the
  harvest assertion pins `expiresAt` to its `exp` claim.
- `test/keychain.test.ts`: a record stored without `expiresAt` whose JWT access token has
  expired is refreshed on materialize; an opaque token without `expiresAt` is handed out
  unchanged with no refresh attempt.

`npm run typecheck` clean; the new keychain case and the full CLI-visible behavior are
covered by the suites above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791560204&installation_model_id=19911&pr_number=1017&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1017&signature=45b633839d6f5a64e072370b9df03071e0600726169e7101d7071babf556a152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->