### PR TITLE
CLI: stop requiring OPENAI_API_KEY when Codex runs on a ChatGPT subscription

### DIFF
--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -13,6 +13,8 @@ type SecretCondition =
   | { kind: "service-absent"; service: DeclaredServiceName }
   | { kind: "all"; conditions: SecretCondition[] }
   | { kind: "any"; conditions: SecretCondition[] }
+  | { kind: "not"; condition: SecretCondition }
+  | { kind: "secret-mapped"; service: DeclaredServiceName; name: string }
   | { kind: "target"; target: QmConfig["target"] }
   | { kind: "model-provider"; provider: ModelProvider };
 
@@ -58,17 +60,44 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
   {
     name: "OPENAI_API_KEY",
     service: "core",
+    // Mirrors the runtime gate (src/deployment/secret-schema.ts): the key is
+    // needed for the Codex harness or an OpenAI base model, UNLESS the Codex
+    // harness authenticates by ChatGPT subscription instead — a CODEX_AUTH_FILE
+    // or CODEX_AUTH_CREDENTIAL delivered by env or by a secretEnv mapping.
+    // Without this exemption `qm up` demands a key the runtime never reads.
     required: {
       when: {
-        kind: "any",
+        kind: "all",
         conditions: [
-          { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
-          { kind: "model-provider", provider: "openai" },
+          {
+            kind: "any",
+            conditions: [
+              { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
+              { kind: "model-provider", provider: "openai" },
+            ],
+          },
+          {
+            kind: "not",
+            condition: {
+              kind: "all",
+              conditions: [
+                { kind: "env-equals", service: "core", name: "HARNESS", value: "codex" },
+                {
+                  kind: "any",
+                  conditions: [
+                    { kind: "env-present", service: "core", name: "CODEX_AUTH_FILE" },
+                    { kind: "env-present", service: "core", name: "CODEX_AUTH_CREDENTIAL" },
+                    { kind: "secret-mapped", service: "core", name: "CODEX_AUTH_CREDENTIAL" },
+                  ],
+                },
+              ],
+            },
+          },
         ],
       },
     },
     description:
-      'OpenAI API key: the Codex harness needs it (its CLI cannot do browser OAuth in a container), and it bills the base model when modelProvider is "openai".',
+      'OpenAI API key: the Codex harness needs it unless a ChatGPT-subscription login is configured (CODEX_AUTH_FILE or CODEX_AUTH_CREDENTIAL), and it bills the base model when modelProvider is "openai".',
   },
   {
     name: "PUBLIC_API_URL",
@@ -478,6 +507,8 @@ function conditionMatches(config: QmConfig, condition: SecretCondition): boolean
   if (condition.kind === "service-absent") return !config.services.includes(condition.service);
   if (condition.kind === "all") return condition.conditions.every((nested) => conditionMatches(config, nested));
   if (condition.kind === "any") return condition.conditions.some((nested) => conditionMatches(config, nested));
+  if (condition.kind === "not") return !conditionMatches(config, condition.condition);
+  if (condition.kind === "secret-mapped") return Boolean(config.secretEnv?.[condition.service]?.[condition.name]);
   if (condition.kind === "target") return config.target === condition.target;
   if (condition.kind === "model-provider") return effectiveModelProvider(config) === condition.provider;
   if (condition.kind === "env-all-absent") {
@@ -684,6 +715,8 @@ function conditionClause(condition: SecretCondition): string {
   if (condition.kind === "service-absent") return `the ${condition.service} service is not enabled`;
   if (condition.kind === "all") return condition.conditions.map(conditionClause).join(" and ");
   if (condition.kind === "any") return condition.conditions.map(conditionClause).join(" or ");
+  if (condition.kind === "not") return `it is not the case that ${conditionClause(condition.condition)}`;
+  if (condition.kind === "secret-mapped") return `config secretEnv.${condition.service} maps ${condition.name}`;
   if (condition.kind === "target") return `the target is ${condition.target}`;
   if (condition.kind === "env-all-absent")
     return `none of env.${condition.service}.{${condition.names.join(", ")}} are set`;

--- a/cli/test/secrets.test.ts
+++ b/cli/test/secrets.test.ts
@@ -223,6 +223,41 @@ test("an OpenAI base model and the Codex harness agree on one required key", () 
   assert.equal(matches[0]!.required, true);
 });
 
+test("a ChatGPT-subscription Codex login lifts the OPENAI_API_KEY requirement, matching the runtime gate", () => {
+  // The runtime (src/deployment/secret-schema.ts) exempts the key when
+  // HARNESS=codex and CODEX_AUTH_FILE or CODEX_AUTH_CREDENTIAL is configured;
+  // without the same exemption here, `qm up` refuses a deployment the runtime
+  // boots happily.
+  // Exempted configs drop the key from the catalog entirely, the same
+  // "absent rather than optional" shape the Codex rule already has when
+  // another provider is selected.
+  const hasOpenAIKey = (config: QmConfig) => computedSecrets(config).some((secret) => secret.name === "OPENAI_API_KEY");
+  const mapped = makeConfig({
+    modelProvider: "openai",
+    env: { core: { HARNESS: "codex" } },
+    secretEnv: { core: { CODEX_AUTH_CREDENTIAL: "CODEX_AUTH_CREDENTIAL" } },
+  });
+  assert.equal(hasOpenAIKey(mapped), false);
+
+  const envDelivered = makeConfig({
+    modelProvider: "openai",
+    env: { core: { HARNESS: "codex", CODEX_AUTH_CREDENTIAL: "cred-id" } },
+  });
+  assert.equal(hasOpenAIKey(envDelivered), false);
+
+  const authFile = makeConfig({ env: { core: { HARNESS: "codex", CODEX_AUTH_FILE: "~/.codex/auth.json" } } });
+  assert.equal(hasOpenAIKey(authFile), false);
+
+  // The exemption is Codex-scoped: an OpenAI base model on another harness
+  // still bills by API key regardless of a mapped credential.
+  const piOnOpenAI = makeConfig({
+    modelProvider: "openai",
+    env: { core: { HARNESS: "pi" } },
+    secretEnv: { core: { CODEX_AUTH_CREDENTIAL: "CODEX_AUTH_CREDENTIAL" } },
+  });
+  assert.equal(secretByName(piOnOpenAI, "OPENAI_API_KEY").required, true);
+});
+
 test("omitting modelProvider preserves the pre-existing deferred-to-Admin behavior", () => {
   const deferred = makeConfig();
   assert.equal(secretByName(deferred, "ANTHROPIC_API_KEY").required, false);


### PR DESCRIPTION
## Problem

The runtime secret schema (`src/deployment/secret-schema.ts`) exempts `OPENAI_API_KEY`
when `HARNESS=codex` authenticates by ChatGPT subscription (`CODEX_AUTH_FILE` or
`CODEX_AUTH_CREDENTIAL`), but the CLI's secret catalog cannot express that exemption, so
`qm up` hard-aborts on a keyless deployment the runtime boots happily:

```
missing or insecure required core secrets: OPENAI_API_KEY
```

The only workaround is setting a throwaway `OPENAI_API_KEY` to pass the CLI's gate, then
unsetting it in the provider's secret store so the runtime reboots keyless.

## Fix

Two condition kinds the catalog lacked, then a rule rewrite that mirrors the runtime gate
exactly:

- `not` — negation of a nested condition.
- `secret-mapped` — true when the config's `secretEnv.<service>` maps the named variable
  (which is how a keychain credential id is normally delivered, so the evaluator cannot
  see it in `env`).

The `OPENAI_API_KEY` rule becomes: required when (the Codex harness runs, or the base
model provider is OpenAI) and NOT (the Codex harness runs with `CODEX_AUTH_FILE` or
`CODEX_AUTH_CREDENTIAL` configured via env or a secretEnv mapping) — the same predicate
the runtime evaluates at boot. The description now names the subscription alternative.

Exempted configs drop the key from the computed catalog entirely, matching the rule's
existing "absent rather than optional" shape when another provider is selected.

## Tests

`cli/test/secrets.test.ts` pins all four corners: a secretEnv-mapped credential, an
env-delivered credential id, and a `CODEX_AUTH_FILE` each lift the requirement; an OpenAI
base model on a non-Codex harness stays required regardless of a mapped credential. The
pre-existing "Codex harness + OpenAI provider collapse to one required key" case still
passes unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791560214&installation_model_id=19911&pr_number=1018&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1018&signature=ab77a23e9f8aebc5d1182d32959208091acc46b612b1171d67ba98d5acd47987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->