### PR TITLE
proposal: support external identity sessions in the auth broker

### DIFF
--- a/adrs/external-identity-sessions.md
+++ b/adrs/external-identity-sessions.md
@@ -1,0 +1,28 @@
+# External identity sessions in the auth broker
+
+We run QM behind Portal, but the people using it already have accounts in another
+identity service. That service can verify an email and password, return a short-lived
+access token, and answer a current-user endpoint. The built-in auth plugin currently
+owns the right OIDC boundary for Portal, but it only supports emailed sign-in links.
+
+Could the broker accept a small external credential verifier while continuing to issue
+the same authorization-code, PKCE, nonce, ID-token, and userinfo responses? The
+verifier would return an immutable provider user ID, verified email, configured QM
+principal, access-token expiry, and opaque provider material. Exact configured
+ID/email/principal bindings would decide admission; provider roles would grant nothing.
+
+The provider material and a random application-session ID need durable Core storage,
+encrypted with the existing credential key. The browser would receive only the random
+session ID. A private broker endpoint would recheck current-user state and another
+would revoke the application session. Portal could then fail closed before protected
+requests and before relaying later SSE chunks after expiry, logout, binding disable,
+identity change, provider deletion, or provider outage.
+
+For the first implementation, sessions would last no more than 15 minutes and never
+refresh or slide. Passwords and provider refresh tokens would be discarded. Failed
+login limits would reuse the broker's existing durable claim store. Existing email-link
+deployments and Portal sessions would keep their current behavior unless the external
+verifier is explicitly configured.
+
+If this direction fits QM, I can send the implementation and focused auth, Portal, and
+durability tests as a follow-up.


### PR DESCRIPTION
The built-in broker already gives Portal the OIDC checks we need, but it cannot delegate credential verification to an existing identity service or revoke that provider-backed application session. This proposes a small opt-in verifier and durable session/status boundary while leaving current email-link deployments unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791563094&installation_model_id=19911&pr_number=1020&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1020&signature=440d9438b172b1dd396e43fa43d78a8555315dfcd8d7359cbf21daf405829740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->