### PR TITLE
Name the deployment's public URL in the connect-your-account refusal

### DIFF
--- a/src/core/individual-auth-routing.ts
+++ b/src/core/individual-auth-routing.ts
@@ -18,6 +18,17 @@ export type IndividualAuthRouting =
   | { kind: "oauth"; provider: "openai"; harness: "pi"; model: string }
   | null;
 
+/**
+ * The refusal an unconnected person sees when the org requires individual
+ * model auth. With the deployment's public URL configured, the message names
+ * the exact address to visit; a person reading it in Slack has no other way
+ * to discover where "the web app" lives.
+ */
+export function connectAccountMessage(publicUrl?: string): string {
+  const where = publicUrl ? `at ${publicUrl}` : "from the AI account panel in the web app";
+  return `This organization has each person chat on their own AI account, and yours isn't connected yet. Connect Claude or ChatGPT ${where}, then try again.`;
+}
+
 export function resolveIndividualAuthRouting(
   anthCred: UserModelCredential | null,
   oaiCred: UserModelCredential | null,

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2655,7 +2655,11 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             }
           }
           if (!userHarnessOverride) {
-            throw new NonRetryableTurnError(connectAccountMessage(deps.publicUrl));
+            // A refusal, not a turn failure: the surface delivers a refusal's
+            // reason verbatim, where a failed turn is wrapped in the generic
+            // "something went wrong" copy and the person never learns where
+            // to connect their account.
+            return { status: "refused", sessionId: session.id, reason: connectAccountMessage(deps.publicUrl) };
           }
         }
         const effectiveModel = userModelOverride ?? input.model;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -159,7 +159,7 @@ import type { Orchestrator, OrchestratorDeps, OrchestratorInput } from "./orches
 import { isHarnessId, resolveModel, CODEX_SUBSCRIPTION_PROVIDER } from "../model/pi-models.ts";
 import type { ProviderKeys } from "../harness/pi-harness.ts";
 import type { CodexTurnAuth } from "../harness/harness.ts";
-import { resolveIndividualAuthRouting } from "./individual-auth-routing.ts";
+import { connectAccountMessage, resolveIndividualAuthRouting } from "./individual-auth-routing.ts";
 import {
   MAX_AUTO_ATTACHMENT_SCREEN_BYTES,
   approvalGrantId,
@@ -2655,9 +2655,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             }
           }
           if (!userHarnessOverride) {
-            throw new NonRetryableTurnError(
-              "This organization has each person chat on their own AI account, and yours isn't connected yet. Open the web app and connect Claude or ChatGPT from the AI account panel, then try again.",
-            );
+            throw new NonRetryableTurnError(connectAccountMessage(deps.publicUrl));
           }
         }
         const effectiveModel = userModelOverride ?? input.model;

--- a/src/core/orchestrator/types.ts
+++ b/src/core/orchestrator/types.ts
@@ -106,6 +106,8 @@ export interface OrchestratorDeps {
   defaultHarness?: string;
   userModelCredentials?: UserModelCredentialStore;
   brandingDefault?: OrgBranding;
+  /** The deployment's public web address, shown in user-facing connect prompts. */
+  publicUrl?: string;
   resolveBaseModelId?: () => string | undefined;
   sessionTapeMode?: "shadow" | "serve";
   sessions: SessionStore;

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -1388,6 +1388,7 @@ export function buildApp(
     defaultHarness: fallbackHarness,
     userModelCredentials,
     ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
+    ...(config.publicUrl ? { publicUrl: config.publicUrl } : {}),
     sessionTapeMode: config.sessionTapeMode,
     sessions,
     workspace,

--- a/test/user-model-auth-injection.test.ts
+++ b/test/user-model-auth-injection.test.ts
@@ -10,7 +10,7 @@ import { createUserModelCredentialStore } from "../src/model/user-model-credenti
 import { readFileSync } from "node:fs";
 import { prepareCodexHome } from "../src/harness/codex-harness.ts";
 import { codexOAuthAuthFromValue } from "../src/harness/codex-auth-store.ts";
-import { resolveIndividualAuthRouting } from "../src/core/individual-auth-routing.ts";
+import { connectAccountMessage, resolveIndividualAuthRouting } from "../src/core/individual-auth-routing.ts";
 import { resolveModel } from "../src/model/pi-models.ts";
 import type { UserModelCredential } from "../src/model/user-model-credential-store.ts";
 
@@ -207,6 +207,15 @@ test("codex-subscription model ids resolve to pi-ai's openai-codex provider", ()
 
 test("routing: no credentials -> null (falls through to gate, no deployment key)", () => {
   assert.equal(resolveIndividualAuthRouting(null, null, undefined), null);
+});
+
+test("the unconnected-user refusal names the deployment's public URL when configured", () => {
+  assert.equal(
+    connectAccountMessage("https://qm.example.com"),
+    "This organization has each person chat on their own AI account, and yours isn't connected yet. Connect Claude or ChatGPT at https://qm.example.com, then try again.",
+  );
+  // Without a configured URL the message still points somewhere actionable.
+  assert.match(connectAccountMessage(), /AI account panel in the web app/);
 });
 
 test("per-user codex child auth is derived material: valid chatgpt auth without the refresh token", () => {


### PR DESCRIPTION
When an org enables individual model auth, an unconnected person's first message is refused with directions to "the web app" — but the refusal is usually read on a chat surface where nothing says where the web app lives, so the person has no path to follow.

The refusal now names the deployment's configured public URL: *"…Connect Claude or ChatGPT at https://qm.example.com, then try again."* The message moves to a pure helper (`connectAccountMessage`) beside the routing logic, `publicUrl` is plumbed through `OrchestratorDeps` from the existing config field, and deployments without a configured public URL keep an equivalent of the old wording. Covered by a unit test on both shapes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791568576&installation_model_id=19911&pr_number=1022&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1022&signature=02f8b56d21c971dd3582b402f3f4d2754dbb2671cc9de0b4119f7ab1ed01d628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->