### PR TITLE
portal: default sessions to 7 days rolling, 30 days absolute

### DIFF
--- a/cli/templates/fly/portal.toml
+++ b/cli/templates/fly/portal.toml
@@ -17,7 +17,6 @@ primary_region = "sjc"
   OIDC_SCOPES = "openid email profile"
   OIDC_PRINCIPAL_CLAIM = "email"
   OIDC_ALLOWED_EMAIL_DOMAIN = "example.com"
-  PORTAL_SESSION_TTL_S = "28800"
 
 [http_service]
   internal_port = 8080

--- a/deploy/portal/fly.toml
+++ b/deploy/portal/fly.toml
@@ -17,7 +17,6 @@ primary_region = "sjc"
   OIDC_SCOPES = "openid email profile"
   OIDC_PRINCIPAL_CLAIM = "email"
   OIDC_ALLOWED_EMAIL_DOMAIN = "example.com"
-  PORTAL_SESSION_TTL_S = "28800"
 
 [http_service]
   internal_port = 8080

--- a/plugins/portal/README.md
+++ b/plugins/portal/README.md
@@ -25,8 +25,8 @@ surfaces, and it does **not** import the core.
    signature and payload (`nonce`/`aud`/`iss`/`sub`/timestamps and, for Slack, the `team_id`
    workspace pin) against the configured HTTPS JWKS, then reads
    the subject from userinfo. The verified `sub` **is** the core principal id. It mints a
-   signed `portal_session` cookie (`{sub, org, auth, exp}`, HMAC, 8h sliding lifetime with a
-   24h absolute maximum by default).
+   signed `portal_session` cookie (`{sub, org, auth, exp}`, HMAC, 7-day sliding lifetime with a
+   30-day absolute maximum by default).
 3. **Proxy** — every other path requires a valid session. The portal picks the upstream by the
    **exact first path segment**, strips the prefix, and proxies to the private upstream,
    synthesizing the surface cookie for compatibility and attaching a short-lived signed portal
@@ -161,7 +161,7 @@ Non-secret (`[env]`): `PORT` (8097 local / 8080 image), `PORTAL_PUBLIC_URL`, `CO
 `CORE_ORG_ID`, `WEB_UI_UPSTREAM`, `ADMIN_UPSTREAM`,
 `OIDC_AUTH_ENDPOINT` / `OIDC_TOKEN_ENDPOINT` / `OIDC_USERINFO_ENDPOINT` / `OIDC_ISSUER` /
 `OIDC_JWKS_URI` / `OIDC_SCOPES` / `OIDC_CLIENT_ID`, `PORTAL_EXPECTED_TEAM_ID`,
-`PORTAL_SESSION_TTL_S`, `PORTAL_SESSION_MAX_TTL_S`. `PORTAL_SESSION_MAX_TTL_S` caps a session's total life from authentication; it defaults to the larger of one day and `PORTAL_SESSION_TTL_S`, and boot fails if it is set below the TTL.
+`PORTAL_SESSION_TTL_S`, `PORTAL_SESSION_MAX_TTL_S`. `PORTAL_SESSION_MAX_TTL_S` caps a session's total life from authentication; it defaults to the larger of 30 days and `PORTAL_SESSION_TTL_S`, and boot fails if it is set below the TTL.
 There is no `PORTAL_ADMIN_PRINCIPALS` — admin
 access is derived from the core (see the security model above).
 For local development only, `PORTAL_LOCAL_AUTH_BYPASS=1` mints a local session as

--- a/plugins/portal/src/index.ts
+++ b/plugins/portal/src/index.ts
@@ -62,8 +62,8 @@ import {
 const PORT = portFromEnv(8097);
 const PUBLIC_URL = (process.env.PORTAL_PUBLIC_URL ?? `http://localhost:${PORT}`).replace(/\/$/, "");
 const SESSION_SECRET = process.env.PORTAL_SESSION_SECRET;
-const SESSION_TTL_S = Number(process.env.PORTAL_SESSION_TTL_S ?? 28800);
-const SESSION_MAX_TTL_S = Number(process.env.PORTAL_SESSION_MAX_TTL_S ?? Math.max(86400, SESSION_TTL_S));
+const SESSION_TTL_S = Number(process.env.PORTAL_SESSION_TTL_S ?? 604800);
+const SESSION_MAX_TTL_S = Number(process.env.PORTAL_SESSION_MAX_TTL_S ?? Math.max(2592000, SESSION_TTL_S));
 const SESSION_RENEW_AFTER_S = Math.floor(SESSION_TTL_S / 2);
 const APPS_DOMAIN = process.env.PORTAL_APPS_DOMAIN || process.env.DEPLOY_APPS_DOMAIN || undefined;
 const COOKIE_DOMAIN =

--- a/plugins/portal/test/entry.test.ts
+++ b/plugins/portal/test/entry.test.ts
@@ -141,7 +141,7 @@ test("a session TTL above the default max ceiling still boots, but a contradicto
     OIDC_CLIENT_ID: "client-id",
     OIDC_CLIENT_SECRET: "client-secret",
     OIDC_ALLOWED_EMAILS: "admin@example.com",
-    PORTAL_SESSION_TTL_S: "604800",
+    PORTAL_SESSION_TTL_S: "5184000",
   };
   delete baseEnv.PORTAL_SESSION_MAX_TTL_S;
 

--- a/plugins/portal/test/local-auth-bypass.test.ts
+++ b/plugins/portal/test/local-auth-bypass.test.ts
@@ -38,7 +38,7 @@ test("local auth bypass signs in loopback portal requests without OIDC", async (
   const login = await fetch(`${base}/auth/login?returnTo=/admin/`, { redirect: "manual" });
   assert.equal(login.status, 302);
   assert.equal(login.headers.get("location"), "/admin/");
-  assert.match(login.headers.get("set-cookie") ?? "", /portal_session=/);
+  assert.match(login.headers.get("set-cookie") ?? "", /portal_session=[^,]*Max-Age=604800\b/);
 
   const admin = await fetch(`${base}/admin/api/me`);
   assert.equal(admin.status, 200);

--- a/plugins/portal/test/playground.test.ts
+++ b/plugins/portal/test/playground.test.ts
@@ -42,6 +42,8 @@ process.env.ADMIN_UPSTREAM = upstreamUrl;
 process.env.CORE_API_URL = upstreamUrl;
 process.env.PORTAL_PLAYGROUND = "1";
 process.env.PORTAL_PLAYGROUND_MINTS_PER_IP = "3";
+const SESSION_TTL_S = 28800;
+process.env.PORTAL_SESSION_TTL_S = String(SESSION_TTL_S);
 delete process.env.PORTAL_LOCAL_AUTH_BYPASS;
 
 const { server, mintBucketOf } = await import("../src/index.ts");
@@ -108,9 +110,9 @@ test("sliding renewal preserves the anon flag", async () => {
     org: process.env.CORE_ORG_ID ?? "acme",
     name: "Guest",
     anon: true,
-    auth: now - 15000,
-    iat: now - 15000,
-    exp: now + 13800,
+    auth: now - SESSION_TTL_S / 2 - 600,
+    iat: now - SESSION_TTL_S / 2 - 600,
+    exp: now + SESSION_TTL_S / 2 - 600,
   };
   const res = await fetch(`${base}/`, {
     headers: { ...HTML, cookie: `portal_session=${encodeURIComponent(seal(aged, key))}` },

--- a/plugins/portal/test/router.test.ts
+++ b/plugins/portal/test/router.test.ts
@@ -95,6 +95,8 @@ process.env.CORE_SIGNING_SECRET = "router-test-core-secret";
 process.env.WEB_UI_UPSTREAM = upstreamUrl;
 process.env.ADMIN_UPSTREAM = upstreamUrl;
 process.env.CORE_API_URL = upstreamUrl;
+const SESSION_TTL_S = 28800;
+process.env.PORTAL_SESSION_TTL_S = String(SESSION_TTL_S);
 
 const { server } = await import("../src/index.ts");
 const { deriveKey, seal, open } = await import("../src/session.ts");
@@ -105,7 +107,7 @@ const sessionKey = deriveKey("router-test-portal-secret", "portal.session.v1");
 function sessionCookie(sub: string, ageS = 0): string {
   const now = Math.floor(Date.now() / 1000);
   const iat = now - ageS;
-  return `portal_session=${encodeURIComponent(seal({ k: "session", sub, org: "acme", iat, exp: iat + 28800 }, sessionKey))}`;
+  return `portal_session=${encodeURIComponent(seal({ k: "session", sub, org: "acme", iat, exp: iat + SESSION_TTL_S }, sessionKey))}`;
 }
 
 test.after(() => {
@@ -561,10 +563,13 @@ test("sliding renewal: a fresh session is NOT re-stamped, an aged one is re-issu
   const setCookie = aged.headers.get("set-cookie") ?? "";
   const m = setCookie.match(/portal_session=([^;]+)/);
   assert.ok(m, "an aged session is re-stamped through the proxy");
-  assert.match(setCookie, /Max-Age=28800/, "the renewed cookie carries a full TTL");
+  assert.match(setCookie, new RegExp(`Max-Age=${SESSION_TTL_S}\\b`), "the renewed cookie carries a full TTL");
   const claims = open(decodeURIComponent(m![1] ?? ""), sessionKey) as { sub: string; exp: number } | null;
   assert.equal(claims?.sub, "U1", "the renewed cookie is valid and preserves the sub");
-  assert.ok((claims?.exp ?? 0) > Math.floor(Date.now() / 1000) + 28000, "exp is pushed out to ~now + full TTL");
+  assert.ok(
+    (claims?.exp ?? 0) > Math.floor(Date.now() / 1000) + SESSION_TTL_S - 800,
+    "exp is pushed out to ~now + full TTL",
+  );
 });
 
 test("admin-status probe is memoized within the TTL (one round-trip per sub)", async () => {


### PR DESCRIPTION
## What changed

The portal's default browser-session lifetimes go up.

| | before | after |
|---|---|---|
| `PORTAL_SESSION_TTL_S` (rolling; renewed on activity after half elapses) | `28800` (8 h) | `604800` (7 d) |
| `PORTAL_SESSION_MAX_TTL_S` default (absolute cap from authentication) | `max(86400, TTL)` (24 h) | `max(2592000, TTL)` (30 d) |
| renewal point | `floor(TTL / 2)` | unchanged |

Both env vars still override the defaults exactly as before, and boot still refuses a max below the rolling TTL.

## Why

With the built-in email auth broker there is no upstream identity-provider session behind the portal cookie, so every portal expiry costs the user a fresh emailed sign-in link. At 8 h / 24 h that is a link nearly every day, which is too aggressive for a default. Seven days rolling with a 30-day hard cap keeps the absolute bound while making the common case (daily use) stay signed in.

## Every instance, not just the constant

- `plugins/portal/src/index.ts` — the two defaults.
- `deploy/portal/fly.toml` and `cli/templates/fly/portal.toml` — both templates pinned `PORTAL_SESSION_TTL_S = "28800"` into the `[env]` block, and the CLI copies that block verbatim into every derived Fly machine env. Left in place, the old lifetime would have survived on every Fly deployment regardless of the code default. The pin is removed so the code default governs; operators who want a different value set `env.portal.PORTAL_SESSION_TTL_S` in their deployment config, which already flows into the derived toml.
- `plugins/portal/README.md` — the two places that documented 8 h / 24 h / "one day".
- `plugins/portal/test/router.test.ts`, `plugins/portal/test/playground.test.ts` — the sliding-renewal tests aged a cookie past 4 h assuming the implicit 8 h default; they now pin `PORTAL_SESSION_TTL_S` themselves and derive their fixtures from it, so they test the renewal mechanism rather than whichever default is current.
- `plugins/portal/test/local-auth-bypass.test.ts` — runs with the TTL unset, so it now asserts the minted cookie's `Max-Age=604800`; a silent revert of the default fails a test.
- `plugins/portal/test/entry.test.ts` — the boot check that probes "TTL above the default max cap still boots" used 604800, which is no longer above the cap; it now uses 5184000.

Unrelated `86400`/`28800` occurrences (favicon cache max-age, playground mint window, turn wall-clock bounds, OAuth token fixtures, microvm durations) were reviewed and left alone.

## Trade-offs surfaced in review (unchanged here, flagged for the maintainer)

- The allow-list (`OIDC_ALLOWED_EMAILS` / domain) is checked only at sign-in, so removing someone now leaves an existing session valid for up to 7 days rolling / 30 days absolute instead of 8 h / 24 h. Re-checking the rule at renewal would close that, but the session subject is not always an email (`OIDC_PRINCIPAL_CLAIM=sub`, Slack team pins, playground guests), so it is left as a follow-up rather than folded in.
- Playground anonymous guests inherit the same rolling TTL, so a try-it deployment keeps a guest scope alive for a week instead of 8 h.

## Verification

- `plugins/portal`: `npm run typecheck` clean, `npm test` 124/124.
- `cli`: `npm run typecheck` clean, `npm test` 539/539 (includes the derive-byte-for-byte check against the checked-in Fly tomls).
- root `prettier --check`, `eslint`, `oxlint --deny-warnings` clean on the touched paths.
- Independent fresh-context review: no bugs; findings were the two trade-offs above plus the missing default assertion, which is now added.
