### PR TITLE
Fix Codex JSON-RPC framing for Unicode line separators

### DIFF
--- a/src/harness/codex-app-server.ts
+++ b/src/harness/codex-app-server.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { createInterface } from "node:readline";
 import { errMessage } from "../util/errors.ts";
 
 export class CodexRpcError extends Error {
@@ -151,14 +150,24 @@ export class CodexAppServer {
     this.processClosed = new Promise<void>((resolve) => {
       resolveProcessClosed = resolve;
     });
-    const lines = createInterface({ input: this.process.stdout! });
-    lines.on("line", (line) => {
+    let pendingOutput = "";
+    const receiveLine = (line: string) => {
       this.eventTail = this.eventTail
         .then(() => this.receive(line))
         .catch((error) => {
           this.failAll(error instanceof Error ? error : new Error(String(error)));
           this.process.kill("SIGTERM");
         });
+    };
+    this.process.stdout!.setEncoding("utf8");
+    this.process.stdout!.on("data", (chunk: string) => {
+      const lines = (pendingOutput + chunk).split("\n");
+      pendingOutput = lines.pop()!;
+      for (const line of lines) receiveLine(line);
+    });
+    this.process.stdout!.on("end", () => {
+      if (pendingOutput) receiveLine(pendingOutput);
+      pendingOutput = "";
     });
     this.process.stderr?.on("data", (chunk: Buffer) => {
       this.stderr = `${this.stderr}${chunk.toString()}`.slice(-16_384);

--- a/test/codex-app-server.test.ts
+++ b/test/codex-app-server.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CodexAppServer } from "../src/harness/codex-app-server.ts";
+
+const cases = [
+  { name: "U+2028 inside strings", text: "before\u2028after", ending: "\n", fragmented: false },
+  { name: "U+2029 inside strings", text: "before\u2029after", ending: "\n", fragmented: false },
+  { name: "split UTF-8 and CRLF frames", text: '界🙂\u2028\u2029\n\r\\quoted"', ending: "\r\n", fragmented: true },
+  { name: "an unterminated final frame at EOF", text: "before\u2028after", ending: "", fragmented: true },
+];
+
+for (const { name, text, ending, fragmented } of cases) {
+  test(`Codex JSON-RPC preserves ${name}`, async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "qm-codex-framing-"));
+    const binary = join(dir, "codex");
+    writeFileSync(
+      binary,
+      `#!${process.execPath}
+const readline = require("node:readline");
+readline.createInterface({ input: process.stdin }).on("line", line => {
+  const request = JSON.parse(line);
+  const text = ${JSON.stringify(text)};
+  const data = Buffer.from(
+    JSON.stringify({ method: "rawResponseItem/completed", params: { output: text } }) + "\\n" +
+    JSON.stringify({ id: request.id, result: { text } }) + ${JSON.stringify(ending)}
+  );
+  const split = ${fragmented} ? data.indexOf(Buffer.from(JSON.stringify(text).slice(1, -1))) + 1 : data.length;
+  process.stdout.write(data.subarray(0, split));
+  setTimeout(() => {
+    process.stdout.write(data.subarray(split));
+    if (${ending === ""}) process.stdout.end();
+  }, 20);
+});
+`,
+    );
+    chmodSync(binary, 0o755);
+    const notifications: unknown[] = [];
+    const server = new CodexAppServer({
+      binaryPath: binary,
+      cwd: dir,
+      onNotification: (_method, params) => {
+        notifications.push(params);
+      },
+      onRequest: async () => ({}),
+    });
+    t.after(async () => {
+      await server.close();
+      rmSync(dir, { recursive: true, force: true });
+    });
+    assert.deepEqual(await server.request("test"), { text });
+    assert.deepEqual(notifications, [{ output: text }]);
+    if (ending) assert.deepEqual(await server.request("test"), { text });
+    assert.equal(server.error(), null);
+  });
+}


### PR DESCRIPTION
## Summary

Fix Codex JSON-RPC framing so literal Unicode line and paragraph separators inside JSON strings cannot terminate a session.

`node:readline` splits U+2028 and U+2029 on the tested Node runtime. Both are legal unescaped characters in JSON strings. Splitting a notification at either character produces an apparent parse error, triggers subprocess termination, and can make retries fail again when the same content is replayed.

Replace the stdout line reader with UTF-8 decoding and ASCII-LF-only framing. Keep notification ordering, CRLF compatibility, and handling of a final unterminated frame at EOF. No content sanitization or unrelated runtime lifecycle changes.

## Verification

- 75 affected tests pass; typecheck and lint pass.
- Synthetic subprocess regression tests cover U+2028, U+2029, coalesced frames, fragmented UTF-8, CRLF, EOF, and subsequent requests.
- Reproduced against a native Codex app-server: valid LF-delimited JSON fails with the old reader and survives unchanged with this fix.
- Independent adversarial review found no blockers in the framing change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791588244&installation_model_id=19911&pr_number=1034&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1034&signature=7d936a7fe54fb3e41d858e28c6922e9381aec7cdfd7710097ba21012f88a8a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->