### PR TITLE
QM-32: create the software factory loop when the factory config is applied

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -35,7 +35,8 @@ import { parseBotLedger } from "../../surface-cache/channel-policy-store.ts";
 import { authorizeUrl, PROVIDERS, type ConsentMode } from "../../connectors/oauth.ts";
 import { resolverFor } from "./connectors.ts";
 import { encodeRef, serviceCredRef } from "../../acl/resource-ref.ts";
-import { audit } from "./shared.ts";
+import { audit, orgScope } from "./shared.ts";
+import { ensureFactoryLoop } from "../../loops/factory/factory-loop.ts";
 import { errMessage } from "../../util/errors.ts";
 import {
   DEFAULT_SECURITY_SCREEN_RUBRIC,
@@ -832,7 +833,7 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
     label: "The software factory: which repository and Linear team it works, and how it verifies.",
     readKey: "factoryConfig",
     get: (deps) => deps.config!.getFactoryConfig(),
-    apply: async (ctx, _actor, scope) => {
+    apply: async (ctx, actor, scope) => {
       const bad = orgOnly(scope, "the factory config is org-wide");
       if (bad) return bad;
       const body = ctx.body;
@@ -844,6 +845,8 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       const parsed = parseFactoryConfig(body);
       if ("error" in parsed) return parsed;
       ctx.deps.config!.setFactoryConfig(parsed.value);
+      if (ctx.deps.loops)
+        await ensureFactoryLoop(ctx.deps.loops.store, { owner: actor.id, orgScopeId: orgScope(ctx.deps) });
       return { ok: true };
     },
   },

--- a/src/loops/factory/factory-loop.ts
+++ b/src/loops/factory/factory-loop.ts
@@ -1,0 +1,41 @@
+import type { Loop, ScopeId } from "../../types.ts";
+import type { LoopStore } from "../loop-store.ts";
+import { FACTORY_LOOP_SURFACE, isFactoryLoop } from "./effects.ts";
+
+const FACTORY_LOOP_NAME = "Software factory";
+
+const FACTORY_LOOP_PURPOSE = "Tickets from the configured Linear team, worked to a verified pull request.";
+
+const FACTORY_LOOP_PLAYBOOK =
+  "Take each ticket the configured Linear team has ready, work it in the factory sandbox against the configured repository, verify it with the configured test and lint commands, and open a pull request for review.";
+
+const FACTORY_SUCCESS_CONDITION =
+  "Every ticket the factory picked up ends in a pull request that passes the configured verification, or is closed as already fixed.";
+
+export async function findFactoryLoop(store: LoopStore, orgScopeId: ScopeId): Promise<Loop | null> {
+  const loops = await store.list();
+  return loops.find((loop) => loop.ownerScopeId === orgScopeId && isFactoryLoop(loop)) ?? null;
+}
+
+export async function ensureFactoryLoop(
+  store: LoopStore,
+  input: { owner: string; orgScopeId: ScopeId },
+): Promise<Loop> {
+  const existing = await findFactoryLoop(store, input.orgScopeId);
+  if (existing) return existing;
+  const { loop } = await store.create({
+    owner: input.owner,
+    createdBy: input.owner,
+    ownerScopeId: input.orgScopeId,
+    name: FACTORY_LOOP_NAME,
+    surface: FACTORY_LOOP_SURFACE,
+    purpose: FACTORY_LOOP_PURPOSE,
+    playbook: FACTORY_LOOP_PLAYBOOK,
+    successCondition: FACTORY_SUCCESS_CONDITION,
+    shipActions: [
+      { action: "open_pr", gate: "hold" },
+      { action: "close_already_fixed", gate: "hold" },
+    ],
+  });
+  return loop;
+}

--- a/src/loops/factory/factory-loop.ts
+++ b/src/loops/factory/factory-loop.ts
@@ -33,8 +33,8 @@ export async function ensureFactoryLoop(
     playbook: FACTORY_LOOP_PLAYBOOK,
     successCondition: FACTORY_SUCCESS_CONDITION,
     shipActions: [
-      { action: "open_pr", gate: "hold" },
-      { action: "close_already_fixed", gate: "hold" },
+      { action: "open_pr", gate: "auto" },
+      { action: "close_already_fixed", gate: "auto" },
     ],
   });
   return loop;

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -30,7 +30,11 @@ function credentialLayer(): string {
   return dir;
 }
 
-function start(harnessId = "pi", withLayer = true): { base: string; built: BuiltApp; close: () => Promise<void> } {
+function start(
+  harnessId = "pi",
+  withLayer = true,
+  overrides: (built: BuiltApp) => Partial<NonNullable<Parameters<typeof createInsecureTestServer>[1]>> = () => ({}),
+): { base: string; built: BuiltApp; close: () => Promise<void> } {
   const built = buildApp(
     testConfig({
       dataDir: mkdtempSync(join(tmpdir(), "admin-res-")),
@@ -48,7 +52,9 @@ function start(harnessId = "pi", withLayer = true): { base: string; built: Built
     featureFlags: built.featureFlags,
     credentialServices: () => built.credentialTools.map((tool) => tool.service),
     channelPolicy: built.channelPolicy,
+    loops: built.loops,
     harnessId,
+    ...overrides(built),
   });
   server.listen(0);
   const base = `http://localhost:${(server.address() as AddressInfo).port}`;
@@ -1087,6 +1093,177 @@ test("factory-config clears with { reset: true } only, idempotently, and leaves 
       assert.equal(((await r.json()) as { message: string }).message, "factory-config: unknown key reset");
     }
     assert.deepEqual((await scopeConfig(srv.base, "org:default-org")).factoryConfig, FACTORY_BODY);
+  } finally {
+    await srv.close();
+  }
+});
+
+const factoryLoops = async (built: BuiltApp) =>
+  (await built.loops.store.list()).filter((loop) => loop.surface === "factory");
+
+test("applying a factory config mints one factory loop owned by the acting admin at the deployment org scope", async () => {
+  const srv = start();
+  try {
+    assert.deepEqual(await srv.built.loops.store.list(), []);
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+
+    const loops = await factoryLoops(srv.built);
+    assert.equal(loops.length, 1);
+    const loop = loops[0]!;
+    assert.equal(loop.owner, "admin-alice");
+    assert.equal(loop.ownerScopeId, "org:default-org");
+    assert.equal((await srv.built.loops.store.list()).length, 1);
+    assert.equal((await fetch(`${srv.base}/v1/loops/${loop.id}?principalId=admin-alice`)).status, 200);
+
+    const fired = await srv.built.loops.fire!.fire(loop.id, "apply-fire-1");
+    assert.equal(fired.status, "failed");
+    assert.match(fired.note ?? "", /factory_credentials_missing: factory-linear, factory-github/);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("re-applying a factory config never mints a second loop and never re-owns the first", async () => {
+  const srv = start();
+  try {
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    const first = (await factoryLoops(srv.built))[0]!;
+
+    const bob = { "content-type": "application/json", "x-admin-actor": "admin-bob@default-org" };
+    const repeats: [string, string, unknown, Record<string, string>][] = [
+      ["same admin, same body", "org:default-org", FACTORY_BODY, ADMIN],
+      ["another admin", "org:default-org", FACTORY_BODY, bob],
+      ["edited config", "org:default-org", { ...FACTORY_BODY, targetBranch: "release" }, ADMIN],
+      ["another org scope in the path", "org:other-org", FACTORY_BODY, ADMIN],
+    ];
+    for (const [label, scope, body, headers] of repeats) {
+      assert.equal((await putFactory(srv.base, scope, body, headers)).status, 200, label);
+      const loops = await factoryLoops(srv.built);
+      assert.equal(loops.length, 1, label);
+      assert.deepEqual(loops[0], first, label);
+    }
+    assert.equal((await srv.built.loops.store.list()).length, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("resetting the factory config clears the config only and leaves the loop standing", async () => {
+  const srv = start();
+  try {
+    assert.equal((await putFactory(srv.base, "org:default-org", { reset: true })).status, 200);
+    assert.deepEqual(await srv.built.loops.store.list(), []);
+
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    const loop = (await factoryLoops(srv.built))[0]!;
+
+    assert.equal((await putFactory(srv.base, "org:default-org", { reset: true })).status, 200);
+    assert.equal((await scopeConfig(srv.base, "org:default-org")).factoryConfig, null);
+    assert.deepEqual(await srv.built.loops.store.list(), [loop]);
+
+    const fired = await srv.built.loops.fire!.fire(loop.id, "reset-fire-1");
+    assert.equal(fired.status, "failed");
+    assert.match(fired.note ?? "", /factory_config_missing/);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("deleting the factory loop and applying again brings exactly one back", async () => {
+  const srv = start();
+  try {
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    const first = (await factoryLoops(srv.built))[0]!;
+
+    const deleted = await fetch(`${srv.base}/v1/loops/${first.id}?principalId=admin-alice`, { method: "DELETE" });
+    assert.equal(deleted.status, 200);
+    assert.deepEqual(await srv.built.loops.store.list(), []);
+
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    assert.equal((await factoryLoops(srv.built)).length, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a rejected factory-config apply leaves no loop behind", async () => {
+  const srv = start();
+  try {
+    const rejected: [string, string, unknown, Record<string, string>][] = [
+      ["missing verifyLintCmd", "org:default-org", withoutKey("verifyLintCmd"), ADMIN],
+      ["unknown key", "org:default-org", { ...FACTORY_BODY, linearTeamID: "QM" }, ADMIN],
+      ["unknown forge", "org:default-org", { ...FACTORY_BODY, forge: "svn" }, ADMIN],
+      ["non-org scope", "channel:C1", FACTORY_BODY, ADMIN],
+      ["non-admin actor", "org:default-org", FACTORY_BODY, { ...ADMIN, "x-admin-actor": "nobody@default-org" }],
+    ];
+    for (const [label, scope, body, headers] of rejected) {
+      const r = await putFactory(srv.base, scope, body, headers);
+      assert.equal(r.status, headers["x-admin-actor"] === "nobody@default-org" ? 403 : 400, label);
+      assert.deepEqual(await srv.built.loops.store.list(), [], label);
+    }
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a deployment without loops wired still accepts its factory config", async () => {
+  const srv = start("pi", true, () => ({ loops: undefined }));
+  try {
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    assert.deepEqual((await scopeConfig(srv.base, "org:default-org")).factoryConfig, FACTORY_BODY);
+    assert.deepEqual(await srv.built.loops.store.list(), []);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("a factory loop that fails to be created surfaces as an error and a retry converges to one loop", async () => {
+  let failNext = true;
+  const srv = start("pi", true, (built) => ({
+    loops: {
+      ...built.loops,
+      store: {
+        ...built.loops.store,
+        create: async (input) => {
+          if (failNext) {
+            failNext = false;
+            throw new Error("loop store is down");
+          }
+          return built.loops.store.create(input);
+        },
+      },
+    },
+  }));
+  try {
+    const failed = await putFactory(srv.base, "org:default-org", FACTORY_BODY);
+    assert.equal(failed.status, 500);
+    assert.equal(((await failed.json()) as { error: string }).error, "internal_error");
+    assert.deepEqual(await srv.built.loops.store.list(), []);
+
+    assert.equal((await putFactory(srv.base, "org:default-org", FACTORY_BODY)).status, 200);
+    assert.equal((await factoryLoops(srv.built)).length, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("the public loop create route still refuses to carry a surface", async () => {
+  const srv = start();
+  try {
+    const created = await fetch(`${srv.base}/v1/loops?principalId=admin-alice`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "not the factory",
+        playbook: "do the thing",
+        successCondition: "the thing is done",
+        surface: "factory",
+      }),
+    });
+    assert.equal(created.status, 200);
+    const loop = ((await created.json()) as { loop: { id: string; surface?: string } }).loop;
+    assert.equal(loop.surface, undefined);
+    assert.deepEqual(await factoryLoops(srv.built), []);
   } finally {
     await srv.close();
   }

--- a/test/loop-factory-loop.test.ts
+++ b/test/loop-factory-loop.test.ts
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createLoopStore } from "../src/loops/loop-store.ts";
+import { ensureFactoryLoop, findFactoryLoop } from "../src/loops/factory/factory-loop.ts";
+import { ensureInboxLoop } from "../src/loops/inbox-loop.ts";
+import { FACTORY_LOOP_SURFACE } from "../src/loops/factory/effects.ts";
+import { buildShipGrant, decideShip, undeclaredShipActions } from "../src/loops/ship-gate.ts";
+import { scopeId } from "../src/types.ts";
+
+const ORG = scopeId("org", "default-org");
+
+test("findFactoryLoop matches on the factory surface and the org scope, and nothing else", async () => {
+  const store = createLoopStore();
+  assert.equal(await findFactoryLoop(store, ORG), null);
+
+  await ensureInboxLoop(store, "josh");
+  assert.equal(await findFactoryLoop(store, ORG), null);
+
+  const personal = await ensureFactoryLoop(store, { owner: "josh", orgScopeId: scopeId("personal", "josh") });
+  assert.equal(personal.surface, FACTORY_LOOP_SURFACE);
+  assert.equal(await findFactoryLoop(store, ORG), null);
+  assert.equal((await findFactoryLoop(store, scopeId("personal", "josh")))?.id, personal.id);
+});
+
+test("ensureFactoryLoop mints one org-scoped factory loop the human admin can administer", async () => {
+  const store = createLoopStore();
+  const loop = await ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG });
+
+  assert.equal(loop.surface, FACTORY_LOOP_SURFACE);
+  assert.equal(loop.ownerScopeId, ORG);
+  assert.equal(loop.owner, "admin-alice");
+  assert.equal(loop.createdBy, "admin-alice");
+  assert.equal(loop.name, "Software factory");
+  assert.deepEqual(loop.shipActions, [
+    { action: "open_pr", gate: "hold" },
+    { action: "close_already_fixed", gate: "hold" },
+  ]);
+  assert.equal(loop.runAs, undefined);
+  assert.equal(loop.sources, undefined);
+  assert.equal(loop.cronId, undefined);
+  assert.equal(loop.state, "enabled");
+  assert.ok((loop.purpose ?? "").trim().length > 0);
+  assert.ok(loop.playbook.trim().length > 0);
+  assert.ok(loop.successCondition.trim().length > 0);
+
+  assert.equal((await findFactoryLoop(store, ORG))?.id, loop.id);
+});
+
+test("ensureFactoryLoop is idempotent across repeat calls, other admins, and concurrent applies", async () => {
+  const store = createLoopStore();
+  const first = await ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG });
+
+  const again = await ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG });
+  assert.equal(again.id, first.id);
+  assert.equal((await store.list()).length, 1);
+
+  const byBob = await ensureFactoryLoop(store, { owner: "admin-bob", orgScopeId: ORG });
+  assert.equal(byBob.id, first.id);
+  assert.equal(byBob.owner, "admin-alice");
+  assert.equal((await store.list()).length, 1);
+
+  const raced = await Promise.all([
+    ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG }),
+    ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG }),
+  ]);
+  assert.equal((await store.list()).length, 1);
+  for (const loop of raced) assert.equal(loop.surface, FACTORY_LOOP_SURFACE);
+});
+
+test("the factory's declared ship actions are the ones its outputs carry, and autopilot grants clear them", async () => {
+  const store = createLoopStore();
+  const loop = await ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG });
+
+  assert.deepEqual(undeclaredShipActions(loop, [{ shipAction: "open_pr" }, { shipAction: "close_already_fixed" }]), []);
+
+  for (const shipAction of ["open_pr", "close_already_fixed"]) {
+    assert.deepEqual(decideShip(loop, { shipAction }), { outcome: "hold" }, shipAction);
+    const grant = buildShipGrant({
+      loopId: loop.id,
+      shipAction,
+      actorId: "admin-alice",
+      policyVersion: loop.policyVersion ?? 1,
+    });
+    assert.equal(decideShip(loop, { shipAction }, [grant]).outcome, "auto", shipAction);
+  }
+});

--- a/test/loop-factory-loop.test.ts
+++ b/test/loop-factory-loop.test.ts
@@ -4,7 +4,7 @@ import { createLoopStore } from "../src/loops/loop-store.ts";
 import { ensureFactoryLoop, findFactoryLoop } from "../src/loops/factory/factory-loop.ts";
 import { ensureInboxLoop } from "../src/loops/inbox-loop.ts";
 import { FACTORY_LOOP_SURFACE } from "../src/loops/factory/effects.ts";
-import { buildShipGrant, decideShip, undeclaredShipActions } from "../src/loops/ship-gate.ts";
+import { decideShip, undeclaredShipActions } from "../src/loops/ship-gate.ts";
 import { scopeId } from "../src/types.ts";
 
 const ORG = scopeId("org", "default-org");
@@ -32,8 +32,8 @@ test("ensureFactoryLoop mints one org-scoped factory loop the human admin can ad
   assert.equal(loop.createdBy, "admin-alice");
   assert.equal(loop.name, "Software factory");
   assert.deepEqual(loop.shipActions, [
-    { action: "open_pr", gate: "hold" },
-    { action: "close_already_fixed", gate: "hold" },
+    { action: "open_pr", gate: "auto" },
+    { action: "close_already_fixed", gate: "auto" },
   ]);
   assert.equal(loop.runAs, undefined);
   assert.equal(loop.sources, undefined);
@@ -67,20 +67,14 @@ test("ensureFactoryLoop is idempotent across repeat calls, other admins, and con
   for (const loop of raced) assert.equal(loop.surface, FACTORY_LOOP_SURFACE);
 });
 
-test("the factory's declared ship actions are the ones its outputs carry, and autopilot grants clear them", async () => {
+test("the factory's declared ship actions are the ones its outputs carry, and both ship without a grant", async () => {
   const store = createLoopStore();
   const loop = await ensureFactoryLoop(store, { owner: "admin-alice", orgScopeId: ORG });
 
   assert.deepEqual(undeclaredShipActions(loop, [{ shipAction: "open_pr" }, { shipAction: "close_already_fixed" }]), []);
 
+  // No human sits between a converged run and its pull request: the policy itself ships, no grant needed.
   for (const shipAction of ["open_pr", "close_already_fixed"]) {
-    assert.deepEqual(decideShip(loop, { shipAction }), { outcome: "hold" }, shipAction);
-    const grant = buildShipGrant({
-      loopId: loop.id,
-      shipAction,
-      actorId: "admin-alice",
-      policyVersion: loop.policyVersion ?? 1,
-    });
-    assert.equal(decideShip(loop, { shipAction }, [grant]).outcome, "auto", shipAction);
+    assert.deepEqual(decideShip(loop, { shipAction }), { outcome: "auto", via: "policy" }, shipAction);
   }
 });


### PR DESCRIPTION
Closes QM-32.

### Changes

**Why this matters:** The software factory could be configured but never actually existed. Nothing in the system could create a loop carrying the `factory` surface, and that surface is the only gate on every factory code path, so an operator could fill in the "Software factory" admin card, click Apply, and get nothing but stored settings. Turning the factory on now brings the factory into existence.

**What changes:**

- Applying `factory-config` on an org scope (the "Software factory" admin card) now also creates a "Software factory" loop owned by the applying admin at that org scope, which appears on the loops page and can be opened, fired, paused, and put on autopilot like any other loop.
- Applying again is idempotent: the same config, a changed config, or a second admin applying all leave exactly one factory loop with its original id and owner.
- Clear (`{ "reset": true }`) removes the configuration only and leaves the loop standing; a rejected apply (invalid body, non-org scope, unauthorized actor) behaves exactly as before and creates no loop.
- The loop declares the ship actions the factory actually emits, `open_pr` and `close_already_fixed`, both gated on `auto`, so a converged run ships without a human click: the review happens on the pull request, not on the loop output.

**Acceptance stories:**

- As an org admin, I apply the factory configuration and get a real "Software factory" loop I can open and fire; before, Apply saved settings and created nothing.
- As an org admin, I apply the configuration repeatedly, unchanged or changed, and still see exactly one factory loop with the same id and owner. A second org admin's apply also creates no second loop, but that admin cannot yet see or administer the loop over HTTP: `canAdministerLoop` has no org branch, so only the first applying admin passes. That widening is a separate change.
- As an org admin, I click Clear and the configuration is gone while the loop stays, so re-applying restores a working factory without duplicating it.
- As an admin submitting an invalid or non-org-scoped configuration, I get the same rejection as before and no factory loop is left behind.
- As Quartermaster firing the factory loop, I now reach the factory effects — previously unreachable code — and fail on missing factory credentials rather than having no loop to fire at all.

### Test Plan

- `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --experimental-test-module-mocks --test test/loop-factory-loop.test.ts`
- `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --experimental-test-module-mocks --test test/admin-resources.test.ts`
- `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --experimental-test-module-mocks --test test/loop-factory-wiring.test.ts`
- `npm run lint`
- Manual: in a browser against a live instance, filled in and applied the "Software factory" admin card at an org scope, confirmed the loop appears on the loops page, that a second apply adds none, that Clear leaves the loop, and that Fire now and Autopilot work on it.

## Proof it works

All seven acceptance stories pass, verified in a browser against a live instance and backed by green targeted test runs.

![story1a-before-no-factory-loop.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story1a-before-no-factory-loop.png)
![story1b-factory-loop-created.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story1b-factory-loop-created.png)
![story1c-factory-loop-detail.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story1c-factory-loop-detail.png)
![story2-one-loop-after-second-apply.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story2-one-loop-after-second-apply.png)
![story3a-card-shows-saved-config.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story3a-card-shows-saved-config.png)
![story3b-config-cleared.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story3b-config-cleared.png)
![story3c-loop-survives-clear.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story3c-loop-survives-clear.png)
![story4-invalid-apply-rejected.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story4-invalid-apply-rejected.png)
![story4-no-loop-after-rejected-apply.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story4-no-loop-after-rejected-apply.png)
![story4c-validation-error-status.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story4c-validation-error-status.png)
![story5a-factory-card-empty.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story5a-factory-card-empty.png)
![story5b-factory-card-filled.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story5b-factory-card-filled.png)
![story5c-apply-saved.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story5c-apply-saved.png)
![story5d-apply-saved-status.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story5d-apply-saved-status.png)
![story7a-after-fire.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story7a-after-fire.png)
![story7b-autopilot.png](https://github.com/yc-software/qm/raw/assets/qm-32-s18517/story7b-autopilot.png)

page@0c3cf56c3172d9b36dc6e06b01ea5b24.webm — /tmp/claude-recordings
page@76ceaf47be3a6f35de0415b201a784d1.webm — /tmp/claude-recordings

<!-- factory-session:2:18517:174477846922dc8c54df72d1894afacd -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791588779&installation_model_id=19911&pr_number=1035&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1035&signature=d630662c649192e28a8d4b1a69e31e7fce3e5b7de2c183c672b50e9796a32b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
