### PR TITLE
QM-31: Bootstrap the factory source clone separately from the work repo

### DIFF
--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -13,7 +13,7 @@ import type { SuccessVerdict } from "../success-evaluation.ts";
 import { createSweeper } from "../../util/sweeper.ts";
 import { swallow } from "../../util/errors.ts";
 import { shq } from "../../util/shell.ts";
-import { awaitProcessExit } from "../../sandbox/await-process-exit.ts";
+import { pollProcess } from "../../sandbox/process-poll.ts";
 import { enumerateFactoryCandidates } from "./linear-intake.ts";
 import { readFactoryCredentials } from "./credentials.ts";
 import { preflightFactorySandbox, type PreflightResult } from "./preflight.ts";
@@ -107,12 +107,18 @@ async function bootstrapFactorySource(sandbox: Sandbox, handle: SandboxHandle, g
   const { processId } = await sandbox.startProcess(handle, FACTORY_SOURCE_BOOTSTRAP_SCRIPT, {
     env: factorySourceGitEnv(githubToken),
   });
-  const status = await awaitProcessExit(sandbox, handle, processId, FACTORY_SOURCE_BOOTSTRAP_TIMEOUT_MS);
+  const { output, status } = await pollProcess(sandbox, handle, processId, {
+    deadlineMs: FACTORY_SOURCE_BOOTSTRAP_TIMEOUT_MS,
+    collect: true,
+  });
+  // Auth failures, a missing branch, and a missing repository all exit 128; only git's own words tell them apart.
+  const tail = output.replaceAll(githubToken, "***").trim().split("\n").slice(-5).join(" | ");
+  const detail = (reason: string): string => `factory_source_bootstrap_failed: ${reason}${tail ? ` — ${tail}` : ""}`;
   if (status.state !== "exited") {
     await sandbox.signalProcess(handle, processId, "TERM").catch((e: unknown) => swallow("factory bootstrap term", e));
-    throw new Error("factory_source_bootstrap_failed: timeout");
+    throw new Error(detail("timeout"));
   }
-  if (status.code !== 0) throw new Error(`factory_source_bootstrap_failed: exit ${status.code}`);
+  if (status.code !== 0) throw new Error(detail(`exit ${status.code}`));
 }
 
 export async function loadFactoryContext(deps: FactoryEffectsDeps): Promise<FactoryContext> {

--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -1,4 +1,9 @@
-import type { Sandbox, SandboxHandle } from "../../sandbox/sandbox.ts";
+import {
+  CapabilityUnsupportedError,
+  supportsProcessSessions,
+  type Sandbox,
+  type SandboxHandle,
+} from "../../sandbox/sandbox.ts";
 import type { FactoryConfig, ScopedConfigStore } from "../../resolution/config-store.ts";
 import type { ServiceCredentialReader } from "../../credentials/keychain.ts";
 import type { Loop, LoopItem, ScopeId } from "../../types.ts";
@@ -7,6 +12,8 @@ import type { CapturedArtifact, LoopRunnerEffects } from "../runner.ts";
 import type { SuccessVerdict } from "../success-evaluation.ts";
 import { createSweeper } from "../../util/sweeper.ts";
 import { swallow } from "../../util/errors.ts";
+import { shq } from "../../util/shell.ts";
+import { awaitProcessExit } from "../../sandbox/await-process-exit.ts";
 import { enumerateFactoryCandidates } from "./linear-intake.ts";
 import { readFactoryCredentials } from "./credentials.ts";
 import { preflightFactorySandbox, type PreflightResult } from "./preflight.ts";
@@ -17,6 +24,23 @@ import type { ForgeRef } from "./ship.ts";
 
 const DEFAULT_FACTORY_REPO_DIR = "/workspace/repo";
 const DEFAULT_PAUSE_POLL_MS = 30_000;
+
+const FACTORY_SOURCE_CLONE_DIR = "/workspace/qm-yc";
+const FACTORY_SOURCE_CLONE_URL = "https://github.com/yc-software/qm-yc.git";
+const FACTORY_SOURCE_BOOTSTRAP_TIMEOUT_MS = 300_000;
+
+export const FACTORY_SOURCE_DIR = `${FACTORY_SOURCE_CLONE_DIR}/layer/factory`;
+export const FACTORY_SOURCE_BRANCH = "qm-30-s18477";
+
+const FACTORY_SOURCE_BOOTSTRAP_SCRIPT = [
+  "set -e;",
+  `if [ -d ${shq(`${FACTORY_SOURCE_CLONE_DIR}/.git`)} ]; then`,
+  `git -C ${shq(FACTORY_SOURCE_CLONE_DIR)} fetch --depth 1 origin ${shq(FACTORY_SOURCE_BRANCH)};`,
+  `git -C ${shq(FACTORY_SOURCE_CLONE_DIR)} checkout -f FETCH_HEAD;`,
+  "else",
+  `git clone --depth 1 --single-branch --branch ${shq(FACTORY_SOURCE_BRANCH)} ${shq(FACTORY_SOURCE_CLONE_URL)} ${shq(FACTORY_SOURCE_CLONE_DIR)};`,
+  "fi",
+].join(" ");
 
 export const FACTORY_LOOP_SURFACE = "factory";
 
@@ -69,6 +93,28 @@ const prTarget = (artifacts: CapturedArtifact[], config: FactoryConfig): { ref: 
   return pr?.label && ref ? { ref, branch: pr.label } : null;
 };
 
+const factorySourceGitEnv = (githubToken: string): Record<string, string> => ({
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_CONFIG_COUNT: "1",
+  GIT_CONFIG_KEY_0: `url.https://x-access-token:${githubToken}@github.com/.insteadOf`,
+  GIT_CONFIG_VALUE_0: "https://github.com/",
+});
+
+async function bootstrapFactorySource(sandbox: Sandbox, handle: SandboxHandle, githubToken: string): Promise<void> {
+  if (!supportsProcessSessions(sandbox)) {
+    throw new CapabilityUnsupportedError(sandbox.profile.backend, "process sessions");
+  }
+  const { processId } = await sandbox.startProcess(handle, FACTORY_SOURCE_BOOTSTRAP_SCRIPT, {
+    env: factorySourceGitEnv(githubToken),
+  });
+  const status = await awaitProcessExit(sandbox, handle, processId, FACTORY_SOURCE_BOOTSTRAP_TIMEOUT_MS);
+  if (status.state !== "exited") {
+    await sandbox.signalProcess(handle, processId, "TERM").catch((e: unknown) => swallow("factory bootstrap term", e));
+    throw new Error("factory_source_bootstrap_failed: timeout");
+  }
+  if (status.code !== 0) throw new Error(`factory_source_bootstrap_failed: exit ${status.code}`);
+}
+
 export async function loadFactoryContext(deps: FactoryEffectsDeps): Promise<FactoryContext> {
   const config = deps.config.getFactoryConfig();
   if (!config) throw new Error("factory_config_missing");
@@ -112,12 +158,20 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
       let preflight: PreflightResult;
       try {
         preflight = await preflightFactorySandbox(deps.sandbox, preflightHandle);
+        if (preflight.ok) await bootstrapFactorySource(deps.sandbox, preflightHandle, githubToken);
       } finally {
         await teardownWarm(preflightHandle);
       }
       if (!preflight.ok) throw new Error(`factory_preflight_failed: ${preflightDetail(preflight)}`);
 
-      const env = renderFactoryEnv({ config, guidance, linearApiKey, githubToken, repoDir });
+      const env = renderFactoryEnv({
+        config,
+        guidance,
+        linearApiKey,
+        githubToken,
+        repoDir,
+        factorySourceDir: FACTORY_SOURCE_DIR,
+      });
 
       const controller = new AbortController();
       const pausePoll = createSweeper(
@@ -136,6 +190,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
           sandbox: deps.sandbox,
           scopeId: loop.ownerScopeId,
           repoDir,
+          factorySourceDir: FACTORY_SOURCE_DIR,
           ticketId: item.sourceKey,
           env,
           signal: controller.signal,

--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -16,10 +16,11 @@ export interface FactoryEnvInput {
   linearApiKey: string;
   githubToken: string;
   repoDir: string;
+  factorySourceDir: string;
 }
 
 export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string> {
-  const { config, guidance, linearApiKey, githubToken, repoDir } = input;
+  const { config, guidance, linearApiKey, githubToken, repoDir, factorySourceDir } = input;
   return {
     ...(guidance !== undefined ? { IO_FEEDBACK: guidance } : {}),
     IO_LINEAR_API_KEY: linearApiKey,
@@ -36,7 +37,7 @@ export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string>
     IO_VERIFY_TEST_FILE_CMD: config.verifyTestFileCmd,
     IO_VERIFY_LINT_CMD: config.verifyLintCmd,
     IO_REPO_DIR: repoDir,
-    IO_FACTORY_SOURCE_DIR: repoDir,
+    IO_FACTORY_SOURCE_DIR: factorySourceDir,
     IO_REPO_CLONE_URL: config.repoCloneUrl,
     ...(config.repoSetupCmd !== undefined ? { IO_REPO_SETUP_CMD: config.repoSetupCmd } : {}),
     ...(config.proofStartCmd !== undefined ? { IO_PROOF_START_CMD: config.proofStartCmd } : {}),
@@ -51,6 +52,7 @@ export interface FactoryProcessInput {
   sandbox: Sandbox;
   scopeId: ScopeId;
   repoDir: string;
+  factorySourceDir: string;
   ticketId: string;
   env: Record<string, string>;
   onChunk?: (chunk: string) => void;
@@ -68,7 +70,7 @@ export interface FactoryProcessResult {
 }
 
 export async function runFactoryProcess(input: FactoryProcessInput): Promise<FactoryProcessResult> {
-  const { scopeId, repoDir, ticketId, env, onChunk, signal } = input;
+  const { scopeId, repoDir, factorySourceDir, ticketId, env, onChunk, signal } = input;
   if (!TICKET_RE.test(ticketId)) throw new Error("factory_ticket_invalid");
   const sandbox = input.sandbox;
   if (!supportsProcessSessions(sandbox)) {
@@ -79,10 +81,14 @@ export async function runFactoryProcess(input: FactoryProcessInput): Promise<Fac
   const grace = input.termGraceMs ?? FACTORY_TERM_GRACE_MS;
   const handle = await sandbox.provision([{ scopeId, mode: "rw", mountPath: "" }]);
   try {
-    const { processId } = await sandbox.startProcess(handle, `bash ${FACTORY_WRAPPER} ${ticketId}`, {
-      cwd: repoDir,
-      env,
-    });
+    const { processId } = await sandbox.startProcess(
+      handle,
+      `bash ${factorySourceDir}/${FACTORY_WRAPPER} ${ticketId}`,
+      {
+        cwd: repoDir,
+        env,
+      },
+    );
     try {
       let cursor = 0;
       let stdout = "";

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -1,15 +1,22 @@
-import { test } from "node:test";
+import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createFactoryLoopEffects,
   loadFactoryContext,
+  FACTORY_SOURCE_BRANCH,
+  FACTORY_SOURCE_DIR,
   type FactoryContext,
   type FactoryEffectsDeps,
   type FactoryWorkEffects,
 } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
 import { FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
-import { renderFactoryEnv } from "../src/loops/factory/process-work.ts";
+import { FACTORY_WRAPPER, renderFactoryEnv } from "../src/loops/factory/process-work.ts";
+import { shq } from "../src/util/shell.ts";
 import { LINEAR_GRAPHQL_URL } from "../src/loops/factory/linear-intake.ts";
 import { FORGE_CHECKS } from "../src/loops/factory/forge-evaluate.ts";
 import type { DecryptedServiceCredential, ServiceCredentialReader } from "../src/credentials/keychain.ts";
@@ -28,6 +35,8 @@ const ORG_SCOPE = "org:acme";
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
 const REPO_DIR = "/workspace/repo";
+const CLONE_DIR = "/workspace/qm-yc";
+const CLONE_URL = "https://github.com/yc-software/qm-yc.git";
 const TICKET = "QM-12";
 
 const CONFIG: FactoryConfig = {
@@ -100,7 +109,13 @@ const OPEN_PR_ARTIFACT = {
 type Call =
   | { op: "provision"; layers: WorkspaceLayer[]; handle: SandboxHandle }
   | { op: "run"; handle: SandboxHandle; command: string }
-  | { op: "startProcess"; handle: SandboxHandle; command: string; opts: StartProcessOptions | undefined }
+  | {
+      op: "startProcess";
+      handle: SandboxHandle;
+      command: string;
+      opts: StartProcessOptions | undefined;
+      processId: string;
+    }
   | { op: "readProcess"; handle: SandboxHandle; processId: string }
   | { op: "signalProcess"; handle: SandboxHandle; processId: string; signal: string }
   | { op: "teardown"; handle: SandboxHandle; opts: TeardownOptions | undefined };
@@ -121,6 +136,7 @@ function fakeSandbox(
     probeMissing?: string[];
     stdout?: string;
     teardownError?: Error;
+    bootstrapExit?: number;
     read?: (n: number, calls: Call[]) => Promise<ReadProcessResult>;
   } = {},
 ): FakeSandbox {
@@ -134,6 +150,7 @@ function fakeSandbox(
       : { chunks: "", cursor: stdout.length, status: exited };
   const unused = (name: string) => () => Promise.reject(new Error(`the factory effects must not call ${name}`));
   let provisioned = 0;
+  let started = 0;
   const sandbox: Record<string, unknown> = {
     profile: {
       backend: "fake",
@@ -162,12 +179,18 @@ function fakeSandbox(
     listDir: unused("listDir"),
     removeDir: unused("removeDir"),
     startProcess: (handle: SandboxHandle, command: string, startOpts?: StartProcessOptions) => {
-      calls.push({ op: "startProcess", handle, command, opts: startOpts });
-      return Promise.resolve({ processId: "p1" });
+      started += 1;
+      const processId = `p${started}`;
+      calls.push({ op: "startProcess", handle, command, opts: startOpts, processId });
+      return Promise.resolve({ processId });
     },
     readProcess: (handle: SandboxHandle, processId: string) => {
       calls.push({ op: "readProcess", handle, processId });
-      const n = calls.filter((call) => call.op === "readProcess").length;
+      const start = calls.find((call) => call.op === "startProcess" && call.processId === processId);
+      if (start?.op === "startProcess" && !start.command.includes(FACTORY_WRAPPER)) {
+        return Promise.resolve({ chunks: "", cursor: 0, status: { state: "exited", code: opts.bootstrapExit ?? 0 } });
+      }
+      const n = calls.filter((call) => call.op === "readProcess" && call.processId === processId).length;
       return (opts.read ?? defaultRead)(n, calls);
     },
     writeStdin: unused("writeStdin"),
@@ -185,6 +208,44 @@ function fakeSandbox(
 }
 
 const ops = (calls: Call[]): string[] => calls.map((call) => call.op);
+
+const wrapperStart = (calls: Call[]): Extract<Call, { op: "startProcess" }> => {
+  const start = calls.find((call) => call.op === "startProcess" && call.command.includes(FACTORY_WRAPPER));
+  assert.ok(start?.op === "startProcess", "the wrapper was never started");
+  return start;
+};
+
+const bootstrapStarts = (calls: Call[]): Extract<Call, { op: "startProcess" }>[] =>
+  calls.filter(
+    (call): call is Extract<Call, { op: "startProcess" }> =>
+      call.op === "startProcess" && !call.command.includes(FACTORY_WRAPPER),
+  );
+
+const runWithFakeGit = (script: string, failOn = ""): { code: number; git: string[]; output: string } => {
+  const bin = mkdtempSync(join(tmpdir(), "factory-bootstrap-bin-"));
+  const log = join(bin, "git.log");
+  const fakeGit = [
+    "#!/bin/sh",
+    `printf '%s\\n' "$*" >> ${shq(log)}`,
+    'if [ -n "${FAKE_GIT_FAIL:-}" ]; then case "$*" in *"$FAKE_GIT_FAIL"*) exit 1;; esac; fi',
+    "",
+  ].join("\n");
+  writeFileSync(join(bin, "git"), fakeGit, "utf8");
+  chmodSync(join(bin, "git"), 0o755);
+  const result = spawnSync("/bin/sh", ["-c", script], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}:/usr/bin:/bin`, FAKE_GIT_FAIL: failOn },
+  });
+  const git = existsSync(log)
+    ? readFileSync(log, "utf8")
+        .split("\n")
+        .filter((line) => line !== "")
+    : [];
+  rmSync(bin, { recursive: true, force: true });
+  assert.equal(result.error, undefined, String(result.error));
+  assert.equal(typeof result.status, "number", `killed by ${result.signal}`);
+  return { code: result.status ?? 1, git, output: `${result.stdout}${result.stderr}` };
+};
 
 function fakeConfig(initial: FactoryConfig | null): {
   config: FactoryEffectsDeps["config"];
@@ -295,6 +356,20 @@ async function workedRunId(effects: FactoryWorkEffects, item: LoopItem = ITEM): 
   return runId;
 }
 
+const tempCloneDir = (t: TestContext): string => {
+  const root = mkdtempSync(join(tmpdir(), "factory-bootstrap-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return join(root, "qm-yc");
+};
+
+async function recordedBootstrapScript(cloneDir: string): Promise<string> {
+  const fake = fakeSandbox();
+  await workedRunId(createFactoryLoopEffects(deps({ sandbox: fake.sandbox })));
+  const bootstrap = bootstrapStarts(fake.calls)[0];
+  assert.ok(bootstrap);
+  return bootstrap.command.replaceAll(CLONE_DIR, cloneDir);
+}
+
 test("the composed object exposes exactly the four work-side effects and does no I/O to build them", async () => {
   const fake = fakeSandbox();
   const fetched = fakeFetch([intakePage(["QM-12", "QM-13"])]);
@@ -400,6 +475,8 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
   assert.deepEqual(ops(fake.calls), [
     "provision",
     "run",
+    "startProcess",
+    "readProcess",
     "teardown",
     "provision",
     "startProcess",
@@ -408,16 +485,15 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
     "readProcess",
     "teardown",
   ]);
-  const preflightTeardown = fake.calls[2];
+  const preflightTeardown = fake.calls.find((call) => call.op === "teardown");
   assert.ok(preflightTeardown?.op === "teardown");
   assert.deepEqual(preflightTeardown.opts, { keepWarm: true });
   const provision = fake.calls[0];
   assert.ok(provision?.op === "provision");
   assert.deepEqual(provision.layers, [{ scopeId: LOOP.ownerScopeId, mode: "rw", mountPath: "" }]);
 
-  const started = fake.calls[4];
-  assert.ok(started?.op === "startProcess");
-  assert.equal(started.command, `bash .claude/io-coding-agent-js.sh ${TICKET}`);
+  const started = wrapperStart(fake.calls);
+  assert.equal(started.command, `bash ${FACTORY_SOURCE_DIR}/.claude/io-coding-agent-js.sh ${TICKET}`);
   assert.equal(started.opts?.cwd, REPO_DIR);
   assert.notEqual(started.handle.id, preflightTeardown.handle.id);
   assert.deepEqual(
@@ -428,6 +504,7 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
       linearApiKey: LINEAR_KEY,
       githubToken: GITHUB_TOKEN,
       repoDir: REPO_DIR,
+      factorySourceDir: FACTORY_SOURCE_DIR,
     }),
   );
   assert.equal(runId, "factory:loop-1:item-1:1");
@@ -439,12 +516,104 @@ test("work omits IO_FEEDBACK without guidance, honours repoDir, and numbers the 
 
   const runId = await workedRunId(effects, { ...ITEM, attempts: 2 });
 
-  const started = fake.calls.find((call) => call.op === "startProcess");
-  assert.ok(started?.op === "startProcess");
+  const started = wrapperStart(fake.calls);
   assert.equal(started.opts?.cwd, "/srv/code");
   assert.equal("IO_FEEDBACK" in (started.opts?.env ?? {}), false);
   assert.equal(started.opts?.env?.IO_REPO_DIR, "/srv/code");
+  assert.equal(started.opts?.env?.IO_FACTORY_SOURCE_DIR, FACTORY_SOURCE_DIR);
+  assert.notEqual(started.opts?.env?.IO_FACTORY_SOURCE_DIR, started.opts?.env?.IO_REPO_DIR);
   assert.equal(runId, "factory:loop-1:item-1:3");
+});
+
+test("work bootstraps the factory control plane on the preflight handle before the wrapper, once per call", async () => {
+  const fake = fakeSandbox();
+  const effects = createFactoryLoopEffects(deps({ sandbox: fake.sandbox }));
+
+  await workedRunId(effects);
+
+  assert.ok(FACTORY_SOURCE_DIR.startsWith(`${CLONE_DIR}/`), FACTORY_SOURCE_DIR);
+  const bootstraps = bootstrapStarts(fake.calls);
+  assert.equal(bootstraps.length, 1);
+  const bootstrap = bootstraps[0];
+  assert.ok(bootstrap);
+  assert.ok(fake.calls.indexOf(bootstrap) < fake.calls.indexOf(wrapperStart(fake.calls)));
+  const preflightProvision = fake.calls[0];
+  assert.ok(preflightProvision?.op === "provision");
+  assert.equal(bootstrap.handle.id, preflightProvision.handle.id);
+
+  await workedRunId(effects, { ...ITEM, attempts: 1 });
+  assert.equal(bootstrapStarts(fake.calls).length, 2);
+});
+
+test("the bootstrap command clones a cold checkout and converges a warm one without re-cloning", async (t) => {
+  const cloneDir = tempCloneDir(t);
+  const script = await recordedBootstrapScript(cloneDir);
+
+  const cold = runWithFakeGit(script);
+
+  assert.equal(cold.code, 0, cold.output);
+  assert.deepEqual(cold.git, [
+    `clone --depth 1 --single-branch --branch ${FACTORY_SOURCE_BRANCH} ${CLONE_URL} ${cloneDir}`,
+  ]);
+
+  mkdirSync(join(cloneDir, ".git"), { recursive: true });
+  const warm = runWithFakeGit(script);
+
+  assert.equal(warm.code, 0, warm.output);
+  assert.deepEqual(warm.git, [
+    `-C ${cloneDir} fetch --depth 1 origin ${FACTORY_SOURCE_BRANCH}`,
+    `-C ${cloneDir} checkout -f FETCH_HEAD`,
+  ]);
+});
+
+test("a failed fetch fails the bootstrap instead of checking out a stale FETCH_HEAD", async (t) => {
+  const cloneDir = tempCloneDir(t);
+  const script = await recordedBootstrapScript(cloneDir);
+  mkdirSync(join(cloneDir, ".git"), { recursive: true });
+
+  const result = runWithFakeGit(script, "fetch");
+
+  assert.notEqual(result.code, 0);
+  assert.deepEqual(result.git, [`-C ${cloneDir} fetch --depth 1 origin ${FACTORY_SOURCE_BRANCH}`]);
+});
+
+test("a bootstrap that exits non-zero fails the run loudly, starts no wrapper and stores nothing", async () => {
+  const fake = fakeSandbox({ bootstrapExit: 128 });
+  const effects = createFactoryLoopEffects(deps({ sandbox: fake.sandbox }));
+
+  const error = await rejection(workedRunId(effects));
+
+  assert.equal(error.message, "factory_source_bootstrap_failed: exit 128");
+  assert.deepEqual(ops(fake.calls), ["provision", "run", "startProcess", "readProcess", "teardown"]);
+  assert.equal(
+    fake.calls.some((call) => call.op === "startProcess" && call.command.includes(FACTORY_WRAPPER)),
+    false,
+  );
+  const teardown = fake.calls.find((call) => call.op === "teardown");
+  assert.ok(teardown?.op === "teardown");
+  assert.deepEqual(teardown.opts, { keepWarm: true });
+  assert.deepEqual(await effects.captureOutputs({ loop: LOOP, item: ITEM, runId: "factory:loop-1:item-1:1" }), []);
+});
+
+test("the bootstrap authenticates through the process env alone and never puts the token in a command", async () => {
+  const fake = fakeSandbox();
+  const effects = createFactoryLoopEffects(deps({ sandbox: fake.sandbox }));
+
+  await workedRunId(effects);
+
+  for (const call of fake.calls) {
+    if (call.op === "run" || call.op === "startProcess") {
+      assert.equal(call.command.includes(GITHUB_TOKEN), false, call.command);
+    }
+  }
+  const bootstrap = bootstrapStarts(fake.calls)[0];
+  assert.ok(bootstrap);
+  assert.deepEqual(bootstrap.opts?.env, {
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: `url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf`,
+    GIT_CONFIG_VALUE_0: "https://github.com/",
+  });
 });
 
 test("a preflight that misses tools names them and never starts the wrapper", async () => {
@@ -608,13 +777,7 @@ test("evaluate releases the stored run whatever the outcome", async () => {
 });
 
 test("a fresh attempt for an item evicts the previous attempt's stored run and leaves other items alone", async () => {
-  const perRunStdout = async (_n: number, calls: Call[]): Promise<ReadProcessResult> => {
-    const since = calls.slice(calls.map((call) => call.op).lastIndexOf("startProcess"));
-    return since.filter((call) => call.op === "readProcess").length === 1
-      ? { chunks: WORK_STDOUT, cursor: WORK_STDOUT.length, status: { state: "running" } }
-      : { chunks: "", cursor: WORK_STDOUT.length, status: { state: "exited", code: 0 } };
-  };
-  const effects = createFactoryLoopEffects(deps({ sandbox: fakeSandbox({ read: perRunStdout }).sandbox }));
+  const effects = createFactoryLoopEffects(deps({ sandbox: fakeSandbox().sandbox }));
   const other = { ...ITEM, id: "item-2" };
 
   const first = await workedRunId(effects);
@@ -683,9 +846,8 @@ test("pausing the loop mid-run terminates the process, rejects work, and stores 
     const signal = fake.calls.find((call) => call.op === "signalProcess");
     assert.ok(signal?.op === "signalProcess");
     assert.equal(signal.signal, "TERM");
-    assert.equal(signal.processId, "p1");
-    const started = fake.calls.find((call) => call.op === "startProcess");
-    assert.ok(started?.op === "startProcess");
+    const started = wrapperStart(fake.calls);
+    assert.equal(signal.processId, started.processId);
     assert.equal(signal.handle.id, started.handle.id);
     assert.deepEqual(await effects.captureOutputs({ loop: LOOP, item: ITEM, runId: "factory:loop-1:item-1:1" }), []);
   }

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -137,6 +137,7 @@ function fakeSandbox(
     stdout?: string;
     teardownError?: Error;
     bootstrapExit?: number;
+    bootstrapOutput?: string;
     read?: (n: number, calls: Call[]) => Promise<ReadProcessResult>;
   } = {},
 ): FakeSandbox {
@@ -188,7 +189,12 @@ function fakeSandbox(
       calls.push({ op: "readProcess", handle, processId });
       const start = calls.find((call) => call.op === "startProcess" && call.processId === processId);
       if (start?.op === "startProcess" && !start.command.includes(FACTORY_WRAPPER)) {
-        return Promise.resolve({ chunks: "", cursor: 0, status: { state: "exited", code: opts.bootstrapExit ?? 0 } });
+        const chunks = opts.bootstrapOutput ?? "";
+        return Promise.resolve({
+          chunks,
+          cursor: chunks.length,
+          status: { state: "exited", code: opts.bootstrapExit ?? 0 },
+        });
       }
       const n = calls.filter((call) => call.op === "readProcess" && call.processId === processId).length;
       return (opts.read ?? defaultRead)(n, calls);
@@ -593,6 +599,21 @@ test("a bootstrap that exits non-zero fails the run loudly, starts no wrapper an
   assert.ok(teardown?.op === "teardown");
   assert.deepEqual(teardown.opts, { keepWarm: true });
   assert.deepEqual(await effects.captureOutputs({ loop: LOOP, item: ITEM, runId: "factory:loop-1:item-1:1" }), []);
+});
+
+test("a failed bootstrap names git's reason in the error and masks the token", async () => {
+  const fake = fakeSandbox({
+    bootstrapExit: 128,
+    bootstrapOutput: `Cloning into '/workspace/qm-yc'...\nfatal: could not read Username for 'https://github.com/': terminal prompts disabled\nremote: ${GITHUB_TOKEN}\n`,
+  });
+  const effects = createFactoryLoopEffects(deps({ sandbox: fake.sandbox }));
+
+  const error = await rejection(workedRunId(effects));
+
+  assert.match(error.message, /^factory_source_bootstrap_failed: exit 128 — /);
+  assert.match(error.message, /could not read Username/);
+  assert.equal(error.message.includes(GITHUB_TOKEN), false);
+  assert.match(error.message, /\*\*\*/);
 });
 
 test("the bootstrap authenticates through the process env alone and never puts the token in a command", async () => {

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -27,6 +27,7 @@ import type { WorkspaceLayer } from "../src/types.ts";
 const HANDLE: SandboxHandle = { id: "sbx-1", rootDir: "/workspace" };
 const SCOPE_ID = "org:acme";
 const REPO_DIR = "/workspace/repo";
+const SOURCE_DIR = "/workspace/qm-yc/layer/factory";
 const TICKET = "QM-12";
 
 type ProcessMethod = "startProcess" | "readProcess" | "writeStdin" | "signalProcess" | "listProcesses";
@@ -71,6 +72,7 @@ const ENV_INPUT: FactoryEnvInput = {
   linearApiKey: "lin_api_secret",
   githubToken: "ghp_secret",
   repoDir: REPO_DIR,
+  factorySourceDir: SOURCE_DIR,
 };
 
 const OPTIONAL_KEYS = ["IO_FEEDBACK", "IO_REPO_SETUP_CMD", "IO_PROOF_START_CMD", "IO_PROOF_BASE_URL_CMD"];
@@ -176,6 +178,7 @@ const baseInput = (fake: Fake, extra: Partial<FactoryProcessInput> = {}): Factor
   sandbox: fake.sandbox,
   scopeId: SCOPE_ID,
   repoDir: REPO_DIR,
+  factorySourceDir: SOURCE_DIR,
   ticketId: TICKET,
   env: { IO_LINEAR_API_KEY: "lin_api_secret" },
   ...extra,
@@ -218,7 +221,7 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
     IO_VERIFY_TEST_FILE_CMD: "npm test --",
     IO_VERIFY_LINT_CMD: "npm run lint",
     IO_REPO_DIR: REPO_DIR,
-    IO_FACTORY_SOURCE_DIR: REPO_DIR,
+    IO_FACTORY_SOURCE_DIR: SOURCE_DIR,
     IO_REPO_CLONE_URL: "https://github.com/acme/widgets.git",
     IO_REPO_SETUP_CMD: "npm ci",
     IO_PROOF_START_CMD: "npm run dev",
@@ -227,6 +230,7 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
     IO_FOLLOWUPS_ENABLED: "false",
     IO_FOLLOWUP_TEAM_ID: "team_123",
   });
+  assert.notEqual(env.IO_FACTORY_SOURCE_DIR, env.IO_REPO_DIR);
   assert.equal(FULL_CONFIG.slackChannel, "C123");
   for (const key of Object.keys(env)) assert.equal(key.startsWith("SLACK_"), false, `${key} is a SLACK_ key`);
   for (const key of FORBIDDEN_KEYS) assert.equal(Object.hasOwn(env, key), false, `${key} should never be set`);
@@ -242,6 +246,7 @@ test("renderFactoryEnv omits every optional key whose source is absent", () => {
     linearApiKey: "lin_min",
     githubToken: "ghp_min",
     repoDir: "/srv/repo",
+    factorySourceDir: SOURCE_DIR,
   });
   assert.deepEqual(
     Object.keys(env).sort(),
@@ -271,7 +276,7 @@ test("runFactoryProcess starts the wrapper, streams every chunk to exit and hand
 
   assert.deepEqual(fake.calls.provision, [[{ scopeId: SCOPE_ID, mode: "rw", mountPath: "" }]]);
   assert.equal(fake.calls.startProcess.length, 1);
-  assert.equal(fake.calls.startProcess[0]?.command, `bash ${FACTORY_WRAPPER} ${TICKET}`);
+  assert.equal(fake.calls.startProcess[0]?.command, `bash ${SOURCE_DIR}/${FACTORY_WRAPPER} ${TICKET}`);
   assert.equal(fake.calls.startProcess[0]?.opts?.cwd, REPO_DIR);
   assert.equal(fake.calls.startProcess[0]?.opts?.env, env);
 

--- a/test/loop-fire.test.ts
+++ b/test/loop-fire.test.ts
@@ -10,9 +10,10 @@ import { createIdempotencyStore } from "../src/idempotency/idempotency-store.ts"
 import { FACTORY_LOOP_SURFACE, type FactoryEffectsDeps } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
 import { FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
+import { FACTORY_WRAPPER } from "../src/loops/factory/process-work.ts";
 import type { FactoryConfig } from "../src/resolution/config-store.ts";
 import type { ServiceCredentialReader } from "../src/credentials/keychain.ts";
-import type { ReadProcessResult, Sandbox } from "../src/sandbox/sandbox.ts";
+import type { ReadProcessResult, Sandbox, SandboxHandle } from "../src/sandbox/sandbox.ts";
 import { scopeId, type TurnRequest, type TurnResult } from "../src/types.ts";
 
 function fakeIdentity() {
@@ -595,6 +596,8 @@ function factorySandbox(
   const probe = FACTORY_REQUIRED_TOOLS.map((tool) => `${tool}=ok 1.0`).join("\n");
   const unused = (name: string) => () => Promise.reject(new Error(`a factory loop must not call ${name}`));
   let provisioned = 0;
+  let started = 0;
+  const wrapperProcessIds = new Set<string>();
   const defaultRead = async (): Promise<ReadProcessResult> => {
     const sinceStart = ops.slice(ops.lastIndexOf("startProcess"));
     return sinceStart.filter((op) => op === "readProcess").length === 1
@@ -612,9 +615,17 @@ function factorySandbox(
       return record("provision", { id: `sbx-${provisioned}`, rootDir: "/workspace" });
     },
     run: () => record("run", { stdout: `${probe}\n`, stderr: "", code: 0, timedOut: false }),
-    startProcess: () => record("startProcess", { processId: "p1" }),
-    readProcess: () => {
+    startProcess: (_handle: SandboxHandle, command: string) => {
+      started += 1;
+      const processId = `p${started}`;
+      if (command.includes(FACTORY_WRAPPER)) wrapperProcessIds.add(processId);
+      return record("startProcess", { processId });
+    },
+    readProcess: (_handle: SandboxHandle, processId: string) => {
       ops.push("readProcess");
+      if (!wrapperProcessIds.has(processId)) {
+        return Promise.resolve({ chunks: "", cursor: 0, status: { state: "exited" as const, code: 0 } });
+      }
       return (opts.read ?? defaultRead)(ops);
     },
     signalProcess: () => record("signalProcess", undefined),
@@ -859,7 +870,15 @@ test("factory surface: a fire drives the factory effects and takes no agent turn
   assert.equal(intake?.url, LINEAR_URL);
   assert.match(intake?.body ?? "", /"teamId":"TEAM-1"/);
   assert.equal(intake?.headers.get("Authorization"), LINEAR_KEY);
-  assert.deepEqual(fake.sandbox.ops.slice(0, 5), ["provision", "run", "teardown", "provision", "startProcess"]);
+  assert.deepEqual(fake.sandbox.ops.slice(0, 7), [
+    "provision",
+    "run",
+    "startProcess",
+    "readProcess",
+    "teardown",
+    "provision",
+    "startProcess",
+  ]);
   const items = await s.items.byLoop(loop.id);
   assert.equal(items[0]?.sourceKey, FACTORY_TICKET);
   const output = (await s.outputs.awaitingReview(loop.id))[0];


### PR DESCRIPTION
Closes QM-31.

### Changes

**Why this matters:** The factory loop started its coding-agent wrapper from the subject
repository it was about to work on, and pointed the wrapper's factory-source directory at
that same place. The wrapper, its workflows and its factory tools live in a different
repository, and nothing ever put them in the sandbox, so a work run launched a script that
was not there. The failure was silent: the run degraded to a "no pull request" verdict,
burned an attempt, and gave the operator no signal about the real cause.

**What changes:**

- Before a work run starts, the factory materialises its own control plane in the sandbox:
  a shallow clone of `yc-software/qm-yc` at a pinned branch into `/workspace/qm-yc`. A
  sandbox that already holds that checkout fetches and re-checks-out the pinned branch
  rather than re-cloning, so a warm sandbox converges instead of running a stale copy.
- The wrapper is launched by absolute path out of that checkout while the working directory
  stays the subject repo, so the wrapper still clones `IO_REPO_CLONE_URL` and runs
  `IO_REPO_SETUP_CMD` exactly where it did before.
- `IO_FACTORY_SOURCE_DIR` now names the control-plane checkout and `IO_REPO_DIR` the subject
  repo — two distinct directories, as the wrapper's contract requires. Every other variable
  in the wrapper's environment is unchanged.
- A bootstrap that fails or times out now fails the run loudly with
  `factory_source_bootstrap_failed` and never starts the wrapper. The GitHub token
  authenticates the clone through the process environment only, so it appears in no command
  string and in no checked-out git remote.

**Acceptance stories:**

- The factory works a ticket on a cold sandbox: before, the wrapper was started from a path
  that did not exist; now the control plane is cloned into the sandbox first and the wrapper
  runs from it.
- The factory works a ticket on a sandbox it has used before: the existing checkout is
  fetched and moved onto the pinned branch, so it never re-clones and never runs the control
  plane it first happened to fetch.
- The wrapper gets the control-plane directory and the subject-repo directory as two
  different values, so its control-plane snapshot step finds the files it copies instead of
  aborting.
- An operator looking at a run whose clone failed sees `factory_source_bootstrap_failed`,
  where before the item quietly burned an attempt and reported "no pull request".
- The factory clones with its GitHub credential: the token travels only in the process
  environment, so no logged command string and no persisted git remote carries it.

### Test Plan

- `npm run typecheck`
- `npm run lint`
- `node --test test/loop-factory-process-work.test.ts test/loop-factory-effects.test.ts test/loop-factory-wiring.test.ts`
- `npm run test:all` — the three remaining failures reproduce identically on a clean
  `origin/main` worktree and are unrelated to this change.
- Manual: drove the bootstrap and the wrapper launch against a real local git remote
  standing in for the control-plane repository — cold clone, warm fetch and checkout, a
  flipped branch pin, and a missing branch all behaved as intended.

## Proof it works

Proven at runtime: the pre-fix code was first reproduced failing, then the fixed code was
driven against a real git remote and a faithful wrapper stub, covering all five acceptance
stories plus adversarial probes. Captured output is archived with the run, not in the diff:

- story-all-before-prefix-baseline.txt — `.io-agent-qm-31/screenshots/`
- story-all-after-runtime-proof.txt — `.io-agent-qm-31/screenshots/`
- adversarial-probes.txt — `.io-agent-qm-31/screenshots/`

<!-- factory-session:2:18516:6dbd53626e579b385b7f44eeb4e8de88 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791589333&installation_model_id=19911&pr_number=1036&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1036&signature=717a1d5f7827f1a19ccb9b9525c312ce10fe77d9a4e32446863a3dde6697f97d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->