### PR TITLE
fix: tighten tab action overlay around icons

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -6999,7 +6999,6 @@ h3.ambient-field-label {
   display: flex;
   align-items: center;
   gap: 2px;
-  padding-left: 10px;
   border-radius: 5px;
   background: color-mix(in srgb, var(--background) 96%, transparent);
   opacity: 0;

--- a/plugins/web-ui/test/split-tiles-and-titles.test.ts
+++ b/plugins/web-ui/test/split-tiles-and-titles.test.ts
@@ -94,6 +94,7 @@ test("tab actions overlay the title instead of reserving title space", () => {
   assert.match(actions, /right: 0;/);
   assert.match(actions, /background: color-mix\(in srgb, var\(--background\) 96%, transparent\);/);
   assert.doesNotMatch(actions, /gradient|blur/);
+  assert.doesNotMatch(actions, /padding(?:-[\w-]+)?\s*:/, "the overlay must hug its action buttons");
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*position: relative;/);
   assert.match(css, /\.dv-tab \.split-pane-title \{[^}]*flex: 1 1 auto;/);
   const draw = split.slice(split.indexOf("class PaneTab"), split.indexOf("class StripDrop"));


### PR DESCRIPTION
Remove the leftover 10px left padding so the tab action background hugs the link button without changing tab or title geometry.

- 46 focused tests, web typechecks, lint, and formatting pass.
- 67 live browser checks cover overlay edges, hover, keyboard focus, narrow panes, and sharing.
- Six title/theme variants and two close-only pane cases pass.
- Synthetic-data preview verified under isolated browser restrictions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791590074&installation_model_id=19911&pr_number=1037&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1037&signature=ea6f9daa83527ca4ec5713637507d3d8f24e968ca21904e67fafc53f57cdd5e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->