### PR TITLE
Release dev slots after 24 hours of inactivity

### DIFF
--- a/.codex/skills/dev-instance/SKILL.md
+++ b/.codex/skills/dev-instance/SKILL.md
@@ -109,9 +109,10 @@ canary message is deleted right after it round-trips. `CANARY_CHANNEL=<channel i
 slot env overrides. With no eligible channel at all, `up` prints `delivery unverified` (or
 fails under `--strict`).
 
-A forgotten instance cleans itself up: after 8 hours with no Slack events and no CLI
+A forgotten instance cleans itself up: after 24 hours with no Slack activity and no CLI control
 actions the supervisor tears itself down and frees the slot
-(`DEV_INSTANCE_IDLE_HOURS` overrides; `0` disables).
+on its next idle check (every 10 minutes). Health checks, status reads, and automatic
+canaries do not reset the timer. `DEV_INSTANCE_IDLE_HOURS` overrides the timeout; `0` disables it.
 
 ## Real by Default
 

--- a/scripts/dev/supervisor/main.ts
+++ b/scripts/dev/supervisor/main.ts
@@ -32,11 +32,11 @@ const HEALTH_FAIL_THRESHOLD = 3;
 const CANARY_INTERVAL_MS = Number(process.env.DEV_INSTANCE_CANARY_INTERVAL_MS || 10 * 60_000);
 const IDLE_HOURS = (() => {
   const raw = process.env.DEV_INSTANCE_IDLE_HOURS;
-  if (raw === undefined || raw === "") return 8;
+  if (raw === undefined || raw === "") return 24;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) {
-    console.warn(`[supervisor] DEV_INSTANCE_IDLE_HOURS=${raw} is not a number -- using the 8h default`);
-    return 8;
+    console.warn(`[supervisor] DEV_INSTANCE_IDLE_HOURS=${raw} is not a number -- using the 24h default`);
+    return 24;
   }
   return n;
 })();

--- a/src/slack/dev-introspection.ts
+++ b/src/slack/dev-introspection.ts
@@ -139,10 +139,12 @@ function attachRawFrameTap(
         return;
       }
       state.lastEventAtRaw = now();
-      const text = frame?.type === "events_api" ? frame.payload?.event?.text : undefined;
+      const event = frame?.type === "events_api" ? frame.payload?.event : undefined;
+      const text = event?.subtype === "message_deleted" ? event.previous_message?.text : event?.text;
       const isCanary = typeof text === "string" && text.includes(CANARY_PREFIX);
-      if (!isCanary) state.lastActivityAt = now();
-      if (frame?.type !== "events_api" || !isCanary) return;
+      const isActivity = ["events_api", "interactive", "slash_commands"].includes(frame?.type);
+      if (isActivity && !isCanary) state.lastActivityAt = now();
+      if (frame?.type !== "events_api" || !isCanary || event?.subtype === "message_deleted") return;
       const nonce = text.slice(text.indexOf(CANARY_PREFIX) + CANARY_PREFIX.length).trim();
       const waiter = canaryWaiters.get(nonce);
       if (!waiter) return;

--- a/test/slack-dev-introspection.test.ts
+++ b/test/slack-dev-introspection.test.ts
@@ -185,3 +185,36 @@ test("lastActivityAt tracks real inbound frames but never canary traffic", async
     assert.equal(dev.state.lastActivityAt, before, "canary round trip must not count as activity");
   });
 });
+
+test("canary deletion and connection maintenance do not keep an idle slot alive", async () => {
+  const app = makeApp();
+  let clock = 1000;
+  const dev = installDevIntrospection(app, { enabled: true, now: () => clock });
+  assert.ok(dev);
+  try {
+    emitFrame(app, { type: "events_api", payload: { event: { type: "message", text: "hello" } } });
+    assert.equal(dev.state.lastActivityAt, 1000);
+    clock = 2000;
+    emitFrame(app, {
+      type: "events_api",
+      payload: {
+        event: { type: "message", subtype: "message_deleted", previous_message: { text: "qm-canary:probe" } },
+      },
+    });
+    emitFrame(app, { type: "disconnect", reason: "refresh_requested" });
+    emitFrame(app, { type: "hello", num_connections: 1 });
+    assert.equal(dev.state.lastActivityAt, 1000);
+    assert.equal(dev.state.lastEventAtRaw, 2000);
+    clock = 3000;
+    emitFrame(app, {
+      type: "events_api",
+      payload: { event: { type: "message", subtype: "message_deleted", previous_message: { text: "hello" } } },
+    });
+    assert.equal(dev.state.lastActivityAt, 3000);
+    clock = 4000;
+    emitFrame(app, { type: "slash_commands", payload: { command: "/qm" } });
+    assert.equal(dev.state.lastActivityAt, 4000);
+  } finally {
+    await dev.close();
+  }
+});


### PR DESCRIPTION
Dev supervisors now release their slot after 24 hours without Slack activity or CLI control actions by default. The existing 10-minute idle sweep stops the instance and frees its lease; explicit timeout overrides remain supported.

Exclude canary deletion events and connection maintenance frames from idle activity, so automatic monitoring cannot keep a forgotten instance alive. Document the timeout and sweep cadence.

Validation: 32 existing dev CLI, child supervisor, and Slack introspection tests passed, plus the new fake-clock regression covering canary deletion, socket refresh, real message deletion, and slash commands. Typecheck, affected-file ESLint, and formatting passed. Independent adversarial review found the canary cleanup issue; it is fixed and re-review is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791590927&installation_model_id=19911&pr_number=1039&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1039&signature=e3d88e7573800026e548aeed416adffd92236fdab1fcff767d547f5d8fa02805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->