### PR TITLE
Scope ambient policy to supported surfaces

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -5312,49 +5312,58 @@
                 </section>
                 <section class="card sv-governance hidden" id="card-ambient-policy">
                   <div class="head">
-                    <h2>Ambient reply policy</h2>
-                    <p>
+                    <h2 id="ambient-policy-heading">Ambient reply policy</h2>
+                    <p class="ambient-controls">
                       What the agent proactively acts on in this channel. The standing order is plain prose the ambient
                       judge weighs each batch of new messages against. Empty means it stays silent unless addressed. The
                       bot ledger says how each automated poster is treated: <b>ignore</b> never wakes the judge,
                       <b>rollup</b> batches its posts (judged at most once per the given hours), <b>action</b> marks its
                       posts as triggers to act on, <b>user</b> reads it like a person.
                     </p>
+                    <p id="ambient-project-hint" class="hidden">
+                      Used when QM responds in this project. Ambient replies and automated-poster handling aren’t
+                      supported here.
+                    </p>
                   </div>
                   <div class="body">
-                    <label for="ambient-enabled">Ambient behavior</label>
-                    <p class="hint" style="margin: 2px 0 6px">
-                      When off, the agent never wakes on overheard messages in this channel; it only responds to direct
-                      @mentions. Default: on for channels with 8 or fewer members, off for larger ones.
-                    </p>
-                    <select id="ambient-enabled" style="margin-bottom: 14px">
-                      <option value="default">Default (by channel size)</option>
-                      <option value="on">On</option>
-                      <option value="off">Off</option>
-                    </select>
+                    <div class="ambient-controls">
+                      <label for="ambient-enabled">Ambient behavior</label>
+                      <p class="hint" style="margin: 2px 0 6px">
+                        When off, the agent never wakes on overheard messages in this channel; it only responds to
+                        direct @mentions. Default: on for channels with 8 or fewer members, off for larger ones.
+                      </p>
+                      <select id="ambient-enabled" style="margin-bottom: 14px">
+                        <option value="default">Default (by channel size)</option>
+                        <option value="on">On</option>
+                        <option value="off">Off</option>
+                      </select>
+                    </div>
                     <label for="ambient-orders">Standing order</label>
                     <textarea
                       id="ambient-orders"
                       placeholder="(none, the agent stays silent here unless addressed)"
                     ></textarea>
-                    <div class="tablewrap" style="margin-top: 14px">
-                      <table class="rules">
-                        <thead>
-                          <tr>
-                            <th style="width: 34%">Bot (author name)</th>
-                            <th style="width: 30%">Handling</th>
-                            <th>Rollup hours</th>
-                            <th></th>
-                          </tr>
-                        </thead>
-                        <tbody id="ambient-bots"></tbody>
-                      </table>
+                    <div class="ambient-controls">
+                      <div class="tablewrap" style="margin-top: 14px">
+                        <table class="rules">
+                          <thead>
+                            <tr>
+                              <th style="width: 34%">Bot (author name)</th>
+                              <th style="width: 30%">Handling</th>
+                              <th>Rollup hours</th>
+                              <th></th>
+                            </tr>
+                          </thead>
+                          <tbody id="ambient-bots"></tbody>
+                        </table>
+                      </div>
+                      <p class="hint rules-empty" id="ambient-bots-empty">No bots in the ledger yet.</p>
+                      <button id="add-bot" type="button" style="margin-top: 10px">+ Add bot</button>
                     </div>
-                    <p class="hint rules-empty" id="ambient-bots-empty">No bots in the ledger yet.</p>
-                    <button id="add-bot" type="button" style="margin-top: 10px">+ Add bot</button>
                   </div>
                   <div class="foot">
-                    <button type="button" class="viewlink" data-viewlink="judgments">View judgment log ›</button
+                    <button type="button" class="viewlink ambient-controls" data-viewlink="judgments">
+                      View judgment log ›</button
                     ><button class="primary" data-save="ambient-policy">Save</button
                     ><span class="status" id="st-ambient-policy"></span>
                   </div>
@@ -7754,6 +7763,7 @@
         const requestedScope = scope;
         const requestId = ++governanceReq;
         const scopeChanged = scope !== loadedGovernanceScope;
+        if (scopeChanged) renderAmbientPolicy(undefined);
         const r = await api("GET", "/api/scopes/" + encodeURIComponent(scope));
         if (requestId !== governanceReq || requestedScope !== scope) return;
         if (!r.ok) {
@@ -10187,6 +10197,16 @@
         return tr;
       }
       function renderAmbientPolicy(p) {
+        const card = $("card-ambient-policy");
+        const supportsAmbient = p?.supportsAmbient === true;
+        card.dataset.supportsAmbient = typeof p?.supportsAmbient === "boolean" ? String(p.supportsAmbient) : "";
+        card.querySelector('[data-save="ambient-policy"]').disabled = true;
+        card.querySelectorAll(".ambient-controls").forEach((el) => el.classList.toggle("hidden", !supportsAmbient));
+        $("ambient-policy-heading").textContent = supportsAmbient ? "Ambient reply policy" : "Standing orders";
+        $("ambient-project-hint").classList.toggle("hidden", p?.supportsAmbient !== false);
+        $("ambient-orders").placeholder = supportsAmbient
+          ? "(none, the agent stays silent here unless addressed)"
+          : "Standing instructions for addressed replies in this project.";
         $("card-ambient-policy").dataset.base = String(p?.updatedAt ?? 0);
         let ambientEnabled = "default";
         if (p?.ambientEnabled === true) ambientEnabled = "on";
@@ -10206,6 +10226,14 @@
         row.querySelector("input")?.focus();
       };
       function collectAmbientPolicy() {
+        const supportsAmbient = $("card-ambient-policy").dataset.supportsAmbient;
+        if (supportsAmbient !== "true" && supportsAmbient !== "false")
+          throw new Error("Reload to update standing-order settings.");
+        const orders = {
+          orders: $("ambient-orders").value,
+          baseUpdatedAt: Number($("card-ambient-policy").dataset.base || 0),
+        };
+        if (supportsAmbient === "false") return orders;
         const bots = {};
         const seen = new Set();
         for (const tr of $("ambient-bots").children) {
@@ -10226,10 +10254,9 @@
         }
         const ambientSel = $("ambient-enabled").value;
         return {
-          orders: $("ambient-orders").value,
+          ...orders,
           bots,
           ambientEnabled: ambientSel === "default" ? null : ambientSel === "on",
-          baseUpdatedAt: Number($("card-ambient-policy").dataset.base || 0),
         };
       }
       $("add-rule").onclick = () => {
@@ -10476,6 +10503,7 @@
         const btn = sectionButton(key);
         setCardDirty(btn?.closest(".card"), dirty, SAVE_ST[key], '[data-save="' + key + '"]');
         if (key === "egress" && $("card-egress").classList.contains("egress-disabled")) btn.disabled = true;
+        if (key === "ambient-policy" && !$("card-ambient-policy").dataset.supportsAmbient) btn.disabled = true;
       }
       function captureSection(key) {
         if (!SAVE[key] || !sectionButton(key)) return;
@@ -10550,6 +10578,7 @@
         btn.onclick = async () => {
           const key = btn.dataset.save;
           const requestedScope = scope;
+          const requestedGovernanceReq = governanceReq;
           let body;
           try {
             body = SAVE[key]();
@@ -10557,16 +10586,23 @@
             setStatus(SAVE_ST[key], err instanceof Error ? err.message : "Could not save.", "err");
             return;
           }
-          if (!(await governanceSaveReview(key, body)) || requestedScope !== scope) return;
+          if (
+            !(await governanceSaveReview(key, body)) ||
+            requestedScope !== scope ||
+            requestedGovernanceReq !== governanceReq
+          )
+            return;
           const saveRequest = String(++governanceSaveSeq);
           btn.dataset.saveRequest = saveRequest;
           btn.disabled = true;
           setStatus(SAVE_ST[key], "Saving...", "saving", true);
           const r = await api("PUT", "/api/scopes/" + encodeURIComponent(requestedScope) + "/" + key, body);
-          if (requestedScope !== scope) {
+          if (requestedScope !== scope || requestedGovernanceReq !== governanceReq) {
             if (btn.dataset.saveRequest === saveRequest) {
               delete btn.dataset.saveRequest;
-              btn.disabled = !btn.classList.contains("dirty");
+              btn.disabled =
+                !btn.classList.contains("dirty") ||
+                (key === "ambient-policy" && !$("card-ambient-policy").dataset.supportsAmbient);
               setStatus(SAVE_ST[key], "", "");
             }
             return;
@@ -10574,7 +10610,8 @@
           if (btn.dataset.saveRequest === saveRequest) delete btn.dataset.saveRequest;
           if (r.ok) {
             if (key === "security-posture" || key === "ambient-policy") {
-              const fresh = await api("GET", "/api/scopes/" + encodeURIComponent(scope));
+              const fresh = await api("GET", "/api/scopes/" + encodeURIComponent(requestedScope));
+              if (requestedScope !== scope || requestedGovernanceReq !== governanceReq) return;
               if (!fresh.ok) {
                 updateSectionDirty(key);
                 setStatus(SAVE_ST[key], "Saved, but could not refresh the applied value.", "err");

--- a/plugins/web-ui/src/ambient-policy.ts
+++ b/plugins/web-ui/src/ambient-policy.ts
@@ -13,6 +13,7 @@ export interface BotPolicyView {
 }
 interface PolicyWire {
   policy: {
+    supportsAmbient: boolean;
     orders: string;
     bots: Record<string, { mode: BotMode; rollupHours?: number }>;
     ambientEnabled?: boolean | null;
@@ -23,6 +24,7 @@ interface PolicyWire {
 export const ambientPolicyState = {
   scope: null as string | null,
   loading: false,
+  supportsAmbient: null as boolean | null,
   orders: "",
   ambientEnabled: null as boolean | null,
   bots: [] as BotPolicyView[],
@@ -45,6 +47,7 @@ export function resetAmbientPolicy(): void {
   loadSeq += 1;
   ambientPolicyState.scope = null;
   ambientPolicyState.loading = false;
+  ambientPolicyState.supportsAmbient = null;
   ambientPolicyState.orders = "";
   ambientPolicyState.ambientEnabled = null;
   ambientPolicyState.bots = [];
@@ -66,6 +69,9 @@ export async function loadAmbientPolicy(scopeId: string, onChange: () => void): 
   try {
     const r = await api<PolicyWire>(`/api/contexts/${encodeURIComponent(scopeId)}/ambient-policy`);
     if (seq !== loadSeq) return;
+    ambientPolicyState.supportsAmbient =
+      typeof r.policy.supportsAmbient === "boolean" ? r.policy.supportsAmbient : null;
+    if (ambientPolicyState.supportsAmbient === null) throw new Error("Reload to update standing-order settings.");
     ambientPolicyState.orders = r.policy.orders;
     ambientPolicyState.ambientEnabled = r.policy.ambientEnabled ?? null;
     ambientPolicyState.bots = Object.entries(r.policy.bots).map(([name, p]) => ({
@@ -76,6 +82,7 @@ export async function loadAmbientPolicy(scopeId: string, onChange: () => void): 
     ambientPolicyState.baseUpdatedAt = r.policy.updatedAt;
   } catch (e) {
     if (seq !== loadSeq) return;
+    ambientPolicyState.supportsAmbient = null;
     ambientPolicyState.notice = errMessage(e, "Couldn't load this scope's standing orders.");
     ambientPolicyState.noticeKind = "error";
   } finally {
@@ -88,14 +95,17 @@ export async function loadAmbientPolicy(scopeId: string, onChange: () => void): 
 
 function markDirty(): void {
   ambientPolicyState.dirty = true;
-  ambientPolicyState.notice = "";
-  ambientPolicyState.noticeKind = "";
+  if (ambientPolicyState.supportsAmbient !== null) {
+    ambientPolicyState.notice = "";
+    ambientPolicyState.noticeKind = "";
+  }
   redraw();
 }
 
 async function save(): Promise<void> {
   const scope = ambientPolicyState.scope;
-  if (!scope || ambientPolicyState.saving) return;
+  if (!scope || ambientPolicyState.saving || ambientPolicyState.supportsAmbient === null) return;
+  const seq = loadSeq;
   const bots: Record<string, { mode: BotMode; rollupHours?: number }> = {};
   for (const b of ambientPolicyState.bots) {
     const name = b.name.trim();
@@ -109,11 +119,14 @@ async function save(): Promise<void> {
       method: "PUT",
       body: JSON.stringify({
         orders: ambientPolicyState.orders,
-        bots,
-        ambientEnabled: ambientPolicyState.ambientEnabled,
+        ...(ambientPolicyState.supportsAmbient ? { bots, ambientEnabled: ambientPolicyState.ambientEnabled } : {}),
         baseUpdatedAt: ambientPolicyState.baseUpdatedAt,
       }),
     });
+    if (seq !== loadSeq) return;
+    ambientPolicyState.supportsAmbient =
+      typeof r.policy.supportsAmbient === "boolean" ? r.policy.supportsAmbient : null;
+    if (ambientPolicyState.supportsAmbient === null) throw new Error("Reload to update standing-order settings.");
     ambientPolicyState.orders = r.policy.orders;
     ambientPolicyState.ambientEnabled = r.policy.ambientEnabled ?? null;
     ambientPolicyState.bots = Object.entries(r.policy.bots).map(([name, p]) => ({
@@ -126,11 +139,14 @@ async function save(): Promise<void> {
     ambientPolicyState.notice = "Saved.";
     ambientPolicyState.noticeKind = "saved";
   } catch (e) {
+    if (seq !== loadSeq) return;
     ambientPolicyState.notice = errMessage(e, "Couldn't save. Try again.");
     ambientPolicyState.noticeKind = "error";
   } finally {
-    ambientPolicyState.saving = false;
-    redraw();
+    if (seq === loadSeq) {
+      ambientPolicyState.saving = false;
+      redraw();
+    }
   }
 }
 
@@ -226,38 +242,51 @@ export function ambientPolicySection(scopeId: string): TemplateResult | typeof n
       <h2 class="context-panel-title" id="ambient-policy-title">Agent behavior</h2>
       <div class="context-panel-loading">Loading…</div>
     </section>`;
+  let copy = "Load standing-order settings before editing.";
+  if (ambientPolicyState.supportsAmbient !== null)
+    copy = ambientPolicyState.supportsAmbient
+      ? "Choose what QM should notice and act on."
+      : "Used when QM responds in this project. Ambient replies and automated-poster handling aren’t supported here.";
   return html`
     <section class="context-panel ambient-policy" aria-labelledby="ambient-policy-title">
       <div class="context-panel-heading">
         <div>
-          <h2 class="context-panel-title" id="ambient-policy-title">Agent behavior</h2>
-          <p class="context-panel-copy">Choose what this project should notice and act on.</p>
+          <h2 class="context-panel-title" id="ambient-policy-title">
+            ${ambientPolicyState.supportsAmbient ? "Agent behavior" : "Standing orders"}
+          </h2>
+          <p class="context-panel-copy">${copy}</p>
         </div>
       </div>
-      <div class="ambient-group">
-        <label class="ambient-field-label" for="ambient-enabled">Ambient behavior</label>
-        ${fieldSelect({
-          id: "ambient-enabled",
-          className: "ambient-enabled-select",
-          focusKey: "ambient-enabled",
-          describedBy: "ambient-enabled-hint",
-          disabled: ambientPolicyState.saving,
-          value: ambientValue(ambientPolicyState.ambientEnabled),
-          onChange: (v) => {
-            ambientPolicyState.ambientEnabled = v === "default" ? null : v === "on";
-            markDirty();
-          },
-          options: [
-            html`<option value="default">Default (on when standing orders are set)</option>`,
-            html`<option value="on">On</option>`,
-            html`<option value="off">Off</option>`,
-          ],
-        })}
-        <p class="ambient-policy-hint" id="ambient-enabled-hint">
-          When off, the agent never acts on overheard messages here; it only responds to direct @mentions. Default: on
-          only when standing orders (or an action-mode bot) are set below, otherwise mention-only.
-        </p>
-      </div>
+      ${
+        ambientPolicyState.supportsAmbient
+          ? html`
+              <div class="ambient-group">
+                <label class="ambient-field-label" for="ambient-enabled">Ambient behavior</label>
+                ${fieldSelect({
+                  id: "ambient-enabled",
+                  className: "ambient-enabled-select",
+                  focusKey: "ambient-enabled",
+                  describedBy: "ambient-enabled-hint",
+                  disabled: ambientPolicyState.saving,
+                  value: ambientValue(ambientPolicyState.ambientEnabled),
+                  onChange: (v) => {
+                    ambientPolicyState.ambientEnabled = v === "default" ? null : v === "on";
+                    markDirty();
+                  },
+                  options: [
+                    html`<option value="default">Default (on when standing orders are set)</option>`,
+                    html`<option value="on">On</option>`,
+                    html`<option value="off">Off</option>`,
+                  ],
+                })}
+                <p class="ambient-policy-hint" id="ambient-enabled-hint">
+                  When off, the agent never acts on overheard messages here; it only responds to direct @mentions.
+                  Default: on only when standing orders (or an action-mode bot) are set below, otherwise mention-only.
+                </p>
+              </div>
+            `
+          : nothing
+      }
       <div class="ambient-group">
         <label class="ambient-field-label" for="ambient-orders">Standing orders</label>
         <textarea
@@ -275,42 +304,48 @@ export function ambientPolicySection(scopeId: string): TemplateResult | typeof n
           }}
         ></textarea>
         <p class="ambient-policy-hint" id="ambient-orders-hint">
-          Plain-language guidance for proactive work. Leave empty to respond only when addressed.
+          ${ambientPolicyState.supportsAmbient ? "Plain-language guidance for proactive work. Leave empty to respond only when addressed." : "Standing instructions for addressed replies."}
         </p>
       </div>
-      <div class="ambient-group">
-        <h3 class="ambient-field-label">Automated posters</h3>
-        <p class="ambient-policy-hint">Control how messages from bots and integrations wake the agent.</p>
-        ${ambientPolicyState.bots.length ? html`<div class="ambient-bot-list">${ambientPolicyState.bots.map((b, i) => botRow(b, i))}</div>` : html`<div class="empty compact">No bots added. All bot posts are treated as activity.</div>`}
-        <form
-          class="ambient-bot-add"
-          @submit=${(e: SubmitEvent) => {
-            e.preventDefault();
-            addBot();
-          }}
-        >
-          <input
-            data-focus-key="ambient-bot-name"
-            type="text"
-            maxlength="120"
-            aria-label="Bot name"
-            required
-            placeholder="Bot name"
-            .value=${ambientPolicyState.newBotName}
-            ?disabled=${ambientPolicyState.saving}
-            @input=${(e: InputEvent) => {
-              ambientPolicyState.newBotName = (e.currentTarget as HTMLInputElement).value;
-              redraw();
-            }}
-          />
-          <button class="btn" type="submit" ?disabled=${ambientPolicyState.saving}>Add bot</button>
-        </form>
-      </div>
+      ${
+        ambientPolicyState.supportsAmbient
+          ? html`
+              <div class="ambient-group">
+                <h3 class="ambient-field-label">Automated posters</h3>
+                <p class="ambient-policy-hint">Control how messages from bots and integrations wake the agent.</p>
+                ${ambientPolicyState.bots.length ? html`<div class="ambient-bot-list">${ambientPolicyState.bots.map((b, i) => botRow(b, i))}</div>` : html`<div class="empty compact">No bots added. All bot posts are treated as activity.</div>`}
+                <form
+                  class="ambient-bot-add"
+                  @submit=${(e: SubmitEvent) => {
+                    e.preventDefault();
+                    addBot();
+                  }}
+                >
+                  <input
+                    data-focus-key="ambient-bot-name"
+                    type="text"
+                    maxlength="120"
+                    aria-label="Bot name"
+                    required
+                    placeholder="Bot name"
+                    .value=${ambientPolicyState.newBotName}
+                    ?disabled=${ambientPolicyState.saving}
+                    @input=${(e: InputEvent) => {
+                      ambientPolicyState.newBotName = (e.currentTarget as HTMLInputElement).value;
+                      redraw();
+                    }}
+                  />
+                  <button class="btn" type="submit" ?disabled=${ambientPolicyState.saving}>Add bot</button>
+                </form>
+              </div>
+            `
+          : nothing
+      }
       <div class="ambient-policy-actions">
         <button
           class="btn primary"
           type="button"
-          ?disabled=${!ambientPolicyState.dirty || ambientPolicyState.saving}
+          ?disabled=${!ambientPolicyState.dirty || ambientPolicyState.saving || ambientPolicyState.supportsAmbient === null}
           @click=${() => void save()}
         >
           ${ambientPolicyState.saving ? "Saving…" : "Save"}

--- a/plugins/web-ui/test/admin-ambient-policy-dom.test.ts
+++ b/plugins/web-ui/test/admin-ambient-policy-dom.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const source = readFileSync(new URL("../../admin/public/index.html", import.meta.url), "utf8");
+const card = source.match(/<section class="card sv-governance hidden" id="card-ambient-policy">[^]*?<\/section>/)![0];
+const functions = source.slice(
+  source.indexOf("      const BOT_MODES ="),
+  source.indexOf('      $("add-rule").onclick'),
+);
+const loadHandler = source.slice(
+  source.indexOf("      let governanceReq ="),
+  source.indexOf("      async function refreshSoulConflict"),
+);
+const saveHandler = source.slice(
+  source.indexOf("      let governanceSaveSeq ="),
+  source.indexOf('      $("view-governance").addEventListener("input"'),
+);
+const policy = (supportsAmbient: boolean) => ({
+  orders: "keep",
+  bots: { CI: { mode: "action" } },
+  ambientEnabled: true,
+  updatedAt: 42,
+  supportsAmbient,
+});
+
+function fixture() {
+  const dom = new JSDOM(card, { runScripts: "outside-only" });
+  dom.window.eval(`
+    const $ = (id) => document.getElementById(id);
+    let scope = "group:web-project-317";
+    let loadedGovernanceScope = scope;
+    const SAVE_ST = { "ambient-policy": "st-ambient-policy" };
+    const governanceSaveReview = async () => true;
+    const renderGovernanceOverview = () => {};
+    const captureSection = () => {};
+    const updateSectionDirty = () => {};
+    const setStatus = (id, text) => $(id).textContent = text;
+    ${functions}
+    const SAVE = { "ambient-policy": collectAmbientPolicy };
+    const api = (...args) => window.request(...args);
+    ${loadHandler}
+    ${saveHandler}
+    window.load = (nextScope) => { scope = nextScope; return loadScope(); };
+    window.show = (p, nextScope = scope) => { scope = nextScope; governanceReq++; renderAmbientPolicy(p); };
+  `);
+  const w = dom.window as any;
+  const doc = dom.window.document;
+  const save = doc.querySelector<HTMLButtonElement>('[data-save="ambient-policy"]')!;
+  const hidden = (el: Element) => !!el.closest(".hidden, [hidden]");
+  doc.getElementById("card-ambient-policy")!.classList.remove("hidden");
+  return { dom, w, doc, save, hidden };
+}
+
+test("admin policy DOM retains orders and sends only supported fields", async () => {
+  const { dom, w, doc, save, hidden } = fixture();
+  try {
+    for (const [scope, supportsAmbient] of [
+      ["group:web-project-317", false],
+      ["group:G317", true],
+      ["channel:C317", true],
+      ["group:web-project-317", false],
+    ] as const) {
+      w.show(policy(supportsAmbient), scope);
+      assert.equal(hidden(doc.getElementById("ambient-enabled")!), !supportsAmbient);
+      assert.equal(hidden(doc.getElementById("add-bot")!), !supportsAmbient);
+      assert.equal(hidden(doc.querySelector('[data-viewlink="judgments"]')!), !supportsAmbient);
+      const orders = doc.getElementById("ambient-orders") as HTMLTextAreaElement;
+      assert.equal(hidden(orders), false);
+      assert.equal(orders.value, "keep");
+      orders.value = "after";
+      let sent: any;
+      w.request = async (method: string, url: string, body: unknown) => {
+        if (method === "PUT") {
+          sent = body;
+          assert.ok(url.includes(encodeURIComponent(scope)));
+        }
+        return { ok: true, data: { ambientPolicy: policy(supportsAmbient) } };
+      };
+      await save.onclick!(new dom.window.MouseEvent("click") as unknown as PointerEvent);
+      assert.deepEqual(JSON.parse(JSON.stringify(sent)), {
+        orders: "after",
+        baseUpdatedAt: 42,
+        ...(supportsAmbient ? { bots: policy(true).bots, ambientEnabled: true } : {}),
+      });
+    }
+    for (const p of [undefined, { orders: "old", bots: {}, updatedAt: 1 }]) {
+      save.disabled = false;
+      w.show(p);
+      assert.equal(save.disabled, true);
+      let writes = 0;
+      w.request = async () => {
+        writes++;
+        return { ok: true };
+      };
+      await save.onclick!(new dom.window.MouseEvent("click") as unknown as PointerEvent);
+      assert.equal(writes, 0);
+      assert.match(doc.getElementById("st-ambient-policy")!.textContent!, /reload/i);
+    }
+  } finally {
+    dom.window.close();
+  }
+});
+
+for (const backToProject of [false, true])
+  test(`admin policy save refresh ignores stale scope responses (round trip=${backToProject})`, async () => {
+    const { dom, w, doc, save } = fixture();
+    try {
+      w.show(policy(false));
+      let refresh!: () => void;
+      const started = new Promise<void>((resolve) => {
+        refresh = resolve;
+      });
+      let resolve!: (r: unknown) => void;
+      w.request = async (method: string) => {
+        if (method === "PUT") return { ok: true };
+        refresh();
+        return new Promise((r) => {
+          resolve = r;
+        });
+      };
+      const saving = save.onclick!(new dom.window.MouseEvent("click") as unknown as PointerEvent);
+      await started;
+      w.show({ ...policy(true), orders: "new scope" }, "channel:C317");
+      if (backToProject) w.show({ ...policy(false), orders: "new scope" }, "group:web-project-317");
+      resolve({ ok: true, data: { ambientPolicy: { ...policy(false), orders: "stale" } } });
+      await saving;
+      assert.equal((doc.getElementById("ambient-orders") as HTMLTextAreaElement).value, "new scope");
+      assert.notEqual(doc.getElementById("st-ambient-policy")!.textContent, "Saved");
+    } finally {
+      dom.window.close();
+    }
+  });
+
+test("admin scope load clears unsupported controls and cannot submit before a successful response", async () => {
+  const { dom, w, doc, save, hidden } = fixture();
+  try {
+    w.show(policy(true));
+    let resolve!: (r: unknown) => void;
+    let writes = 0;
+    w.request = async (method: string) => {
+      if (method === "PUT") writes++;
+      return new Promise((r) => {
+        resolve = r;
+      });
+    };
+    const loading = w.load("group:another-project");
+    assert.equal(save.disabled, true);
+    assert.equal(hidden(doc.getElementById("ambient-enabled")!), true);
+    await save.onclick!(new dom.window.MouseEvent("click") as unknown as PointerEvent);
+    assert.equal(writes, 0);
+    w.show(policy(false), "group:web-project-317");
+    resolve({ ok: true, data: { ambientPolicy: policy(true) } });
+    await loading;
+    assert.equal(hidden(doc.getElementById("ambient-enabled")!), true);
+  } finally {
+    dom.window.close();
+  }
+});

--- a/plugins/web-ui/test/ambient-policy-dom.test.ts
+++ b/plugins/web-ui/test/ambient-policy-dom.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+import { createServer } from "vite";
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+const policy = (supportsAmbient: boolean) => ({
+  orders: "keep",
+  bots: { CI: { mode: "action" } },
+  ambientEnabled: true,
+  updatedAt: 42,
+  supportsAmbient,
+});
+
+test("member policy DOM and payloads follow server applicability across scope changes", async (t) => {
+  const dom = new JSDOM('<!doctype html><main id="main"></main>', { url: "http://localhost/" });
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  for (const [key, value] of Object.entries({
+    window: dom.window,
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    customElements: dom.window.customElements,
+    Document: dom.window.Document,
+    CSSStyleSheet: dom.window.CSSStyleSheet,
+  })) {
+    previous.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+  const oldFetch = globalThis.fetch;
+  const vite = await createServer({
+    configFile: false,
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    cacheDir: "node_modules/.vite-policy-test",
+  });
+  try {
+    const mod = await vite.ssrLoadModule("/src/ambient-policy.ts");
+    const { render } = await import("lit");
+    const state = mod.ambientPolicyState;
+    const host = document.querySelector("main")!;
+    const redraw = () => render(mod.ambientPolicySection(state.scope), host);
+    const save = () => host.querySelector<HTMLButtonElement>(".ambient-policy-actions button")!;
+    const edit = () => {
+      const input = host.querySelector<HTMLTextAreaElement>("#ambient-orders")!;
+      input.value = "after";
+      input.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    };
+    await t.test(
+      "project orders remain editable; Slack channel and group controls still send complete payloads",
+      async () => {
+        for (const [scope, supportsAmbient] of [
+          ["group:web-project-317", false],
+          ["group:G317", true],
+          ["channel:C317", true],
+          ["group:web-project-317", false],
+        ] as const) {
+          let sent: any;
+          globalThis.fetch = async (_url, init) => {
+            if (init?.method === "PUT") sent = JSON.parse(String(init.body));
+            return Response.json({ policy: policy(supportsAmbient) });
+          };
+          await mod.loadAmbientPolicy(scope, redraw);
+          assert.equal(host.querySelector<HTMLTextAreaElement>("#ambient-orders")!.value, "keep");
+          assert.equal(!!host.querySelector("#ambient-enabled"), supportsAmbient);
+          assert.equal(!!host.querySelector(".ambient-bot-add"), supportsAmbient);
+          if (!supportsAmbient) assert.match(host.textContent!, /Used when QM responds in this project/);
+          edit();
+          save().click();
+          await tick();
+          assert.deepEqual(sent, {
+            orders: "after",
+            baseUpdatedAt: 42,
+            ...(supportsAmbient ? { bots: policy(true).bots, ambientEnabled: true } : {}),
+          });
+        }
+      },
+    );
+    await t.test("failed or incompatible loads cannot submit policy", async () => {
+      for (const response of [
+        () => Response.json({ message: "failed" }, { status: 500 }),
+        () => Response.json({ policy: { orders: "old", bots: {}, updatedAt: 1 } }),
+      ]) {
+        mod.resetAmbientPolicy();
+        let writes = 0;
+        globalThis.fetch = async (_url, init) => {
+          if (init?.method === "PUT") writes++;
+          return response();
+        };
+        await mod.loadAmbientPolicy("group:web-project-317", redraw);
+        edit();
+        assert.equal(save().disabled, true);
+        save().click();
+        await tick();
+        assert.equal(writes, 0);
+        assert.match(host.textContent!, /failed|reload/i);
+      }
+    });
+    await t.test("stale load and save responses cannot overwrite the newly selected scope", async () => {
+      mod.resetAmbientPolicy();
+      let resolve!: (r: Response) => void;
+      globalThis.fetch = () =>
+        new Promise<Response>((r) => {
+          resolve = r;
+        });
+      const loading = mod.loadAmbientPolicy("group:G317", redraw);
+      globalThis.fetch = async () => Response.json({ policy: policy(false) });
+      await mod.loadAmbientPolicy("group:web-project-317", redraw);
+      resolve(Response.json({ policy: policy(true) }));
+      await loading;
+      assert.equal(host.querySelector("#ambient-enabled"), null);
+      globalThis.fetch = () =>
+        new Promise<Response>((r) => {
+          resolve = r;
+        });
+      edit();
+      save().click();
+      globalThis.fetch = async () => Response.json({ policy: { ...policy(true), orders: "new scope" } });
+      await mod.loadAmbientPolicy("channel:C317", redraw);
+      resolve(Response.json({ policy: { ...policy(false), orders: "stale" } }));
+      await tick();
+      assert.equal(state.orders, "new scope");
+      assert.equal(state.notice, "");
+      assert.ok(host.querySelector("#ambient-enabled"));
+    });
+  } finally {
+    await vite.close();
+    dom.window.close();
+    globalThis.fetch = oldFetch;
+    for (const [key, value] of previous) {
+      if (value) Object.defineProperty(globalThis, key, value);
+      else Reflect.deleteProperty(globalThis, key);
+    }
+  }
+});

--- a/plugins/web-ui/test/ambient-policy-server-route.test.ts
+++ b/plugins/web-ui/test/ambient-policy-server-route.test.ts
@@ -85,3 +85,15 @@ test("PUT relays orders, bots, and the conflict snapshot under the signed-in pri
   assert.deepEqual(call.body.bots, { "General Agent": { mode: "rollup", rollupHours: 4 } });
   assert.equal(call.body.baseUpdatedAt, 42);
 });
+
+test("project orders-only PUT preserves field omission and rejects caller identity/scope overrides", async () => {
+  const before = calls.length;
+  const scope = "group:web-project-317";
+  const r = await fetch(`${base}/api/contexts/${encodeURIComponent(scope)}/ambient-policy`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ principalId: "mallory", scope: "channel:C1", orders: "project order", baseUpdatedAt: 42 }),
+  });
+  assert.equal(r.status, 200);
+  assert.deepEqual(calls[before]!.body, { principalId: "alice", scope, orders: "project order", baseUpdatedAt: 42 });
+});

--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -30,6 +30,7 @@ import {
   type PublicServiceCredential,
   type ServiceCredentialInput,
 } from "../../credentials/keychain.ts";
+import { supportsAmbientControls, UNSUPPORTED_AMBIENT_CONTROLS } from "../../surface-cache/policy-scope.ts";
 import { parseBotLedger } from "../../surface-cache/channel-policy-store.ts";
 import { authorizeUrl, PROVIDERS, type ConsentMode } from "../../connectors/oauth.ts";
 import { resolverFor } from "./connectors.ts";
@@ -264,6 +265,7 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       const p = await deps.channelPolicy.get(ref).catch(() => undefined);
       if (p === undefined) return undefined;
       return {
+        supportsAmbient: supportsAmbientControls(scope),
         orders: p?.orders ?? "",
         bots: p?.bots ?? {},
         ambientEnabled: p?.ambientEnabled ?? null,
@@ -281,12 +283,15 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
         ambientEnabled?: unknown;
         baseUpdatedAt?: unknown;
       };
+      const supportsAmbient = supportsAmbientControls(scope);
+      if (!supportsAmbient && (Object.hasOwn(b, "bots") || Object.hasOwn(b, "ambientEnabled")))
+        return { error: UNSUPPORTED_AMBIENT_CONTROLS };
       if (typeof b.orders !== "string") return { error: "ambient-policy requires { orders: string }" };
       if (b.orders.length > MAX_ORDERS_CHARS)
         return {
-          error: `standing order is capped at ${MAX_ORDERS_CHARS} characters — it is rendered into every ambient judgment`,
+          error: `standing order is capped at ${MAX_ORDERS_CHARS} characters`,
         };
-      const parsed = parseBotLedger(b.bots);
+      const parsed = parseBotLedger(supportsAmbient ? b.bots : {});
       if ("error" in parsed) return { error: parsed.error };
       if (b.ambientEnabled !== undefined && b.ambientEnabled !== null && typeof b.ambientEnabled !== "boolean")
         return { error: "ambientEnabled must be a boolean or null (null = default rule)" };
@@ -300,8 +305,9 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
       }
       await deps.channelPolicy.set(ref, b.orders, {
         setBy: actor.id,
-        bots: parsed.bots,
-        ambientEnabled: b.ambientEnabled as boolean | null | undefined,
+        ...(supportsAmbient
+          ? { bots: parsed.bots, ambientEnabled: b.ambientEnabled as boolean | null | undefined }
+          : {}),
       });
       audit(ctx.deps, { principalId: actor.id, action: "surface.policy.set", resource: ref, scopeLabel: scope });
       return { ok: true };

--- a/src/api/routes/context-policy.ts
+++ b/src/api/routes/context-policy.ts
@@ -1,5 +1,6 @@
 import { parseScopeId } from "../../types.ts";
 import { parseBotLedger } from "../../surface-cache/channel-policy-store.ts";
+import { supportsAmbientControls, UNSUPPORTED_AMBIENT_CONTROLS } from "../../surface-cache/policy-scope.ts";
 import { sendJson } from "../http.ts";
 import { audit, isObj } from "./shared.ts";
 import { type ApiCtx, type Route } from "./route.ts";
@@ -34,6 +35,7 @@ export async function getContextPolicy(ctx: ApiCtx): Promise<void> {
   const p = await deps.channelPolicy.get(container);
   return sendJson(res, 200, {
     policy: {
+      supportsAmbient: supportsAmbientControls(scope),
       orders: p?.orders ?? "",
       bots: p?.bots ?? {},
       ambientEnabled: p?.ambientEnabled ?? null,
@@ -58,12 +60,15 @@ export async function setContextPolicy(ctx: ApiCtx): Promise<void> {
   if (!deps.channelPolicy)
     return sendJson(res, 404, { error: "not_found", message: "not available on this deployment" });
   if (!(await memberScope(ctx, principalId, scope))) return sendJson(res, 403, { error: "forbidden" });
+  const supportsAmbient = supportsAmbientControls(scope);
+  if (!supportsAmbient && (Object.hasOwn(b, "bots") || Object.hasOwn(b, "ambientEnabled")))
+    return sendJson(res, 400, { error: "bad_request", message: UNSUPPORTED_AMBIENT_CONTROLS });
   if (typeof b.orders !== "string")
     return sendJson(res, 400, { error: "bad_request", message: "orders (string) required" });
   if (b.orders.length > MAX_ORDERS_CHARS)
     return sendJson(res, 400, {
       error: "bad_request",
-      message: `standing order is capped at ${MAX_ORDERS_CHARS} characters — it is rendered into every ambient judgment`,
+      message: `standing order is capped at ${MAX_ORDERS_CHARS} characters`,
     });
   const parsed = parseBotLedger(b.bots ?? {});
   if ("error" in parsed) return sendJson(res, 400, { error: "bad_request", message: parsed.error });
@@ -81,12 +86,17 @@ export async function setContextPolicy(ctx: ApiCtx): Promise<void> {
   }
   const p = await deps.channelPolicy.set(container, b.orders, {
     setBy: principalId,
-    bots: parsed.bots,
-    ambientEnabled: b.ambientEnabled as boolean | null | undefined,
+    ...(supportsAmbient ? { bots: parsed.bots, ambientEnabled: b.ambientEnabled as boolean | null | undefined } : {}),
   });
   audit(deps, { principalId, action: "surface.policy.set", resource: container, scopeLabel: scope });
   return sendJson(res, 200, {
-    policy: { orders: p.orders, bots: p.bots, ambientEnabled: p.ambientEnabled ?? null, updatedAt: p.updatedAt },
+    policy: {
+      supportsAmbient,
+      orders: p.orders,
+      bots: p.bots,
+      ambientEnabled: p.ambientEnabled ?? null,
+      updatedAt: p.updatedAt,
+    },
   });
 }
 

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -24,6 +24,7 @@ import { deriveTurnOutcome, approvalBlocksInput } from "./turn-outcome.ts";
 import { applyPromptVars, loadProtocolFile, type PromptVars } from "../resolution/prompt-vars.ts";
 import { cleanBrandingLabel, resolveBranding } from "../resolution/branding.ts";
 import { resolveReachableChannel } from "../resolution/scope-reach.ts";
+import { isProjectGroupRef } from "../projects/project-store.ts";
 import { reachEnqueue } from "../reach/reach.ts";
 import { turnDeliveryProvenance } from "../delivery/delivery-store.ts";
 import type { DirectoryStore, DirectoryChannel, DirectoryMember } from "../directory/directory-store.ts";
@@ -971,7 +972,8 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
       else if (modeName === "mode-conversation") frameMd = MODE_CONVERSATION_MD;
       let frameVars: PromptVars = {};
       if (modeName === "mode-autonomous") {
-        frameVars = { botName, surfaceTool, slack: isSlack };
+        const webProject = isWeb && conversation.kind === "group" && isProjectGroupRef(conversation.channelRef ?? "");
+        frameVars = { botName, surfaceTool, slack: isSlack, webProject, autonomous: !webProject };
       } else if (modeName === "mode-conversation") {
         frameVars = {
           botName,

--- a/src/core/orchestrator/surface-tools.ts
+++ b/src/core/orchestrator/surface-tools.ts
@@ -28,6 +28,7 @@ import type {
 } from "../../tools/primitives.ts";
 import { collectBlob, MAX_BLOB_BYTES, type BlobTransferStore } from "../../persistence/blob-transfer.ts";
 import { collectNamedOutbound, type ArtifactRegistration } from "../attachments.ts";
+import { supportsAmbientControls, UNSUPPORTED_AMBIENT_CONTROLS } from "../../surface-cache/policy-scope.ts";
 import { parseBotLedger, type BotPolicy } from "../../surface-cache/channel-policy-store.ts";
 import { isoFromTs } from "../../util/message-tag.ts";
 import { errMessage } from "../../util/errors.ts";
@@ -445,6 +446,7 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
       const p = await deps.channelPolicy.get(conversation.channelRef);
       return {
         ok: true,
+        supportsAmbient: supportsAmbientControls(scopeId),
         orders: p?.orders ?? "",
         ...(p?.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}),
         ...(p?.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
@@ -454,6 +456,9 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
       if (!deps.channelPolicy) return { ok: false, message: "standing orders aren't available on this turn" };
       if (conversation.kind === "dm" || !conversation.channelRef)
         return { ok: false, message: "standing orders are per-channel — you can only set one from inside a channel." };
+      const supportsAmbient = supportsAmbientControls(scopeId);
+      if (!supportsAmbient && (bots !== undefined || ambientEnabled !== undefined))
+        return { ok: false, message: UNSUPPORTED_AMBIENT_CONTROLS };
       let parsedBots: Record<string, BotPolicy> | undefined;
       if (bots !== undefined) {
         const parsed = parseBotLedger(bots);
@@ -476,6 +481,7 @@ export function createSurfaceToolDeps(ctx: SurfaceToolsContext): SurfaceToolDeps
       return {
         ok: true,
         orders,
+        supportsAmbient,
         ...(p.bots && Object.keys(p.bots).length ? { bots: p.bots } : {}),
         ...(p.ambientEnabled !== undefined ? { ambientEnabled: p.ambientEnabled } : {}),
       };

--- a/src/harness/agent-tools.ts
+++ b/src/harness/agent-tools.ts
@@ -2245,11 +2245,13 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
     label: "guidance",
     description:
       "Read or rewrite your durable guidance — the standing instructions you carry into " +
-      "future turns. Two scopes: `channel` = how you behave in THIS channel (when to chime " +
-      "in unprompted, where replies land, ongoing 'whenever X, do Y' orders — evaluated " +
-      "against every new message automatically, so never build a poll or timer for these); " +
+      "future turns. Two scopes: `channel` = how you behave in THIS Slack channel or group DM " +
+      "(when to chime in unprompted, where replies land, ongoing 'whenever X, do Y' orders — " +
+      "evaluated against every new message automatically, so never build a poll or timer for these); " +
+      "in web projects, `channel` orders affect addressed replies only and never trigger unprompted turns. " +
+      "Omit `ambientEnabled` and `bots` for web projects. " +
       "`conversation` = your standing instructions for this conversation (tone, defaults, " +
-      "recurring preferences). Default scope: `channel` when you're in a channel, else " +
+      "recurring preferences). Default scope: `channel` in a channel, group DM or web project, else " +
       "`conversation`. Conversation guidance lives on the surrounding scope — in a personal " +
       "context it is shared by ALL of that person's sessions, not tied to the session that " +
       "wrote it. Never store session pins or 'for this session' notes here: ALL pinning goes " +
@@ -2265,7 +2267,7 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
       ambientEnabled: Type.Optional(
         Type.Union([Type.Boolean(), Type.Null()], {
           description:
-            "Channel scope only. true judges every message for an unprompted reply, false responds only when addressed, and null uses the platform default.",
+            "Slack channel/group-DM scope only; unsupported in web projects. true judges every message for an unprompted reply, false responds only when addressed, and null uses the platform default.",
         }),
       ),
       bots: Type.Optional(
@@ -2277,7 +2279,7 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
           }),
           {
             description:
-              "Per-bot handling for automated posters in this channel, keyed by bot author name: " +
+              "Per-bot handling for automated posters in Slack channels and group DMs (unsupported in web projects), keyed by bot author name: " +
               "ignore (never wakes you), rollup (batch; judge at most every rollupHours), action " +
               "(their posts are triggers to act on), user (treat like a person).",
           },
@@ -2313,7 +2315,7 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
           const soul = tc.soulRead();
           const convoExists = !isUnavailable(soul) && !!soul.soul && soul.soul.trim().length > 0;
           const ledger =
-            channel!.bots && Object.keys(channel!.bots).length
+            channel!.supportsAmbient !== false && channel!.bots && Object.keys(channel!.bots).length
               ? "\n\nBot ledger:\n" +
                 Object.entries(channel!.bots)
                   .map(([n, b]) => `- ${n}: ${b.mode}${b.rollupHours ? ` (every ${b.rollupHours}h)` : ""}`)
@@ -2324,7 +2326,10 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
             : "";
           let ambientState = "default";
           if (channel!.ambientEnabled !== undefined) ambientState = channel!.ambientEnabled ? "on" : "off";
-          const ambient = `\n\nAmbient replies: ${ambientState}`;
+          const ambient =
+            channel!.supportsAmbient === false
+              ? "\n\nStanding orders in this project affect addressed replies only. Ambient replies and bot handling are not supported here."
+              : `\n\nAmbient replies: ${ambientState}`;
           const body =
             (channel!.orders.trim() ? channel!.orders : "[no channel guidance set]") + ambient + ledger + note;
           return recordResult(callId, { tool: "guidance", scope, ok: true }, text(body));
@@ -2343,7 +2348,11 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
         const r = await tc.setStandingOrder(orders, params.bots, params.ambientEnabled);
         if (!r.ok)
           return recordResult(callId, { tool: "guidance", scope, ok: false }, text(`[error] ${r.message}`), true);
-        return recordResult(callId, { tool: "guidance", scope, ok: true }, text("[channel guidance updated]"));
+        const message =
+          r.supportsAmbient === false
+            ? "[project standing orders updated — these affect addressed replies only]"
+            : "[channel guidance updated]";
+        return recordResult(callId, { tool: "guidance", scope, ok: true }, text(message));
       }
 
       if (params.ambientEnabled !== undefined) {

--- a/src/resolution/protocols/mode-autonomous.md
+++ b/src/resolution/protocols/mode-autonomous.md
@@ -1,18 +1,20 @@
 # This session
 You are {{botName}}, present in this conversation on its own — no person is talking to you and no one ever reads this transcript; it is your private worklog. Your words reach people ONLY through the `{{surfaceTool}}` tool — `post` to reply here, `reach` to send elsewhere. Everything else you write here is notes to yourself, so when a turn's work is done, end with a short log line to yourself — "Replied in thread", "Not for me — stayed silent", "Nothing to add" — never a message addressed to a person; there is no one here to address.
 
-You see every message posted here as it arrives — you do NOT need to be @mentioned, and you never poll, scan, or run a timer to keep up; new messages come to you. Most of them aren't for you.
+{{#if autonomous}}You see every message posted here as it arrives — you do NOT need to be @mentioned, and you never poll, scan, or run a timer to keep up; new messages come to you. Most of them aren't for you.
 
 Speak only when it's warranted:
 - Addressed — named or @mentioned, however informal → reply with the `{{surfaceTool}}` tool's `post` action, or decline with `stay_silent` and a brief reason.
 - A standing order for this conversation calls for it → do what it says.
 - You can clearly, concretely help → you may chime in.
-- Otherwise end the turn without posting. Silence is the default and costs nothing.
+- Otherwise end the turn without posting. Silence is the default and costs nothing.{{/if}}{{#if webProject}}Web-project message handling is addressed-only. You do not automatically observe or evaluate other project messages. Standing orders affect addressed replies only; they never trigger unprompted turns. Do not promise passive monitoring of this project.
+
+When addressed, reply with the `{{surfaceTool}}` tool's `post` action, or decline with `stay_silent` and a brief reason.{{/if}}
 
 Two verbs, and the difference is the audience. `post` answers HERE — in the conversation you're in; it cannot go anywhere else. A plain `post` lands in the thread (or DM) you were addressed in, which is almost always what you want. Within that: `ts` replies under a different earlier message here; `broadcast: true` posts at this channel's top level instead of in the thread (a deliberate wider-audience move). `reach` is the ONLY way to send to a DIFFERENT audience — a teammate's DM (`recipient`), another channel (`channel`), or a group (`participants`); core resolves the name and tells you who it matched, so a message can never slip into the wrong channel by accident. A standing order about placement wins.
 
 When an addressed request needs tool work before you can answer, post ONE short line first — what you're about to do, a few words, nothing more ("Checking the deploy logs.", "On it — running the suite."). Then work in silence and post the complete answer when done. Skip the preamble post when you can answer immediately, and never let it pre-judge the answer — it says what you'll do, not what you expect to find.
 
-A request to change your ONGOING behavior here — "from now on…", "whenever X, do Y", "stop replying in threads", "keep an eye out for Z" — is an EDIT to this conversation's durable guidance, not a one-off act: read it with the `guidance` tool, amend it (keep what's still true), save it, and confirm the new rule in your reply. The guidance is re-evaluated against every new message automatically — no cron, no poll.
+A request to change your ONGOING behavior here — "from now on…", "whenever X, do Y", "stop replying in threads", "keep an eye out for Z" — is an EDIT to this conversation's durable guidance, not a one-off act: read it with the `guidance` tool, amend it (keep what's still true), save it, and confirm the new rule in your reply. {{#if autonomous}}The guidance is re-evaluated against every new message automatically — no cron, no poll.{{/if}}{{#if webProject}}Saved guidance applies to addressed replies only, not automatically to every new project message.{{/if}}
 
 Anything you post is read by people: lead with the substance, describe work in human terms, never machinery (no tool names, scopes, or raw error strings). {{#if slack}}You're on Slack: keep each posted message to at most two sentences unless asked for more. You see only a recent window here; use the `{{surfaceTool}}` tool's read actions (or `POST $AGENT_API_URL/v1/surface-context`) to reach further back and into other channels.{{/if}}

--- a/src/surface-cache/policy-scope.ts
+++ b/src/surface-cache/policy-scope.ts
@@ -1,0 +1,10 @@
+import { parseScopeId } from "../types.ts";
+import { isProjectGroupRef } from "../projects/project-store.ts";
+
+export function supportsAmbientControls(scope: string): boolean {
+  const { kind, ref } = parseScopeId(scope);
+  return !!ref && (kind === "channel" || (kind === "group" && !isProjectGroupRef(ref)));
+}
+
+export const UNSUPPORTED_AMBIENT_CONTROLS =
+  "Web projects support standing orders, but not ambient behavior or bot handling. Omit bots and ambientEnabled.";

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -374,7 +374,7 @@ interface SurfaceFileResult {
 }
 
 type SurfaceStandingOrderResult =
-  | { ok: true; orders: string; bots?: Record<string, BotPolicy>; ambientEnabled?: boolean }
+  | { ok: true; orders: string; supportsAmbient?: boolean; bots?: Record<string, BotPolicy>; ambientEnabled?: boolean }
   | { ok: false; message: string };
 
 export interface SurfaceToolDeps {

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -668,7 +668,13 @@ test("ambient-policy edits a channel's standing order and bot ledger through the
     const empty = (await (await fetch(`${srv.base}/v1/admin/scopes/channel:C1`, { headers: ADMIN })).json()) as {
       ambientPolicy: { orders: string; bots: object; updatedAt: number };
     };
-    assert.deepEqual(empty.ambientPolicy, { orders: "", bots: {}, ambientEnabled: null, updatedAt: 0 });
+    assert.deepEqual(empty.ambientPolicy, {
+      orders: "",
+      bots: {},
+      ambientEnabled: null,
+      updatedAt: 0,
+      supportsAmbient: true,
+    });
 
     const badScope = await fetch(`${srv.base}/v1/admin/scopes/org:default-org/ambient-policy`, {
       method: "PUT",
@@ -893,3 +899,114 @@ test("historical cutover policies remain visible and clearable without layer too
     await srv.close();
   }
 });
+
+test("admin project policy preserves orders and legacy options, rejects unsupported fields before all mutation", async () => {
+  const srv = start();
+  const ref = "web-project-317";
+  const scope = `group:${ref}`;
+  const url = `${srv.base}/v1/admin/scopes/${scope}`;
+  const put = (body: unknown, headers = ADMIN) =>
+    fetch(`${url}/ambient-policy`, { method: "PUT", headers, body: JSON.stringify(body) });
+  try {
+    const bots = { CI: { mode: "action" as const } };
+    await srv.built.channelPolicy.set(ref, "before", { bots, ambientEnabled: true });
+    const before = await srv.built.channelPolicy.get(ref);
+    const history = await srv.built.channelPolicy.history(ref);
+    const read = await fetch(url, { headers: ADMIN });
+    assert.equal(read.status, 200);
+    const policy = ((await read.json()) as any).ambientPolicy;
+    assert.equal(policy.supportsAmbient, false);
+    assert.equal(policy.orders, "before");
+    const audits: unknown[] = [];
+    const record = srv.built.auditLog.record.bind(srv.built.auditLog);
+    srv.built.auditLog.record = (e) => {
+      audits.push(e);
+      record(e);
+    };
+    const outsider = { ...ADMIN, "x-admin-actor": "nobody@default-org" };
+    assert.equal((await fetch(url, { headers: outsider })).status, 403);
+    assert.equal((await put({ orders: "not authorized" }, outsider)).status, 403);
+    for (const field of [
+      { ambientEnabled: true },
+      { ambientEnabled: false },
+      { ambientEnabled: null },
+      { ambientEnabled: {} },
+      { bots: {} },
+      { bots: null },
+      { bots },
+    ]) {
+      for (const orders of ["partial write forbidden", undefined]) {
+        const r = await put({ orders, supportsAmbient: true, ...field });
+        assert.equal(r.status, 400);
+        assert.match(((await r.json()) as any).message, /standing orders.*not.*ambient/i);
+      }
+    }
+    assert.equal((await put({})).status, 400);
+    assert.equal((await put({ orders: "x".repeat(20_001) })).status, 400);
+    assert.equal((await put({ orders: "stale", baseUpdatedAt: -1 })).status, 409);
+    assert.deepEqual(await srv.built.channelPolicy.get(ref), before);
+    assert.deepEqual(await srv.built.channelPolicy.history(ref), history);
+    assert.deepEqual(audits, []);
+    assert.equal((await put({ orders: "after", baseUpdatedAt: before!.updatedAt })).status, 200);
+    const after = await srv.built.channelPolicy.get(ref);
+    assert.equal(after!.orders, "after");
+    assert.equal(after!.ambientEnabled, true);
+    assert.deepEqual(after!.bots, bots);
+    assert.deepEqual((await srv.built.channelPolicy.history(ref)).slice(1), history);
+    assert.deepEqual(
+      audits.map((e: any) => e.action),
+      ["surface.policy.set", "ambient-policy.update"],
+    );
+    for (const slack of ["channel:C317", "group:G317"]) {
+      for (const ambientEnabled of [true, false, null]) {
+        const r = await fetch(`${srv.base}/v1/admin/scopes/${slack}/ambient-policy`, {
+          method: "PUT",
+          headers: ADMIN,
+          body: JSON.stringify({ orders: "watch", bots, ambientEnabled }),
+        });
+        assert.equal(r.status, 200);
+        const got = await fetch(`${srv.base}/v1/admin/scopes/${slack}`, { headers: ADMIN });
+        const p = ((await got.json()) as any).ambientPolicy;
+        assert.equal(p.supportsAmbient, true);
+        assert.equal(p.ambientEnabled, ambientEnabled);
+        assert.deepEqual(p.bots, bots);
+      }
+    }
+  } finally {
+    await srv.close();
+  }
+});
+
+for (const scope of ["group:web-project-limit", "channel:C-limit", "group:G-limit"])
+  test(`admin policy size limit is applicability-neutral: ${scope}`, async () => {
+    const srv = start();
+    const ref = scope.slice(scope.indexOf(":") + 1);
+    const put = (orders: string) =>
+      fetch(`${srv.base}/v1/admin/scopes/${scope}/ambient-policy`, {
+        method: "PUT",
+        headers: ADMIN,
+        body: JSON.stringify({ orders, ...(scope.startsWith("group:web-project-") ? {} : { bots: {} }) }),
+      });
+    try {
+      assert.equal((await put("x".repeat(20_000))).status, 200);
+      const before = await srv.built.channelPolicy.get(ref);
+      const history = await srv.built.channelPolicy.history(ref);
+      const audits: unknown[] = [];
+      const record = srv.built.auditLog.record.bind(srv.built.auditLog);
+      srv.built.auditLog.record = (e) => {
+        audits.push(e);
+        record(e);
+      };
+      const oversized = await put("x".repeat(20_001));
+      assert.equal(oversized.status, 400);
+      assert.equal(
+        ((await oversized.json()) as { message: string }).message,
+        "standing order is capped at 20000 characters",
+      );
+      assert.deepEqual(await srv.built.channelPolicy.get(ref), before);
+      assert.deepEqual(await srv.built.channelPolicy.history(ref), history);
+      assert.deepEqual(audits, []);
+    } finally {
+      await srv.close();
+    }
+  });

--- a/test/agent-tools.test.ts
+++ b/test/agent-tools.test.ts
@@ -4,6 +4,8 @@ import { createAgentTools, pauseStampAfterToolCall, type ToolContextRef } from "
 import { filterHistoryForAudience } from "../src/resolution/context-filter.ts";
 import { CommandDenied, NeedsApproval, type ToolContext } from "../src/tools/primitives.ts";
 import type { EntryType, SessionEntry } from "../src/types.ts";
+import { createSurfaceToolDeps, type SurfaceToolsContext } from "../src/core/orchestrator/surface-tools.ts";
+import { createMemoryChannelPolicyStore } from "../src/surface-cache/channel-policy-store.ts";
 import type { ComputerStatus } from "../src/sandbox/sandbox.ts";
 
 function fakeToolContext(sink?: { lastExecOpts?: Parameters<ToolContext["execute"]>[1] }): ToolContext {
@@ -2647,3 +2649,124 @@ test("execute output from a reached room is external even for a local-looking co
   await call(execute, { command: "cat notes.md", scope: "channel:C2" });
   assert.deepEqual(seen, [{ provenance: "external", source: "reached room" }]);
 });
+
+test("project guidance uses the real writer, preserves legacy options and refuses unsupported controls", async () => {
+  const channelPolicy = createMemoryChannelPolicyStore();
+  const ref = "web-project-317";
+  const bots = { CI: { mode: "action" as const } };
+  await channelPolicy.set(ref, "before", { bots, ambientEnabled: true });
+  const audits: unknown[] = [];
+  const context = {
+    deps: { deliveries: {}, channelPolicy, auditLog: { record: (e: unknown) => audits.push(e) } },
+    input: { surfaceTools: true },
+    actor: { id: "U1" },
+    conversation: { kind: "group", channelRef: ref },
+    session: { id: "S1" },
+    scopeId: `group:${ref}`,
+    defaultDestination: {},
+    strictReadOnly: false,
+  } as unknown as SurfaceToolsContext;
+  const surface = createSurfaceToolDeps(context)!;
+  assert.equal(createSurfaceToolDeps({ ...context, strictReadOnly: true }), undefined);
+  assert.equal(createSurfaceToolDeps({ ...context, input: { ...context.input, surfaceTools: false } }), undefined);
+  const tc = {
+    ...fakeToolContext(),
+    getStandingOrder: surface.getStandingOrder,
+    setStandingOrder: surface.setStandingOrder,
+  };
+  const guidance = tool("guidance", tc);
+  const out = textOut(await call(guidance, { action: "read" }));
+  assert.match(out, /before/);
+  assert.match(out, /not supported/i);
+  assert.doesNotMatch(out, /Ambient replies: (on|off|default)|Bot ledger:/);
+  const before = await channelPolicy.get(ref);
+  const history = await channelPolicy.history(ref);
+  for (const field of [
+    { ambientEnabled: true },
+    { ambientEnabled: false },
+    { ambientEnabled: null },
+    { ambientEnabled: {} },
+    { bots: {} },
+    { bots: null },
+    { bots },
+  ]) {
+    for (const content of ["partial change forbidden", undefined]) {
+      const r = textOut(await call(guidance, { action: "write", content, ...field }));
+      assert.match(r, /\[error\].*standing orders.*not.*ambient/i);
+      assert.deepEqual(await channelPolicy.get(ref), before);
+      assert.deepEqual(await channelPolicy.history(ref), history);
+      assert.equal(audits.length, 0);
+    }
+  }
+  assert.match(textOut(await call(guidance, { action: "write", content: "after" })), /updated/);
+  const after = await channelPolicy.get(ref);
+  assert.equal(after!.orders, "after");
+  assert.equal(after!.ambientEnabled, true);
+  assert.deepEqual(after!.bots, bots);
+  assert.equal(audits.length, 1);
+  assert.deepEqual((await channelPolicy.history(ref)).slice(1), history);
+});
+
+test("guidance model-facing description states the web-project exception before any tool call", () => {
+  const guidance = createAgentTools({ current: null }, { surfaceTools: true }).find((t) => t.name === "guidance")!;
+  assert.match(guidance.description, /Slack channel or group DM/);
+  assert.match(guidance.description, /evaluated against every new message automatically/);
+  assert.match(guidance.description, /in web projects, `channel` orders affect addressed replies only/);
+  assert.match(guidance.description, /never trigger unprompted turns/);
+  assert.match(guidance.description, /Omit `ambientEnabled` and `bots` for web projects/);
+  assert.match(guidance.description, /Default scope: `channel` in a channel, group DM or web project/);
+});
+
+for (const field of ["ambientEnabled", "bots"])
+  test(`guidance model-facing ${field} schema excludes web projects`, () => {
+    const guidance = createAgentTools({ current: null }, { surfaceTools: true }).find((t) => t.name === "guidance")!;
+    const parameters = guidance.parameters as { properties: Record<string, { description?: string }> };
+    assert.match(parameters.properties[field]!.description!, /Slack/);
+    assert.match(parameters.properties[field]!.description!, /unsupported in web projects/);
+  });
+
+for (const [scope, kind, ref] of [
+  ["group:web-project-guidance-contract", "group", "web-project-guidance-contract"],
+  ["channel:C-guidance-contract", "channel", "C-guidance-contract"],
+  ["group:G-guidance-contract", "group", "G-guidance-contract"],
+] as const)
+  test(`guidance response semantics before and after orders-only write: ${scope}`, async (t) => {
+    const channelPolicy = createMemoryChannelPolicyStore();
+    const project = ref.startsWith("web-project-");
+    await channelPolicy.set(ref, "before", { ambientEnabled: true });
+    const surface = createSurfaceToolDeps({
+      deps: { deliveries: {}, channelPolicy, auditLog: { record() {} } },
+      input: { surfaceTools: true },
+      actor: { id: "U1" },
+      conversation: { kind, channelRef: ref },
+      session: { id: "S1" },
+      scopeId: scope,
+      defaultDestination: {},
+      strictReadOnly: false,
+    } as unknown as SurfaceToolsContext)!;
+    const guidance = tool("guidance", {
+      ...fakeToolContext(),
+      getStandingOrder: surface.getStandingOrder,
+      setStandingOrder: surface.setStandingOrder,
+    });
+    await t.test("read before write", async () => {
+      const read = textOut(await call(guidance, { action: "read" }));
+      assert.match(read, /before/);
+      if (project) assert.match(read, /addressed replies only/);
+      else assert.match(read, /Ambient replies: on/);
+    });
+    await t.test("write success and subsequent read", async () => {
+      const saved = textOut(await call(guidance, { action: "write", content: "after" }));
+      if (project) {
+        assert.match(saved, /project standing orders updated/);
+        assert.match(saved, /addressed replies only/);
+        assert.doesNotMatch(saved, /channel guidance updated/);
+      } else assert.equal(saved, "[channel guidance updated]");
+      const read = textOut(await call(guidance, { action: "read" }));
+      assert.match(read, /after/);
+      if (project) assert.match(read, /addressed replies only/);
+      else assert.match(read, /Ambient replies: on/);
+      assert.equal((await channelPolicy.get(ref))!.orders, "after");
+      assert.equal((await channelPolicy.get(ref))!.ambientEnabled, true);
+    });
+  });

--- a/test/context-policy-routes.test.ts
+++ b/test/context-policy-routes.test.ts
@@ -25,7 +25,12 @@ function makeCtx(over: {
   body?: unknown;
   contexts?: string[];
   store?: ReturnType<typeof createMemoryChannelPolicyStore>;
-}): { ctx: ApiCtx; out: { status: number; body: unknown }; store: ReturnType<typeof createMemoryChannelPolicyStore> } {
+}): {
+  ctx: ApiCtx;
+  out: { status: number; body: unknown };
+  store: ReturnType<typeof createMemoryChannelPolicyStore>;
+  audits: unknown[];
+} {
   const { res, out } = fakeRes();
   const store = over.store ?? createMemoryChannelPolicyStore();
   const audits: unknown[] = [];
@@ -42,7 +47,7 @@ function makeCtx(over: {
       auditLog: { record: (e: unknown) => audits.push(e) },
     },
   } as unknown as ApiCtx;
-  return { ctx, out, store };
+  return { ctx, out, store, audits };
 }
 
 test("context policy read requires membership and a Slack-backed scope", async () => {
@@ -172,3 +177,147 @@ test("a stale baseUpdatedAt bounces instead of reverting a concurrent edit", asy
   assert.equal(fresh.out.status, 200);
   assert.equal((await store.get("C3"))?.orders, "v2");
 });
+
+for (const scope of [
+  "group:web-project-317",
+  "group:web-project-",
+  "group:web-project-invalid:tail",
+  "channel:C317",
+  "group:G317",
+]) {
+  test(`policy applicability and orders-only saves preserve legacy options: ${scope}`, async () => {
+    const ref = scope.slice(scope.indexOf(":") + 1);
+    const store = createMemoryChannelPolicyStore();
+    const bots = { CI: { mode: "action" as const } };
+    await store.set(ref, "before", { bots, ambientEnabled: true });
+    const before = await store.get(ref);
+    const history = await store.history(ref);
+    const supportsAmbient = !scope.startsWith("group:web-project-");
+    const read = makeCtx({
+      store,
+      contexts: [scope],
+      url: `http://x/v1/contexts/policy?principalId=alice&scope=${scope}`,
+    });
+    await getContextPolicy(read.ctx);
+    assert.equal(read.out.status, 200);
+    assert.equal((read.out.body as any).policy.supportsAmbient, supportsAmbient);
+    const write = makeCtx({
+      store,
+      contexts: [scope],
+      body: { principalId: "alice", scope, orders: "after", baseUpdatedAt: before!.updatedAt },
+    });
+    await setContextPolicy(write.ctx);
+    assert.equal(write.out.status, 200);
+    assert.equal((write.out.body as any).policy.supportsAmbient, supportsAmbient);
+    assert.equal((await store.get(ref))!.orders, "after");
+    assert.equal((await store.get(ref))!.ambientEnabled, true);
+    assert.deepEqual((await store.get(ref))!.bots, supportsAmbient ? {} : bots);
+    assert.equal(write.audits.length, 1);
+    assert.deepEqual((await store.history(ref)).slice(1), history);
+  });
+}
+
+for (const field of [
+  { ambientEnabled: true },
+  { ambientEnabled: false },
+  { ambientEnabled: null },
+  { ambientEnabled: {} },
+  { bots: {} },
+  { bots: null },
+  { bots: { CI: { mode: "action" } } },
+]) {
+  test(`project policy rejects supplied fields atomically: ${JSON.stringify(field)}`, async () => {
+    const scope = "group:web-project-317";
+    const ref = "web-project-317";
+    const store = createMemoryChannelPolicyStore();
+    await store.set(ref, "keep", { ambientEnabled: false, bots: { CI: { mode: "ignore" } } });
+    const before = await store.get(ref);
+    const history = await store.history(ref);
+    for (const orders of ["do not write this", undefined]) {
+      const c = makeCtx({
+        store,
+        contexts: [scope],
+        body: { principalId: "alice", scope, orders, supportsAmbient: true, ...field },
+      });
+      await setContextPolicy(c.ctx);
+      assert.equal(c.out.status, 400);
+      assert.match((c.out.body as any).message, /standing orders.*not.*ambient/i);
+      assert.deepEqual(await store.get(ref), before);
+      assert.deepEqual(await store.history(ref), history);
+      assert.equal(c.audits.length, 0);
+    }
+  });
+}
+
+test("project membership, orders validation and conflicts fail independently without writes", async () => {
+  const scope = "group:web-project-317";
+  const store = createMemoryChannelPolicyStore();
+  await store.set("web-project-317", "keep");
+  const before = await store.get("web-project-317");
+  const history = await store.history("web-project-317");
+  const outsider = makeCtx({
+    store,
+    contexts: [],
+    url: `http://x/v1/contexts/policy?principalId=alice&scope=${scope}`,
+    body: { principalId: "alice", scope, orders: "bad" },
+  });
+  await getContextPolicy(outsider.ctx);
+  assert.equal(outsider.out.status, 403);
+  await setContextPolicy(outsider.ctx);
+  assert.equal(outsider.out.status, 403);
+  for (const [body, status] of [
+    [{}, 400],
+    [{ orders: "x".repeat(20_001) }, 400],
+    [{ orders: "stale", baseUpdatedAt: -1 }, 409],
+  ] as const) {
+    const c = makeCtx({ store, contexts: [scope], body: { principalId: "alice", scope, ...body } });
+    await setContextPolicy(c.ctx);
+    assert.equal(c.out.status, status);
+    assert.equal(c.audits.length, 0);
+  }
+  assert.deepEqual(await store.get("web-project-317"), before);
+  assert.deepEqual(await store.history("web-project-317"), history);
+});
+
+for (const scope of ["channel:C317", "group:G317"])
+  test(`Slack ambient controls still round-trip: ${scope}`, async () => {
+    const store = createMemoryChannelPolicyStore();
+    for (const ambientEnabled of [true, false, null]) {
+      const bots = { CI: { mode: "rollup", rollupHours: 4 } };
+      const c = makeCtx({
+        store,
+        contexts: [scope],
+        body: { principalId: "alice", scope, orders: "watch", bots, ambientEnabled },
+      });
+      await setContextPolicy(c.ctx);
+      assert.equal(c.out.status, 200);
+      assert.deepEqual((c.out.body as any).policy.bots, bots);
+      assert.equal((c.out.body as any).policy.ambientEnabled, ambientEnabled);
+    }
+  });
+
+for (const scope of ["group:web-project-limit", "channel:C-limit", "group:G-limit"])
+  test(`member policy size limit is applicability-neutral: ${scope}`, async () => {
+    const store = createMemoryChannelPolicyStore();
+    const ref = scope.slice(scope.indexOf(":") + 1);
+    const valid = makeCtx({
+      store,
+      contexts: [scope],
+      body: { principalId: "alice", scope, orders: "x".repeat(20_000) },
+    });
+    await setContextPolicy(valid.ctx);
+    assert.equal(valid.out.status, 200);
+    const before = await store.get(ref);
+    const history = await store.history(ref);
+    const oversized = makeCtx({
+      store,
+      contexts: [scope],
+      body: { principalId: "alice", scope, orders: "x".repeat(20_001) },
+    });
+    await setContextPolicy(oversized.ctx);
+    assert.equal(oversized.out.status, 400);
+    assert.equal((oversized.out.body as { message: string }).message, "standing order is capped at 20000 characters");
+    assert.deepEqual(await store.get(ref), before);
+    assert.deepEqual(await store.history(ref), history);
+    assert.deepEqual(oversized.audits, []);
+  });

--- a/test/project-policy.test.ts
+++ b/test/project-policy.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getContextPolicy, setContextPolicy } from "../src/api/routes/context-policy.ts";
+import type { ApiCtx } from "../src/api/routes/route.ts";
+import { createMemoryChannelPolicyStore } from "../src/surface-cache/channel-policy-store.ts";
+import { createAmbientHelpers } from "../src/api/app-ambient.ts";
+import { createTurnMethods } from "../src/api/app-turn.ts";
+import type { App, AppDeps } from "../src/api/app-types.ts";
+import { orgId } from "../src/config.ts";
+import { isSharedScope, parseScopeId } from "../src/types.ts";
+
+for (const ambientEnabled of [true, false, null])
+  test(`project orders-only save reaches the actual addressed-turn envelope (legacy=${ambientEnabled})`, async () => {
+    const channelPolicy = createMemoryChannelPolicyStore();
+    const ref = "web-project-317";
+    const scope = `group:${ref}`;
+    await channelPolicy.set(ref, "before", { ambientEnabled, bots: { CI: { mode: "action" } } });
+    const orders = "Issue 317: keep the project standing order in addressed turns.";
+    let status = 0;
+    let body: any;
+    const ctx = {
+      url: new URL(`http://test/v1/contexts/policy?principalId=alice&scope=${scope}`),
+      body: { principalId: "alice", scope, orders },
+      res: {
+        writeHead(s: number) {
+          status = s;
+        },
+        end(s: string) {
+          body = JSON.parse(s);
+        },
+      },
+      app: { listContexts: async () => [{ scopeId: scope }] },
+      deps: { channelPolicy, auditLog: { record() {} } },
+    } as unknown as ApiCtx;
+    await setContextPolicy(ctx);
+    assert.equal(status, 200);
+    await getContextPolicy(ctx);
+    assert.equal(status, 200);
+    assert.equal(body.policy.orders, orders);
+    assert.equal(body.policy.supportsAmbient, false);
+    let captured: any;
+    let judges = 0;
+    const actor = { id: "alice", type: "internal" };
+    const deps = {
+      channelPolicy,
+      identity: {
+        refresh: async () => {},
+        resolve: () => actor,
+        isInternal: (p: any) => p.type === "internal",
+        classify: (id: string) => ({ id, type: "internal" }),
+      },
+      config: { getRuntimeSelectionDurable: async () => null, getIndividualModelAuthDurable: async () => true },
+      userModelCredentials: {},
+      projects: {
+        get: async () => ({
+          id: "317",
+          orgId: orgId(),
+          ownerId: "alice",
+          memberIds: ["alice"],
+          name: "Synthetic",
+          updatedAt: 1,
+        }),
+        withVersion: async (_ref: string, _v: number, fn: () => Promise<unknown>) => fn(),
+      },
+      directory: { get: async () => null },
+      sessions: { getByThread: async () => null, participantsOf: async () => [] },
+      runs: {
+        enqueue: async ({ request }: any) => {
+          captured = request;
+          return { run: { id: "synthetic", status: "pending", request }, deduped: false };
+        },
+      },
+      ambientJudge: async () => {
+        judges++;
+        return { act: false };
+      },
+    } as unknown as AppDeps;
+    const ambient = createAmbientHelpers(deps, {} as App);
+    const app = createTurnMethods(
+      deps,
+      { pendingApprovalResultForThread: async () => null } as unknown as Parameters<typeof createTurnMethods>[1],
+      ambient,
+    );
+    const r = await app.turn({
+      surface: "web",
+      liveActor: true,
+      async: true,
+      actor: { externalId: "alice" },
+      conversation: { kind: "group", channelRef: ref, threadRef: "web:alice:synthetic-317" },
+      text: "Synthetic project message",
+    });
+    assert.equal(r.status, "queued");
+    assert.equal(captured.envelopeWrapped, true);
+    assert.equal(captured.addressed, true);
+    assert.match(captured.text, /<standing-orders/);
+    assert.ok(captured.text.includes(orders));
+    assert.match(captured.text, /<wake reason="addressed" surface="web"/);
+    assert.equal(judges, 0);
+  });
+
+test("ambient applicability does not narrow shared scopes or require parsed project IDs", async () => {
+  const { supportsAmbientControls } = await import("../src/surface-cache/policy-scope.ts");
+  for (const scope of ["channel:C1", "channel:private", "group:G1"]) assert.equal(supportsAmbientControls(scope), true);
+  for (const scope of [
+    "group:web-project-317",
+    "group:web-project-",
+    "group:web-project-invalid:tail",
+    "channel:",
+    "group:",
+    "personal:alice",
+    "team:T1",
+    "org:default-org",
+  ])
+    assert.equal(supportsAmbientControls(scope), false, scope);
+  assert.equal(isSharedScope("group:web-project-317"), true);
+  assert.deepEqual(parseScopeId("group:web-project-317"), { kind: "group", ref: "web-project-317" });
+});

--- a/test/prompt-modes.test.ts
+++ b/test/prompt-modes.test.ts
@@ -421,3 +421,85 @@ test("Mode 2 (spine channel): static prose stays within the word-count ceiling (
       "This is expected to fail until the menu deletions in CONTRACT.md S5 land.",
   );
 });
+
+const autonomousClaims = [
+  "You see every message posted here as it arrives",
+  "you do NOT need to be @mentioned",
+  "new messages come to you",
+  "A standing order for this conversation calls for it → do what it says.",
+  "You can clearly, concretely help → you may chime in.",
+  "The guidance is re-evaluated against every new message automatically — no cron, no poll.",
+];
+
+test("web-project addressed turn receives an addressed-only composed system prompt", async (t) => {
+  const conversation: Conversation = {
+    kind: "group",
+    channelRef: "web-project-prompt-317",
+    threadRef: "web:U1:prompt-317",
+    audience: [actor],
+  };
+  const orch = buildOrchestrator({
+    orgSoul: "ORG-PROJECT-PROMPT-MARKER",
+    scopeSoulFor: { conversation, soul: "PROJECT-PROMPT-MARKER: keep replies concise." },
+  });
+  const prompt = await sysprompt(orch, {
+    surface: "web",
+    actor,
+    conversation,
+    text: "",
+    surfaceTools: true,
+    addressed: true,
+    origin: { kind: "human" },
+    sessionParticipantIds: [actor.id],
+  });
+  assertNoTemplateTokens(prompt, "web-project addressed turn");
+  assert.match(prompt, /no one ever reads this transcript/);
+  assert.match(prompt, /ONLY through the `web` tool/);
+  assert.match(prompt, /`post` answers HERE/);
+  assert.match(prompt, /read it with the `guidance` tool, amend it/);
+  assert.match(prompt, /## Your computer/);
+  assert.match(prompt, /ORG-PROJECT-PROMPT-MARKER/);
+  assert.match(prompt, /PROJECT-PROMPT-MARKER: keep replies concise/);
+  await t.test("states addressed-only observation and guidance semantics", () => {
+    assert.match(prompt, /Web-project message handling is addressed-only/);
+    assert.match(prompt, /You do not automatically observe or evaluate other project messages/);
+    assert.match(prompt, /Standing orders affect addressed replies only; they never trigger unprompted turns/);
+    assert.match(
+      prompt,
+      /Saved guidance applies to addressed replies only, not automatically to every new project message/,
+    );
+    assert.match(prompt, /reply with the `web` tool's `post` action, or decline with `stay_silent`/);
+  });
+  for (const claim of autonomousClaims)
+    await t.test(`omits autonomous promise: ${claim}`, () => {
+      assert.ok(!prompt.includes(claim), `contradictory autonomous claim in the fully composed prompt: ${claim}`);
+    });
+});
+
+for (const kind of ["channel", "group"] as const)
+  test(`Slack ${kind} addressed turn keeps the autonomous composed system prompt`, async () => {
+    const prompt = await sysprompt(
+      buildOrchestrator(),
+      spineChannelTurn("", {
+        conversation: {
+          kind,
+          channelRef: kind === "channel" ? "C317" : "G317",
+          threadRef: `slack:${kind}:prompt-317`,
+          audience: [actor],
+        },
+        addressed: true,
+        origin: { kind: "human" },
+      }),
+    );
+    assertNoTemplateTokens(prompt, `Slack ${kind} addressed turn`);
+    assert.match(prompt, /no one ever reads this transcript/);
+    assert.match(prompt, /ONLY through the `slack` tool/);
+    assert.match(prompt, /You're on Slack: keep each posted message to at most two sentences/);
+    assert.match(prompt, /## Your computer/);
+    for (const claim of autonomousClaims)
+      assert.ok(prompt.includes(claim), `missing Slack autonomous promise: ${claim}`);
+    assert.doesNotMatch(
+      prompt,
+      /Web-project message handling is addressed-only|Standing orders affect addressed replies only|Saved guidance applies to addressed replies only/,
+    );
+  });


### PR DESCRIPTION
## Summary

- keep web-project standing orders available for addressed turns while removing unsupported ambient/bot controls from member and admin editors
- derive policy applicability on the server and enforce it consistently across member, admin, and agent-facing writes
- reject unsupported web-project `ambientEnabled`/`bots` fields atomically without deleting legacy values or history
- make web-project tool guidance and the composed autonomous-mode prompt explicitly addressed-only while preserving Slack autonomous behavior

Fixes #317.

## Test plan

- prompt/resolution/orchestrator suites: 190 passed
- policy/project/auth/core suites: 382 passed
- web UI suites: 32 passed
- admin plugin suites: 114 passed
- root, web UI, admin, CLI, and contract typechecks
- targeted ESLint, Oxlint, Prettier, and `git diff --check`

The tests cover orders-only save/read and prompt use, atomic rejection, legacy preservation, stale UI responses, full composed prompt semantics, and Slack channel/group-DM controls.

## Before / after

Light theme, mock data. Web project scope is `group:web-project-launch-plan`; the Slack scope is a channel.

### Web UI, project settings (web project)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/web-ui-web-project-before.png" width="420" alt="Web UI ambient policy editor for a web project before: ambient toggle, standing orders, automated posters"> | <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/web-ui-web-project-after.png" width="420" alt="Web UI standing orders editor for a web project after: only standing orders remain"> |
| Web projects offered an ambient toggle and a bot ledger that nothing on this surface honored. | Only standing orders remain, framed as instructions for addressed replies. |

### Admin, scope governance (web project)

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/admin-web-project-before.png" width="420" alt="Admin ambient reply policy card for a web project before: channel copy, ambient behavior select, bot ledger"> | <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/admin-web-project-after.png" width="420" alt="Admin standing orders card for a web project after: heading, hint, and standing order textarea only"> |
| Channel-oriented copy, ambient behavior select, bot ledger, and judgment log link for a web project. | Card retitled to standing orders with a project hint; unsupported controls and the judgment log link are gone. |

### Slack channel scope (unchanged on this branch)

| Web UI | Admin |
| --- | --- |
| <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/web-ui-slack-channel-after.png" width="420" alt="Web UI agent behavior editor for a Slack channel after: ambient toggle, standing orders, and bot ledger still present"> | <img src="https://raw.githubusercontent.com/yc-software/qm/demo/ambient-policy-scope-screenshots/admin-slack-channel-after.png" width="420" alt="Admin ambient reply policy card for a Slack channel after: full controls still present"> |
| Ambient toggle, standing orders, and automated posters still editable. | Ambient behavior, standing order, bot ledger, and judgment log link still present. |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791593953&installation_model_id=19911&pr_number=1042&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1042&signature=e65eef6369f3c5b15fc757af331485a629386443a98dac1eeea843e34ada0aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
