### PR TITLE
Make admin runtime editing scope-aware

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,7 @@
       "entry": [
         "src/migrate-main.ts",
         "src/sandbox/local-sandbox.ts",
+        "scripts/admin-runtime.browser.mjs",
         "scripts/aws-deploy-smoke.ts",
         "scripts/aws-litestream-smoke.ts",
         "scripts/backfill-search-index.ts",

--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -5502,24 +5502,33 @@
                   <h2>Models &amp; browsing</h2>
                   <p>The models, browser runtime, and organization context available on future turns.</p>
                 </div>
-                <section class="card sv-models setting-row hidden" id="card-base-model">
+                <section class="card sv-governance setting-row hidden" id="card-base-model">
                   <div class="head">
                     <h2>Default runtime</h2>
+                    <p id="base-runtime-target"></p>
                   </div>
                   <div class="body">
-                    <label for="base-harness">Harness</label>
-                    <select id="base-harness" style="max-width: 360px"></select>
-                    <label for="base-model">Model</label>
-                    <select id="base-model" style="max-width: 360px"></select>
-                    <label for="base-effort">Reasoning level</label>
-                    <select id="base-effort" style="max-width: 360px"></select>
-                    <label class="setting-toggle" id="base-fast-mode-control" style="display: none; margin-top: 10px">
-                      <input type="checkbox" id="base-fast-mode" />
+                    <label class="setting-toggle hidden" id="base-inherit-control">
+                      <input type="checkbox" id="base-inherit" />
                       <span class="setting-switch" aria-hidden="true"></span>
-                      <span class="setting-copy"
-                        ><strong>Fast mode</strong><small>Only available for supported models.</small></span
-                      >
+                      <span class="setting-copy"><strong>Use organization default</strong></span>
                     </label>
+                    <p class="hint" id="base-runtime-note" aria-live="polite"></p>
+                    <div id="base-runtime-fields">
+                      <label for="base-harness">Harness</label>
+                      <select id="base-harness" style="max-width: 360px"></select>
+                      <label for="base-model">Model</label>
+                      <select id="base-model" style="max-width: 360px"></select>
+                      <label for="base-effort">Reasoning level</label>
+                      <select id="base-effort" style="max-width: 360px"></select>
+                      <label class="setting-toggle" id="base-fast-mode-control" style="display: none; margin-top: 10px">
+                        <input type="checkbox" id="base-fast-mode" />
+                        <span class="setting-switch" aria-hidden="true"></span>
+                        <span class="setting-copy"
+                          ><strong>Fast mode</strong><small>Only available for supported models.</small></span
+                        >
+                      </label>
+                    </div>
                   </div>
                   <div class="foot">
                     <button class="primary" data-save="runtime">Apply</button
@@ -6181,7 +6190,6 @@
         $("card-feature-flags").classList.remove("hidden");
 
         [
-          $("card-base-model"),
           providers,
           $("card-webui-models"),
           $("card-soul"),
@@ -6195,6 +6203,7 @@
         ].forEach((card) => content.insertBefore(card, anchor));
         content.insertBefore(anchor, $("card-service-credentials"));
         [
+          $("card-base-model"),
           $("card-security-posture"),
           governanceAmbient,
           $("card-external-slack"),
@@ -6330,6 +6339,7 @@
       let memDraft = null;
       let memDraftScope = null;
       let cronDestinationEditId = null;
+      let webuiModelIds = [];
       let ackEmojiNames = [];
       let ackEmojiStandard = [];
       let ackEmojiCatalog = {};
@@ -7713,12 +7723,17 @@
         } else {
           setGovernanceStatus("governance-status-audience", "Inherited", "Resolved at organization scope", "neutral");
         }
-        const model = data.baseModel || data.baseModelDefault || "Deployment default";
+        const inherited = !scope.startsWith("org:") && !data.runtime && !data.baseModel;
+        const model = data.runtime?.modelId || data.baseModel || data.baseModelDefault || "Deployment default";
         const option = (data.baseModelOptions || []).find((candidate) => candidate.id === model);
         setGovernanceStatus(
           "governance-status-model",
-          option?.name || model,
-          data.baseModel ? "Local override" : "Effective default",
+          inherited ? "Inherited from organization" : option?.name || model,
+          inherited
+            ? "No local runtime override"
+            : data.runtime || data.baseModel
+              ? "Local override"
+              : "Deployment default",
           "neutral",
         );
       }
@@ -7750,13 +7765,46 @@
           go({ view: "governance", scope: attachment.environmentId, session: null, page: 1 });
       }
       let governanceReq = 0;
+      let runtimeScope = null;
+      let runtimeClearable = false;
+      let syncRuntimeControls = () => {};
+      function runtimeInherits() {
+        return runtimeClearable && !scope.startsWith("org:") && $("base-inherit").checked;
+      }
+      function runtimeSelectionValid() {
+        return ["base-harness", "base-model", "base-effort"].every((id) => {
+          const select = $(id);
+          return select.value && select.selectedOptions[0] && !select.selectedOptions[0].disabled;
+        });
+      }
+      function runtimeCanSave() {
+        return (
+          view === "governance" &&
+          runtimeScope === scope &&
+          !sectionButton("runtime").dataset.saveRequest &&
+          (runtimeInherits() || runtimeSelectionValid())
+        );
+      }
       async function loadScope() {
         const requestedScope = scope;
         const requestId = ++governanceReq;
         const scopeChanged = scope !== loadedGovernanceScope;
-        const r = await api("GET", "/api/scopes/" + encodeURIComponent(scope));
+        runtimeScope = null;
+        $("base-runtime-target").textContent = "Applies to " + requestedScope;
+        syncRuntimeControls();
+        sectionButton("runtime").disabled = true;
+        $("card-base-model").classList.remove("hidden");
+        $("base-inherit-control").classList.add("hidden");
+        $("base-runtime-fields").classList.add("hidden");
+        $("base-runtime-note").textContent = "";
+        setStatus("st-runtime", "Loading runtime settings…", "", true);
+        const [r, resources] = await Promise.all([
+          api("GET", "/api/scopes/" + encodeURIComponent(requestedScope)),
+          api("GET", "/api/resources"),
+        ]);
         if (requestId !== governanceReq || requestedScope !== scope) return;
-        if (!r.ok) {
+        if (!r.ok || r.data.scopeId !== requestedScope) {
+          setStatus("st-runtime", "Runtime settings could not be loaded. Reload to retry.", "err", true);
           setStatus(
             "st-policy",
             r.status === 403 ? "You don't administer this scope." : r.data?.message || "Failed to load.",
@@ -7820,77 +7868,120 @@
         const opts = r.data.baseModelOptions || [];
         const dflt = r.data.baseModelDefault || "";
         const harnessDefault = r.data.harnessDefault || "pi";
-        const harnessOptions =
-          Array.isArray(r.data.harnessOptions) && r.data.harnessOptions.length
-            ? r.data.harnessOptions
-            : [harnessDefault];
+        const harnessOptions = Array.isArray(r.data.harnessOptions) ? r.data.harnessOptions : [harnessDefault];
         const modelsByHarness = r.data.modelsByHarness || {};
-        const showBaseModel = scope.startsWith("org:") && opts.length > 0 && dflt && "runtime" in r.data;
-        $("card-base-model").classList.toggle("hidden", !showBaseModel);
+        const runtimeResource = resources.ok && resources.data.resources?.find((resource) => resource.id === "runtime");
+        const showBaseModel =
+          runtimeResource &&
+          (runtimeResource.target === "any" || (runtimeResource.target === "org" && scope.startsWith("org:")));
+        setStatus(
+          "st-runtime",
+          resources.ok ? "" : "Runtime capabilities could not be loaded. Reload to retry.",
+          "err",
+          true,
+        );
+        $("card-base-model").classList.toggle("hidden", resources.ok && !showBaseModel);
         if (showBaseModel) {
-          const current = r.data.runtime || { harnessId: harnessDefault, modelId: r.data.baseModel || dflt };
-          const harness = $("base-harness");
-          harness.textContent = "";
-          harnessOptions.forEach((id) => {
-            const o = document.createElement("option");
-            o.value = id;
-            o.textContent =
-              { pi: "pi (default)", opencode: "OpenCode", codex: "Codex", claude: "Claude Code" }[id] || id;
-            harness.appendChild(o);
-          });
-          harness.value = harnessOptions.includes(current.harnessId) ? current.harnessId : harnessOptions[0];
-          const effort = $("base-effort");
-          const thinkingLevelsByHarness = r.data.thinkingLevelsByHarness || {};
-          const syncEffort = () => {
-            const thinkingLevels = thinkingLevelsByHarness[harness.value] || ["auto"];
-            const prior = effort.value || current.effortLevel || "auto";
-            effort.textContent = "";
-            thinkingLevels.forEach((level) => {
-              const o = document.createElement("option");
-              o.value = level;
-              o.textContent =
-                {
-                  auto: "Auto",
-                  low: "Low",
-                  medium: "Medium",
-                  high: "High",
-                  xhigh: "Extra high",
-                  max: "Max",
-                  ultracode: "Ultracode",
-                }[level] || level;
-              effort.appendChild(o);
-            });
-            effort.value = thinkingLevels.includes(prior) ? prior : "auto";
+          const hasOverride = r.data.runtime != null || r.data.baseModel != null;
+          const current = r.data.runtime || {
+            harnessId: hasOverride || scope.startsWith("org:") ? harnessDefault : "",
+            modelId: r.data.baseModel || (scope.startsWith("org:") ? dflt : ""),
           };
+          runtimeScope = requestedScope;
+          runtimeClearable = runtimeResource.clearable === true;
+          const inherit = $("base-inherit");
+          inherit.checked = !hasOverride && !scope.startsWith("org:");
+          $("base-inherit-control").classList.toggle("hidden", !runtimeClearable || scope.startsWith("org:"));
+          const approvedHarnesses = r.data.approvedHarnesses || [harnessDefault];
+          const fill = (select, options, value, prompt) => {
+            select.textContent = "";
+            options.forEach(({ id, name, available = true }) => {
+              const option = document.createElement("option");
+              option.value = id;
+              option.textContent = available ? name : name + " (unavailable)";
+              option.disabled = !available;
+              select.appendChild(option);
+            });
+            if (!options.some((option) => option.id === value)) {
+              const option = document.createElement("option");
+              option.value = value;
+              option.textContent = value ? value + " (unavailable)" : prompt;
+              option.disabled = true;
+              select.appendChild(option);
+            }
+            select.value = value;
+          };
+          const harness = $("base-harness");
+          const model = $("base-model");
+          const effort = $("base-effort");
+          fill(
+            harness,
+            harnessOptions.map((id) => ({
+              id,
+              name: { pi: "pi (default)", opencode: "OpenCode", codex: "Codex", claude: "Claude Code" }[id] || id,
+              available: approvedHarnesses.includes(id),
+            })),
+            current.harnessId,
+            "Choose a harness…",
+          );
+          const thinkingLevelsByHarness = r.data.thinkingLevelsByHarness || {};
           const fastMode = $("base-fast-mode");
           fastMode.checked = current.fastMode === true;
-          const syncFastMode = () => {
+          syncRuntimeControls = () => {
+            const busy = runtimeScope !== scope || !!sectionButton("runtime").dataset.saveRequest;
+            const inherited = runtimeInherits();
+            inherit.disabled = busy || !runtimeClearable;
+            [harness, model, effort].forEach((select) => (select.disabled = busy || inherited));
+            $("base-runtime-fields").classList.toggle("hidden", inherited || runtimeScope !== scope);
             const fastCapable =
               (r.data.fastModeHarnessIds || []).includes(harness.value) &&
-              (r.data.fastModeModelIds || []).includes($("base-model").value);
+              (r.data.fastModeModelIds || []).includes(model.value);
             $("base-fast-mode-control").style.display = fastCapable ? "" : "none";
-            fastMode.disabled = !fastCapable;
+            fastMode.disabled = busy || inherited || !fastCapable;
             if (!fastCapable) fastMode.checked = false;
+            $("base-runtime-note").textContent = inherited
+              ? "Organization defaults apply while no local override is saved."
+              : runtimeSelectionValid()
+                ? ""
+                : "Choose an available harness, model and reasoning level.";
           };
-          const syncModels = () => {
-            const selectedHarness = harness.value;
-            const compatible = modelsByHarness[selectedHarness] || opts;
-            const sel = $("base-model");
-            const prior = sel.value || current.modelId;
-            sel.textContent = "";
-            compatible.forEach((m) => {
-              const o = document.createElement("option");
-              o.value = m.id;
-              o.textContent = m.name + " (" + m.id + ")";
-              sel.appendChild(o);
-            });
-            sel.value = compatible.some((m) => m.id === prior) ? prior : (compatible[0] || {}).id || "";
-            sel.oninput = syncFastMode;
-            syncEffort();
-            syncFastMode();
+          const syncModels = (modelId, effortLevel, initializing = false) => {
+            const compatible = modelsByHarness[harness.value] || (harness.value === harnessDefault ? opts : []);
+            const levels = thinkingLevelsByHarness[harness.value] || ["auto"];
+            if (!initializing) {
+              if (!compatible.some((m) => m.id === modelId && m.available !== false))
+                modelId = compatible.find((m) => m.available !== false)?.id || "";
+              if (!levels.includes(effortLevel)) effortLevel = "auto";
+            }
+            fill(
+              model,
+              compatible.map((m) => ({ id: m.id, name: m.name + " (" + m.id + ")", available: m.available })),
+              modelId,
+              "Choose a model…",
+            );
+            fill(
+              effort,
+              levels.map((id) => ({
+                id,
+                name:
+                  {
+                    auto: "Auto",
+                    low: "Low",
+                    medium: "Medium",
+                    high: "High",
+                    xhigh: "Extra high",
+                    max: "Max",
+                    ultracode: "Ultracode",
+                  }[id] || id,
+              })),
+              effortLevel,
+              "Choose a reasoning level…",
+            );
+            syncRuntimeControls();
           };
-          harness.oninput = syncModels;
-          syncModels();
+          harness.oninput = () => syncModels(model.value, effort.value);
+          model.oninput = effort.oninput = inherit.oninput = syncRuntimeControls;
+          syncModels(current.modelId, current.effortLevel || "auto", true);
         }
         const showWebuiModels = scope.startsWith("org:") && opts.length > 0;
         $("card-webui-models").classList.toggle("hidden", !showWebuiModels);
@@ -10420,12 +10511,15 @@
         "external-slack-participants": () => ({ on: $("external-slack-participants").checked }),
         "org-ambient": () => ({ on: $("org-ambient").checked }),
         "channel-header-pin-default": () => ({ on: $("channel-header-pin-default").checked }),
-        runtime: () => ({
-          harnessId: $("base-harness").value,
-          modelId: $("base-model").value,
-          effortLevel: $("base-effort").value,
-          fastMode: $("base-fast-mode").checked,
-        }),
+        runtime: () =>
+          runtimeInherits()
+            ? { inherit: true }
+            : {
+                harnessId: $("base-harness").value,
+                modelId: $("base-model").value,
+                effortLevel: $("base-effort").value,
+                fastMode: $("base-fast-mode").checked,
+              },
         "webui-models": () => ({ ids: webuiModelIds }),
         "people-directory-url": () => ({ url: $("people-directory-url").value.trim() }),
         "ack-emoji": () => ({ names: ackEmojiNames }),
@@ -10476,6 +10570,7 @@
         const btn = sectionButton(key);
         setCardDirty(btn?.closest(".card"), dirty, SAVE_ST[key], '[data-save="' + key + '"]');
         if (key === "egress" && $("card-egress").classList.contains("egress-disabled")) btn.disabled = true;
+        if (key === "runtime" && !runtimeCanSave()) btn.disabled = true;
       }
       function captureSection(key) {
         if (!SAVE[key] || !sectionButton(key)) return;
@@ -10550,6 +10645,8 @@
         btn.onclick = async () => {
           const key = btn.dataset.save;
           const requestedScope = scope;
+          const runtimeRequest = governanceReq;
+          if (key === "runtime" && (!runtimeCanSave() || !btn.classList.contains("dirty"))) return;
           let body;
           try {
             body = SAVE[key]();
@@ -10558,11 +10655,19 @@
             return;
           }
           if (!(await governanceSaveReview(key, body)) || requestedScope !== scope) return;
+          if (key === "runtime" && (runtimeRequest !== governanceReq || !runtimeCanSave())) return;
           const saveRequest = String(++governanceSaveSeq);
           btn.dataset.saveRequest = saveRequest;
           btn.disabled = true;
+          if (key === "runtime") syncRuntimeControls();
           setStatus(SAVE_ST[key], "Saving...", "saving", true);
           const r = await api("PUT", "/api/scopes/" + encodeURIComponent(requestedScope) + "/" + key, body);
+          if (key === "runtime" && (runtimeRequest !== governanceReq || requestedScope !== scope)) {
+            if (btn.dataset.saveRequest === saveRequest) delete btn.dataset.saveRequest;
+            syncRuntimeControls();
+            btn.disabled = !btn.classList.contains("dirty") || !runtimeCanSave();
+            return;
+          }
           if (requestedScope !== scope) {
             if (btn.dataset.saveRequest === saveRequest) {
               delete btn.dataset.saveRequest;
@@ -10572,6 +10677,7 @@
             return;
           }
           if (btn.dataset.saveRequest === saveRequest) delete btn.dataset.saveRequest;
+          if (key === "runtime") syncRuntimeControls();
           if (r.ok) {
             if (key === "security-posture" || key === "ambient-policy") {
               const fresh = await api("GET", "/api/scopes/" + encodeURIComponent(scope));
@@ -10587,8 +10693,15 @@
             } else if (key === "branding") {
               location.reload();
               return;
-            } else if (SAVE_RELOADS.has(key)) await loadScope();
-            else {
+            } else if (SAVE_RELOADS.has(key)) {
+              const reloadRequest = governanceReq + 1;
+              await loadScope();
+              if (
+                key === "runtime" &&
+                (reloadRequest !== governanceReq || runtimeScope !== requestedScope || scope !== requestedScope)
+              )
+                return;
+            } else {
               if (key === "egress") {
                 renderGovernanceOverview({ ...governanceOverviewData, egress: body });
                 populateEgress(body);

--- a/plugins/admin/test/default-view.test.ts
+++ b/plugins/admin/test/default-view.test.ts
@@ -254,7 +254,7 @@ test("default runtime controls save reasoning level and fast mode", () => {
   assert.match(html, /base-fast-mode-control"\)\.style\.display = fastCapable \? "" : "none"/);
   assert.match(
     html,
-    /runtime: \(\) => \(\{[\s\S]*effortLevel: \$\("base-effort"\)\.value,[\s\S]*fastMode: \$\("base-fast-mode"\)\.checked/,
+    /runtime: \(\) =>[\s\S]*runtimeInherits\(\)[\s\S]*effortLevel: \$\("base-effort"\)\.value,[\s\S]*fastMode: \$\("base-fast-mode"\)\.checked/,
   );
 });
 

--- a/plugins/admin/test/runtime-card.test.ts
+++ b/plugins/admin/test/runtime-card.test.ts
@@ -1,0 +1,618 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+function source(from: string, to: string): string {
+  const start = html.indexOf(from);
+  const end = html.indexOf(to, start);
+  assert.ok(start >= 0 && end > start);
+  return html.slice(start, end);
+}
+class Element {
+  children: Element[] = [];
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  disabled = false;
+  checked = false;
+  hidden = false;
+  text = "";
+  private selected = "";
+  classes = new Set<string>();
+  oninput?: () => void;
+  onchange?: () => void;
+  onclick?: () => Promise<void>;
+  classList = {
+    add: (...names: string[]) => names.forEach((name) => this.classes.add(name)),
+    remove: (...names: string[]) => names.forEach((name) => this.classes.delete(name)),
+    contains: (name: string) => this.classes.has(name),
+    toggle: (name: string, on = !this.classes.has(name)) => {
+      if (on) this.classes.add(name);
+      else this.classes.delete(name);
+      return on;
+    },
+  };
+  readonly tagName: string;
+  constructor(tagName = "DIV") {
+    this.tagName = tagName;
+  }
+  get value() {
+    return this.selected;
+  }
+  set value(value: string) {
+    this.selected = this.tagName === "SELECT" && !this.children.some((o) => o.value === value) ? "" : value;
+  }
+  get textContent() {
+    return this.text;
+  }
+  set textContent(value: string) {
+    this.text = value;
+    this.children = [];
+    if (this.tagName === "SELECT") this.selected = "";
+  }
+  get options() {
+    return this.children;
+  }
+  get selectedOptions() {
+    return this.children.filter((o) => o.value === this.value);
+  }
+  appendChild(child: Element) {
+    this.children.push(child);
+    if (this.tagName === "SELECT" && this.children.length === 1) this.selected = child.value;
+    return child;
+  }
+  append(...children: Element[]) {
+    children.forEach((child) => this.appendChild(child));
+  }
+  setAttribute(name: string, value: string) {
+    this.dataset[name] = value;
+  }
+  remove() {}
+  querySelectorAll(_selector: string): Element[] {
+    return [];
+  }
+  querySelector(_selector: string): Element | null {
+    return null;
+  }
+  closest(_selector: string): Element | null {
+    return null;
+  }
+}
+const model = (id: string) => ({ id, name: id, available: true });
+function config(
+  runtime: Record<string, unknown> | null = { harnessId: "pi", modelId: "alpha", effortLevel: "high", fastMode: true },
+): any {
+  return {
+    scopeId: "channel:A",
+    runtime,
+    baseModel: runtime?.modelId ?? null,
+    harnessDefault: "pi",
+    baseModelDefault: "alpha",
+    baseModelOptions: [model("alpha"), model("beta")],
+    harnessOptions: ["pi", "codex"],
+    approvedHarnesses: ["pi", "codex"],
+    modelsByHarness: { pi: [model("alpha"), model("beta")], codex: [model("gpt-fixture")] },
+    thinkingLevelsByHarness: { pi: ["auto", "low", "high"], codex: ["auto", "low", "high"] },
+    fastModeHarnessIds: ["pi"],
+    fastModeModelIds: ["alpha"],
+  };
+}
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+const ok = (data: any) => ({ ok: true, status: 200, data });
+function harness() {
+  const nodes = new Map<string, Element>();
+  const $ = (id: string): Element => {
+    if (!nodes.has(id))
+      nodes.set(
+        id,
+        new Element(
+          ["base-model", "base-harness", "base-effort"].includes(id) || id.endsWith("-add") ? "SELECT" : "DIV",
+        ),
+      );
+    return nodes.get(id)!;
+  };
+  $("egress-capability").querySelector = (selector) => $("egress-capability-" + selector);
+  const card = $("card-base-model");
+  const button = new Element("BUTTON");
+  button.dataset.save = "runtime";
+  button.closest = () => card;
+  card.querySelector = (selector) => (selector === "button.dirty" && !button.classes.has("dirty") ? null : button);
+  card.querySelectorAll = () => [
+    $("base-inherit"),
+    $("base-harness"),
+    $("base-model"),
+    $("base-effort"),
+    $("base-fast-mode"),
+    button,
+  ];
+  const document = {
+    createElement: (tag: string) => new Element(tag.toUpperCase()),
+    querySelectorAll: (selector: string) => (selector === "[data-save]" ? [button] : []),
+    querySelector: (selector: string) => {
+      if (selector === '[data-save="runtime"]') return button;
+      return selector === '[data-save="egress"]' ? $("egress-save") : null;
+    },
+  };
+  const calls: { method: string; path: string; body: any }[] = [];
+  const statuses = new Map<string, string>();
+  const overview = new Map<string, [string, string]>();
+  const state = {
+    data: config(),
+    manifest: [{ id: "runtime", target: "any", clearable: true }],
+    get: null as null | (() => Promise<any>),
+    put: null as null | (() => Promise<any>),
+    resources: null as null | (() => Promise<any>),
+  };
+  const context = vm.createContext({
+    $,
+    document,
+    scope: "channel:A",
+    view: "governance",
+    loadedGovernanceScope: null,
+    loadedCommandPolicyPresent: false,
+    soulVersion: 0,
+    soulSaved: "",
+    soulHistory: [],
+    serviceCredDirectory: [],
+    governanceOrgAmbientSaved: "",
+    webuiModelIds: [],
+    ackEmojiNames: [],
+    governanceOverviewData: {},
+    titleCase: (s: string) => s,
+    collectEgress: () => ({}),
+    setGovernanceStatus: (id: string, value: string, detail: string) => overview.set(id, [value, detail]),
+    setStatus: (id: string, message: string, kind: string) => {
+      statuses.set(id, message);
+      $(id).classes = new Set(["status", kind]);
+    },
+    governanceSaveReview: async () => true,
+    api: async (method: string, path: string, body?: any) => {
+      calls.push({ method, path, body: body && JSON.parse(JSON.stringify(body)) });
+      if (path === "/api/resources") return state.resources ? state.resources() : ok({ resources: state.manifest });
+      if (method === "GET")
+        return state.get ? state.get() : ok({ ...state.data, scopeId: decodeURIComponent(path.split("/").at(-1)!) });
+      if (state.put) return state.put();
+      if (body.inherit) state.data = { ...state.data, runtime: null, baseModel: null };
+      else state.data = { ...state.data, runtime: { ...body }, baseModel: body.modelId };
+      return ok({});
+    },
+  });
+  for (const name of [
+    "renderEnvironmentNotice",
+    "syncGovernanceSectionNav",
+    "renderPolicy",
+    "updateSoulWorkbench",
+    "renderSoulHistory",
+    "renderAmbientPolicy",
+    "populateEgress",
+    "renderServiceCreds",
+    "loadCustomProviders",
+    "loadPersonalKeychainSummary",
+    "resetScForm",
+    "initCustomDropdowns",
+  ])
+    context[name] = () => {};
+  vm.runInContext(
+    source("      function setCardDirty(card, dirty, statusId, saveSelector)", "      function tableWrap(t)"),
+    context,
+  );
+  vm.runInContext(
+    source("      function renderGovernanceOverview(data)", "      function syncGovernanceSectionNav()"),
+    context,
+  );
+  vm.runInContext(source("      let governanceReq = 0;", "      async function refreshSoulConflict()"), context);
+  vm.runInContext(source("      const SAVE = {", "      function saveKeyForTarget(target)"), context);
+  vm.runInContext(
+    source("      let governanceSaveSeq = 0;", '      $("view-governance").addEventListener("input"'),
+    context,
+  );
+  return {
+    $,
+    button,
+    context,
+    state,
+    statuses,
+    overview,
+    calls,
+    load: (scope = context.scope) => {
+      context.scope = scope;
+      return context.loadScope() as Promise<void>;
+    },
+    input: (id: string, value: string | boolean) => {
+      const node = $(id);
+      if (typeof value === "boolean") node.checked = value;
+      else node.value = value;
+      node.oninput?.();
+      context.updateSectionDirty("runtime");
+    },
+    save: () => button.onclick!(),
+    puts: () => calls.filter((call) => call.method === "PUT"),
+  };
+}
+
+for (const scope of ["org:acme", "channel:A", "group:project-A", "personal:alice", "team:T1"]) {
+  test(`runtime card loads and saves the exact ${scope} scope`, async () => {
+    const h = harness();
+    await h.load(scope);
+    assert.equal(h.$("card-base-model").classes.has("hidden"), false);
+    assert.equal(h.$("base-model").value, "alpha");
+    assert.equal(h.$("base-effort").value, "high");
+    h.input("base-model", "beta");
+    await h.save();
+    assert.equal(h.puts()[0]?.path, `/api/scopes/${encodeURIComponent(scope)}/runtime`);
+    assert.equal(h.puts()[0]?.body.modelId, "beta");
+    assert.equal(h.button.disabled, true);
+    if (!scope.startsWith("org:")) assert.equal(h.$("card-webui-models").classes.has("hidden"), true);
+  });
+}
+test("scope reload initializes model and effort from the response, never the prior form", async () => {
+  const h = harness();
+  await h.load("org:acme");
+  h.state.data = config({ harnessId: "pi", modelId: "beta", effortLevel: "low" });
+  await h.load("org:acme");
+  assert.equal(h.$("base-model").value, "beta");
+  assert.equal(h.$("base-effort").value, "low");
+  await h.load("channel:B");
+  assert.equal(h.$("base-model").value, "beta");
+  assert.equal(h.$("base-effort").value, "low");
+});
+test("manifest applicability and clearability control only runtime", async () => {
+  const h = harness();
+  h.state.manifest[0]!.target = "org";
+  await h.load();
+  assert.equal(h.$("card-base-model").classes.has("hidden"), true);
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  await h.load("org:acme");
+  assert.equal(h.$("card-base-model").classes.has("hidden"), false);
+  h.state.manifest[0]!.target = "any";
+  h.state.manifest[0]!.clearable = false;
+  await h.load("channel:A");
+  assert.equal(h.$("base-inherit-control").classes.has("hidden"), true);
+});
+test("inherited state is truthful and reset deletes the override rather than copying org values", async () => {
+  const h = harness();
+  h.state.data = config(null);
+  await h.load();
+  assert.equal(h.$("base-inherit").checked, true);
+  assert.equal(h.$("base-runtime-fields").classes.has("hidden"), true);
+  assert.match(h.overview.get("governance-status-model")!.join(" "), /[Ii]nherit.*organization/);
+  assert.equal(h.button.disabled, true);
+  h.input("base-inherit", false);
+  assert.equal(h.button.disabled, true);
+  h.input("base-harness", "pi");
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.state.data.runtime.modelId, "beta");
+  h.input("base-inherit", true);
+  await h.save();
+  assert.deepEqual(h.puts().at(-1)!.body, { inherit: true });
+  assert.equal(h.state.data.runtime, null);
+  assert.equal(h.$("base-inherit").checked, true);
+  h.state.data.baseModelDefault = "not-the-org-runtime";
+  await h.load();
+  assert.equal(h.$("base-inherit").checked, true);
+  assert.equal(h.button.disabled, true);
+});
+test("legacy model-only rows are overrides and can be reset", async () => {
+  const h = harness();
+  h.state.data = { ...config(null), baseModel: "beta" };
+  await h.load();
+  assert.equal(h.$("base-inherit").checked, false);
+  assert.equal(h.$("base-model").value, "beta");
+  h.input("base-inherit", true);
+  await h.save();
+  assert.deepEqual(h.puts()[0]?.body, { inherit: true });
+});
+test("empty deployment catalog does not hide alternative or custom harness models", async () => {
+  const h = harness();
+  h.state.data = config({ harnessId: "codex", modelId: "gpt-fixture", effortLevel: "low" });
+  h.state.data.baseModelOptions = [];
+  h.state.data.modelsByHarness.pi = [];
+  await h.load("org:acme");
+  assert.equal(h.$("card-base-model").classes.has("hidden"), false);
+  assert.equal(h.$("base-model").value, "gpt-fixture");
+  h.state.data = config({ harnessId: "pi", modelId: "custom/deepseek" });
+  h.state.data.modelsByHarness.pi.push(model("custom/deepseek"));
+  await h.load();
+  assert.equal(h.$("base-model").value, "custom/deepseek");
+});
+test("missing saved model, harness and effort stay visible without silently substituting", async () => {
+  for (const missing of [{ modelId: "retired" }, { harnessId: "removed" }, { effortLevel: "retired-effort" }]) {
+    const h = harness();
+    h.state.data = config({ harnessId: "pi", modelId: "alpha", effortLevel: "high", ...missing });
+    await h.load();
+    for (const [key, value] of Object.entries(missing))
+      assert.equal(
+        h.$({ modelId: "base-model", harnessId: "base-harness", effortLevel: "base-effort" }[key]!).value,
+        value,
+      );
+    h.input("base-fast-mode", false);
+    await h.save();
+    assert.equal(h.puts().length, 0);
+    h.input("base-inherit", true);
+    await h.save();
+    assert.deepEqual(h.puts()[0]?.body, { inherit: true });
+  }
+});
+test("empty catalogs allow reset but not an empty override", async () => {
+  const h = harness();
+  h.state.data.baseModelOptions = [];
+  h.state.data.harnessOptions = [];
+  h.state.data.modelsByHarness = {};
+  await h.load();
+  assert.equal(h.$("card-base-model").classes.has("hidden"), false);
+  h.input("base-fast-mode", false);
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.input("base-inherit", true);
+  await h.save();
+  assert.deepEqual(h.puts()[0]?.body, { inherit: true });
+});
+test("harness changes retain compatible effort and normalize unsupported fast mode", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-harness", "codex");
+  assert.equal(h.$("base-model").value, "gpt-fixture");
+  assert.equal(h.$("base-effort").value, "high");
+  assert.equal(h.$("base-fast-mode").checked, false);
+  assert.equal(h.$("base-fast-mode").disabled, true);
+});
+test("rapid switching and failed loads never permit writing the previous scope's form", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  const pending = deferred<any>();
+  h.state.get = () => pending.promise;
+  const loading = h.load("channel:B");
+  const staleSave = h.save();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const staleWrites = h.puts().length;
+  h.state.get = null;
+  h.state.data = config({ harnessId: "pi", modelId: "beta", effortLevel: "low" });
+  await h.load("channel:C");
+  pending.resolve(ok({ ...config(), scopeId: "channel:B" }));
+  await Promise.all([loading, staleSave]);
+  assert.equal(staleWrites, 0);
+  assert.equal(h.$("base-effort").value, "low");
+  h.state.get = async () => ({ ok: false, status: 403, data: {} });
+  await h.load("channel:D");
+  h.input("base-model", "alpha");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  assert.equal(h.button.disabled, true);
+});
+test("mismatched response and missing/failed manifest fail closed and recover on reload", async () => {
+  const h = harness();
+  h.state.get = async () => ok({ ...config(), scopeId: "channel:wrong" });
+  await h.load();
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.state.get = null;
+  for (const response of [{ ok: false, status: 502, data: {} }, ok({ resources: [] })]) {
+    h.state.resources = async () => response;
+    await h.load();
+    h.input("base-model", "beta");
+    await h.save();
+    assert.equal(h.puts().length, 0);
+  }
+  h.state.resources = null;
+  await h.load();
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts().length, 1);
+});
+test("delayed writes retain their target and cannot paint a newer scope or permit duplicate Apply", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  const pending = deferred<any>();
+  h.state.put = () => pending.promise;
+  const saving = h.save();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const duplicate = h.save();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const count = h.puts().length;
+  await h.load("channel:B");
+  pending.resolve(ok({}));
+  await Promise.all([saving, duplicate]);
+  assert.equal(count, 1);
+  assert.equal(h.puts()[0]!.path, "/api/scopes/channel%3AA/runtime");
+  assert.notEqual(h.statuses.get("st-runtime"), "Saved");
+});
+test("same-scope reload during a pending write rejects that write's stale UI completion", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  const pending = deferred<any>();
+  h.state.put = () => pending.promise;
+  const saving = h.save();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  h.state.data = config({ harnessId: "pi", modelId: "alpha", effortLevel: "low" });
+  await h.load();
+  pending.resolve(ok({}));
+  await saving;
+  assert.equal(h.$("base-effort").value, "low");
+  assert.notEqual(h.statuses.get("st-runtime"), "Saved");
+});
+test("failed writes keep the draft and error; failed readback never claims Saved", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  h.state.put = async () => ({ ok: false, status: 400, data: { message: "not serviceable" } });
+  await h.save();
+  assert.equal(h.$("base-model").value, "beta");
+  assert.equal(h.statuses.get("st-runtime"), "not serviceable");
+  assert.equal(h.button.disabled, false);
+  h.state.put = async () => {
+    h.state.get = async () => ({ ok: false, status: 502, data: {} });
+    return ok({});
+  };
+  await h.save();
+  assert.notEqual(h.statuses.get("st-runtime"), "Saved");
+  assert.equal(h.button.disabled, true);
+});
+
+test("an unloaded form and an A-B-A stale load cannot create an override", async () => {
+  const h = harness();
+  h.button.classList.add("dirty");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  const old = deferred<any>();
+  h.state.get = () => old.promise;
+  const first = h.load("channel:A");
+  h.state.get = null;
+  await h.load("channel:B");
+  h.state.data = config({ harnessId: "pi", modelId: "beta", effortLevel: "low" });
+  await h.load("channel:A");
+  old.resolve(ok({ ...config(), scopeId: "channel:A" }));
+  await first;
+  assert.equal(h.$("base-model").value, "beta");
+  assert.equal(h.$("base-effort").value, "low");
+  assert.equal(h.button.disabled, true);
+});
+
+test("a delayed manifest cannot reenable stale scope values and manifest failure is visible", async () => {
+  const h = harness();
+  await h.load();
+  const manifest = deferred<any>();
+  h.state.resources = () => manifest.promise;
+  const pending = h.load("channel:B");
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.state.resources = async () => ({ ok: false, status: 503, data: {} });
+  await h.load("channel:C");
+  const error = h.statuses.get("st-runtime");
+  assert.match(error!, /could not be loaded/);
+  assert.equal(h.button.disabled, true);
+  assert.equal(h.$("card-base-model").classes.has("hidden"), false);
+  manifest.resolve(ok({ resources: h.state.manifest }));
+  await pending;
+  assert.equal(h.statuses.get("st-runtime"), error);
+  assert.equal(h.button.disabled, true);
+});
+
+test("reload during confirmation cancels a captured draft even at the same scope", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  const review = deferred<boolean>();
+  h.context.governanceSaveReview = () => review.promise;
+  const saving = h.save();
+  await h.load();
+  review.resolve(true);
+  await saving;
+  assert.equal(h.puts().length, 0);
+});
+
+test("late write failure never replaces another scope's load error", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  const write = deferred<any>();
+  h.state.put = () => write.promise;
+  const saving = h.save();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  h.state.get = async () => ({ ok: false, status: 403, data: {} });
+  await h.load("channel:B");
+  const error = h.statuses.get("st-runtime");
+  write.resolve({ ok: false, status: 400, data: { message: "old failure" } });
+  await saving;
+  assert.equal(h.statuses.get("st-runtime"), error);
+  assert.equal(h.button.disabled, true);
+});
+
+test("authorization rejection remains visible without discarding the draft", async () => {
+  const h = harness();
+  await h.load();
+  h.input("base-model", "beta");
+  h.state.put = async () => ({ ok: false, status: 403, data: {} });
+  await h.save();
+  assert.equal(h.statuses.get("st-runtime"), "Not authorized for this scope.");
+  assert.equal(h.$("base-model").value, "beta");
+  assert.equal(h.button.disabled, false);
+});
+
+test("persisted unapproved harness remains unavailable even when retained by the API", async () => {
+  const h = harness();
+  h.state.data.approvedHarnesses = ["codex"];
+  await h.load();
+  assert.equal(h.$("base-harness").value, "pi");
+  assert.equal(h.$("base-harness").selectedOptions[0]?.disabled, true);
+  assert.match(h.$("base-harness").selectedOptions[0]!.textContent, /unavailable/);
+  h.input("base-effort", "low");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.input("base-harness", "codex");
+  await h.save();
+  assert.equal(h.puts()[0]?.body.harnessId, "codex");
+  assert.equal(h.puts()[0]?.body.modelId, "gpt-fixture");
+});
+
+test("persisted unserviceable model is unavailable, resettable and recoverable", async () => {
+  const h = harness();
+  h.state.data.modelsByHarness.pi[0].available = false;
+  await h.load();
+  assert.equal(h.$("base-model").value, "alpha");
+  assert.equal(h.$("base-model").selectedOptions[0]?.disabled, true);
+  assert.match(h.$("base-model").selectedOptions[0]!.textContent, /unavailable/);
+  h.input("base-effort", "low");
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts()[0]?.body.modelId, "beta");
+  h.state.data = config();
+  h.state.data.modelsByHarness.pi[0].available = false;
+  await h.load();
+  h.input("base-inherit", true);
+  await h.save();
+  assert.deepEqual(h.puts().at(-1)?.body, { inherit: true });
+});
+
+test("default approval fallback does not bless a retained alternative harness", async () => {
+  const h = harness();
+  h.state.data = config({ harnessId: "codex", modelId: "gpt-fixture" });
+  h.state.data.approvedHarnesses = null;
+  await h.load();
+  assert.equal(h.$("base-harness").selectedOptions[0]?.disabled, true);
+  h.input("base-harness", "pi");
+  await h.save();
+  assert.equal(h.puts()[0]?.body.harnessId, "pi");
+});
+
+test("only the scoped Governance view can apply runtime and names its target", async () => {
+  const h = harness();
+  await h.load("team:T1");
+  assert.equal(h.$("base-runtime-target").textContent, "Applies to team:T1");
+  h.input("base-model", "beta");
+  h.context.view = "models";
+  await h.save();
+  assert.equal(h.puts().length, 0);
+  h.context.view = "governance";
+  await h.load("team:T1");
+  h.input("base-model", "beta");
+  await h.save();
+  assert.equal(h.puts()[0]?.path, "/api/scopes/team%3AT1/runtime");
+});
+
+test("harness changes skip a retained unavailable first model", async () => {
+  const h = harness();
+  h.state.data = config({ harnessId: "codex", modelId: "gpt-fixture" });
+  h.state.data.modelsByHarness.pi[0].available = false;
+  await h.load();
+  h.input("base-harness", "pi");
+  assert.equal(h.$("base-model").value, "beta");
+  await h.save();
+  assert.equal(h.puts()[0]?.body.modelId, "beta");
+});

--- a/plugins/admin/test/scopes.test.ts
+++ b/plugins/admin/test/scopes.test.ts
@@ -3,15 +3,19 @@ import assert from "node:assert/strict";
 import { createServer, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 
-const calls: { method: string; url: string; actor: string | null; signed: boolean }[] = [];
+const calls: { method: string; url: string; actor: string | null; signed: boolean; body: string }[] = [];
 const core = createServer((req: IncomingMessage, res) => {
-  req.on("data", () => {});
+  let body = "";
+  req.on("data", (chunk: Buffer) => {
+    body += chunk.toString();
+  });
   req.on("end", () => {
     calls.push({
       method: req.method ?? "",
       url: req.url ?? "",
       actor: (req.headers["x-admin-actor"] as string) ?? null,
       signed: Boolean(req.headers["x-timestamp"] && req.headers["x-signature"]),
+      body,
     });
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ scopeId: "org:acme", scopes: [] }));
@@ -85,4 +89,38 @@ test("the scope directory requires a signed-in cookie → 401 (no core hop)", as
   const before = calls.length;
   assert.equal((await fetch(`${base}/api/scopes`)).status, 401);
   assert.equal(calls.length, before, "a signed-out request is rejected at the surface, never forwarded");
+});
+
+test("runtime set and inherit preserve the selected scope, body, actor and signature", async () => {
+  for (const scope of ["org:acme", "channel:C1", "group:web-project-1", "personal:alice", "team:T1"]) {
+    for (const body of [
+      { harnessId: "pi", modelId: "custom-deepseek", effortLevel: "high", fastMode: false },
+      { inherit: true },
+    ]) {
+      const response = await fetch(`${base}/api/scopes/${encodeURIComponent(scope)}/runtime`, {
+        method: "PUT",
+        headers: { cookie: ADMIN, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      assert.equal(response.status, 200);
+      const call = calls.at(-1)!;
+      assert.equal(call.method, "PUT");
+      assert.equal(call.url, `/v1/admin/scopes/${encodeURIComponent(scope)}/runtime`);
+      assert.equal(call.actor, "U-admin@acme");
+      assert.equal(call.signed, true);
+      assert.deepEqual(JSON.parse(call.body), body);
+    }
+  }
+});
+
+test("signed-out runtime writes and manifest reads never reach core", async () => {
+  const before = calls.length;
+  const response = await fetch(`${base}/api/scopes/channel%3AC1/runtime`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ inherit: true }),
+  });
+  assert.equal(response.status, 401);
+  assert.equal((await fetch(`${base}/api/resources`)).status, 401);
+  assert.equal(calls.length, before);
 });

--- a/scripts/admin-runtime.browser.mjs
+++ b/scripts/admin-runtime.browser.mjs
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import test from "node:test";
+
+const { chromium } = await import(process.env.PLAYWRIGHT_MODULE || "playwright");
+const html = readFileSync(new URL("../plugins/admin/public/index.html", import.meta.url), "utf8").replaceAll(
+  "__ADMIN_BASE__",
+  "",
+);
+const targets = ["channel:C1", "group:web-project-fixture", "personal:alice", "team:T1"];
+const model = (id, available = true) => ({ id, name: id, available });
+const initial = { harnessId: "pi", modelId: "alpha", effortLevel: "high", fastMode: true };
+const rows = new Map();
+const writes = [];
+let unavailable = false;
+let approved = ["pi", "codex"];
+let manifest = { id: "runtime", target: "any", clearable: true };
+function config(scope) {
+  const runtime = rows.has(scope) ? rows.get(scope) : initial;
+  return {
+    scopeId: scope,
+    runtime,
+    baseModel: runtime?.modelId ?? null,
+    harnessDefault: "pi",
+    baseModelDefault: "alpha",
+    harnessOptions: ["pi", "codex"],
+    approvedHarnesses: approved,
+    baseModelOptions: [model("alpha", !unavailable), model("beta")],
+    modelsByHarness: { pi: [model("alpha", !unavailable), model("beta")], codex: [model("gpt-fixture")] },
+    thinkingLevelsByHarness: { pi: ["auto", "low", "high"], codex: ["auto", "low", "high"] },
+    fastModeHarnessIds: ["pi"],
+    fastModeModelIds: ["alpha"],
+    serviceCredentials: [],
+    soul: "",
+    webuiModels: [],
+  };
+}
+const server = createServer(async (req, res) => {
+  const path = new URL(req.url, "http://localhost").pathname;
+  const json = (data, status = 200) => {
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(data));
+  };
+  if (path === "/api/me") return json({ org: "acme", principal: "synthetic-admin", isAdmin: true });
+  if (path === "/api/scopes")
+    return json({ scopes: targets.map((scopeId) => ({ scopeId, label: scopeId, sessions: 1 })), environments: [] });
+  if (path === "/api/resources") return json({ resources: [manifest] });
+  if (path.startsWith("/api/scopes/")) {
+    const [, scope, resource] = path.match(/^\/api\/scopes\/([^/]+)(?:\/(.+))?$/);
+    const target = decodeURIComponent(scope);
+    if (req.method === "PUT") {
+      let body = "";
+      for await (const chunk of req) body += chunk.toString();
+      const value = JSON.parse(body);
+      writes.push({ target, resource, body: value });
+      rows.set(target, value.inherit ? null : value);
+      return json({ ok: true });
+    }
+    return json(config(target));
+  }
+  if (path.startsWith("/api/")) return json({ sessions: [], total: 0, errors: [], providers: [] });
+  res.writeHead(200, { "content-type": "text/html" });
+  res.end(html);
+});
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const base = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch({ headless: true });
+test.after(async () => {
+  await browser.close();
+  await new Promise((resolve) => server.close(resolve));
+});
+
+async function ready(page) {
+  await page.locator("#app-view:not(.hidden)").waitFor();
+  await page.locator("#st-runtime").filter({ hasNotText: "Loading" }).waitFor({ state: "attached" });
+}
+async function runtimeVisible(page, target) {
+  await page.locator("#card-base-model").waitFor({ state: "visible", timeout: 2000 });
+  assert.ok((await page.locator("#base-runtime-target").textContent()).includes(target));
+  assert.equal(new URL(page.url()).searchParams.get("scope"), target);
+}
+async function pick(page, id, label) {
+  const dropdown = page.locator(`#${id} + .dd`);
+  await dropdown.locator(".dd-btn").click();
+  await dropdown.getByRole("option", { name: label, exact: true }).click();
+}
+async function save(page) {
+  await page.locator('[data-save="runtime"]').click();
+  await page.locator("#st-runtime").filter({ hasText: "Saved" }).waitFor();
+}
+for (const target of targets) {
+  test(`real router, refresh/history and runtime PUT for ${target}`, async () => {
+    rows.clear();
+    approved = ["pi", "codex"];
+    unavailable = false;
+    const page = await browser.newPage();
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    try {
+      await page.goto(base + "/history");
+      await page.getByRole("link", { name: target, exact: false }).first().click();
+      await page.locator("#tabs").getByRole("button", { name: "Governance", exact: true }).click();
+      await ready(page);
+      await runtimeVisible(page, target);
+      assert.ok((await page.locator("#shellbar").textContent()).includes(target));
+      await page.reload();
+      await ready(page);
+      await runtimeVisible(page, target);
+      assert.equal(await page.locator(".card.dirty").count(), 0);
+      await page.locator("#tabs").getByRole("button", { name: "Models", exact: true }).click();
+      await page.waitForURL("**/models");
+      await ready(page);
+      assert.equal(await page.locator("#card-base-model").isVisible(), false);
+      await page.goBack();
+      await ready(page);
+      await runtimeVisible(page, target);
+      await page.goForward();
+      await ready(page);
+      assert.equal(new URL(page.url()).pathname, "/models");
+      assert.equal(await page.locator("#card-base-model").isVisible(), false);
+      await page.goBack();
+      await ready(page);
+      await runtimeVisible(page, target);
+      const before = writes.length;
+      await pick(page, "base-model", "beta (beta)");
+      await pick(page, "base-effort", "Low");
+      await save(page);
+      assert.deepEqual(writes.slice(before), [
+        {
+          target,
+          resource: "runtime",
+          body: { harnessId: "pi", modelId: "beta", effortLevel: "low", fastMode: false },
+        },
+      ]);
+      await page.reload();
+      await ready(page);
+      await runtimeVisible(page, target);
+      assert.equal(await page.locator("#base-model").inputValue(), "beta");
+      assert.equal(await page.locator("#base-effort").inputValue(), "low");
+      await page.locator("#base-inherit-control").click();
+      await save(page);
+      assert.deepEqual(writes.at(-1), { target, resource: "runtime", body: { inherit: true } });
+      assert.equal(rows.get(target), null);
+      assert.equal(rows.has("org:acme"), false);
+      await page.reload();
+      await ready(page);
+      await runtimeVisible(page, target);
+      assert.equal(await page.locator("#base-inherit").isChecked(), true);
+      assert.equal(await page.locator("#base-runtime-fields").isVisible(), false);
+      assert.deepEqual(errors, []);
+    } finally {
+      await page.close();
+    }
+  });
+}
+test("retained unavailable choices are visibly disabled and allow recovery or reset", async () => {
+  rows.clear();
+  approved = ["codex"];
+  unavailable = true;
+  const page = await browser.newPage();
+  try {
+    await page.goto(base + "/governance?scope=channel%3AC1");
+    await ready(page);
+    await runtimeVisible(page, "channel:C1");
+    await page.locator("#base-harness + .dd .dd-btn").click();
+    assert.equal(await page.locator("#base-harness + .dd .dd-item.dis").textContent(), "pi (default) (unavailable)");
+    await page.keyboard.press("Escape");
+    await pick(page, "base-effort", "Low");
+    assert.equal(await page.locator('[data-save="runtime"]').isDisabled(), true);
+    await pick(page, "base-harness", "Codex");
+    await save(page);
+    assert.equal(writes.at(-1).body.harnessId, "codex");
+    rows.clear();
+    approved = ["pi", "codex"];
+    await page.reload();
+    await ready(page);
+    await page.locator("#base-model + .dd .dd-btn").click();
+    assert.equal(await page.locator("#base-model + .dd .dd-item.dis").textContent(), "alpha (alpha) (unavailable)");
+    await page.keyboard.press("Escape");
+    await pick(page, "base-model", "beta (beta)");
+    await save(page);
+    assert.equal(writes.at(-1).body.modelId, "beta");
+    rows.clear();
+    await page.reload();
+    await ready(page);
+    await page.locator("#base-inherit-control").click();
+    await save(page);
+    assert.deepEqual(writes.at(-1).body, { inherit: true });
+  } finally {
+    await page.close();
+  }
+});
+test("runtime manifest gating and other org-only Models controls remain intact", async () => {
+  rows.clear();
+  approved = ["pi", "codex"];
+  unavailable = false;
+  const page = await browser.newPage();
+  try {
+    await page.goto(base + "/models");
+    await ready(page);
+    assert.equal(await page.locator("#card-base-model").isVisible(), false);
+    assert.equal(await page.locator("#card-webui-models").isVisible(), true);
+    assert.equal(await page.locator("#card-custom-providers").isVisible(), true);
+    await page.locator("#tabs").getByRole("button", { name: "Governance", exact: true }).click();
+    await ready(page);
+    await runtimeVisible(page, "org:acme");
+    assert.equal(await page.locator("#base-inherit-control").isVisible(), false);
+    assert.equal(await page.locator("#card-webui-models").isVisible(), false);
+    manifest = { ...manifest, target: "org" };
+    await page.goto(base + "/governance?scope=team%3AT1");
+    await ready(page);
+    assert.equal(await page.locator("#card-base-model").isVisible(), false);
+    manifest = { ...manifest, target: "any", clearable: false };
+    await page.reload();
+    await ready(page);
+    await runtimeVisible(page, "team:T1");
+    assert.equal(await page.locator("#base-inherit-control").isVisible(), false);
+  } finally {
+    manifest = { id: "runtime", target: "any", clearable: true };
+    await page.close();
+  }
+});

--- a/src/api/routes/admin/scope-config.ts
+++ b/src/api/routes/admin/scope-config.ts
@@ -9,6 +9,7 @@ import {
   defaultModelForHarness,
   modelProviderAvailabilityFor,
   modelServiceable,
+  modelSupportedByHarness,
   ALL_PROVIDERS_AVAILABLE,
   resolveModel,
   thinkingLevelsForHarness,
@@ -295,7 +296,7 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
       ? await selectableModelCatalog(deps.modelCredentialFetch)
       : builtInModelCatalog();
   const runtime = values.runtime as { harnessId?: unknown; modelId?: unknown } | null | undefined;
-  const approvedHarnesses = (await deps.config.getApprovedHarnessesDurable()) ?? [deps.harnessId ?? "pi"];
+  const approvedHarnesses = await deps.config.getApprovedHarnessesDurable();
   const resolvedCurrent = runtime && typeof runtime.modelId === "string" ? resolveModel(runtime.modelId) : null;
   const currentProvider = resolvedCurrent?.provider;
   const currentModel =
@@ -308,16 +309,22 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
     const models = selectableCatalogForHarness(catalog, harnessId);
     if (currentModel && runtime?.harnessId === harnessId && !models.some((model) => model.id === currentModel.id))
       models.push(currentModel);
-    return models.filter(
-      (model) =>
-        modelServiceable(model.id, providersFor(harnessId)) ||
-        (runtime?.harnessId === harnessId && currentModel?.id === model.id),
-    );
+    return models
+      .filter(
+        (model) =>
+          modelServiceable(model.id, providersFor(harnessId)) ||
+          (runtime?.harnessId === harnessId && currentModel?.id === model.id),
+      )
+      .map((model) => ({
+        ...model,
+        available: modelSupportedByHarness(model.id, harnessId) && modelServiceable(model.id, providersFor(harnessId)),
+      }));
   };
   return sendJson(res, 200, {
     scopeId: targetScope,
     ...environmentMetadata,
     ...values,
+    approvedHarnesses,
     soulVersion: deps.config.soulVersion(targetScope),
     soulHistory: deps.config.soulHistory(targetScope),
     directoryMembers: parseScopeId(targetScope).kind === "org" ? ((await deps.directory?.list()) ?? []) : [],
@@ -325,7 +332,8 @@ export async function getScopeConfig(ctx: ApiCtx): Promise<void> {
     baseModelOptions: modelsFor(deps.harnessId ?? "pi"),
     harnessDefault: deps.harnessId ?? "pi",
     harnessOptions: HARNESS_IDS.filter(
-      (id) => id !== "mock" && (approvedHarnesses.includes(id) || runtime?.harnessId === id),
+      (id) =>
+        id !== "mock" && ((approvedHarnesses ?? [deps.harnessId ?? "pi"]).includes(id) || runtime?.harnessId === id),
     ),
     modelsByHarness: Object.fromEntries(HARNESS_IDS.map((id) => [id, modelsFor(id)])),
     thinkingLevelsByHarness: Object.fromEntries(

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -114,7 +114,14 @@ test("GET /v1/admin/resources returns a manifest entry for every registered reso
     const r = await fetch(`${srv.base}/v1/admin/resources`, { headers: ADMIN });
     assert.equal(r.status, 200);
     const body = (await r.json()) as {
-      resources: { id: string; kind: string; target?: string; secret?: boolean; enumValues?: unknown[] }[];
+      resources: {
+        id: string;
+        kind: string;
+        target?: string;
+        clearable?: boolean;
+        secret?: boolean;
+        enumValues?: unknown[];
+      }[];
     };
     const ids = body.resources.map((x) => x.id).sort();
     assert.deepEqual(ids, ADMIN_RESOURCES.map((x) => x.id).sort());
@@ -127,6 +134,9 @@ test("GET /v1/admin/resources returns a manifest entry for every registered reso
     assert.equal(byId.get("service-credentials")?.target, "org");
     assert.equal(byId.get("service-credentials")?.secret, true);
     assert.equal(byId.has("import"), false);
+    assert.equal(byId.get("runtime")?.target, "any");
+    assert.equal(byId.get("runtime")?.clearable, true);
+    assert.equal(byId.get("runtime")?.kind, "custom");
   } finally {
     await srv.close();
   }

--- a/test/admin-runtime-card.test.ts
+++ b/test/admin-runtime-card.test.ts
@@ -1,0 +1,212 @@
+import "./support/auto-fake-sprites.ts";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { resolveRuntimeChoiceDurable } from "../src/harness/harness-router.ts";
+import { setCustomProviders } from "../src/model/custom-providers.ts";
+import { projectScopeId } from "../src/projects/project-store.ts";
+import { testConfig } from "./support/test-config.ts";
+
+const ORG = "org:default-org";
+const fallback = { harnessId: "pi" as const, modelId: "claude-opus-5" };
+const override = { harnessId: "codex", modelId: "gpt-5.5", effortLevel: "high", fastMode: false };
+async function start() {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "runtime-card-")) }));
+  const server = createInsecureTestServer(built.app, {
+    config: built.config,
+    admin: built.admin,
+    identity: built.identity,
+    auditLog: built.auditLog,
+    harnessId: "pi",
+    baseModelDefault: fallback.modelId,
+    providerKeys: { anthropic: true, openai: false, openrouter: false, codexOAuth: true },
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  await built.config.setRuntimeSelectionLatest(ORG, fallback);
+  built.config.setApprovedHarnesses(["pi", "codex"]);
+  await built.config.flushScope(ORG);
+  const headers = (actor: string) => ({ "content-type": "application/json", "x-admin-actor": `${actor}@default-org` });
+  const get = (scope: string, actor = "admin-alice") =>
+    fetch(`${base}/v1/admin/scopes/${encodeURIComponent(scope)}`, { headers: headers(actor) });
+  const put = (scope: string, body: unknown, actor = "admin-alice") =>
+    fetch(`${base}/v1/admin/scopes/${encodeURIComponent(scope)}/runtime`, {
+      method: "PUT",
+      headers: headers(actor),
+      body: JSON.stringify(body),
+    });
+  return { built, get, put, close: () => new Promise<void>((resolve) => server.close(() => resolve())) };
+}
+
+test("admin runtime round trips every existing scope kind without touching siblings or org", async () => {
+  const s = await start();
+  try {
+    const project = await s.built.projects.create({ name: "Runtime fixture", ownerId: "owner-alice" });
+    for (const scope of ["channel:C1", projectScopeId(project.id), "personal:alice", "team:T1"]) {
+      assert.equal((await s.put(scope, override)).status, 200);
+      const data = (await (await s.get(scope)).json()) as any;
+      assert.equal(data.scopeId, scope);
+      assert.equal(data.runtime.modelId, override.modelId);
+      assert.equal(data.runtime.effortLevel, "high");
+      assert.equal(data.baseModel, override.modelId);
+      assert.equal((await s.built.config.getRuntimeSelectionDurable(ORG))?.modelId, fallback.modelId);
+      assert.equal(await s.built.config.getRuntimeSelectionDurable("channel:untouched"), null);
+      assert.equal((await s.put(scope, { inherit: true })).status, 200);
+      const reset = (await (await s.get(scope)).json()) as any;
+      assert.equal(reset.runtime, null);
+      assert.equal(reset.baseModel, null);
+      assert.deepEqual(await resolveRuntimeChoiceDurable(s.built.config, ORG, scope, fallback), fallback);
+    }
+    assert.equal((await s.put(ORG, override)).status, 200);
+    assert.equal(((await (await s.get(ORG)).json()) as any).runtime.harnessId, "codex");
+    assert.deepEqual(await resolveRuntimeChoiceDurable(s.built.config, ORG, "channel:C1", fallback), override);
+  } finally {
+    await s.close();
+  }
+});
+
+test("reset clears legacy model-only rows and follows future org tuple changes", async () => {
+  const s = await start();
+  try {
+    s.built.config.setBaseModel("channel:legacy", "claude-fable-5");
+    await s.built.config.flushScope("channel:legacy");
+    const legacy = (await (await s.get("channel:legacy")).json()) as any;
+    assert.equal(legacy.runtime, null);
+    assert.equal(legacy.baseModel, "claude-fable-5");
+    assert.equal((await s.put("channel:legacy", { inherit: true })).status, 200);
+    assert.equal((await s.put(ORG, override)).status, 200);
+    assert.deepEqual(await resolveRuntimeChoiceDurable(s.built.config, ORG, "channel:legacy", fallback), override);
+    assert.equal(await s.built.config.getBaseModelOwnDurable("channel:legacy"), null);
+  } finally {
+    await s.close();
+  }
+});
+
+test("registered custom models are exposed and accepted through the existing scoped runtime", async () => {
+  const s = await start();
+  try {
+    setCustomProviders([
+      {
+        id: "runtime-fixture",
+        name: "Fixture",
+        protocol: "openai",
+        baseUrl: "https://unused.invalid/v1",
+        models: [{ id: "custom-deepseek" }],
+      },
+    ]);
+    const data = (await (await s.get("channel:C1")).json()) as any;
+    assert.ok(data.modelsByHarness.pi.some((m: any) => m.id === "custom-deepseek"));
+    assert.equal(
+      (await s.put("channel:C1", { harnessId: "pi", modelId: "custom-deepseek", effortLevel: "low", fastMode: false }))
+        .status,
+      200,
+    );
+    assert.equal(((await (await s.get("channel:C1")).json()) as any).runtime.modelId, "custom-deepseek");
+  } finally {
+    setCustomProviders([]);
+    await s.close();
+  }
+});
+
+test("runtime validation still rejects unsupported tuples and credentials without changing saved state", async () => {
+  const s = await start();
+  try {
+    assert.equal((await s.put("channel:C1", override)).status, 200);
+    const saved = await s.built.config.getRuntimeSelectionDurable("channel:C1");
+    for (const body of [
+      { harnessId: "opencode", modelId: "claude-opus-5" },
+      { harnessId: "codex", modelId: "claude-opus-5" },
+      { harnessId: "pi", modelId: "not-a-model" },
+      { harnessId: "pi", modelId: "gpt-5.5" },
+      { ...override, effortLevel: "max" },
+      { ...override, fastMode: "yes" },
+    ]) {
+      assert.equal((await s.put("channel:C1", body)).status, 400);
+      assert.deepEqual(await s.built.config.getRuntimeSelectionDurable("channel:C1"), saved);
+    }
+    assert.equal(
+      (await s.put("channel:C1", { harnessId: "pi", modelId: "claude-fable-5", fastMode: true })).status,
+      200,
+    );
+    assert.equal((await s.built.config.getRuntimeSelectionDurable("channel:C1"))?.fastMode, false);
+  } finally {
+    await s.close();
+  }
+});
+
+test("project ownership, membership, revoked grants and inactive admins cannot read or mutate admin runtime", async () => {
+  const s = await start();
+  try {
+    const project = await s.built.projects.create({ name: "Owner is not admin", ownerId: "owner-alice" });
+    await s.built.projects.addMember(project.id, "owner-alice", "member-bob");
+    const scope = projectScopeId(project.id);
+    await s.built.admin.revokeGrant({ id: "admin-bob", type: "internal" }, "admin-alice", ORG, "org_admin");
+    for (const actor of ["owner-alice", "member-bob", "admin-alice"]) {
+      assert.equal((await s.get(scope, actor)).status, 403);
+      for (const body of [override, { inherit: true }]) assert.equal((await s.put(scope, body, actor)).status, 403);
+    }
+    await s.built.identity.deactivate("admin-bob");
+    assert.equal((await s.get(scope, "admin-bob")).status, 403);
+    assert.equal((await s.put(scope, override, "admin-bob")).status, 403);
+    assert.equal(await s.built.config.getRuntimeSelectionDurable(scope), null);
+    assert.equal((await s.built.config.getRuntimeSelectionDurable(ORG))?.modelId, fallback.modelId);
+  } finally {
+    await s.close();
+  }
+});
+
+test("readback marks a retained unserviceable saved model unavailable and a recovery choice available", async () => {
+  const s = await start();
+  try {
+    await s.built.config.setRuntimeSelectionLatest("channel:C1", { harnessId: "pi", modelId: "gpt-5.5" });
+    const data = (await (await s.get("channel:C1")).json()) as any;
+    assert.equal(data.runtime.modelId, "gpt-5.5");
+    assert.equal(data.modelsByHarness.pi.find((m: any) => m.id === "gpt-5.5").available, false);
+    assert.equal(data.baseModelOptions.find((m: any) => m.id === "gpt-5.5").available, false);
+    assert.equal(data.modelsByHarness.pi.find((m: any) => m.id === "claude-opus-5").available, true);
+    assert.equal((await s.put("channel:C1", { harnessId: "pi", modelId: "gpt-5.5" })).status, 400);
+    assert.equal((await s.put("channel:C1", fallback)).status, 200);
+    assert.equal((await s.put("channel:C1", { inherit: true })).status, 200);
+  } finally {
+    await s.close();
+  }
+});
+
+test("retained harness options do not imply approval and retained incompatible models remain unavailable", async () => {
+  const s = await start();
+  try {
+    await s.built.config.setRuntimeSelectionLatest("channel:C1", { harnessId: "codex", modelId: "claude-opus-5" });
+    s.built.config.setApprovedHarnesses(["pi"]);
+    await s.built.config.flushScope(ORG);
+    const data = (await (await s.get("channel:C1")).json()) as any;
+    assert.ok(data.harnessOptions.includes("codex"));
+    assert.deepEqual(data.approvedHarnesses, ["pi"]);
+    assert.equal(data.modelsByHarness.codex.find((m: any) => m.id === "claude-opus-5").available, false);
+    assert.equal((await s.put("channel:C1", override)).status, 400);
+    assert.equal((await s.put("channel:C1", { inherit: true })).status, 200);
+  } finally {
+    await s.close();
+  }
+});
+
+test("scoped readback uses durable harness approval even when its org cache is stale", async () => {
+  const s = await start();
+  try {
+    await s.built.config.setRuntimeSelectionLatest("channel:C1", { harnessId: "codex", modelId: "gpt-5.5" });
+    s.built.config.setApprovedHarnesses(["pi"]);
+    await s.built.config.flushScope(ORG);
+    s.built.config.getApprovedHarnesses = () => ["codex"];
+    const data = (await (await s.get("channel:C1")).json()) as any;
+    assert.deepEqual(data.approvedHarnesses, ["pi"]);
+    assert.ok(data.harnessOptions.includes("codex"));
+    assert.equal((await s.put("channel:C1", override)).status, 400);
+    assert.equal((await s.put("channel:C1", { inherit: true })).status, 200);
+  } finally {
+    await s.close();
+  }
+});

--- a/test/model-credential-route.test.ts
+++ b/test/model-credential-route.test.ts
@@ -409,7 +409,9 @@ test("admin scope keeps the selected runtime model visible when its provider is 
     };
     assert.deepEqual(data.runtime, { harnessId: "pi", modelId: "claude-opus-5", orgRevision: 1, revision: 1 });
     assert.deepEqual(data.harnessOptions, ["pi"]);
-    assert.deepEqual(data.modelsByHarness.pi, [{ id: "claude-opus-5", name: "Claude Opus 5", provider: "anthropic" }]);
+    assert.deepEqual(data.modelsByHarness.pi, [
+      { id: "claude-opus-5", name: "Claude Opus 5", provider: "anthropic", available: false },
+    ]);
   } finally {
     await srv.close();
   }


### PR DESCRIPTION
## Summary

- move the runtime override card from org-wide Models to scoped Governance and show the exact target being edited
- preserve scope across refresh and browser history while retaining stale-load, stale-write, and in-flight guards
- disable retained-but-unapproved harnesses and retained-but-unserviceable models without losing reset or valid-choice recovery
- expose durable approval and server-computed availability through the existing scope response, keeping authorization and validation unchanged

Fixes #589.

## Test plan

- admin UI/proxy/auth suites: 144 passed
- core authorization/resolution/catalog suites: 113 passed
- full-page Chromium suite against a local synthetic API: 6 passed
- independent manual browser QA: scoped target, refresh, Models isolation, Back restoration, and successful scoped runtime PUT
- root/admin typechecks, repository ESLint, Oxlint, Knip, targeted Prettier, and `git diff --check`

Coverage includes channel, project, personal, team, and organization scopes; inheritance reset; stale approvals; alternative/custom/empty catalogs; and authorization negatives.


## Before / after

Light theme, rendered against a synthetic catalog (`pi`/`codex`/`claude` harnesses, Claude and GPT models) with the shell served from each branch's `plugins/admin/public/index.html`.

| Before (`main`) | After (this branch) |
| --- | --- |
| ![Models view with the org-wide runtime card](https://raw.githubusercontent.com/yc-software/qm/demo/admin-scoped-runtime-screenshots/before-models-runtime-card.png) | ![Models view without the runtime card](https://raw.githubusercontent.com/yc-software/qm/demo/admin-scoped-runtime-screenshots/after-models.png) |
| Models view: the runtime card sits on the org-wide view with no indication of which scope it edits. | Models view: the runtime card is gone; only the org-wide cards remain. |
| No runtime card on Governance for non-org scopes; per-channel and per-project runtime could not be edited. | ![Governance view for channel:C0AB12CD3 with the scoped runtime card](https://raw.githubusercontent.com/yc-software/qm/demo/admin-scoped-runtime-screenshots/after-governance-channel.png) |
| | Governance for `channel:C0AB12CD3`: the card states the exact target and offers "Use organization default" to fall back to inheritance. |
| Retained-but-unapproved harnesses and unserviceable models rendered as ordinary selectable options. | ![Scoped runtime card with an unapproved harness and unavailable model disabled](https://raw.githubusercontent.com/yc-software/qm/demo/admin-scoped-runtime-screenshots/after-governance-disabled-state.png) |
| | Retained `claude` harness (not approved) and its retained model render as "(unavailable)" and the card asks for an available choice before Apply is enabled. |
| | ![Harness menu with the unapproved harness disabled](https://raw.githubusercontent.com/yc-software/qm/demo/admin-scoped-runtime-screenshots/after-governance-disabled-harness-menu.png) |
| | Harness menu open: the retained unapproved harness is disabled while approved harnesses stay selectable. |
