### PR TITLE
Omit AI authorship attribution from contributions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Reject GitHub noreply addresses in Co-Authored-By trailers
+      - name: Reject AI coauthors and GitHub noreply coauthor addresses
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -108,12 +108,14 @@ jobs:
           offenders=""
           for sha in $(git rev-list "$base..$HEAD_SHA"); do
             if git log -1 --format='%(trailers:key=Co-authored-by,valueonly)' "$sha" \
-              | grep -qi '@users\.noreply\.github\.com'; then
+              | grep -Ei '(@users\.noreply\.github\.com|noreply@(openai|anthropic|cursor)\.com|^(Codex|Claude Code|Claude (Opus|Sonnet|Haiku)|Copilot|Cursor)([[:space:]<]|$))' > /dev/null; then
               offenders="$offenders $sha"
             fi
           done
           [ -n "$offenders" ] || exit 0
           echo "$offenders" | xargs git show -s --format='%h %s' >&2
+          echo "Co-Authored-By trailers must credit human contributors, not AI tools." >&2
+          echo "Remove Codex, Claude, and other AI coauthor trailers from the listed PR commits." >&2
           echo "Co-Authored-By trailers must not use @users.noreply.github.com addresses:" >&2
           echo "GitHub credits them to whichever account owns that username, which may be a stranger." >&2
           echo "This repo bans all such addresses, including your own privacy address;" >&2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ To run and test, see [`README.md`](./README.md).
 
 Two habits that keep task-focused changes from scarring the rest of the repo:
 
+- **Do not add AI authorship attribution to commits or pull requests.** Omit
+  `Co-authored-by` trailers for Codex, Claude, or other AI tools, and omit
+  tool-generated attribution footers such as `Generated with Codex`. Preserve
+  legitimate human coauthors. CI rejects AI coauthor trailers on new PR commits;
+  do not rewrite existing repository history to remove attribution.
 - **Fix every instance, not just the reported one.** When you find a bug or a pattern
   worth changing, grep the whole repo (`src/`, `plugins/`, `test/`, `scripts/`) for the
   same pattern and fix all of it in the same change. One autocorrected call site with


### PR DESCRIPTION
Add shared AGENTS.md guidance to omit AI coauthor trailers and generated attribution footers while preserving human coauthors and existing history. Extend the existing Co-author trailers check to reject known AI identities alongside the existing GitHub noreply restriction.

This reuses the same PR commit scan and checkout with no additional CI jobs, dependencies, or network calls.

Validation: exercised the actual workflow shell against 12 temporary Git fixtures (AI identities, mixed case, human coauthors, multiple trailers, existing noreply restriction, and historical attribution exclusion); all passed in under one second combined. Typecheck, lint, formatting, and git diff checks passed. Independent review found no actionable issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791596436&installation_model_id=19911&pr_number=1046&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1046&signature=91d763f950337dc2ed96d57dd995a167a80b6a3708766c4c7b888e1aabce1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->