### PR TITLE
Add native runtime selection and resume tasks on the selected model

### DIFF
--- a/src/api/agent-api-catalog.ts
+++ b/src/api/agent-api-catalog.ts
@@ -80,6 +80,7 @@ const FAMILIES: AgentApiFamily[] = [
   },
   {
     match: (m, p) => p === "/v1/runtime-config" && (m === "GET" || m === "PUT"),
+    when: () => false,
     guidance:
       "Runtime choice is scoped: changing it affects this personal or shared context, not the whole org. Confirm before changing a shared scope. An inherit reset follows future org defaults automatically.",
     routes: [

--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -1,4 +1,3 @@
-import { validateRuntimeChoice } from "../runtime-config.ts";
 import { parseAckEmoji } from "../../slack/config.ts";
 import { orgId as configOrgId } from "../../config.ts";
 import type { ServerDeps } from "../deps.ts";
@@ -632,9 +631,12 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
         return {
           error: `model ${modelId} isn't serviceable on this deployment: its provider key is not configured for the ${harnessId} harness`,
         };
-      const choice = { harnessId, modelId, effortLevel, fastMode };
-      const error = validateRuntimeChoice(choice);
-      if (error) return { error };
+      const choice = {
+        harnessId,
+        modelId,
+        effortLevel,
+        fastMode: fastMode && harnessSupportsFastMode(harnessId) && fastModeModelIds().includes(modelId),
+      };
       await ctx.deps.config!.setRuntimeSelectionLatest(scope, choice);
       return { ok: true };
     },

--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -1,3 +1,4 @@
+import { validateRuntimeChoice } from "../runtime-config.ts";
 import { parseAckEmoji } from "../../slack/config.ts";
 import { orgId as configOrgId } from "../../config.ts";
 import type { ServerDeps } from "../deps.ts";
@@ -631,12 +632,10 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
         return {
           error: `model ${modelId} isn't serviceable on this deployment: its provider key is not configured for the ${harnessId} harness`,
         };
-      await ctx.deps.config!.setRuntimeSelectionLatest(scope, {
-        harnessId,
-        modelId,
-        effortLevel,
-        fastMode: fastMode && harnessSupportsFastMode(harnessId) && fastModeModelIds().includes(modelId),
-      });
+      const choice = { harnessId, modelId, effortLevel, fastMode };
+      const error = validateRuntimeChoice(choice);
+      if (error) return { error };
+      await ctx.deps.config!.setRuntimeSelectionLatest(scope, choice);
       return { ok: true };
     },
   },

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1,4 +1,4 @@
-import { runtimeFallback, runtimeConfigBody, validateRuntimeChoice, webuiModelEnabled } from "../runtime-config.ts";
+import { runtimeFallback, runtimeConfigBody, webuiModelEnabled } from "../runtime-config.ts";
 import { sessionSharingRoutes } from "./session-sharing.ts";
 import type { Grant, ScopeId } from "../../types.ts";
 import { parseScopeId, scopeId as makeScopeId } from "../../types.ts";
@@ -10,6 +10,7 @@ import {
   modelSupportedByHarness,
   modelOfferedInWebui,
   THINKING_LEVELS,
+  fastModeModelIds,
 } from "../../model/pi-models.ts";
 import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../../model/model-catalog.ts";
 import { errMessage } from "../../util/errors.ts";
@@ -1167,9 +1168,7 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "effort_not_supported" });
     const fastMode = ctx.body.fastMode ?? false;
     if (typeof fastMode !== "boolean") return sendJson(ctx.res, 400, { error: "fast_mode_invalid" });
-    const choice = { harnessId, modelId, effortLevel, fastMode };
-    const error = validateRuntimeChoice(choice);
-    if (error) return sendJson(ctx.res, 400, { error });
+    const choice = { harnessId, modelId, effortLevel, fastMode: fastMode && fastModeModelIds().includes(modelId) };
     await config.setRuntimeSelectionLatest(target.scope, choice);
   }
   audit(ctx.deps, {

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -1,3 +1,4 @@
+import { runtimeFallback, runtimeConfigBody, validateRuntimeChoice, webuiModelEnabled } from "../runtime-config.ts";
 import { sessionSharingRoutes } from "./session-sharing.ts";
 import type { Grant, ScopeId } from "../../types.ts";
 import { parseScopeId, scopeId as makeScopeId } from "../../types.ts";
@@ -6,16 +7,9 @@ import { ByteSourceTooLargeError } from "../../files/durable-byte-store.ts";
 import {
   defaultModelForHarness,
   isHarnessId,
-  modelProviderAvailabilityFor,
   modelSupportedByHarness,
-  serviceableModelIds,
-  ALL_PROVIDERS_AVAILABLE,
-  fastModeModelIds,
-  safeModelMetadata,
   modelOfferedInWebui,
-  modelUnavailableReason,
   THINKING_LEVELS,
-  type HarnessId,
 } from "../../model/pi-models.ts";
 import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../../model/model-catalog.ts";
 import { errMessage } from "../../util/errors.ts";
@@ -1107,11 +1101,6 @@ async function getSurfaceConfig(ctx: ApiCtx): Promise<void> {
   });
 }
 
-function runtimeFallback(ctx: ApiCtx): { harnessId: HarnessId; modelId: string } {
-  const harnessId = isHarnessId(ctx.deps.harnessId) ? ctx.deps.harnessId : "pi";
-  return { harnessId, modelId: ctx.deps.baseModelDefault ?? defaultModelForHarness(harnessId) };
-}
-
 async function runtimeTarget(ctx: ApiCtx): Promise<{ actorId: string; scope: ScopeId } | null> {
   const actorId =
     ctx.capability?.actorId ??
@@ -1130,130 +1119,12 @@ async function runtimeTarget(ctx: ApiCtx): Promise<{ actorId: string; scope: Sco
   return null;
 }
 
-async function runtimeConfigBody(ctx: ApiCtx, scope: ScopeId): Promise<Record<string, unknown>> {
-  const config = ctx.deps.config!;
-  const fallback = runtimeFallback(ctx);
-  const org = orgScope(ctx.deps);
-  const approvedHarnesses = ((await config.getApprovedHarnessesDurable()) ?? [fallback.harnessId]).filter(isHarnessId);
-  const configuredKeys = ctx.deps.providerKeys ?? ALL_PROVIDERS_AVAILABLE;
-  const managedKeys = ctx.deps.modelCredentials ? await ctx.deps.modelCredentials.availability() : configuredKeys;
-  const providersFor = (harnessId: string) => modelProviderAvailabilityFor(harnessId, configuredKeys, managedKeys);
-  const catalog =
-    ctx.deps.modelCredentials && managedKeys.openrouter
-      ? await selectableModelCatalog(ctx.deps.modelCredentialFetch)
-      : builtInModelCatalog();
-  const orgStored = await config.getRuntimeSelectionDurable(org);
-  const orgLegacyModel = orgStored ? null : await config.getBaseModelOwnDurable(org);
-  let orgDefault: {
-    harnessId: HarnessId;
-    modelId: string;
-    effortLevel?: string;
-    fastMode?: boolean;
-    revision: number;
-  } = { ...fallback, revision: orgStored?.revision ?? 0 };
-  if (orgStored && isHarnessId(orgStored.harnessId)) {
-    orgDefault = {
-      harnessId: orgStored.harnessId,
-      modelId: orgStored.modelId,
-      ...(orgStored.effortLevel ? { effortLevel: orgStored.effortLevel } : {}),
-      ...(typeof orgStored.fastMode === "boolean" ? { fastMode: orgStored.fastMode } : {}),
-      revision: orgStored.revision ?? 0,
-    };
-  } else if (orgLegacyModel) {
-    orgDefault = { harnessId: fallback.harnessId, modelId: orgLegacyModel, revision: 0 };
-  }
-  const stored = scope === org ? orgStored : await config.getRuntimeSelectionDurable(scope);
-  const legacyModel = scope === org ? null : await config.getBaseModelOwnDurable(scope);
-  let scopeOverride: {
-    harnessId: HarnessId;
-    modelId: string;
-    effortLevel?: string;
-    fastMode?: boolean;
-    orgRevision?: number;
-  } | null = null;
-  if (stored && isHarnessId(stored.harnessId)) {
-    scopeOverride = {
-      harnessId: stored.harnessId,
-      modelId: stored.modelId,
-      ...(stored.effortLevel ? { effortLevel: stored.effortLevel } : {}),
-      ...(typeof stored.fastMode === "boolean" ? { fastMode: stored.fastMode } : {}),
-      orgRevision: stored.orgRevision,
-    };
-  } else if (legacyModel) {
-    scopeOverride = { harnessId: fallback.harnessId, modelId: legacyModel, orgRevision: 0 };
-  }
-  const effective = scopeOverride ?? orgDefault;
-  const selected = [orgDefault, scopeOverride, effective].filter((choice) => choice !== null);
-  const allowlist = await config.getWebuiModelsDurable(org);
-  const modelsByHarness = Object.fromEntries(
-    approvedHarnesses.map((harnessId) => {
-      const ids =
-        allowlist != null
-          ? allowlist.filter((id) => modelSupportedByHarness(id, harnessId))
-          : selectableCatalogForHarness(catalog, harnessId)
-              .filter((model) => modelOfferedInWebui(model.id))
-              .map((model) => model.id);
-      for (const choice of selected) {
-        if (
-          allowlist?.length !== 0 &&
-          choice.harnessId === harnessId &&
-          modelSupportedByHarness(choice.modelId, harnessId) &&
-          !ids.includes(choice.modelId)
-        )
-          ids.push(choice.modelId);
-      }
-      return [harnessId, serviceableModelIds(ids, providersFor(harnessId))];
-    }),
-  );
-  const advertisedModelIds = new Set(Object.values(modelsByHarness).flat());
-  const modelCatalog = Object.fromEntries(
-    [...advertisedModelIds].flatMap((id) => {
-      const metadata = safeModelMetadata(id);
-      return metadata ? [[id, metadata]] : [];
-    }),
-  );
-  return {
-    scopeId: scope,
-    approvedHarnesses,
-    modelsByHarness,
-    modelCatalog,
-    orgDefault,
-    scopeOverride,
-    effective: {
-      harnessId: effective.harnessId,
-      modelId: effective.modelId,
-      ...(effective.effortLevel ? { effortLevel: effective.effortLevel } : {}),
-      ...(typeof effective.fastMode === "boolean" ? { fastMode: effective.fastMode } : {}),
-    },
-    ...(!modelsByHarness[effective.harnessId]?.includes(effective.modelId)
-      ? {
-          unavailableReason:
-            modelUnavailableReason(effective.modelId) ?? "Selected model is unavailable; choose another model",
-        }
-      : {}),
-    upgradeAvailable: Boolean(scopeOverride && scopeOverride.orgRevision !== orgDefault.revision),
-    fastModeModelIds: fastModeModelIds(),
-    interactiveFastMode: await config.getInteractiveFastModeDurable(),
-  };
-}
-
 async function getRuntimeConfig(ctx: ApiCtx): Promise<void> {
   if (!ctx.deps.config) return sendJson(ctx.res, 404, { error: "not_found" });
   const target = await runtimeTarget(ctx);
   if (!target) return sendJson(ctx.res, 403, { error: "forbidden" });
   await ctx.deps.refreshModels?.();
   return sendJson(ctx.res, 200, await runtimeConfigBody(ctx, target.scope));
-}
-
-async function webuiModelEnabled(ctx: ApiCtx, modelId: string): Promise<boolean> {
-  const config = ctx.deps.config!;
-  const picker = await config.getWebuiModelsDurable(orgScope(ctx.deps));
-  if (picker == null || picker.includes(modelId)) return true;
-  if (picker.length === 0) return false;
-  const org = orgScope(ctx.deps);
-  const stored = await config.getRuntimeSelectionDurable(org);
-  const orgModel = stored?.modelId ?? (await config.getBaseModelOwnDurable(org)) ?? runtimeFallback(ctx).modelId;
-  return modelId === orgModel;
 }
 
 async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
@@ -1296,12 +1167,10 @@ async function putRuntimeConfig(ctx: ApiCtx): Promise<void> {
       return sendJson(ctx.res, 400, { error: "effort_not_supported" });
     const fastMode = ctx.body.fastMode ?? false;
     if (typeof fastMode !== "boolean") return sendJson(ctx.res, 400, { error: "fast_mode_invalid" });
-    await config.setRuntimeSelectionLatest(target.scope, {
-      harnessId,
-      modelId,
-      effortLevel,
-      fastMode: fastMode && fastModeModelIds().includes(modelId),
-    });
+    const choice = { harnessId, modelId, effortLevel, fastMode };
+    const error = validateRuntimeChoice(choice);
+    if (error) return sendJson(ctx.res, 400, { error });
+    await config.setRuntimeSelectionLatest(target.scope, choice);
   }
   audit(ctx.deps, {
     principalId: target.actorId,

--- a/src/api/runtime-config.ts
+++ b/src/api/runtime-config.ts
@@ -1,0 +1,165 @@
+import type { ServerDeps } from "./deps.ts";
+import type { ScopeId } from "../types.ts";
+import { orgScope } from "./routes/shared.ts";
+import {
+  defaultModelForHarness,
+  isHarnessId,
+  modelProviderAvailabilityFor,
+  modelSupportedByHarness,
+  serviceableModelIds,
+  ALL_PROVIDERS_AVAILABLE,
+  fastModeModelIds,
+  safeModelMetadata,
+  modelOfferedInWebui,
+  modelUnavailableReason,
+  thinkingLevelsForHarness,
+  harnessSupportsFastMode,
+  type HarnessId,
+} from "../model/pi-models.ts";
+import { builtInModelCatalog, selectableCatalogForHarness, selectableModelCatalog } from "../model/model-catalog.ts";
+import type { RuntimeChoice } from "../harness/harness.ts";
+
+export type RuntimeDeps = Pick<
+  ServerDeps,
+  | "config"
+  | "harnessId"
+  | "baseModelDefault"
+  | "providerKeys"
+  | "modelCredentials"
+  | "modelCredentialFetch"
+  | "refreshModels"
+>;
+
+export function runtimeFallback(ctx: { deps: RuntimeDeps }): { harnessId: HarnessId; modelId: string } {
+  const harnessId = isHarnessId(ctx.deps.harnessId) ? ctx.deps.harnessId : "pi";
+  return { harnessId, modelId: ctx.deps.baseModelDefault ?? defaultModelForHarness(harnessId) };
+}
+
+export async function runtimeConfigBody(ctx: { deps: RuntimeDeps }, scope: ScopeId) {
+  const config = ctx.deps.config!;
+  const fallback = runtimeFallback(ctx);
+  const org = orgScope(ctx.deps);
+  const approvedHarnesses = ((await config.getApprovedHarnessesDurable()) ?? [fallback.harnessId]).filter(isHarnessId);
+  const configuredKeys = ctx.deps.providerKeys ?? ALL_PROVIDERS_AVAILABLE;
+  const managedKeys = ctx.deps.modelCredentials ? await ctx.deps.modelCredentials.availability() : configuredKeys;
+  const providersFor = (harnessId: string) => modelProviderAvailabilityFor(harnessId, configuredKeys, managedKeys);
+  const catalog =
+    ctx.deps.modelCredentials && managedKeys.openrouter
+      ? await selectableModelCatalog(ctx.deps.modelCredentialFetch)
+      : builtInModelCatalog();
+  const orgStored = await config.getRuntimeSelectionDurable(org);
+  const orgLegacyModel = orgStored ? null : await config.getBaseModelOwnDurable(org);
+  let orgDefault: {
+    harnessId: HarnessId;
+    modelId: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    revision: number;
+  } = { ...fallback, revision: orgStored?.revision ?? 0 };
+  if (orgStored && isHarnessId(orgStored.harnessId)) {
+    orgDefault = {
+      harnessId: orgStored.harnessId,
+      modelId: orgStored.modelId,
+      ...(orgStored.effortLevel ? { effortLevel: orgStored.effortLevel } : {}),
+      ...(typeof orgStored.fastMode === "boolean" ? { fastMode: orgStored.fastMode } : {}),
+      revision: orgStored.revision ?? 0,
+    };
+  } else if (orgLegacyModel) {
+    orgDefault = { harnessId: fallback.harnessId, modelId: orgLegacyModel, revision: 0 };
+  }
+  const stored = scope === org ? orgStored : await config.getRuntimeSelectionDurable(scope);
+  const legacyModel = scope === org ? null : await config.getBaseModelOwnDurable(scope);
+  let scopeOverride: {
+    harnessId: HarnessId;
+    modelId: string;
+    effortLevel?: string;
+    fastMode?: boolean;
+    orgRevision?: number;
+  } | null = null;
+  if (stored && isHarnessId(stored.harnessId)) {
+    scopeOverride = {
+      harnessId: stored.harnessId,
+      modelId: stored.modelId,
+      ...(stored.effortLevel ? { effortLevel: stored.effortLevel } : {}),
+      ...(typeof stored.fastMode === "boolean" ? { fastMode: stored.fastMode } : {}),
+      orgRevision: stored.orgRevision,
+    };
+  } else if (legacyModel) {
+    scopeOverride = { harnessId: fallback.harnessId, modelId: legacyModel, orgRevision: 0 };
+  }
+  const effective = scopeOverride ?? orgDefault;
+  const selected = [orgDefault, scopeOverride, effective].filter((choice) => choice !== null);
+  const allowlist = await config.getWebuiModelsDurable(org);
+  const modelsByHarness = Object.fromEntries(
+    approvedHarnesses.map((harnessId) => {
+      const ids =
+        allowlist != null
+          ? allowlist.filter((id) => modelSupportedByHarness(id, harnessId))
+          : selectableCatalogForHarness(catalog, harnessId)
+              .filter((model) => modelOfferedInWebui(model.id))
+              .map((model) => model.id);
+      for (const choice of selected) {
+        if (
+          allowlist?.length !== 0 &&
+          choice.harnessId === harnessId &&
+          modelSupportedByHarness(choice.modelId, harnessId) &&
+          !ids.includes(choice.modelId)
+        )
+          ids.push(choice.modelId);
+      }
+      return [harnessId, serviceableModelIds(ids, providersFor(harnessId))];
+    }),
+  );
+  const advertisedModelIds = new Set(Object.values(modelsByHarness).flat());
+  const modelCatalog = Object.fromEntries(
+    [...advertisedModelIds].flatMap((id) => {
+      const metadata = safeModelMetadata(id);
+      return metadata ? [[id, metadata]] : [];
+    }),
+  );
+  return {
+    scopeId: scope,
+    approvedHarnesses,
+    modelsByHarness,
+    modelCatalog,
+    orgDefault,
+    scopeOverride,
+    effective: {
+      harnessId: effective.harnessId,
+      modelId: effective.modelId,
+      ...(effective.effortLevel ? { effortLevel: effective.effortLevel } : {}),
+      ...(typeof effective.fastMode === "boolean" ? { fastMode: effective.fastMode } : {}),
+    },
+    ...(!modelsByHarness[effective.harnessId]?.includes(effective.modelId)
+      ? {
+          unavailableReason:
+            modelUnavailableReason(effective.modelId) ?? "Selected model is unavailable; choose another model",
+        }
+      : {}),
+    upgradeAvailable: Boolean(scopeOverride && scopeOverride.orgRevision !== orgDefault.revision),
+    fastModeModelIds: fastModeModelIds(),
+    interactiveFastMode: await config.getInteractiveFastModeDurable(),
+  };
+}
+
+export function validateRuntimeChoice(choice: RuntimeChoice): string | null {
+  if (!modelSupportedByHarness(choice.modelId, choice.harnessId)) return "model_not_supported";
+  if (choice.effortLevel !== undefined && !thinkingLevelsForHarness(choice.harnessId).includes(choice.effortLevel))
+    return "effort_not_supported";
+  if (choice.fastMode !== undefined && typeof choice.fastMode !== "boolean") return "fast_mode_invalid";
+  if (choice.fastMode && (!harnessSupportsFastMode(choice.harnessId) || !fastModeModelIds().includes(choice.modelId)))
+    return "fast_mode_not_supported";
+  return null;
+}
+
+export async function webuiModelEnabled(ctx: { deps: RuntimeDeps }, modelId: string): Promise<boolean> {
+  modelId = modelId.replace(/^codex\//, "");
+  const config = ctx.deps.config!;
+  const picker = await config.getWebuiModelsDurable(orgScope(ctx.deps));
+  if (picker == null || picker.includes(modelId)) return true;
+  if (picker.length === 0) return false;
+  const org = orgScope(ctx.deps);
+  const stored = await config.getRuntimeSelectionDurable(org);
+  const orgModel = stored?.modelId ?? (await config.getBaseModelOwnDurable(org)) ?? runtimeFallback(ctx).modelId;
+  return modelId === orgModel;
+}

--- a/src/core/individual-auth-routing.ts
+++ b/src/core/individual-auth-routing.ts
@@ -1,5 +1,6 @@
 import {
   codexSubscriptionModelId,
+  CODEX_SUBSCRIPTION_PROVIDER,
   DEFAULT_AGENT_MODEL_ID,
   DEFAULT_CODEX_MODEL_ID,
   defaultModelForHarness,
@@ -24,8 +25,9 @@ export function resolveIndividualAuthRouting(
   requestedModel: string | undefined,
   preferredHarness?: string,
 ): IndividualAuthRouting {
-  if (requestedModel && modelUnavailableReason(requestedModel)) return null;
-  const requestedProvider = requestedModel ? resolveModel(requestedModel)?.provider : undefined;
+  if (requestedModel && (modelUnavailableReason(requestedModel) || !resolveModel(requestedModel))) return null;
+  const rawProvider = requestedModel ? resolveModel(requestedModel)?.provider : undefined;
+  const requestedProvider = rawProvider === CODEX_SUBSCRIPTION_PROVIDER ? "openai" : rawProvider;
   const pick = ((): { provider: "anthropic" | "openai"; cred: UserModelCredential } | null => {
     if (requestedProvider === "anthropic" && anthCred) return { provider: "anthropic", cred: anthCred };
     if (requestedProvider === "openai" && oaiCred) return { provider: "openai", cred: oaiCred };
@@ -40,6 +42,7 @@ export function resolveIndividualAuthRouting(
     (pick.cred.kind !== "apikey" || requestedProvider !== pick.provider)
   )
     return null;
+  if (pick.cred.kind === "apikey" && rawProvider === CODEX_SUBSCRIPTION_PROVIDER) return null;
   if (pick.cred.kind === "apikey" && pick.cred.apiKey) {
     return {
       kind: "apikey",
@@ -58,7 +61,10 @@ export function resolveIndividualAuthRouting(
         kind: "oauth",
         provider: "anthropic",
         harness: "claude",
-        model: defaultModelForHarness("claude", DEFAULT_AGENT_MODEL_ID),
+        model:
+          requestedModel && requestedProvider === "anthropic"
+            ? requestedModel
+            : defaultModelForHarness("claude", DEFAULT_AGENT_MODEL_ID),
       };
     }
     if (preferredHarness === "pi") {
@@ -78,7 +84,10 @@ export function resolveIndividualAuthRouting(
       kind: "oauth",
       provider: "openai",
       harness: "codex",
-      model: defaultModelForHarness("codex", DEFAULT_CODEX_MODEL_ID),
+      model:
+        requestedModel && requestedProvider === "openai"
+          ? requestedModel.replace(/^codex\//, "")
+          : defaultModelForHarness("codex", DEFAULT_CODEX_MODEL_ID),
     };
   }
   return null;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,3 +1,4 @@
+import { recoveredRuntime } from "../harness/runtime-control.ts";
 import { evaluateCommandWithLayer } from "../policy/command-policy.ts";
 import { createSecretValueMasker } from "../security/secret-masking.ts";
 import { shq } from "../util/shell.ts";
@@ -2602,7 +2603,8 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           configuredTurnWallClockSec === null || configuredTurnWallClockSec === undefined
             ? undefined
             : configuredTurnWallClockSec * 1000;
-        let effectiveTurnWallClockMs = configuredTurnWallClockMs;
+        let effectiveTurnWallClockMs =
+          configuredTurnWallClockMs ?? deps.defaultTurnWallClockMs ?? CONFIG_DEFAULTS.turnWallClockSec * 1000;
         if (requestedTurnWallClockMs !== undefined) {
           effectiveTurnWallClockMs =
             configuredTurnWallClockMs !== undefined && configuredTurnWallClockMs > 0
@@ -2612,74 +2614,72 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         const wantsOrgFastMode =
           typeof input.fastMode !== "boolean" && humanTurn && (await deps.config?.getInteractiveFastModeDurable());
         const effectiveFastMode = resolveTurnFastMode(input.fastMode, humanTurn, wantsOrgFastMode === true);
-        let userProviderKeys: ProviderKeys | undefined;
-        let userModelOverride: string | undefined;
-        let userHarnessOverride: string | undefined;
-        let claudeOauthToken: string | undefined;
-        let codexTurnAuth: CodexTurnAuth | undefined;
-        const userCredStore = deps.userModelCredentials;
-        if (userCredStore && humanTurn && (await deps.config?.getIndividualModelAuthDurable())) {
-          const [anthCred, oaiCred] = await Promise.all([
-            userCredStore.get(actor.id, "anthropic"),
-            userCredStore.get(actor.id, "openai"),
-          ]);
-          // The org's harness choice decides how a ChatGPT subscription is
-          // served: pi orgs stay on pi (Codex provider inside pi-ai), others
-          // hop to the codex harness.
-          const orgRuntime = await deps.config?.getRuntimeSelectionDurable(resolution.orgScopeId);
-          const preferredHarness = input.harness ?? orgRuntime?.harnessId ?? deps.defaultHarness;
-          const routing = resolveIndividualAuthRouting(
-            anthCred ?? null,
-            oaiCred ?? null,
-            input.model,
-            preferredHarness,
-          );
-          if (routing?.kind === "apikey") {
-            userHarnessOverride = "pi";
-            userProviderKeys = { [routing.provider]: routing.apiKey };
-            userModelOverride = routing.model;
-          } else if (routing?.kind === "oauth" && routing.provider === "anthropic" && anthCred?.oauth) {
-            // Derived material only — the keychain refreshes centrally
-            // (single-flight, CAS) and the refresh token never leaves it.
-            const derived = await userCredStore.derivedOAuth(actor.id, "anthropic");
-            if (derived) {
-              claudeOauthToken = derived.accessToken;
-              userHarnessOverride = routing.harness;
-              userModelOverride = routing.model;
-            }
-          } else if (
-            routing?.kind === "oauth" &&
-            routing.provider === "openai" &&
-            routing.harness === "pi" &&
-            oaiCred?.oauth
-          ) {
-            // pi-on-ChatGPT: pi-ai's openai-codex provider takes the access
-            // token as its key (the account claim rides inside the JWT).
-            const derived = await userCredStore.derivedOAuth(actor.id, "openai");
-            if (derived) {
-              userProviderKeys = { [CODEX_SUBSCRIPTION_PROVIDER]: derived.accessToken };
-              userHarnessOverride = routing.harness;
-              userModelOverride = routing.model;
-            }
-          } else if (routing?.kind === "oauth" && routing.provider === "openai" && oaiCred?.oauth) {
-            const derived = await userCredStore.derivedOAuth(actor.id, "openai");
-            if (derived?.idToken) {
-              codexTurnAuth = {
-                accessToken: derived.accessToken,
-                idToken: derived.idToken,
-                ...(derived.accountId ? { accountId: derived.accountId } : {}),
-                ...(derived.expiresAt !== undefined ? { expiresAt: derived.expiresAt } : {}),
-              };
-              userHarnessOverride = routing.harness;
-              userModelOverride = routing.model;
-            }
-          }
-          if (!userHarnessOverride) {
-            throw new NonRetryableTurnError(
-              "This organization has each person chat on their own AI account, and yours isn't connected yet. Open the web app and connect Claude or ChatGPT from the AI account panel, then try again.",
+        const loadRuntimeAuth = async (runtime: Partial<RuntimeChoice>) => {
+          let userProviderKeys: ProviderKeys | undefined;
+          let userModelOverride: string | undefined;
+          let userHarnessOverride: string | undefined;
+          let claudeOauthToken: string | undefined;
+          let codexTurnAuth: CodexTurnAuth | undefined;
+          const userCredStore = deps.userModelCredentials;
+          if (userCredStore && humanTurn && (await deps.config?.getIndividualModelAuthDurable())) {
+            const [anthCred, oaiCred] = await Promise.all([
+              userCredStore.get(actor.id, "anthropic"),
+              userCredStore.get(actor.id, "openai"),
+            ]);
+            const orgRuntime = await deps.config?.getRuntimeSelectionDurable(resolution.orgScopeId);
+            const preferredHarness = runtime.harnessId ?? input.harness ?? orgRuntime?.harnessId ?? deps.defaultHarness;
+            const routing = resolveIndividualAuthRouting(
+              anthCred ?? null,
+              oaiCred ?? null,
+              runtime.modelId ?? input.model,
+              preferredHarness,
             );
+            if (routing?.kind === "apikey") {
+              userHarnessOverride = "pi";
+              userProviderKeys = { [routing.provider]: routing.apiKey };
+              userModelOverride = routing.model;
+            } else if (routing?.kind === "oauth" && routing.provider === "anthropic" && anthCred?.oauth) {
+              const derived = await userCredStore.derivedOAuth(actor.id, "anthropic");
+              if (derived) {
+                claudeOauthToken = derived.accessToken;
+                userHarnessOverride = routing.harness;
+                userModelOverride = routing.model;
+              }
+            } else if (
+              routing?.kind === "oauth" &&
+              routing.provider === "openai" &&
+              routing.harness === "pi" &&
+              oaiCred?.oauth
+            ) {
+              const derived = await userCredStore.derivedOAuth(actor.id, "openai");
+              if (derived) {
+                userProviderKeys = { [CODEX_SUBSCRIPTION_PROVIDER]: derived.accessToken };
+                userHarnessOverride = routing.harness;
+                userModelOverride = routing.model;
+              }
+            } else if (routing?.kind === "oauth" && routing.provider === "openai" && oaiCred?.oauth) {
+              const derived = await userCredStore.derivedOAuth(actor.id, "openai");
+              if (derived?.idToken) {
+                codexTurnAuth = {
+                  accessToken: derived.accessToken,
+                  idToken: derived.idToken,
+                  ...(derived.accountId ? { accountId: derived.accountId } : {}),
+                  ...(derived.expiresAt !== undefined ? { expiresAt: derived.expiresAt } : {}),
+                };
+                userHarnessOverride = routing.harness;
+                userModelOverride = routing.model;
+              }
+            }
+            if (!userHarnessOverride) {
+              throw new NonRetryableTurnError(
+                "This organization has each person chat on their own AI account, and yours isn't connected yet. Open the web app and connect Claude or ChatGPT from the AI account panel, then try again.",
+              );
+            }
           }
-        }
+          return { userProviderKeys, userModelOverride, userHarnessOverride, claudeOauthToken, codexTurnAuth };
+        };
+        let { userProviderKeys, userModelOverride, userHarnessOverride, claudeOauthToken, codexTurnAuth } =
+          await loadRuntimeAuth({});
         const effectiveModel = userModelOverride ?? input.model;
         const effectiveHarness = userHarnessOverride ?? input.harness;
         if (userHarnessOverride) {
@@ -2693,13 +2693,44 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
         }
         if (input.harness && !isHarnessId(input.harness))
           throw new NonRetryableTurnError(`runtime ${input.harness} is not approved`);
-        const requestedRuntime: Partial<RuntimeChoice> = {
+        let requestedRuntime: Partial<RuntimeChoice> = {
           ...(effectiveHarness && isHarnessId(effectiveHarness) ? { harnessId: effectiveHarness } : {}),
           ...(effectiveModel ? { modelId: effectiveModel } : {}),
           ...(input.thinkingLevel ? { effortLevel: input.thinkingLevel } : {}),
           ...(typeof effectiveFastMode === "boolean" ? { fastMode: effectiveFastMode } : {}),
         };
-        const runHarnessTurn = (
+        const runtimeClaims: CapabilityClaims = controlClaims ?? {
+          ...scopeAttestation,
+          exp: Date.now() + CAPABILITY_TTL_MS,
+          ...(liveAuthorTurn ? { liveAuthor: true } : {}),
+          ...(automatedTurn ? { triggered: true } : {}),
+        };
+        const restoredRuntime =
+          input.runId && isRetry
+            ? recoveredRuntime(filterHistory(await deps.sessions.getEntries(session.id)), input.runId, actor.id)
+            : undefined;
+        const checkRuntimeAuth = async (choice: RuntimeChoice): Promise<string | null> => {
+          try {
+            const auth = await loadRuntimeAuth(choice);
+            if (
+              auth.userHarnessOverride &&
+              (auth.userHarnessOverride !== choice.harnessId || auth.userModelOverride !== choice.modelId)
+            )
+              return "Your connected AI account cannot serve this model on that harness. Choose a compatible runtime from get.";
+            return null;
+          } catch (error) {
+            return errMessage(error);
+          }
+        };
+        const adoptRuntime = async (choice: RuntimeChoice) => {
+          const error = await checkRuntimeAuth(choice);
+          if (error) throw new NonRetryableTurnError(error);
+          ({ userProviderKeys, userModelOverride, userHarnessOverride, claudeOauthToken, codexTurnAuth } =
+            await loadRuntimeAuth(choice));
+          requestedRuntime = choice;
+        };
+        if (restoredRuntime) await adoptRuntime(restoredRuntime);
+        const runHarnessSegment = (
           harnessInput: string,
           extras: {
             environment?: string;
@@ -2725,7 +2756,17 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             session,
             ...(userProviderKeys ? { providerKeys: userProviderKeys } : {}),
             ...(claudeOauthToken ? { claudeOauthToken } : {}),
-            ...(userHarnessOverride ? { runtimePinned: true } : {}),
+            ...(userHarnessOverride && !restoredRuntime && runtimeHandoffs === 0 ? { runtimePinned: true } : {}),
+            runtimeActorId: actor.id,
+            ...(deps.runtime && input.runId
+              ? {
+                  runtimeControl: (
+                    active: RuntimeChoice,
+                    request: import("../harness/runtime-control.ts").RuntimeRequest,
+                    signal?: AbortSignal,
+                  ) => deps.runtime!(runtimeClaims, active, request, checkRuntimeAuth, !!userHarnessOverride, signal),
+                }
+              : {}),
             ...(codexTurnAuth ? { codexAuth: codexTurnAuth } : {}),
             ...(input.runId ? { runId: input.runId } : {}),
             cancel: turnAbort.signal,
@@ -2742,7 +2783,14 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             surfaceName,
             ...(input.surfaceTools && surfaceToolDeps ? { surfaceTools: true } : {}),
             ...(isPollFire ? { pollFire: true } : {}),
-            ...(effectiveTurnWallClockMs !== undefined ? { turnWallClockMs: effectiveTurnWallClockMs } : {}),
+            ...(effectiveTurnWallClockMs !== undefined
+              ? {
+                  turnWallClockMs:
+                    effectiveTurnWallClockMs > 0
+                      ? Math.max(1, effectiveTurnWallClockMs - (Date.now() - turnStart))
+                      : effectiveTurnWallClockMs,
+                }
+              : {}),
             ...(securityPolicy.inboundScreening === "external"
               ? {
                   screenToolResult: async ({
@@ -2871,7 +2919,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               const meta = {
                 ...rec.meta,
                 ...(actor.displayName?.trim() ? { author: actor.displayName.trim() } : {}),
-                ...(syntheticPrompt ? { hidden: true } : {}),
+                ...(syntheticPrompt || continuation ? { hidden: true } : {}),
                 ...(input.displayText?.trim() && rec.meta.bareText === input.text
                   ? { display: input.displayText }
                   : {}),
@@ -2897,7 +2945,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
                     payload.name = actor.displayName.trim();
                   if (input.displayText?.trim() && payload.text === input.text && typeof payload.display !== "string")
                     payload.display = input.displayText;
-                  if (syntheticPrompt) payload.hidden = true;
+                  if (syntheticPrompt || continuation) payload.hidden = true;
                   return { ...tainted, payload };
                 })();
                 const appended = await withManagedRosterVersion(() => deps.sessions.append(lease, stored));
@@ -3000,6 +3048,53 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
             },
           });
         };
+        let runtimeHandoffs = restoredRuntime ? 1 : 0;
+        const runHarnessTurn = async (...args: Parameters<typeof runHarnessSegment>) => {
+          let segment = await runHarnessSegment(...args);
+          let modelCalls = segment.modelCalls ?? 0;
+          const usage = { cacheRead: 0, cacheWrite: 0, uncachedInput: 0 };
+          const addUsage = () => {
+            if (segment.cacheUsage)
+              for (const key of ["cacheRead", "cacheWrite", "uncachedInput"] as const)
+                usage[key] += segment.cacheUsage[key];
+          };
+          addUsage();
+          while (segment.runtimeHandoff && !segment.stopped && !turnAbort.signal.aborted) {
+            if (++runtimeHandoffs > 8) throw new NonRetryableTurnError("Too many runtime changes in one task");
+            if (effectiveTurnWallClockMs && Date.now() - turnStart >= effectiveTurnWallClockMs)
+              throw new NonRetryableTurnError("The task reached its wall-clock limit during runtime handoff");
+            await adoptRuntime(segment.runtimeHandoff.choice);
+            await deps.harness.turns.resetSession?.(session.id);
+            const resumedHistory = filterHistory(
+              forModelContext((await deps.sessions.getContextWindow(session.id)).entries, {
+                includeSecurityTainted: false,
+              }),
+            );
+            const resumedTape = tapeRows
+              ? {
+                  rows: filterTapeForAudience(
+                    await deps.sessions.getTape(session.id),
+                    conversation.audience,
+                    scopeId,
+                    resolution.orgScopeId,
+                  ),
+                  mode: "shadow" as const,
+                }
+              : undefined;
+            segment = await runHarnessSegment(
+              resumeNote() +
+                "\nRuntime handoff completed. Continue the user's unfinished request using the saved conversation and tool results. Do not repeat completed actions or ask the user to repeat the request.",
+              {
+                ...(turnEnvironment ? { environment: turnEnvironment } : {}),
+                ...(inbound.images.length ? { images: inbound.images } : {}),
+              },
+              { history: resumedHistory, ...(resumedTape ? { tape: resumedTape } : {}) },
+            );
+            modelCalls += segment.modelCalls ?? 0;
+            addUsage();
+          }
+          return { ...segment, modelCalls, cacheUsage: usage };
+        };
         const primaryServedTape = !!tapeRows?.serve && history === visibleHistory;
         let result = await runHarnessTurn(turnInput, {
           ...(turnEnvironment ? { environment: turnEnvironment } : {}),
@@ -3047,7 +3142,8 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
           !input.cancel?.aborted &&
           spine.surfaceOutboundCount === 0 &&
           spine.staySilentReason === undefined &&
-          !result.silent
+          !result.silent &&
+          !(result.runtimeHandoff && result.stopped)
         ) {
           await latchCoverage();
           const primaryStopped = !!result.stopped;

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -2762,7 +2762,7 @@ export function createOrchestrator(deps: OrchestratorDeps): Orchestrator {
               ? {
                   runtimeControl: (
                     active: RuntimeChoice,
-                    request: import("../harness/runtime-control.ts").RuntimeRequest,
+                    request: import("../harness/runtime-types.ts").RuntimeRequest,
                     signal?: AbortSignal,
                   ) => deps.runtime!(runtimeClaims, active, request, checkRuntimeAuth, !!userHarnessOverride, signal),
                 }

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,4 +1,4 @@
-import { recoveredRuntime } from "../harness/runtime-control.ts";
+import { recoveredRuntime } from "../harness/runtime-recovery.ts";
 import { evaluateCommandWithLayer } from "../policy/command-policy.ts";
 import { createSecretValueMasker } from "../security/secret-masking.ts";
 import { shq } from "../util/shell.ts";

--- a/src/core/orchestrator/types.ts
+++ b/src/core/orchestrator/types.ts
@@ -1,3 +1,4 @@
+import type { RuntimeService } from "../../harness/runtime-control.ts";
 import type { SandboxResources } from "../../sandbox/sandbox-resources.ts";
 import type { AwsRoleBroker } from "../../auth/aws-role-broker.ts";
 import type {
@@ -105,6 +106,7 @@ export interface OrchestratorDeps {
   config?: ScopedConfigStore;
   /** The deployment's fallback harness (wiring's config.harness) — used when no org runtime selection exists. */
   defaultHarness?: string;
+  defaultTurnWallClockMs?: number;
   userModelCredentials?: UserModelCredentialStore;
   brandingDefault?: OrgBranding;
   resolveBaseModelId?: () => string | undefined;
@@ -162,6 +164,7 @@ export interface OrchestratorDeps {
   crons?: CronStore;
   webhooks?: WebhookStore;
   control?: ControlService;
+  runtime?: RuntimeService;
   livenessCache?: LivenessCache;
   connectorTokens?: ConnectorTokenStore;
   connectorStatusCache?: ConnectorStatusCache;

--- a/src/core/orchestrator/types.ts
+++ b/src/core/orchestrator/types.ts
@@ -1,4 +1,4 @@
-import type { RuntimeService } from "../../harness/runtime-control.ts";
+import type { RuntimeService } from "../../harness/runtime-types.ts";
 import type { SandboxResources } from "../../sandbox/sandbox-resources.ts";
 import type { AwsRoleBroker } from "../../auth/aws-role-broker.ts";
 import type {

--- a/src/harness/agent-tools.ts
+++ b/src/harness/agent-tools.ts
@@ -1,3 +1,5 @@
+import { createGrindMeter, grindState } from "./grind.ts";
+import type { RuntimeHandoff, RuntimeRequest } from "./runtime-control.ts";
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type, type TSchema } from "typebox";
 import { Check } from "typebox/value";
@@ -43,6 +45,11 @@ function describePublishAudience(a: PublishAudienceDescriptor | undefined): stri
 }
 
 export interface ToolContextRef {
+  runtimeHandoff?: RuntimeHandoff;
+  runtimeRunId?: string;
+  runtimeActorId?: string;
+  runtimeMutationPending?: boolean;
+  runtimeInFlight?: Set<Promise<unknown>>;
   current: ToolContext | null;
   pendingApprovals?: Array<{
     command: string;
@@ -333,10 +340,10 @@ export function coreToolOptions(config: Config): CoreToolOptions {
   };
 }
 
-const READ_ONLY_TOOL_NAMES = new Set(["memory", "history", "finish_silently"]);
+const READ_ONLY_TOOL_NAMES = new Set(["memory", "history", "finish_silently", "runtime"]);
 
 export function pauseStampAfterToolCall(
-  ref: Pick<ToolContextRef, "pausedOnApproval" | "silentRequested">,
+  ref: Pick<ToolContextRef, "pausedOnApproval" | "silentRequested" | "runtimeHandoff">,
   prior?: (
     info: unknown,
     signal?: unknown,
@@ -344,7 +351,7 @@ export function pauseStampAfterToolCall(
 ): (info: unknown, signal?: unknown) => Promise<{ terminate?: boolean } | undefined> {
   return async (info, signal) => {
     const upstream = prior ? await prior(info, signal) : undefined;
-    if (ref.pausedOnApproval || ref.silentRequested) return { ...upstream, terminate: true };
+    if (ref.pausedOnApproval || ref.silentRequested || ref.runtimeHandoff) return { ...upstream, terminate: true };
     return upstream;
   };
 }
@@ -3538,6 +3545,60 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
       }),
     );
 
+  const runtime = defineTool({
+    name: "runtime",
+    label: "runtime",
+    description:
+      "Inspect or change your model, harness, reasoning effort, and fast mode. Use get to see the actual active runtime, saved defaults, and available choices. Use set for requests such as 'switch to Astra and do this'. A successful change stops this runtime and resumes the unfinished task on the selected runtime with saved tool results. Omitted settings are preserved. lifetime defaults to task (this user request, including retries); scope changes the default for future requests in this scope too. inherit returns to the scope default, or clears the scope override when lifetime is scope. Never guess capabilities or claim you cannot switch before using this tool. Call a change by itself, after other tools finish.",
+    parameters: Type.Object({
+      action: Type.Union([Type.Literal("get"), Type.Literal("set"), Type.Literal("inherit")]),
+      model: Type.Optional(Type.String({ description: "Model ID or exact display name from get, such as Astra." })),
+      harness: Type.Optional(Type.String()),
+      effort: Type.Optional(Type.String()),
+      fastMode: Type.Optional(Type.Boolean()),
+      lifetime: Type.Optional(Type.Union([Type.Literal("task"), Type.Literal("scope")])),
+    }),
+    async execute(callId, params) {
+      const request = params as RuntimeRequest;
+      await recordCall(callId, { tool: "runtime", ...request });
+      if (
+        request.action !== "get" &&
+        ref.goal &&
+        (ref.goal.status === "active" ||
+          ref.goal.status === "paused" ||
+          (ref.goal.floor &&
+            !grindState(ref.goal.floor, goalFloorMeter(ref.goal, ref.goalMeter ?? createGrindMeter())).met))
+      ) {
+        return recordCoreAuthoredResult(
+          callId,
+          { tool: "runtime", error: "goal_in_progress" },
+          text(
+            "Runtime changes are unavailable while a goal or work floor is unfinished. Continue the goal on the current runtime.",
+          ),
+          true,
+        );
+      }
+      const result =
+        opts?.readOnly && request.action !== "get"
+          ? { ok: false as const, error: "read_only" }
+          : ((await ref.current?.runtime?.(request, ref.abortSignal)) ?? { ok: false, error: "runtime_unavailable" });
+      const handoff = result.ok ? result.handoff : undefined;
+      const ret = await recordCoreAuthoredResult(
+        callId,
+        {
+          tool: "runtime",
+          action: request.action,
+          ok: result.ok,
+          ...(handoff ? { runtimeHandoff: handoff, runId: ref.runtimeRunId, actorId: ref.runtimeActorId } : {}),
+        },
+        { ...text(JSON.stringify(result)), ...(handoff ? { terminate: true } : {}) },
+        !result.ok,
+      );
+      if (handoff) ref.runtimeHandoff = handoff;
+      return ret;
+    },
+  });
+
   const tools = [
     ...(!opts?.sandboxResources ? [execute] : []),
     ...(credentialExecServices.length ? [credentialExec] : []),
@@ -3555,11 +3616,14 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
     createGoal,
     getGoal,
     updateGoal,
+    runtime,
     ...mcpTools,
   ];
   const mcpNames = new Set(mcpTools.map((t) => t.name));
   const active = opts?.readOnly ? tools.filter((t) => READ_ONLY_TOOL_NAMES.has(t.name) || mcpNames.has(t.name)) : tools;
-  return active.map((t) => withToolBodyTiming(withToolApprovalGate(t, ref, { recordCall, recordResult }), ref));
+  return active.map((t) =>
+    withRuntimeBarrier(withToolBodyTiming(withToolApprovalGate(t, ref, { recordCall, recordResult }), ref), ref),
+  );
 }
 
 const TOOL_APPROVAL_EXEMPT = new Set(["finish_silently", "stay_silent"]);
@@ -3645,4 +3709,48 @@ function withToolBodyTiming(tool: ToolDefinition, ref: ToolContextRef): ToolDefi
       }
     },
   } as ToolDefinition;
+}
+
+function withRuntimeBarrier(tool: ToolDefinition, ref: ToolContextRef): ToolDefinition {
+  return {
+    ...tool,
+    async execute(...args) {
+      const [, params] = args;
+      if (ref.runtimeHandoff || ref.runtimeMutationPending)
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Runtime handoff in progress; this call was not executed. Resume unfinished work on the selected runtime.",
+            },
+          ],
+          details: {},
+          terminate: !!ref.runtimeHandoff,
+        };
+      const mutation = tool.name === "runtime" && (!isObj(params) || params.action !== "get");
+      if (mutation) {
+        ref.runtimeMutationPending = true;
+        try {
+          await Promise.allSettled([...(ref.runtimeInFlight ?? [])]);
+          if (ref.abortSignal?.aborted || ref.pausedOnApproval || ref.silentRequested)
+            return {
+              content: [{ type: "text" as const, text: "Runtime change cancelled before execution." }],
+              details: {},
+              terminate: true,
+            };
+          return await tool.execute(...args);
+        } finally {
+          ref.runtimeMutationPending = false;
+        }
+      }
+      const inFlight = (ref.runtimeInFlight ??= new Set());
+      const result = Promise.resolve().then(() => tool.execute(...args));
+      inFlight.add(result);
+      try {
+        return await result;
+      } finally {
+        inFlight.delete(result);
+      }
+    },
+  };
 }

--- a/src/harness/agent-tools.ts
+++ b/src/harness/agent-tools.ts
@@ -1,5 +1,5 @@
 import { createGrindMeter, grindState } from "./grind.ts";
-import type { RuntimeHandoff, RuntimeRequest } from "./runtime-control.ts";
+import type { RuntimeHandoff, RuntimeRequest } from "./runtime-types.ts";
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type, type TSchema } from "typebox";
 import { Check } from "typebox/value";
@@ -3731,7 +3731,7 @@ function withRuntimeBarrier(tool: ToolDefinition, ref: ToolContextRef): ToolDefi
       if (mutation) {
         ref.runtimeMutationPending = true;
         try {
-          await Promise.allSettled([...(ref.runtimeInFlight ?? [])]);
+          await Promise.allSettled(ref.runtimeInFlight ?? []);
           if (ref.abortSignal?.aborted || ref.pausedOnApproval || ref.silentRequested)
             return {
               content: [{ type: "text" as const, text: "Runtime change cancelled before execution." }],

--- a/src/harness/claude-harness.ts
+++ b/src/harness/claude-harness.ts
@@ -645,7 +645,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
           result = message;
           await recordStep(message);
           await flushThinking();
-          const terminal = ref.silentRequested || ref.pausedOnApproval;
+          const terminal = ref.runtimeHandoff || ref.silentRequested || ref.pausedOnApproval;
           const text = message.subtype === "success" && !terminal ? message.result.trim() : "";
           if (text) {
             const finalEntry = await turn.emit({
@@ -681,7 +681,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
         if (!controller.signal.aborted || error instanceof NonRetryableTurnError) throw error;
         const reply = streamedText.trim();
         await flushThinking();
-        if (reply && !ref.silentRequested && !ref.pausedOnApproval) {
+        if (reply && !ref.runtimeHandoff && !ref.silentRequested && !ref.pausedOnApproval) {
           const finalEntry = await turn.emit({
             type: "assistant",
             payload: { text: reply, stopped: true },
@@ -690,8 +690,9 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
           await tapeReplyCheckpoint(turn, finalEntry);
         }
         return {
-          reply: ref.silentRequested || ref.pausedOnApproval ? "" : reply,
-          stopped: true,
+          reply: ref.runtimeHandoff || ref.silentRequested || ref.pausedOnApproval ? "" : reply,
+          ...(!ref.runtimeHandoff || stopped ? { stopped: true as const } : {}),
+          ...(ref.runtimeHandoff ? { runtimeHandoff: ref.runtimeHandoff } : {}),
           ...(ref.silentRequested ? { silent: true } : {}),
           ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
           ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),
@@ -700,7 +701,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
       }
       const finalResult = result as SDKResultMessage | null;
       const stoppedPartial = async (): Promise<HarnessTurnResult> => {
-        const terminal = ref.silentRequested || ref.pausedOnApproval;
+        const terminal = ref.runtimeHandoff || ref.silentRequested || ref.pausedOnApproval;
         const reply = terminal ? "" : streamedText.trim();
         await flushThinking();
         if (reply && !terminal) {
@@ -713,7 +714,8 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
         }
         return {
           reply,
-          stopped: true,
+          ...(!ref.runtimeHandoff || stopped ? { stopped: true as const } : {}),
+          ...(ref.runtimeHandoff ? { runtimeHandoff: ref.runtimeHandoff } : {}),
           ...(ref.silentRequested ? { silent: true } : {}),
           ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
           ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),
@@ -724,10 +726,10 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
         throw new Error("Claude Agent SDK ended without a result");
       }
       if (finalResult.subtype !== "success") {
-        if (stopped) return stoppedPartial();
+        if (stopped || ref.runtimeHandoff) return stoppedPartial();
         throw new Error(finalResult.errors.join("; ") || `Claude Agent SDK failed: ${finalResult.subtype}`);
       }
-      const terminal = ref.silentRequested || ref.pausedOnApproval;
+      const terminal = ref.runtimeHandoff || ref.silentRequested || ref.pausedOnApproval;
       const reply = terminal ? "" : finalResult.result.trim();
       const usageTotals = [...callUsage.values()].reduce(
         (acc, usage) => {
@@ -741,6 +743,7 @@ export function createClaudeHarness(opts: ClaudeHarnessOptions = {}): Harness {
       return {
         reply,
         ...(stopped ? { stopped: true as const } : {}),
+        ...(ref.runtimeHandoff ? { runtimeHandoff: ref.runtimeHandoff } : {}),
         ...(ref.silentRequested ? { silent: true } : {}),
         ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
         ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),

--- a/src/harness/codex-harness.ts
+++ b/src/harness/codex-harness.ts
@@ -1186,13 +1186,13 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
           entryCount: turn.history.length,
         });
       }
-      if (result.status === "failed" && !state.stopped)
+      if (result.status === "failed" && !state.stopped && !ref.runtimeHandoff)
         throw codexProviderFailure(result.error?.message ?? "Codex turn failed");
       if (turn.cancel?.aborted) {
         runtimeCleanupRequested = true;
         turnResult = { reply: "", stopped: true };
       } else {
-        const terminal = ref.silentRequested || ref.pausedOnApproval;
+        const terminal = ref.runtimeHandoff || ref.silentRequested || ref.pausedOnApproval;
         const reply = terminal ? "" : textFromTurn(result);
         for (const thinking of reasoningFromTurn(result))
           await turn.emit({ type: "thinking", payload: { thinking }, scopeLabel: turn.scopeLabel });
@@ -1207,6 +1207,7 @@ export function createCodexHarness(opts: CodexHarnessOptions = {}): Harness {
         turnResult = {
           reply,
           ...(state.stopped ? { stopped: true as const } : {}),
+          ...(ref.runtimeHandoff ? { runtimeHandoff: ref.runtimeHandoff } : {}),
           ...(ref.silentRequested ? { silent: true } : {}),
           ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
           ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),

--- a/src/harness/harness-router.ts
+++ b/src/harness/harness-router.ts
@@ -149,7 +149,13 @@ export function createHarnessRouter(
           await adapter.turns.resetSession?.(input.session.id);
         }
         lastHarness.set(input.session.id, choice.harnessId);
-        const dispatched: HarnessTurnInput = { ...input, runtime: choice };
+        const dispatched: HarnessTurnInput = {
+          ...input,
+          runtime: choice,
+          tools: input.runtimeControl
+            ? { ...input.tools, runtime: (request, signal) => input.runtimeControl!(choice, request, signal) }
+            : input.tools,
+        };
         return adapter.turns.runTurn(
           adapter.profile.capabilities.has("native-tape") ? dispatched : withTapedEntryMirrors(dispatched),
         );

--- a/src/harness/harness-shared.ts
+++ b/src/harness/harness-shared.ts
@@ -70,6 +70,8 @@ export function withTapedEntryMirrors(turn: HarnessTurnInput): HarnessTurnInput 
 export function harnessToolContext(turn: HarnessTurnInput): ToolContextRef {
   return {
     current: turn.tools,
+    runtimeRunId: turn.runId,
+    runtimeActorId: turn.runtimeActorId,
     pendingApprovals: [],
     pausedOnApproval: false,
     silentRequested: false,

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1,4 +1,4 @@
-import type { RuntimeControl, RuntimeHandoff } from "./runtime-control.ts";
+import type { RuntimeControl, RuntimeHandoff } from "./runtime-types.ts";
 import type { AttachmentMeta, ConversationTurn, ScopeId, Session, SessionEntry } from "../types.ts";
 import type { HarnessId } from "../model/pi-models.ts";
 import type {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1,3 +1,4 @@
+import type { RuntimeControl, RuntimeHandoff } from "./runtime-control.ts";
 import type { AttachmentMeta, ConversationTurn, ScopeId, Session, SessionEntry } from "../types.ts";
 import type { HarnessId } from "../model/pi-models.ts";
 import type {
@@ -82,6 +83,8 @@ export interface HarnessTurnInput {
   attachments?: AttachmentMeta[];
   images?: HarnessImage[];
   runtime?: Partial<RuntimeChoice>;
+  runtimeControl?: RuntimeControl;
+  runtimeActorId?: string;
   readOnly?: boolean;
   surfaceTools?: boolean;
   surfaceName?: string;
@@ -114,6 +117,7 @@ export interface HarnessTurnInput {
 }
 
 export interface HarnessTurnResult {
+  runtimeHandoff?: RuntimeHandoff;
   reply: string;
   silent?: boolean;
   stopped?: true;

--- a/src/harness/opencode-harness.ts
+++ b/src/harness/opencode-harness.ts
@@ -601,7 +601,8 @@ export function createOpenCodeHarness(opts: OpenCodeHarnessOptions = {}): Harnes
               args?: unknown;
             };
             const tool = input.tool ? state.tools.get(input.tool) : undefined;
-            if (!tool) return json(res, 404, { output: `[tool unavailable: ${input.tool ?? "unknown"}]` });
+            if (!tool || (state.child && input.tool === "runtime"))
+              return json(res, 404, { output: `[tool unavailable: ${input.tool ?? "unknown"}]` });
             try {
               const result = await tool.execute(input.callID ?? randomBytes(8).toString("hex"), input.args ?? {});
               const output = (result.content ?? [])
@@ -610,7 +611,12 @@ export function createOpenCodeHarness(opts: OpenCodeHarnessOptions = {}): Harnes
                 .join("\n");
               return json(res, 200, {
                 output,
-                terminate: Boolean(state.ref.pausedOnApproval || state.ref.silentRequested),
+                terminate: Boolean(
+                  result.terminate ||
+                  state.ref.runtimeHandoff ||
+                  state.ref.pausedOnApproval ||
+                  state.ref.silentRequested,
+                ),
               });
             } catch (error) {
               return json(res, 200, { output: `[tool failed] ${errMessage(error)}` });
@@ -1027,7 +1033,7 @@ export function createOpenCodeHarness(opts: OpenCodeHarnessOptions = {}): Harnes
       }
       for (const thinking of reasoningFromParts(parts))
         await turn.emit({ type: "thinking", payload: thinking, scopeLabel: turn.scopeLabel });
-      const reply = textFromParts(parts);
+      const reply = ref.runtimeHandoff ? "" : textFromParts(parts);
       if (reply) {
         const finalEntry = await turn.emit({
           type: "assistant",
@@ -1039,6 +1045,7 @@ export function createOpenCodeHarness(opts: OpenCodeHarnessOptions = {}): Harnes
       return {
         reply,
         ...(state.stopped ? { stopped: true as const } : {}),
+        ...(ref.runtimeHandoff ? { runtimeHandoff: ref.runtimeHandoff } : {}),
         ...(ref.silentRequested ? { silent: true } : {}),
         ...(ref.pendingApprovals?.length ? { pendingApprovals: ref.pendingApprovals } : {}),
         ...(ref.pausedOnApproval ? { pausedOnApproval: true } : {}),

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -999,13 +999,25 @@ export function emptyEndingNote(opts: {
   cancelled: boolean;
   surfaceTools: boolean;
   pollFire: boolean;
-  ref: { silentRequested?: boolean; pausedOnApproval?: boolean; pendingApprovals?: unknown[]; modelCalls?: number };
+  ref: {
+    runtimeHandoff?: unknown;
+    silentRequested?: boolean;
+    pausedOnApproval?: boolean;
+    pendingApprovals?: unknown[];
+    modelCalls?: number;
+  };
   session: AssistantTextSession;
   turnWallClockMs: number;
   elapsedMs: number;
 }): string | null {
   if (opts.wallClock !== "ok" || opts.userAborted || opts.cancelled || opts.surfaceTools) return null;
-  if (opts.ref.silentRequested || opts.ref.pausedOnApproval || opts.ref.pendingApprovals?.length) return null;
+  if (
+    opts.ref.runtimeHandoff ||
+    opts.ref.silentRequested ||
+    opts.ref.pausedOnApproval ||
+    opts.ref.pendingApprovals?.length
+  )
+    return null;
   if (opts.pollFire) return null;
   const calls = opts.ref.modelCalls ?? 0;
   if (calls === 0) return null;
@@ -1688,6 +1700,11 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
         try {
           const turnWallClockMs = turn.turnWallClockMs ?? defaultTurnWallClockMs;
           entry.ref.current = turn.tools;
+          entry.ref.runtimeHandoff = undefined;
+          entry.ref.runtimeMutationPending = false;
+          entry.ref.runtimeInFlight = new Set();
+          entry.ref.runtimeRunId = turn.runId;
+          entry.ref.runtimeActorId = turn.runtimeActorId;
           entry.ref.pendingApprovals = [];
           entry.ref.pausedOnApproval = undefined;
           entry.ref.silentRequested = false;
@@ -2100,6 +2117,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
                 blocked: () =>
                   userAborted ||
                   !!turn.cancel?.aborted ||
+                  !!entry.ref.runtimeHandoff ||
                   !!entry.ref.pausedOnApproval ||
                   !!entry.ref.pendingApprovals?.length,
                 beforePrompt: async (note) => {
@@ -2124,7 +2142,7 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
               wallClock = goalResult.outcome;
               grindWaiverNote = goalResult.waiverNote;
             }
-            if (wallClock === "ok" && !userAborted && !turn.cancel?.aborted) {
+            if (wallClock === "ok" && !entry.ref.runtimeHandoff && !userAborted && !turn.cancel?.aborted) {
               const refusal = providerRefusalError(entry.agentSession, messagesBefore);
               if (refusal) {
                 try {
@@ -2216,6 +2234,23 @@ export function createPiHarness(opts?: PiHarnessOptions): Harness {
               `the turn hit its ${capLabel} wall-clock limit and was stopped` +
                 (wallClock === "abandoned" ? " (a stuck operation did not respond to cancellation)" : ""),
             );
+          }
+          if (entry.ref.runtimeHandoff && !userAborted && !turn.cancel?.aborted) {
+            if (entry.ref.goal) {
+              const goalEntry = await turn.emit({
+                type: "system",
+                payload: { kind: "goal", goal: { ...entry.ref.goal } },
+                scopeLabel: turn.scopeLabel,
+              });
+              await tapeEntryMirror(goalEntry);
+            }
+            return {
+              reply: "",
+              runtimeHandoff: entry.ref.runtimeHandoff,
+              modelCalls: entry.ref.modelCalls ?? 0,
+              compileMs,
+              cacheUsage: sumCacheUsage(callStats) ?? undefined,
+            };
           }
           const freshStopReason = freshAssistantStopReason();
           const cancelStoppedCleanly =

--- a/src/harness/runtime-control.ts
+++ b/src/harness/runtime-control.ts
@@ -1,0 +1,181 @@
+import type { RuntimeChoice } from "./harness.ts";
+import type { CapabilityClaims } from "../auth/capability-token.ts";
+import type { App } from "../api/app.ts";
+import {
+  runtimeConfigBody,
+  validateRuntimeChoice,
+  webuiModelEnabled,
+  type RuntimeDeps,
+} from "../api/runtime-config.ts";
+import { livePersonCapability } from "../api/artifact-share.ts";
+import { parseScopeId, type SessionEntry } from "../types.ts";
+import {
+  ALL_PROVIDERS_AVAILABLE,
+  isHarnessId,
+  thinkingLevelsForHarness,
+  safeModelMetadata,
+  modelSupportedByHarness,
+} from "../model/pi-models.ts";
+import { isObj } from "../util/objects.ts";
+
+export interface RuntimeRequest {
+  action: "get" | "set" | "inherit";
+  model?: string;
+  harness?: string;
+  effort?: string;
+  fastMode?: boolean;
+  lifetime?: "task" | "scope";
+}
+
+export interface RuntimeHandoff {
+  choice: RuntimeChoice;
+  lifetime: "task" | "scope";
+}
+
+export type RuntimeResult =
+  | { ok: false; error: string; message?: string; candidates?: string[] }
+  | { ok: true; handoff?: RuntimeHandoff; [key: string]: unknown };
+
+export type RuntimeControl = (
+  active: RuntimeChoice,
+  request: RuntimeRequest,
+  signal?: AbortSignal,
+) => Promise<RuntimeResult>;
+export type RuntimeService = (
+  claims: CapabilityClaims,
+  active: RuntimeChoice,
+  request: RuntimeRequest,
+  authorizeChoice?: (choice: RuntimeChoice) => Promise<string | null>,
+  individualAuth?: boolean,
+  signal?: AbortSignal,
+) => Promise<RuntimeResult>;
+
+export function createRuntimeService(deps: RuntimeDeps, app: Pick<App, "authorizesCapabilityScope">): RuntimeService {
+  return async (claims, active, request, authorizeChoice, individualAuth, signal) => {
+    if (!deps.config) return { ok: false, error: "runtime_unavailable" };
+    const scope = parseScopeId(claims.scopeId);
+    if (
+      scope.kind === "org" ||
+      (scope.kind === "personal" && scope.ref !== claims.actorId) ||
+      !(await app.authorizesCapabilityScope(claims))
+    )
+      return { ok: false, error: "forbidden" };
+    await deps.refreshModels?.();
+    const snapshot = await runtimeConfigBody(
+      { deps: individualAuth ? { ...deps, providerKeys: ALL_PROVIDERS_AVAILABLE, modelCredentials: undefined } : deps },
+      claims.scopeId,
+    );
+    if (individualAuth && authorizeChoice) {
+      if (snapshot.approvedHarnesses.includes("pi")) {
+        const piModels = snapshot.modelsByHarness.pi ?? [];
+        for (const id of [...piModels]) {
+          const subscriptionId = `codex/${id}`;
+          if (modelSupportedByHarness(subscriptionId, "pi") && !piModels.includes(subscriptionId)) {
+            piModels.push(subscriptionId);
+            const metadata = safeModelMetadata(subscriptionId);
+            if (metadata) snapshot.modelCatalog[subscriptionId] = metadata;
+          }
+        }
+      }
+      for (const harnessId of snapshot.approvedHarnesses) {
+        const candidates = snapshot.modelsByHarness[harnessId] ?? [];
+        const allowed = await Promise.all(
+          candidates.map((modelId) => authorizeChoice({ harnessId, modelId, effortLevel: "auto", fastMode: false })),
+        );
+        snapshot.modelsByHarness[harnessId] = candidates.filter((_, index) => !allowed[index]);
+      }
+    }
+    if (request.action === "get")
+      return {
+        ok: true,
+        active,
+        ...snapshot,
+        effortLevelsByHarness: Object.fromEntries(
+          snapshot.approvedHarnesses.map((id) => [id, thinkingLevelsForHarness(id)]),
+        ),
+        taskLifetime:
+          "The current user request, including retries and runtime handoffs. Future requests use the scope default.",
+      };
+    if (!livePersonCapability(claims) || claims.triggered || claims.botActor)
+      return { ok: false, error: "live_actor_required" };
+    const lifetime = request.lifetime ?? "task";
+    if (request.action === "inherit") {
+      const choice = lifetime === "scope" ? snapshot.orgDefault : snapshot.effective;
+      const error = validateRuntimeChoice(choice);
+      if (error) return { ok: false, error };
+      if (
+        !snapshot.approvedHarnesses.includes(choice.harnessId) ||
+        !snapshot.modelsByHarness[choice.harnessId]?.includes(choice.modelId)
+      )
+        return { ok: false, error: "runtime_unavailable" };
+      const authError = await authorizeChoice?.(choice);
+      if (authError) return { ok: false, error: "account_runtime_unavailable", message: authError };
+      if (signal?.aborted) return { ok: false, error: "cancelled" };
+      if (lifetime === "scope") await deps.config.setRuntimeSelectionLatest(claims.scopeId, null);
+      return { ok: true, handoff: { choice, lifetime } };
+    }
+    if (request.action !== "set") return { ok: false, error: "invalid_action" };
+    const harnessId = request.harness ?? active.harnessId;
+    if (!isHarnessId(harnessId) || !snapshot.approvedHarnesses.includes(harnessId))
+      return { ok: false, error: "harness_not_approved", candidates: snapshot.approvedHarnesses };
+    const candidates = snapshot.modelsByHarness[harnessId] ?? [];
+    let modelId = request.model ?? active.modelId;
+    if (!candidates.includes(modelId)) {
+      const query = modelId.toLowerCase();
+      const matches = candidates.filter((id) => {
+        const meta = snapshot.modelCatalog[id];
+        return [id, meta?.name, meta?.label, meta?.buttonLabel].some((label) => label?.toLowerCase() === query);
+      });
+      if (matches.length !== 1)
+        return {
+          ok: false,
+          error: matches.length ? "model_ambiguous" : "model_unavailable",
+          candidates: matches.length ? matches : candidates,
+        };
+      modelId = matches[0]!;
+    }
+    if (!(await webuiModelEnabled({ deps }, modelId))) return { ok: false, error: "model_not_enabled" };
+    const choice: RuntimeChoice = {
+      harnessId,
+      modelId,
+      effortLevel: request.effort ?? active.effortLevel ?? "auto",
+      fastMode: request.fastMode ?? active.fastMode ?? false,
+    };
+    const error = validateRuntimeChoice(choice);
+    if (error) return { ok: false, error };
+    const authError = await authorizeChoice?.(choice);
+    if (authError) return { ok: false, error: "account_runtime_unavailable", message: authError };
+    if (signal?.aborted) return { ok: false, error: "cancelled" };
+    if (lifetime === "scope") await deps.config.setRuntimeSelectionLatest(claims.scopeId, choice);
+    return { ok: true, handoff: { choice, lifetime } };
+  };
+}
+
+export function recoveredRuntime(
+  entries: readonly SessionEntry[],
+  runId: string,
+  actorId: string,
+): RuntimeChoice | undefined {
+  for (const entry of [...entries].reverse()) {
+    const p = entry.payload;
+    if (
+      entry.type !== "tool_result" ||
+      !isObj(p) ||
+      p.tool !== "runtime" ||
+      p.runId !== runId ||
+      p.actorId !== actorId ||
+      !isObj(p.runtimeHandoff)
+    )
+      continue;
+    const choice = p.runtimeHandoff.choice;
+    if (
+      isObj(choice) &&
+      isHarnessId(choice.harnessId) &&
+      typeof choice.modelId === "string" &&
+      (choice.effortLevel === undefined || typeof choice.effortLevel === "string") &&
+      (choice.fastMode === undefined || typeof choice.fastMode === "boolean")
+    )
+      return choice as unknown as RuntimeChoice;
+  }
+  return undefined;
+}

--- a/src/harness/runtime-control.ts
+++ b/src/harness/runtime-control.ts
@@ -1,5 +1,5 @@
 import type { RuntimeChoice } from "./harness.ts";
-import type { CapabilityClaims } from "../auth/capability-token.ts";
+import type { RuntimeService } from "./runtime-types.ts";
 import type { App } from "../api/app.ts";
 import {
   runtimeConfigBody,
@@ -17,38 +17,6 @@ import {
   modelSupportedByHarness,
 } from "../model/pi-models.ts";
 import { isObj } from "../util/objects.ts";
-
-export interface RuntimeRequest {
-  action: "get" | "set" | "inherit";
-  model?: string;
-  harness?: string;
-  effort?: string;
-  fastMode?: boolean;
-  lifetime?: "task" | "scope";
-}
-
-export interface RuntimeHandoff {
-  choice: RuntimeChoice;
-  lifetime: "task" | "scope";
-}
-
-export type RuntimeResult =
-  | { ok: false; error: string; message?: string; candidates?: string[] }
-  | { ok: true; handoff?: RuntimeHandoff; [key: string]: unknown };
-
-export type RuntimeControl = (
-  active: RuntimeChoice,
-  request: RuntimeRequest,
-  signal?: AbortSignal,
-) => Promise<RuntimeResult>;
-export type RuntimeService = (
-  claims: CapabilityClaims,
-  active: RuntimeChoice,
-  request: RuntimeRequest,
-  authorizeChoice?: (choice: RuntimeChoice) => Promise<string | null>,
-  individualAuth?: boolean,
-  signal?: AbortSignal,
-) => Promise<RuntimeResult>;
 
 export function createRuntimeService(deps: RuntimeDeps, app: Pick<App, "authorizesCapabilityScope">): RuntimeService {
   return async (claims, active, request, authorizeChoice, individualAuth, signal) => {
@@ -68,7 +36,8 @@ export function createRuntimeService(deps: RuntimeDeps, app: Pick<App, "authoriz
     if (individualAuth && authorizeChoice) {
       if (snapshot.approvedHarnesses.includes("pi")) {
         const piModels = snapshot.modelsByHarness.pi ?? [];
-        for (const id of [...piModels]) {
+        for (const id of piModels) {
+          if (id.startsWith("codex/")) continue;
           const subscriptionId = `codex/${id}`;
           if (modelSupportedByHarness(subscriptionId, "pi") && !piModels.includes(subscriptionId)) {
             piModels.push(subscriptionId);

--- a/src/harness/runtime-control.ts
+++ b/src/harness/runtime-control.ts
@@ -8,7 +8,7 @@ import {
   type RuntimeDeps,
 } from "../api/runtime-config.ts";
 import { livePersonCapability } from "../api/artifact-share.ts";
-import { parseScopeId, type SessionEntry } from "../types.ts";
+import { parseScopeId } from "../types.ts";
 import {
   ALL_PROVIDERS_AVAILABLE,
   isHarnessId,
@@ -16,7 +16,6 @@ import {
   safeModelMetadata,
   modelSupportedByHarness,
 } from "../model/pi-models.ts";
-import { isObj } from "../util/objects.ts";
 
 export function createRuntimeService(deps: RuntimeDeps, app: Pick<App, "authorizesCapabilityScope">): RuntimeService {
   return async (claims, active, request, authorizeChoice, individualAuth, signal) => {
@@ -118,33 +117,4 @@ export function createRuntimeService(deps: RuntimeDeps, app: Pick<App, "authoriz
     if (lifetime === "scope") await deps.config.setRuntimeSelectionLatest(claims.scopeId, choice);
     return { ok: true, handoff: { choice, lifetime } };
   };
-}
-
-export function recoveredRuntime(
-  entries: readonly SessionEntry[],
-  runId: string,
-  actorId: string,
-): RuntimeChoice | undefined {
-  for (const entry of [...entries].reverse()) {
-    const p = entry.payload;
-    if (
-      entry.type !== "tool_result" ||
-      !isObj(p) ||
-      p.tool !== "runtime" ||
-      p.runId !== runId ||
-      p.actorId !== actorId ||
-      !isObj(p.runtimeHandoff)
-    )
-      continue;
-    const choice = p.runtimeHandoff.choice;
-    if (
-      isObj(choice) &&
-      isHarnessId(choice.harnessId) &&
-      typeof choice.modelId === "string" &&
-      (choice.effortLevel === undefined || typeof choice.effortLevel === "string") &&
-      (choice.fastMode === undefined || typeof choice.fastMode === "boolean")
-    )
-      return choice as unknown as RuntimeChoice;
-  }
-  return undefined;
 }

--- a/src/harness/runtime-recovery.ts
+++ b/src/harness/runtime-recovery.ts
@@ -1,0 +1,33 @@
+import type { RuntimeChoice } from "./harness.ts";
+import type { SessionEntry } from "../types.ts";
+import { isHarnessId } from "../model/pi-models.ts";
+import { isObj } from "../util/objects.ts";
+
+export function recoveredRuntime(
+  entries: readonly SessionEntry[],
+  runId: string,
+  actorId: string,
+): RuntimeChoice | undefined {
+  for (const entry of [...entries].reverse()) {
+    const p = entry.payload;
+    if (
+      entry.type !== "tool_result" ||
+      !isObj(p) ||
+      p.tool !== "runtime" ||
+      p.runId !== runId ||
+      p.actorId !== actorId ||
+      !isObj(p.runtimeHandoff)
+    )
+      continue;
+    const choice = p.runtimeHandoff.choice;
+    if (
+      isObj(choice) &&
+      isHarnessId(choice.harnessId) &&
+      typeof choice.modelId === "string" &&
+      (choice.effortLevel === undefined || typeof choice.effortLevel === "string") &&
+      (choice.fastMode === undefined || typeof choice.fastMode === "boolean")
+    )
+      return choice as unknown as RuntimeChoice;
+  }
+  return undefined;
+}

--- a/src/harness/runtime-types.ts
+++ b/src/harness/runtime-types.ts
@@ -1,0 +1,34 @@
+import type { RuntimeChoice } from "./harness.ts";
+import type { CapabilityClaims } from "../auth/capability-token.ts";
+
+export interface RuntimeRequest {
+  action: "get" | "set" | "inherit";
+  model?: string;
+  harness?: string;
+  effort?: string;
+  fastMode?: boolean;
+  lifetime?: "task" | "scope";
+}
+
+export interface RuntimeHandoff {
+  choice: RuntimeChoice;
+  lifetime: "task" | "scope";
+}
+
+export type RuntimeResult =
+  | { ok: false; error: string; message?: string; candidates?: string[] }
+  | { ok: true; handoff?: RuntimeHandoff; [key: string]: unknown };
+
+export type RuntimeControl = (
+  active: RuntimeChoice,
+  request: RuntimeRequest,
+  signal?: AbortSignal,
+) => Promise<RuntimeResult>;
+export type RuntimeService = (
+  claims: CapabilityClaims,
+  active: RuntimeChoice,
+  request: RuntimeRequest,
+  authorizeChoice?: (choice: RuntimeChoice) => Promise<string | null>,
+  individualAuth?: boolean,
+  signal?: AbortSignal,
+) => Promise<RuntimeResult>;

--- a/src/resolution/protocols/shared-core.md
+++ b/src/resolution/protocols/shared-core.md
@@ -2,6 +2,9 @@
 
 You are {{botName}}{{#if botHandle}} (@{{botHandle}} in Slack){{/if}} — the shared assistant platform for {{orgName}}. One core serves the whole org, but each conversation is isolated: you see and act only on what the people in this conversation are entitled to. Everything you do is audited.
 
+## Runtime
+Use `runtime` to inspect or change your model, harness, reasoning effort, and fast mode. “Switch to Astra and do this” calls `runtime` with action `set` and model `Astra`; the task resumes automatically on that runtime. Use lifetime `scope` only when asked to change the standing default. Use `get` to discover choices before declaring a runtime unavailable.
+
 ## Sandboxes
 Core is home; sandboxes are optional resources. Creation never changes routing. Select a sandbox or use a stored default. Recovery can expire; save durable code to git and artifacts to Files. Profiles describe capabilities, not running machines.
 

--- a/src/resolution/protocols/shared-core.md
+++ b/src/resolution/protocols/shared-core.md
@@ -3,12 +3,12 @@
 You are {{botName}}{{#if botHandle}} (@{{botHandle}} in Slack){{/if}} — the shared assistant platform for {{orgName}}. One core serves the whole org, but each conversation is isolated: you see and act only on what the people in this conversation are entitled to. Everything you do is audited.
 
 ## Runtime
-Use `runtime` to inspect or change your model, harness, reasoning effort, and fast mode. “Switch to Astra and do this” calls `runtime` with action `set` and model `Astra`; the task resumes automatically on that runtime. Use lifetime `scope` only when asked to change the standing default. Use `get` to discover choices before declaring a runtime unavailable.
+`runtime` discovers/changes models/harnesses and resumes; lifetime `scope` changes defaults.
 
 ## Sandboxes
 Core is home; sandboxes are optional resources. Creation never changes routing. Select a sandbox or use a stored default. Recovery can expire; save durable code to git and artifacts to Files. Profiles describe capabilities, not running machines.
 
-Missing work may live in another conversation's scope. Prefer explicit tools; discover other capabilities through the self-API: `curl -H "x-agent-capability: $AGENT_API_TOKEN" "$AGENT_API_URL/v1/apis"` (also works from a background process until the launching turn's token expires) lists everything your token can do — find deployments across scopes, share what you've made, save a skill, manage credentials, check whether this user is an admin. Consult it before concluding something is lost or impossible.
+Missing work may live in another conversation's scope. Prefer explicit tools; discover other capabilities through the self-API: `curl -H "x-agent-capability: $AGENT_API_TOKEN" "$AGENT_API_URL/v1/apis"` lists everything your token can do — find deployments across scopes, share what you've made, save a skill, manage credentials, check whether this user is an admin. Consult it before concluding something is lost or impossible.
 
 ## Files
 Files people send with the current message are listed each turn at exact, turn-private paths. To send someone a file, write it anywhere in your workspace and name its path to whichever tool sends (below). Files shared WITH you are listed as shared/<name> paths — use `read` to fetch one; not listed means not currently shared. A file someone POSTED in Slack earlier — anywhere the asking person can see — is fetchable by reference: find its message `ts` via `POST $AGENT_API_URL/v1/surface-context`, then `POST $AGENT_API_URL/v1/surface-file` with `{ts, channel?, threadTs?, name?}` and curl the short-lived download. Never ask for a re-upload. To let others see a file of yours, save it with `write` and its `share` field. This plumbing is invisible to people — hand files over by name, never mention inboxes or paths.

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -1,4 +1,4 @@
-import type { RuntimeRequest, RuntimeResult } from "../harness/runtime-control.ts";
+import type { RuntimeRequest, RuntimeResult } from "../harness/runtime-types.ts";
 import { randomUUID } from "node:crypto";
 import type { SandboxResources } from "../sandbox/sandbox-resources.ts";
 import { join } from "node:path";

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -1,3 +1,4 @@
+import type { RuntimeRequest, RuntimeResult } from "../harness/runtime-control.ts";
 import { randomUUID } from "node:crypto";
 import type { SandboxResources } from "../sandbox/sandbox-resources.ts";
 import { join } from "node:path";
@@ -176,6 +177,7 @@ export type AttachResult = { ok: true; files: AttachedFileMeta[]; staged: number
 export type AttachFiles = (files: readonly string[]) => Promise<AttachResult>;
 
 export interface ToolContext extends SurfaceToolDeps {
+  runtime?(request: RuntimeRequest, signal?: AbortSignal): Promise<RuntimeResult>;
   attach: AttachFiles;
   commandCredentialHandles?: readonly string[];
   credentialExecServices?: readonly { service: string; binary: string }[];

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -1,3 +1,4 @@
+import { createRuntimeService } from "./harness/runtime-control.ts";
 import { createPostgresBrokerSessions, type BrokerSessionStore } from "./auth/broker-sessions.ts";
 import { createDirectFileUploads, type DirectFileUploads } from "./files/direct-file-upload.ts";
 import { createPostgresFileUploadStore } from "./files/file-upload-store.ts";
@@ -1473,6 +1474,7 @@ export function buildApp(
     resolution,
     config: configStore,
     defaultHarness: fallbackHarness,
+    defaultTurnWallClockMs: config.turnWallClockMs,
     userModelCredentials,
     ...(config.brandingDefault ? { brandingDefault: config.brandingDefault } : {}),
     sessionTapeMode: config.sessionTapeMode,
@@ -1890,6 +1892,18 @@ export function buildApp(
   });
   cronChanged.notify = (id) => scheduler.notifyChanged(id);
   orchestratorDeps.control = createControlService(app, scheduler, admin);
+  orchestratorDeps.runtime = createRuntimeService(
+    {
+      config: configStore,
+      harnessId: fallbackHarness,
+      baseModelDefault: fallback.modelId,
+      providerKeys: providerKeysPresent(config),
+      modelCredentials,
+      modelCredentialFetch: overrides.modelCredentialFetch,
+      refreshModels,
+    },
+    app,
+  );
   const monitorPoller: MonitorPoller | null =
     processes && supportsProcessSessions(sandbox)
       ? createMonitorPoller({

--- a/test/agent-tools.test.ts
+++ b/test/agent-tools.test.ts
@@ -1417,7 +1417,7 @@ test("readOnly assembles ONLY observational tools — no execute/background/writ
   for (const t of ["execute", "background", "read", "write", "publish", "cron", "webhook", "guidance"]) {
     assert.ok(names(full).has(t), `full toolset has ${t}`);
   }
-  assert.deepEqual([...names(readOnly)].sort(), ["finish_silently", "history", "memory"]);
+  assert.deepEqual([...names(readOnly)].sort(), ["finish_silently", "history", "memory", "runtime"]);
   for (const t of ["execute", "background", "read", "write", "publish", "cron", "webhook", "guidance"]) {
     assert.ok(!names(readOnly).has(t), `read-only toolset drops ${t}`);
   }
@@ -3001,4 +3001,161 @@ test("sandbox call transcripts retain explicit process and lifecycle targets", a
   }
   await call(tool, { action: "set_default", sandbox_id: null, purpose: "Clear default" });
   assert.equal(entries.filter((e) => e.type === "tool_call").at(-1)!.payload.sandbox_id, null);
+});
+
+test("runtime persists its decision before terminating and blocks later effects", async () => {
+  const events: Emitted[] = [];
+  let release!: () => void;
+  const persisted = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const choice = { harnessId: "pi" as const, modelId: "gpt-6-astra" };
+  const ref: ToolContextRef = {
+    current: { ...fakeToolContext(), runtime: async () => ({ ok: true, handoff: { choice, lifetime: "task" } }) },
+    scopeLabel: "personal:U1",
+    runtimeRunId: "run",
+    runtimeActorId: "U1",
+    emit: async (e) => {
+      events.push(e as Emitted);
+      if (e.type === "tool_result") await persisted;
+    },
+  };
+  const tools = createAgentTools(ref);
+  const pending = call(
+    tools.find((t) => t.name === "runtime"),
+    { action: "set", model: "Astra" },
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(ref.runtimeHandoff, undefined);
+  const blocked = (await call(
+    tools.find((t) => t.name === "write"),
+    { path: "should-not-exist", data: "x" },
+  )) as { terminate: boolean };
+  assert.equal(blocked.terminate, false);
+  release();
+  const result = (await pending) as { terminate: boolean };
+  assert.equal(result.terminate, true);
+  assert.deepEqual(ref.runtimeHandoff, { choice, lifetime: "task" });
+  assert.equal(events.filter((e) => e.type === "tool_result").length, 1);
+  assert.equal(events.at(-1)?.payload.runId, "run");
+});
+
+test("runtime persistence failure does not latch a handoff", async () => {
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      runtime: async () => ({
+        ok: true,
+        handoff: { choice: { harnessId: "pi", modelId: "gpt-6-astra" }, lifetime: "task" },
+      }),
+    },
+    scopeLabel: "personal:U1",
+    emit: async (e) => {
+      if (e.type === "tool_result") throw new Error("disk failed");
+    },
+  };
+  await assert.rejects(
+    () =>
+      call(
+        createAgentTools(ref).find((t) => t.name === "runtime"),
+        { action: "set", model: "Astra" },
+      ),
+    /disk failed/,
+  );
+  assert.equal(ref.runtimeHandoff, undefined);
+  assert.equal(ref.runtimeMutationPending, false);
+});
+
+test("runtime pending mutation drains existing calls without premature termination", async () => {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let selected = false;
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      runtime: async (request) => {
+        if (request.action === "get") {
+          await held;
+          return { ok: true };
+        }
+        selected = true;
+        return { ok: false, error: "unavailable" };
+      },
+    },
+  };
+  const runtime = createAgentTools(ref).find((t) => t.name === "runtime");
+  const first = call(runtime, { action: "get" });
+  const second = call(runtime, { action: "set", model: "Astra" });
+  const third = (await call(runtime, { action: "get" })) as { terminate?: boolean };
+  assert.equal(selected, false);
+  assert.equal(third.terminate, false);
+  release();
+  await Promise.all([first, second]);
+  assert.equal(selected, true);
+  assert.equal(ref.runtimeHandoff, undefined);
+  assert.equal(ref.runtimeMutationPending, false);
+});
+
+test("runtime inspection is read-only but runtime changes cannot escape read-only or active goals", async () => {
+  let mutations = 0;
+  const ref: ToolContextRef = {
+    current: {
+      ...fakeToolContext(),
+      runtime: async (request) => {
+        if (request.action !== "get") mutations++;
+        return { ok: true };
+      },
+    },
+  };
+  const runtime = createAgentTools(ref, { readOnly: true }).find((t) => t.name === "runtime");
+  assert.match(textOut(await call(runtime, { action: "get" })), /"ok":true/);
+  assert.match(textOut(await call(runtime, { action: "set", model: "Astra" })), /read_only/);
+  const tools = createAgentTools(ref);
+  await call(
+    tools.find((t) => t.name === "create_goal"),
+    { objective: "finish the work" },
+  );
+  assert.match(
+    textOut(
+      await call(
+        tools.find((t) => t.name === "runtime"),
+        { action: "set", model: "Astra" },
+      ),
+    ),
+    /goal.*unfinished/,
+  );
+  assert.equal(mutations, 0);
+});
+
+test("a queued runtime change cannot mutate after cancellation while draining tools", async () => {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const controller = new AbortController();
+  let selected = false;
+  const ref: ToolContextRef = {
+    abortSignal: controller.signal,
+    current: {
+      ...fakeToolContext(),
+      runtime: async (request) => {
+        if (request.action === "get") {
+          await held;
+          return { ok: true };
+        }
+        selected = true;
+        return { ok: true };
+      },
+    },
+  };
+  const runtime = createAgentTools(ref).find((t) => t.name === "runtime");
+  const first = call(runtime, { action: "get" });
+  const second = call(runtime, { action: "set", model: "Astra", lifetime: "scope" });
+  controller.abort();
+  release();
+  await Promise.all([first, second]);
+  assert.equal(selected, false);
+  assert.equal(ref.runtimeHandoff, undefined);
 });

--- a/test/claude-harness-turn.test.ts
+++ b/test/claude-harness-turn.test.ts
@@ -8,6 +8,8 @@ import type { ScopeId, SessionEntry } from "../src/types.ts";
 type FakeSdkMessage = Record<string, unknown>;
 type Script = (prompts: AsyncIterable<{ message: { content: unknown } }>) => AsyncGenerator<FakeSdkMessage>;
 
+const toolHandlers = new Map<string, (args: unknown) => Promise<unknown>>();
+
 let currentScript: Script = async function* () {};
 
 mock.module("@anthropic-ai/claude-agent-sdk", {
@@ -29,12 +31,10 @@ mock.module("@anthropic-ai/claude-agent-sdk", {
         },
       };
     },
-    tool: (name: string, description: string, schema: unknown, handler: unknown) => ({
-      name,
-      description,
-      schema,
-      handler,
-    }),
+    tool: (name: string, description: string, schema: unknown, handler: (args: unknown) => Promise<unknown>) => {
+      toolHandlers.set(name, handler);
+      return { name, description, schema, handler };
+    },
     createSdkMcpServer: (config: unknown) => config,
   },
 });
@@ -80,7 +80,7 @@ function harnessTurn(overrides: Partial<HarnessTurnInput> = {}): {
     input: "what is the capital of france?",
     systemPrompt: "be brief",
     history: [],
-    tools: {} as HarnessTurnInput["tools"],
+    tools: {} as unknown as HarnessTurnInput["tools"],
     scopeLabel: scope,
     orgScopeId: scope,
     readOnly: true,
@@ -327,4 +327,25 @@ test("the claude harness offers compaction and detection so a utility role canno
     recordModelCall: () => {},
   });
   assert.equal(verdict.respond, true);
+});
+
+test("Claude preserves a committed runtime handoff when SDK interruption returns an error", async () => {
+  const choice = { harnessId: "codex" as const, modelId: "gpt-6-astra" };
+  currentScript = async function* (prompts) {
+    await prompts[Symbol.asyncIterator]().next();
+    await toolHandlers.get("runtime")!({ action: "set", model: "Astra" });
+    yield resultMessage("", { subtype: "error_during_execution", errors: ["turn interrupted"], is_error: true });
+  };
+  const harness = createClaudeHarness({});
+  const { turn, entries } = harnessTurn({
+    readOnly: false,
+    tools: {
+      runtime: async () => ({ ok: true, handoff: { choice, lifetime: "task" } }),
+    } as unknown as HarnessTurnInput["tools"],
+  });
+  const result = await harness.turns.runTurn(turn);
+  assert.deepEqual(result.runtimeHandoff, { choice, lifetime: "task" });
+  assert.equal(result.stopped, undefined);
+  assert.equal(entries.filter((entry) => entry.type === "assistant").length, 0);
+  assert.ok(entries.some((entry) => entry.type === "tool_result"));
 });

--- a/test/context-compaction.test.ts
+++ b/test/context-compaction.test.ts
@@ -100,7 +100,7 @@ function fakeSandbox(): Sandbox {
   };
 }
 
-function buildOrchestrator(harness: Harness, maxContextTokens?: number) {
+function buildOrchestrator(harness: Harness, maxContextTokens?: number, defaultTurnWallClockMs?: number) {
   const config = createMemoryConfigStore(ORG);
   const acl = createAclStore();
   const auditLog = createAuditLog();
@@ -128,6 +128,7 @@ function buildOrchestrator(harness: Harness, maxContextTokens?: number) {
     deploy,
     acl,
     maxContextTokens,
+    defaultTurnWallClockMs,
   });
   return { orch, sessions };
 }
@@ -1093,4 +1094,115 @@ test("the token estimate counts the environment note persisted on a user entry",
   const withEnv = { ...bare, seq: 2, payload: { text: "hi", environment } } as SessionEntry;
   const delta = estimateHistoryTokens([withEnv]) - estimateHistoryTokens([bare]);
   assert.ok(delta >= countTokens(environment) * 0.9, `environment tokens must be counted (delta ${delta})`);
+});
+
+test("runtime handoff continues once with saved results under the original run and remaining deadline", async () => {
+  const base = createMockHarness();
+  const seen: import("../src/harness/harness.ts").HarnessTurnInput[] = [];
+  let resets = 0;
+  const choice = { harnessId: "pi" as const, modelId: "gpt-6-astra", effortLevel: "high", fastMode: false };
+  const harness: Harness = {
+    ...base,
+    turns: {
+      ...base.turns,
+      resetSession: async () => {
+        resets++;
+      },
+      runTurn: async (input) => {
+        seen.push(input);
+        if (seen.length === 1) {
+          await input.emit({ type: "user", payload: { text: input.input }, scopeLabel: input.scopeLabel });
+          await input.emit({
+            type: "tool_result",
+            payload: {
+              tool: "runtime",
+              runId: input.runId,
+              actorId: actor.id,
+              runtimeHandoff: { choice, lifetime: "task" },
+            },
+            scopeLabel: input.scopeLabel,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return { reply: "must not be delivered", runtimeHandoff: { choice, lifetime: "task" }, modelCalls: 1 };
+        }
+        assert.deepEqual(input.runtime, choice);
+        assert.equal(input.runId, "runtime-run");
+        assert.ok(input.history.some((e) => e.type === "tool_result"));
+        assert.ok(input.turnWallClockMs! < seen[0]!.turnWallClockMs!);
+        await input.emit({ type: "assistant", payload: { text: "continued" }, scopeLabel: input.scopeLabel });
+        return { reply: "continued", modelCalls: 1 };
+      },
+    },
+  };
+  const { orch, sessions } = buildOrchestrator(harness, undefined, 60000);
+  await orch.handleTurn({ ...turn("switch then finish"), runId: "runtime-run", surfaceTools: false });
+  assert.equal(seen.length, 2);
+  assert.equal(resets, 1);
+  const session = await sessions.getByThread(conv.threadRef);
+  const entries = await sessions.getEntries(session!.id);
+  assert.deepEqual(
+    entries.filter((e) => e.type === "assistant").map((e) => (e.payload as { text: string }).text),
+    ["continued"],
+  );
+});
+
+test("runtime handoff cannot restart a stopped task", async () => {
+  const base = createMockHarness();
+  let calls = 0;
+  const harness: Harness = {
+    ...base,
+    turns: {
+      ...base.turns,
+      runTurn: async () => {
+        calls++;
+        return {
+          reply: "",
+          stopped: true,
+          runtimeHandoff: { choice: { harnessId: "pi", modelId: "gpt-6-astra" }, lifetime: "task" },
+        };
+      },
+    },
+  };
+  const { orch } = buildOrchestrator(harness);
+  await orch.handleTurn({ ...turn("switch"), surfaceTools: false });
+  assert.equal(calls, 1);
+});
+
+test("a retry restores a committed runtime decision after reset crashes, without replaying the selection", async () => {
+  const base = createMockHarness();
+  const choice = { harnessId: "pi" as const, modelId: "gpt-6-astra" };
+  let calls = 0;
+  const harness: Harness = {
+    ...base,
+    turns: {
+      ...base.turns,
+      resetSession: async () => {
+        throw new Error("worker died during reset");
+      },
+      runTurn: async (input) => {
+        calls++;
+        if (calls === 1) {
+          await input.emit({ type: "user", payload: { text: input.input }, scopeLabel: input.scopeLabel });
+          await input.emit({
+            type: "tool_result",
+            payload: {
+              tool: "runtime",
+              runId: input.runId,
+              actorId: actor.id,
+              runtimeHandoff: { choice, lifetime: "task" },
+            },
+            scopeLabel: input.scopeLabel,
+          });
+          return { reply: "", runtimeHandoff: { choice, lifetime: "task" } };
+        }
+        assert.deepEqual(input.runtime, choice);
+        return { reply: "resumed" };
+      },
+    },
+  };
+  const { orch } = buildOrchestrator(harness);
+  const input = { ...turn("switch and finish"), runId: "retry-runtime", surfaceTools: false };
+  await assert.rejects(() => orch.handleTurn(input), /worker died/);
+  await orch.handleTurn({ ...input, attempt: 2 });
+  assert.equal(calls, 2);
 });

--- a/test/live-slack-release-policy.test.ts
+++ b/test/live-slack-release-policy.test.ts
@@ -19,6 +19,7 @@ test("the deployed release tier covers critical Slack and file paths", () => {
     "dm-reply",
     "file-upload",
     "mention-reply",
+    "runtime-model-handoff",
     "teammate-dm-reach",
     "thread-context",
   ]);

--- a/test/live-slack/scenarios.ts
+++ b/test/live-slack/scenarios.ts
@@ -20,6 +20,60 @@ const AUTH_PROBE_BUDGET_MS = 500;
 
 export const scenarios: Scenario[] = [
   {
+    name: "runtime-model-handoff",
+    lane: "parallel",
+    tags: ["core", "release"],
+    timeoutMs: 5 * 60_000,
+    async run(ctx) {
+      const ch = await ctx.freshChannel();
+      const marker = ctx.marker();
+      const root = await ch.mention(
+        `Use the runtime tool to inspect your active runtime and available models, then switch to a different available Anthropic model for this task only. Keep the pi harness, set effort to auto and fastMode to false. After the handoff, inspect runtime again and calculate 17 × 23. Only after completing these steps, reply with the exact token ${marker}, your active model and the answer.`,
+      );
+      const reply = await ch.waitForBotReply(root, { match: new RegExp(marker), timeoutMs: 4 * 60_000 });
+      assert.match(reply.text ?? "", /\b391\b/);
+      const session = await ctx.core.findSessionByThread(ch.id, root);
+      assert.ok(session, "no core session found for runtime handoff");
+      const handoffEntry = session.entries.find(
+        (entry: any) => entry.type === "tool_result" && entry.payload?.runtimeHandoff,
+      ) as
+        | { payload: { runtimeHandoff: { lifetime: string; choice: { harnessId: string; modelId: string } } } }
+        | undefined;
+      assert.ok(handoffEntry, "no durable runtime handoff recorded");
+      const { lifetime, choice } = handoffEntry.payload.runtimeHandoff;
+      assert.equal(lifetime, "task");
+      assert.equal(choice.harnessId, "pi");
+      const handoffIndex = session.entries.indexOf(handoffEntry);
+      const verification = session.entries
+        .slice(handoffIndex + 1)
+        .find(
+          (entry: any) =>
+            entry.type === "tool_result" &&
+            entry.payload?.tool === "runtime" &&
+            entry.payload?.action === "get" &&
+            entry.payload?.ok === true,
+        ) as { payload: { result: string } } | undefined;
+      assert.ok(verification, "no successful runtime inspection after handoff");
+      const inspected = JSON.parse(verification.payload.result) as { active: { modelId: string } };
+      assert.equal(inspected.active.modelId, choice.modelId);
+      type ModelCall = { step: number; model: string; createdAt: number; usage: { output: number } | null };
+      let modelCalls: ModelCall[];
+      const deadline = Date.now() + 30_000;
+      do {
+        const { requests } = (await ctx.core.getSessionLlm(session.id)) as { requests: ModelCall[] };
+        modelCalls = requests.filter((request) => request.step >= 0).toSorted((a, b) => a.createdAt - b.createdAt);
+        if (modelCalls.some((request) => request.model === choice.modelId && (request.usage?.output ?? 0) > 0)) break;
+        await sleep(500);
+      } while (Date.now() < deadline);
+      assert.ok(modelCalls.length >= 2, "runtime handoff did not produce multiple model calls");
+      assert.notEqual(modelCalls[0]!.model, choice.modelId, "runtime tool selected the already active model");
+      assert.ok(
+        modelCalls.slice(1).some((request) => request.model === choice.modelId && (request.usage?.output ?? 0) > 0),
+        `no real model call used the selected runtime ${choice.modelId}`,
+      );
+    },
+  },
+  {
     name: "mention-reply",
     lane: "parallel",
     tags: ["smoke", "core", "release"],

--- a/test/runtime-tool.test.ts
+++ b/test/runtime-tool.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { createRuntimeService, recoveredRuntime } from "../src/harness/runtime-control.ts";
+import { createRuntimeService } from "../src/harness/runtime-control.ts";
+import { recoveredRuntime } from "../src/harness/runtime-recovery.ts";
 import { createMemoryConfigStore } from "../src/resolution/config-store.ts";
 import type { CapabilityClaims } from "../src/auth/capability-token.ts";
 import type { RuntimeChoice } from "../src/harness/harness.ts";

--- a/test/runtime-tool.test.ts
+++ b/test/runtime-tool.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRuntimeService, recoveredRuntime } from "../src/harness/runtime-control.ts";
+import { createMemoryConfigStore } from "../src/resolution/config-store.ts";
+import type { CapabilityClaims } from "../src/auth/capability-token.ts";
+import type { RuntimeChoice } from "../src/harness/harness.ts";
+import type { SessionEntry } from "../src/types.ts";
+
+const active: RuntimeChoice = { harnessId: "pi", modelId: "claude-opus-5", effortLevel: "high", fastMode: false };
+const claims: CapabilityClaims = {
+  actorId: "alice",
+  scopeId: "personal:alice",
+  liveActor: true,
+  exp: Date.now() + 60000,
+};
+async function setup(allowed = true) {
+  const config = createMemoryConfigStore("default-org");
+  config.setApprovedHarnesses(["pi", "claude", "codex", "opencode"]);
+  await config.flushScope("org:default-org");
+  await config.setRuntimeSelectionLatest("org:default-org", active);
+  const service = createRuntimeService(
+    { config, harnessId: "pi", baseModelDefault: active.modelId },
+    {
+      authorizesCapabilityScope: async () => allowed,
+    },
+  );
+  return { config, service };
+}
+
+test("runtime exposes actual dispatch separately from saved defaults and resolves Astra without losing settings", async () => {
+  const { config, service } = await setup();
+  const running = { ...active, modelId: "claude-sonnet-5" };
+  const state = await service(claims, running, { action: "get" });
+  assert.equal(state.ok, true);
+  assert.deepEqual(state.active, running);
+  assert.equal((state.effective as RuntimeChoice).modelId, active.modelId);
+  const result = await service(claims, running, { action: "set", model: "Astra" });
+  assert.deepEqual(result, { ok: true, handoff: { lifetime: "task", choice: { ...running, modelId: "gpt-6-astra" } } });
+  assert.equal(await config.getRuntimeSelectionDurable(claims.scopeId), null);
+});
+
+test("scope defaults persist and inherit clears them", async () => {
+  const { config, service } = await setup();
+  const result = await service(claims, active, { action: "set", model: "Astra", lifetime: "scope" });
+  assert.equal(result.ok, true);
+  assert.equal((await config.getRuntimeSelectionDurable(claims.scopeId))?.modelId, "gpt-6-astra");
+  const inherited = await service(claims, active, { action: "inherit", lifetime: "scope" });
+  assert.equal(inherited.ok, true);
+  assert.equal(await config.getRuntimeSelectionDurable(claims.scopeId), null);
+});
+
+test("runtime changes reject revoked access, bots, triggers and foreign personal scopes", async () => {
+  const denied = await setup(false);
+  assert.deepEqual(await denied.service(claims, active, { action: "get" }), { ok: false, error: "forbidden" });
+  const { service } = await setup();
+  for (const extra of [{ botActor: true }, { triggered: true }, { liveActor: false }]) {
+    assert.deepEqual(await service({ ...claims, ...extra }, active, { action: "set", model: "Astra" }), {
+      ok: false,
+      error: "live_actor_required",
+    });
+  }
+  assert.deepEqual(await service({ ...claims, scopeId: "personal:bob" }, active, { action: "set", model: "Astra" }), {
+    ok: false,
+    error: "forbidden",
+  });
+});
+
+test("runtime rejects unsupported effort and fast mode instead of silently dropping them", async () => {
+  const { service } = await setup();
+  assert.deepEqual(await service(claims, active, { action: "set", harness: "opencode" }), {
+    ok: false,
+    error: "effort_not_supported",
+  });
+  assert.deepEqual(await service(claims, active, { action: "set", model: "claude-sonnet-5", fastMode: true }), {
+    ok: false,
+    error: "fast_mode_not_supported",
+  });
+});
+
+test("account preflight failure cannot change a scope default", async () => {
+  const { service, config } = await setup();
+  const result = await service(
+    claims,
+    active,
+    { action: "set", model: "Astra", lifetime: "scope" },
+    async () => "account does not support this runtime",
+  );
+  assert.equal(result.ok, false);
+  assert.equal(await config.getRuntimeSelectionDurable(claims.scopeId), null);
+});
+
+test("runtime recovery uses only durable decisions belonging to the same run and actor", () => {
+  const entry = (runId: string, actorId: string, modelId: string): SessionEntry => ({
+    sessionId: "s",
+    seq: 1,
+    parentSeq: null,
+    type: "tool_result",
+    scopeLabel: claims.scopeId,
+    createdAt: 1,
+    payload: { tool: "runtime", runId, actorId, runtimeHandoff: { choice: { ...active, modelId }, lifetime: "task" } },
+  });
+  const entries = [
+    entry("run", "alice", "gpt-6-astra"),
+    entry("other", "alice", "claude-sonnet-5"),
+    entry("run", "bob", "claude-opus-5"),
+  ];
+  assert.equal(recoveredRuntime(entries, "run", "alice")?.modelId, "gpt-6-astra");
+  assert.equal(recoveredRuntime(entries, "new", "alice"), undefined);
+});
+
+test("individual-account availability does not depend on organization provider keys", async () => {
+  const { config } = await setup();
+  const service = createRuntimeService(
+    { config, harnessId: "pi", providerKeys: { anthropic: false, openai: false, openrouter: false } },
+    { authorizesCapabilityScope: async () => true },
+  );
+  const ownRuntime = { ...active, modelId: "gpt-6-astra" };
+  const result = await service(
+    claims,
+    ownRuntime,
+    { action: "set", effort: "xhigh" },
+    async (choice) => (choice.harnessId === "pi" && choice.modelId === "gpt-6-astra" ? null : "no account"),
+    true,
+  );
+  assert.deepEqual(result, {
+    ok: true,
+    handoff: { lifetime: "task", choice: { ...ownRuntime, effortLevel: "xhigh" } },
+  });
+});
+
+test("a saved override removed from the model picker cannot be newly selected", async () => {
+  const { config, service } = await setup();
+  await config.setRuntimeSelectionLatest(claims.scopeId, { ...active, modelId: "gpt-6-astra" });
+  config.setWebuiModels("org:default-org", ["claude-sonnet-5"]);
+  await config.flushScope("org:default-org");
+  assert.deepEqual(await service(claims, active, { action: "set", model: "Astra" }), {
+    ok: false,
+    error: "model_not_enabled",
+  });
+});
+
+test("cancellation during validation prevents a scope write", async () => {
+  const { config, service } = await setup();
+  const controller = new AbortController();
+  const result = await service(
+    claims,
+    active,
+    { action: "set", model: "Astra", lifetime: "scope" },
+    async () => {
+      controller.abort();
+      return null;
+    },
+    false,
+    controller.signal,
+  );
+  assert.deepEqual(result, { ok: false, error: "cancelled" });
+  assert.equal(await config.getRuntimeSelectionDurable(claims.scopeId), null);
+});

--- a/test/user-model-auth-injection.test.ts
+++ b/test/user-model-auth-injection.test.ts
@@ -232,3 +232,13 @@ test("per-user codex child auth is derived material: valid chatgpt auth without 
   assert.ok(!JSON.stringify(child).includes("ref-token"));
   assert.ok(child.tokens?.id_token);
 });
+
+test("individual OAuth routing preserves exact supported runtime selections", () => {
+  assert.equal(
+    resolveIndividualAuthRouting(oauth("anthropic"), null, "claude-sonnet-5", "claude")?.model,
+    "claude-sonnet-5",
+  );
+  assert.equal(resolveIndividualAuthRouting(null, oauth("openai"), "gpt-6-astra", "codex")?.model, "gpt-6-astra");
+  assert.equal(resolveIndividualAuthRouting(null, oauth("openai"), "codex/gpt-5.5", "pi")?.model, "codex/gpt-5.5");
+  assert.equal(resolveIndividualAuthRouting(null, apikey("openai", "test"), "codex/gpt-5.5", "pi"), null);
+});


### PR DESCRIPTION
Requests such as “switch to Astra and finish this task” now use a discoverable `runtime` tool. It reports the active dispatch separately from saved defaults, resolves model display names, preserves omitted effort/fast-mode settings, and supports task overrides or scope defaults and inheritance.

A successful selection is recorded before the current adapter stops. The orchestrator resumes the unfinished request under the same run and lease, with saved tool results, images, refreshed credentials, and the remaining deadline. Worker retries recover the selected runtime from durable entries. All four adapters recognize handoffs; cancellation, approval, and parallel-call barriers prevent later effects. Runtime changes refuse unfinished goals rather than dropping their enforcement.

Runtime discovery and model-enable policy are shared with existing API paths. The native tool rejects unsupported choices explicitly; existing HTTP settings retain their fast-mode normalization behavior. Individual-account choices use the person's credentials, and OAuth routing preserves supported explicit model selections. The redundant runtime self-API listing is hidden.

Validation: core and web UI typechecks, affected ESLint, Oxlint, Knip, and 181 focused tests passed. Independent security and control-flow reviews are clear, including separate reviews of the compatibility fixes and staging scenario. Existing HTTP settings and prompt-budget tests also pass.

Live local web QA on real Codex: Sol discovered the tool, switched to Astra, verified the active model, and returned 17 × 23 = 391 without another user prompt. The next request returned to Sol, confirming task lifetime isolation. This used the current bundled Codex CLI; older CLI versions may advertise Astra but fail provider dispatch. Slack dev slots failed launcher verification, so the local live check used the web surface. A mandatory staging release scenario now exercises an actual Pi model handoff and verifies both post-handoff runtime inspection and successful captured output from the selected model. It awaits execution during deployment qualification.
