### PR TITLE
web-ui: loading state and the live thinking trace

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -6,6 +6,7 @@ import type { AssistantMessage, TextContent } from "@earendil-works/pi-ai";
 import type { UserMessageWithAttachments } from "@earendil-works/pi-web-ui";
 import { markdown } from "./message-markdown";
 import { html, nothing, render, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import {
   Activity,
   Ban,
@@ -17,9 +18,11 @@ import {
   Clock3,
   Copy,
   FileImage,
-  FileText,
   Files,
+  FileText,
   GitFork,
+  Globe,
+  type IconNode,
   Maximize2,
   Paperclip,
   Pause,
@@ -28,13 +31,14 @@ import {
   Plug,
   Radar,
   RefreshCw,
-  Target,
   Rocket,
   ScrollText,
+  Search,
+  Sparkle,
+  Target,
   Terminal,
   Wrench,
   X,
-  type IconNode,
 } from "lucide";
 import {
   continuableMessages,
@@ -89,6 +93,8 @@ import {
   type TimelineItem,
   type ToolPayload,
   type ToolRowModel,
+  type SegmentStatus,
+  segmentStatus,
 } from "./timeline";
 import { CONNECTOR_NAMES, connectorLinksIn, stripConnectorLinks, type ConnectorLink } from "./connector-link";
 import { deepLinkPath, UI_BASE } from "./deep-link";
@@ -106,7 +112,7 @@ import {
   harnessSupportsEffort,
   harnessSupportsFastMode,
 } from "./model-options";
-import { browserRenderableImage, chipBadge, formatBytes, icon, relTime, waveLoader } from "./ui";
+import { browserRenderableImage, chipBadge, formatBytes, icon, pixelLoader, relTime } from "./ui";
 import { appState, renderSidebarTop, switchView, syncUrlFromState } from "./shell";
 import { contextsState, scopeTitle } from "./contexts";
 import { openProjectPage, scopeToolCount, sessionTopbarTpl, setScopedSession } from "./session-scope";
@@ -135,7 +141,7 @@ import { newChatDraftKey, saveDraft, storedDraft } from "./drafts";
 import { createForkOriginController, forkOriginView } from "./fork-origin";
 import { base64ToBytes } from "./paste-text";
 import { tip } from "./tooltip";
-import { workSeconds, workedLabel } from "./work-duration";
+import { elapsedLabel, workSeconds, workStartedAt, workedLabel } from "./work-duration";
 import { markClampedPrompts } from "./prompt-clamp";
 import { decorateTextCodeBlocks, normalizePlainTextFences } from "./text-code";
 
@@ -145,6 +151,11 @@ installMarkdownSanitizer();
 
 const detachedAgents = new WeakSet<Agent>();
 const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+interface LiveWorkSummary {
+  label: string;
+  detail: string;
+  since: number | null;
+}
 interface SettledRowKey {
   index: number;
   activity: WorkBlock["activity"] | undefined;
@@ -279,6 +290,7 @@ export function createChatSurface(
   let ctaThreadRef: string | null | undefined;
   let ctaText = CHAT_CTAS[0]!;
   let workTicker: ReturnType<typeof setInterval> | null = null;
+  let liveElapsedTimer: ReturnType<typeof setInterval> | null = null;
   let revealedTailLen = 0;
   let liveWorkExpanded = false;
 
@@ -905,7 +917,7 @@ export function createChatSurface(
     host.className = "custom-chat";
     render(
       html`<div class="custom-chat-shell">
-        <div class="chat-loading">${waveLoader()}</div>
+        <div class="chat-loading">${pixelLoader("Loading")}</div>
       </div>`,
       host,
     );
@@ -1550,10 +1562,13 @@ export function createChatSurface(
     if (role === "assistant") {
       const msg = message as AssistantMessage;
       if ((msg as AssistantWork).retryableSend) return nothing;
-      const work = isStreaming ? null : (msg as AssistantWork).work;
+      const work = isStreaming ? chatState.liveWork : (msg as AssistantWork).work;
       const text = assistantDisplayText(messageText(msg)).trim();
       const hasText = Boolean(text);
-      const showWork = shouldShowApprovalWork(msg, work, text) && shouldShowWork(work, hasText);
+      const liveThinking = isStreaming ? thinkingParagraphs(msg) : [];
+      const showWork =
+        (shouldShowApprovalWork(msg, work, text) && shouldShowWork(work, hasText)) ||
+        (isStreaming && liveThinking.length > 0);
       const deliveredFiles = (msg as AssistantWork).deliveredFiles;
       const hasVisibleContent =
         showWork ||
@@ -1564,8 +1579,8 @@ export function createChatSurface(
       return html`
         <article class="message-row assistant-row ${isStreaming ? "streaming" : ""}" data-index=${index}>
           <div class="assistant-body">
-            ${showWork ? workBlock(work, isStreaming) : nothing} ${assistantContent(msg, isStreaming, showWork)}
-            ${assistantFileList(deliveredFiles)}
+            ${showWork ? workBlock(work ?? { status: "thinking", activity: [] }, isStreaming, liveThinking) : nothing}
+            ${assistantContent(msg, isStreaming, showWork)} ${assistantFileList(deliveredFiles)}
             ${msg.stopReason === "error" && msg.errorMessage ? html`<div class="composer-error inline">${msg.errorMessage}</div>` : nothing}
             ${msg.stopReason === "aborted" ? html`<div class="stopped-note">${icon(Ban, 13)}<span>Stopped</span></div>` : nothing}
             ${isStreaming ? nothing : messageMeta(msg, index)}
@@ -1770,14 +1785,7 @@ export function createChatSurface(
           );
         for (const link of links) parts.push(connectorWidget(link));
       }
-      if (chunk.type === "thinking" && chunk.thinking.trim()) {
-        parts.push(
-          html`<details class="thinking">
-            <summary>${sheenLabel("Thinking", isStreaming)}</summary>
-            ${markdown(chunk.thinking)}
-          </details>`,
-        );
-      }
+      if (chunk.type === "thinking" && chunk.thinking.trim() && !isStreaming) parts.push(thinkingRow(chunk.thinking));
     }
     if (
       parts.length === 0 &&
@@ -1837,9 +1845,19 @@ export function createChatSurface(
   }
 
   function typingRow(): TemplateResult {
-    return html`<div class="thinking-placeholder">
-      ${waveLoader({ width: 14.1, label: "Thinking" })}${sheenLabel("Thinking", true)}
-    </div>`;
+    return html`<div class="thinking-placeholder">${pixelLoader()}${sheenLabel("Thinking", true)}</div>`;
+  }
+
+  function syncLiveElapsed(el?: Element): void {
+    if (liveElapsedTimer) clearInterval(liveElapsedTimer);
+    liveElapsedTimer = null;
+    if (!(el instanceof HTMLElement)) return;
+    const tick = (): void => {
+      el.textContent = elapsedLabel(Date.now() - Number(el.dataset.since));
+      if (!el.isConnected) syncLiveElapsed();
+    };
+    tick();
+    liveElapsedTimer = setInterval(tick, reduceMotion.matches ? 1000 : 100);
   }
 
   function syncWorkTicker(): void {
@@ -1857,6 +1875,7 @@ export function createChatSurface(
 
   function clearLiveWork(): void {
     chatState.liveWork = null;
+    liveTraceOpen = null;
     chatState.pendingSend = null;
     syncWorkTicker();
   }
@@ -2162,6 +2181,7 @@ export function createChatSurface(
     const work = chatState.liveWork ?? { status: "thinking", activity: [] };
     if (work.status !== "thinking" && work.status !== "working") return nothing;
     const summary = liveWorkSummary(work);
+    const since = summary ? summary.since : workStartedAt(work);
     const expandable = Boolean(summary?.detail);
     const expanded = expandable && liveWorkExpanded;
     let title = "";
@@ -2176,10 +2196,20 @@ export function createChatSurface(
           ${tip(title)}
           @click=${toggleLiveWorkExpanded}
         >
-          ${summary ? html`<span class="tool-icon">${icon(summary.icon, 15)}</span>` : nothing}
+          ${pixelLoader()}
           <span class="live-work-label"
             >${summary ? summary.label : sheenLabel(`Thinking${usedToolsSuffix(work)}`, true)}</span
           >
+          ${
+            since
+              ? html`<span
+                  class="live-work-elapsed"
+                  data-since=${since}
+                  aria-hidden="true"
+                  ${ref(syncLiveElapsed)}
+                ></span>`
+              : nothing
+          }
           ${summary?.detail ? html`<span class="live-work-detail">${summary.detail}</span>` : nothing}
           ${expandable ? html`<span class="live-work-toggle">${icon(ChevronRight, 14)}</span>` : nothing}
         </button>
@@ -2192,16 +2222,16 @@ export function createChatSurface(
     drawActiveChat();
   }
 
-  function liveWorkSummary(work: WorkBlock): { icon: IconNode; label: string; detail: string } | null {
+  function liveWorkSummary(work: WorkBlock): LiveWorkSummary | null {
     if (work.stale) {
       const active = activeToolRow(work);
       const call = (active?.call?.payload ?? {}) as ToolPayload;
       const tool = call.tool ?? "";
       const verb = active ? (TOOL_META[tool] ?? UNKNOWN_TOOL).active : null;
       return {
-        icon: RefreshCw,
         label: verb ? `${verb} interrupted, resuming…` : "Interrupted, resuming…",
         detail: active ? toolDetail(tool, call, (active.result?.payload ?? {}) as ToolPayload) : "",
+        since: active?.call?.createdAt || workStartedAt(work),
       };
     }
     const active = activeToolRow(work);
@@ -2217,22 +2247,16 @@ export function createChatSurface(
     return null;
   }
 
-  function activeToolSummary(row: ToolRowModel, work: WorkBlock): { icon: IconNode; label: string; detail: string } {
+  function activeToolSummary(row: ToolRowModel, work: WorkBlock): LiveWorkSummary {
     const call = (row.call?.payload ?? {}) as ToolPayload;
     const result = (row.result?.payload ?? {}) as ToolPayload;
     const tool = call.tool ?? result.tool ?? "unknown";
     const meta = TOOL_META[tool] ?? UNKNOWN_TOOL;
-    const secs = elapsedSeconds(row.call?.createdAt) || workSeconds(work);
     return {
-      icon: meta.icon,
-      label: secs > 0 ? `${meta.active} for ${secs}s` : meta.active,
+      label: meta.active,
       detail: toolDetail(tool, call, result),
+      since: row.call?.createdAt || workStartedAt(work),
     };
-  }
-
-  function elapsedSeconds(startedAt: number | null | undefined): number {
-    if (typeof startedAt !== "number" || startedAt <= 0) return 0;
-    return Math.max(0, Math.round((Date.now() - startedAt) / 1000));
   }
 
   function usedToolsSuffix(work: WorkBlock): string {
@@ -2240,30 +2264,83 @@ export function createChatSurface(
     return n > 0 ? ` (used ${n} tool${n === 1 ? "" : "s"})` : "";
   }
 
-  function workLabel(work: WorkBlock): string {
-    if (work.stale && (work.status === "thinking" || work.status === "working")) return "Interrupted, resuming…";
-    if (work.status === "thinking") return "Thinking";
-    const secs = workSeconds(work);
-    return work.status === "working" ? `Working for ${secs}s` : workedLabel("Worked", secs);
+  function thinkingParagraphs(message: AssistantMessage): string[] {
+    return message.content
+      .flatMap((chunk) => (chunk.type === "thinking" ? chunk.thinking.split(/\n\s*\n/) : []))
+      .map((p) => p.trim())
+      .filter(Boolean);
   }
 
-  function workBlock(work: WorkBlock, isStreaming: boolean): TemplateResult {
-    if (work.status === "thinking" && !work.activity.length) {
-      return html`<div class="work work-thinking">
-        <div class="work-head">${sheenLabel(workLabel(work), isStreaming)}</div>
-      </div>`;
-    }
+  type TraceKind = "reason" | "search" | "tools";
+
+  function isSearchRow(row: ToolRowModel): boolean {
+    const call = (row.call?.payload ?? {}) as ToolPayload;
+    const tool = call.tool ?? ((row.result?.payload ?? {}) as ToolPayload).tool ?? "";
+    return typeof call.query === "string" || /search|recall|history|web|fetch/i.test(tool);
+  }
+
+  function traceKind(items: TimelineItem[]): TraceKind {
+    const tools = items.filter((it) => it.kind === "tool");
+    if (!tools.length) return "reason";
+    return tools.every((it) => it.kind === "tool" && isSearchRow(it.row)) ? "search" : "tools";
+  }
+
+  const TRACE_ACTIVE: Record<TraceKind, string> = {
+    reason: "Thinking",
+    search: "Searching the web",
+    tools: "Running tools",
+  };
+
+  function traceGlyph(status: SegmentStatus, live: boolean): TemplateResult {
+    if (status === "failed") return html`<span class="work-glyph work-glyph-failed">${icon(X, 14)}</span>`;
+    return html`<span class="work-glyph ${live ? "live" : ""}">${icon(Sparkle, 16)}</span>`;
+  }
+
+  function reasonRows(text: string): TemplateResult[] {
+    return text
+      .split(/\n\s*\n/)
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .map((p, i) => html`<div class="trace-reason" style=${`--i:${i}`}>${p}</div>`);
+  }
+
+  let liveTraceOpen: boolean | null = null;
+
+  function workBlock(work: WorkBlock, isStreaming: boolean, liveThinking: string[] = []): TemplateResult {
+    const live = isStreaming || work.status === "working" || work.status === "thinking";
     const timeline = buildTimeline(work);
-    const rows = timeline.length
-      ? html`<div class="work-rows">${timeline.map((it) => renderTimelineItem(it, work))}</div>`
-      : nothing;
-    const body = html`<div class="work-divider"></div>
-      ${rows}`;
-    if (isStreaming || work.status === "working" || work.status === "thinking") {
-      return html`<div class="work work-working">
-        <div class="work-head">${sheenLabel(workLabel(work), isStreaming)}</div>
-        ${body}
-      </div>`;
+    if (live) {
+      const rows = timeline.filter((it) => !(liveThinking.length && it.kind === "thinking"));
+      const kind = traceKind(rows);
+      if (!rows.length && !liveThinking.length) {
+        return html`<div class="work work-thinking">
+          <div class="work-head">
+            ${traceGlyph("running", true)}
+            <span class="work-title">${sheenLabel(work.stale ? "Interrupted, resuming…" : "Thinking", true)}</span>
+          </div>
+        </div>`;
+      }
+      return html`<details
+        class="work work-working"
+        ?open=${liveTraceOpen ?? true}
+        @toggle=${(e: Event) => {
+          liveTraceOpen = (e.currentTarget as HTMLDetailsElement).open;
+        }}
+      >
+        <summary class="work-head">
+          ${traceGlyph("running", true)}
+          <span class="work-title"
+            >${sheenLabel(work.stale ? "Interrupted, resuming…" : TRACE_ACTIVE[kind], true)}</span
+          >
+          ${icon(ChevronRight, 14)}
+        </summary>
+        <div class="work-body">
+          <div class="work-rows">
+            ${liveThinking.map((p) => html`<div class="trace-reason">${p}</div>`)}
+            ${rows.map((it) => html`<div class="trace-item">${renderTimelineItem(it, work)}</div>`)}
+          </div>
+        </div>
+      </details>`;
     }
     const openFolds = !!work.pendingApprovals?.length;
     const parts: TemplateResult[] = [];
@@ -2274,17 +2351,12 @@ export function createChatSurface(
       seg = [];
       parts.push(
         html`<details class="work-fold" ?open=${openFolds}>
-          <summary class="work-head">${segmentSummaryLabel(items, work)}${icon(ChevronRight, 14)}</summary>
-          <div class="work-divider"></div>
-          <div class="work-rows">${items.map((it) => renderTimelineItem(it, work))}</div>
+          ${workHead(items, work, segmentSummaryLabel(items, work))} ${workRows(items, work)}
         </details>`,
       );
     };
     for (const it of timeline) {
       const demoted = it.kind === "text" && (it.activity.payload as { demoted?: boolean } | null)?.demoted === true;
-      // Closing self-logs after a successful surface post are bookkeeping, not
-      // another piece of visible work. Keeping them in the transcript is useful
-      // for audit/replay, but rendering them creates an empty "Worked" fold.
       if (demoted) continue;
       if (it.kind === "text") {
         flushSeg();
@@ -2298,12 +2370,34 @@ export function createChatSurface(
     return parts.length ? html`<div class="work work-${work.status}">${parts}</div>` : html``;
   }
 
+  function workHead(items: TimelineItem[], work: WorkBlock, label: string | TemplateResult): TemplateResult {
+    return html`<summary class="work-head">
+      ${traceGlyph(segmentStatus(items, work.status), false)}
+      <span class="work-title">${label}</span>
+      ${icon(ChevronRight, 14)}
+    </summary>`;
+  }
+
+  function workRows(items: TimelineItem[], work: WorkBlock): TemplateResult {
+    return html`<div class="work-body">
+      <div class="work-rows">
+        ${items.map((it, i) => html`<div class="trace-item" style=${`--i:${i}`}>${renderTimelineItem(it, work)}</div>`)}
+      </div>
+    </div>`;
+  }
+
+  function segmentToolCount(items: TimelineItem[]): number {
+    return items.filter((it) => it.kind === "tool").length;
+  }
+
   function segmentSummaryLabel(items: TimelineItem[], work: WorkBlock): string {
-    const tools = items.filter((it) => it.kind === "tool").length;
-    if (tools > 0) return `${tools} tool call${tools === 1 ? "" : "s"}`;
     const secs = workSeconds(work);
-    if (work.status === "failed") return secs > 0 ? `Failed after ${secs}s` : "Failed";
-    return workedLabel("Worked", secs);
+    if (segmentStatus(items, work.status) === "failed") return secs > 0 ? `Failed after ${secs}s` : "Failed";
+    const kind = traceKind(items);
+    if (kind === "search") return "Searched the web";
+    const tools = segmentToolCount(items);
+    if (kind === "tools") return `Ran ${tools} tool${tools === 1 ? "" : "s"}`;
+    return workedLabel("Thought", secs);
   }
 
   function approvalSummaryView(a: PendingApproval, expanded = false): TemplateResult {
@@ -2341,37 +2435,92 @@ export function createChatSurface(
   }
 
   function approvalMarker(a: PendingApproval): TemplateResult {
-    return html`<div class="approval-card inline-approval-marker">
-      <div class="approval-text">${approvalSummaryView(a)}</div>
-    </div>`;
+    return html`<div class="approval-card inline-approval-marker">${approvalSummaryView(a)}</div>`;
   }
 
   function sheenLabel(label: string, active: boolean): TemplateResult {
-    return html`<span class="sheen-label ${active ? "thinking-sheen" : ""}" data-sheen=${active ? label : ""}
-      >${label}</span
-    >`;
+    return html`<span class="sheen-label ${active ? "thinking-sheen" : ""}">${label}</span>`;
   }
 
   function renderTimelineItem(item: TimelineItem, work: WorkBlock): TemplateResult {
     const status = work.status;
     const stale = work.stale === true;
-    if (item.kind === "thinking") return thinkingRow(item.activity);
+    if (item.kind === "thinking")
+      return html`${reasonRows((item.activity.payload as { thinking?: string } | null)?.thinking ?? "")}`;
     if (item.kind === "text") return messageRow(item.activity);
     if (item.kind === "approval") return approvalMarker(item.approval);
+    if (item.kind === "tool" && isSearchRow(item.row)) return searchTrace(item.row, work, status, stale);
     return toolRow(item.row, work, status, stale);
   }
 
-  function thinkingRow(activity: ToolActivity): TemplateResult {
-    const text = (activity.payload as { thinking?: string } | null)?.thinking ?? "";
-    const preview = firstLine(text.replace(/\s+/g, " ").trim());
+  interface SearchHit {
+    title: string;
+    url: string;
+  }
+
+  function searchHits(payload: unknown, depth = 0): SearchHit[] {
+    if (!payload || typeof payload !== "object" || depth > 2) return [];
+    if (Array.isArray(payload)) {
+      const hits = payload.filter(
+        (h): h is { url: string; title?: string; name?: string } =>
+          Boolean(h) && typeof h === "object" && typeof (h as { url?: unknown }).url === "string",
+      );
+      if (hits.length) return hits.map((h) => ({ url: h.url, title: h.title ?? h.name ?? h.url }));
+      return payload.flatMap((v) => searchHits(v, depth + 1));
+    }
+    return Object.values(payload as Record<string, unknown>).flatMap((v) => searchHits(v, depth + 1));
+  }
+
+  function hostOf(url: string): string {
+    try {
+      return new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+      return url;
+    }
+  }
+
+  function searchTrace(
+    row: ToolRowModel,
+    work: WorkBlock,
+    status: WorkBlock["status"],
+    stale: boolean,
+  ): TemplateResult {
+    const call = (row.call?.payload ?? {}) as ToolPayload;
+    const hits = searchHits(row.result?.payload ?? null);
+    if (!hits.length) return toolRow(row, work, status, stale);
+    const shown = hits.slice(0, 3);
+    return html`<div class="trace-search">
+      ${
+        call.query ? html`<div class="trace-search-query">${icon(Search, 14)}<span>${call.query}</span></div>` : nothing
+      }
+      ${shown.map(
+        (hit, i) =>
+          html`<a class="trace-search-result" style=${`--i:${i}`} href=${hit.url} target="_blank" rel="noreferrer">
+            <span class="trace-favicon" data-tone=${i % 3}>${icon(Globe, 9)}</span>
+            <span class="trace-search-title">${hit.title}</span>
+            <span class="trace-search-host">${hostOf(hit.url)}</span>
+          </a>`,
+      )}
+      ${hits.length > shown.length ? html`<span class="trace-more">+${hits.length - shown.length} more</span>` : nothing}
+    </div>`;
+  }
+
+  function thinkingRow(text: string, live = false): TemplateResult {
     return html`<details class="thinking-row">
       <summary class="thinking-summary">
-        <span class="tool-icon">${icon(Brain, 13)}</span>
-        <span class="tool-label" title=${preview ? `Thinking: ${preview}` : "Thinking"}>${preview || "Thinking"}</span>
+        <span class="tool-icon">${icon(Sparkle, 13)}</span>
+        ${live ? html`<span class="tool-label">${sheenLabel("Thinking", true)}</span>` : thinkingLabel(text)}
         ${icon(ChevronRight, 14)}
       </summary>
-      <div class="thinking-body">${markdown(text)}</div>
+      <div class="thinking-body">${reasonRows(text)}</div>
     </details>`;
+  }
+
+  function thinkingLabel(text: string): TemplateResult {
+    const preview = firstLine(text.replace(/\s+/g, " ").trim());
+    return html`<span class="tool-label" title=${preview ? `Thinking: ${preview}` : "Thinking"}
+      >${preview || "Thinking"}</span
+    >`;
   }
 
   function messageRow(activity: ToolActivity): TemplateResult {

--- a/plugins/web-ui/src/connectors.ts
+++ b/plugins/web-ui/src/connectors.ts
@@ -2,7 +2,7 @@ import { html, render, type TemplateResult } from "lit";
 import { KeyRound, Link, Plug } from "lucide";
 import { api } from "./core-bridge";
 import { errMessage } from "../../chassis/src/errors";
-import { icon } from "./ui";
+import { icon, pixelLoader } from "./ui";
 import { appState, replacePanePreservingFocus } from "./shell";
 import { scopedSession, scopedViewTopbar } from "./session-scope";
 import { focusDialogCancel, restoreDialogFocus, trapDialogFocus } from "./dialog-focus";
@@ -413,7 +413,7 @@ export function noteConnectorResult(provider: string, status: string): void {
 }
 
 function loadingPlaceholder(label: string): TemplateResult {
-  return html`<div class="kc-loading"><span class="spinner"></span>${label}</div>`;
+  return html`<div class="kc-loading">${pixelLoader()}${label}</div>`;
 }
 
 function drawConnectors(): void {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2185,28 +2185,15 @@ a.chat-row-open {
   background: var(--secondary);
   color: var(--foreground);
 }
-.thinking {
-  border-left: 2px solid var(--border);
-  padding-left: 10px;
-  color: var(--muted-foreground);
-  font-size: 13px;
-}
-.thinking summary {
-  cursor: pointer;
-  font-weight: 600;
-}
 .thinking-placeholder {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
   min-height: 24px;
-  color: var(--muted-foreground);
+  color: var(--ink-2);
   font-size: 13px;
+  font-weight: 500;
   line-height: 1.65;
-}
-.thinking-placeholder .wl-swell {
-  flex: 0 0 auto;
-  color: inherit;
 }
 .work-said {
   color: var(--foreground);
@@ -2215,7 +2202,7 @@ a.chat-row-open {
   margin: 10px 0;
 }
 .work-fold {
-  margin: 2px 0;
+  margin: 4px 0;
 }
 .work-message {
   color: color-mix(in srgb, var(--muted-foreground) 85%, var(--foreground));
@@ -2223,49 +2210,22 @@ a.chat-row-open {
   line-height: 1.6;
 }
 .sheen-label {
-  position: relative;
   display: inline-block;
   color: inherit;
 }
-.sheen-label.thinking-sheen::after {
-  content: attr(data-sheen);
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
+.sheen-label.thinking-sheen {
   color: transparent;
-  background-image: linear-gradient(
-    100deg,
-    transparent 0%,
-    transparent 38%,
-    color-mix(in srgb, var(--background) 66%, var(--muted-foreground)) 50%,
-    transparent 62%,
-    transparent 100%
-  );
-  background-size: 46px 100%;
-  background-position: -56px 0;
-  background-repeat: no-repeat;
+  background-image: linear-gradient(90deg, var(--ink-3) 35%, var(--ink) 50%, var(--ink-3) 65%);
+  background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
-  font: inherit;
-  letter-spacing: inherit;
-  animation: thinking-sheen 2.55s linear infinite;
-  will-change: background-position;
-}
-@keyframes thinking-sheen {
-  0% {
-    background-position: -56px 0;
-  }
-  46% {
-    background-position: calc(100% + 56px) 0;
-  }
-  100% {
-    background-position: calc(100% + 56px) 0;
-  }
+  animation: shimmer-text 1.4s linear infinite;
 }
 @media (prefers-reduced-motion: reduce) {
-  .sheen-label.thinking-sheen::after {
+  .sheen-label.thinking-sheen {
     animation: none;
-    opacity: 0;
+    background: none;
+    color: inherit;
   }
 }
 
@@ -2285,51 +2245,66 @@ a.chat-row-open {
 .work-head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 15px;
+  gap: 8px;
+  width: fit-content;
+  max-width: 100%;
+  height: 30px;
+  margin: 0 -6px;
+  padding: 0 6px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
   line-height: 1.4;
-  font-weight: 400;
-  color: var(--muted-foreground);
+  font-weight: 500;
+  color: var(--ink-2);
+}
+summary.work-head:hover {
+  background: var(--hover-2);
 }
 .work-head .icon {
-  color: var(--muted-foreground);
-  transition: transform 140ms ease;
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  transition: transform 300ms var(--ease-out-strong);
 }
 .work[open] > summary.work-head .icon,
 .work-fold[open] > summary.work-head .icon {
   transform: rotate(90deg);
 }
-.work-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 8px 0 10px;
-}
 .work-rows {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
+  margin: 2px 0 6px 7px;
+  padding: 4px 0 4px 16px;
+  border-left: 1px solid var(--line);
 }
 
 .tool-row,
 .tool-row .tool-summary {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
+  min-height: 24px;
   font-size: 13px;
   line-height: 1.35;
-  color: color-mix(in srgb, var(--muted-foreground) 80%, var(--background));
-}
-.tool-row.tool-running {
-  color: var(--muted-foreground);
+  color: var(--ink);
 }
 .tool-row .tool-summary {
   cursor: pointer;
   min-height: 24px;
+  margin: 0 -3px;
+  padding: 1px 3px;
+  border-radius: var(--radius-sm);
+  transition: background-color 100ms;
 }
 .tool-icon {
   display: inline-flex;
   flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--ink-3);
 }
 .tool-icon .icon {
   color: inherit;
@@ -2356,72 +2331,75 @@ a.chat-row-open {
   min-width: 0;
   list-style: none;
   cursor: pointer;
-  color: color-mix(in srgb, var(--muted-foreground) 80%, var(--background));
+  color: var(--ink-2);
   font-size: 13px;
   line-height: 1.35;
+}
+.thinking-summary:hover {
+  color: var(--ink);
 }
 .thinking-summary::-webkit-details-marker {
   display: none;
 }
 .thinking-summary > .icon:last-child {
   flex: 0 0 auto;
-  transition: transform 140ms ease;
+  color: var(--ink-3);
+  transition: transform 300ms var(--ease-out-strong);
 }
 .thinking-row[open] > .thinking-summary > .icon:last-child {
   transform: rotate(90deg);
 }
+@media (prefers-reduced-motion: reduce) {
+  .work-head .icon,
+  .thinking-summary > .icon:last-child {
+    transition: none;
+  }
+}
 .thinking-body {
-  margin: 5px 0 8px 19px;
-  padding-left: 10px;
-  border-left: 2px solid var(--border);
-  color: var(--muted-foreground);
+  min-height: 0;
+  color: var(--ink-2);
   font-size: 13px;
   line-height: 1.55;
 }
-.tool-row.tool-approval {
-  color: var(--foreground);
+.thinking-body {
+  margin: 2px 0 6px 7px;
+  padding: 2px 0 2px 16px;
+  border-left: 1px solid var(--line);
 }
 .tool-row.tool-failed {
-  color: var(--destructive, #c0392b);
-}
-.tool-row.tool-failed .tool-detail {
-  color: color-mix(in srgb, var(--destructive, #c0392b) 75%, var(--background));
+  color: var(--red-ink);
 }
 .approval-card {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 14px 16px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--foreground) 4%, var(--background));
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.45;
 }
 .inline-approval-marker {
-  gap: 8px;
-  padding: 10px 12px;
-}
-.approval-text {
-  display: flex;
-  flex-direction: column;
   gap: 6px;
-  min-width: 0;
+  padding: 10px 12px;
+  font-size: 12.5px;
 }
 .approval-title {
-  font-size: 14px;
   font-weight: 600;
-  color: var(--foreground);
 }
 .approval-cmd {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 13px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--foreground) 8%, var(--background));
-  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--field);
+  color: var(--ink);
   overflow-x: auto;
   white-space: pre;
 }
-
 .approval-cmd-full {
   display: block;
   white-space: pre-wrap;
@@ -2684,7 +2662,7 @@ a.chat-row-open {
 .bg-activity {
   width: min(var(--content-w), calc(100% - 32px));
   margin: 0 auto 8px;
-  color: var(--muted-foreground);
+  color: var(--ink-2);
   font-size: 12.5px;
 }
 .composer-wrap > .bg-activity {
@@ -2697,7 +2675,7 @@ a.chat-row-open {
   border-radius: inherit;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--secondary) 40%, var(--background));
 }
 .readonly-chat .bg-activity {
@@ -2708,19 +2686,26 @@ a.chat-row-open {
   -webkit-appearance: none;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   width: 100%;
   margin: 0;
-  padding: 2px 0;
+  padding: 3px 6px;
   border: none;
+  border-radius: var(--radius-sm);
   background: none;
   color: inherit;
   font: inherit;
+  font-size: 13px;
+  font-weight: 500;
   text-align: left;
   cursor: pointer;
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
 }
 .bg-activity-strip:hover {
-  color: var(--foreground);
+  background: var(--hover-2);
+  color: var(--ink);
 }
 .bg-activity-label {
   min-width: 0;
@@ -2731,6 +2716,7 @@ a.chat-row-open {
 .bg-activity-toggle {
   flex: 0 0 auto;
   display: inline-flex;
+  color: var(--ink-3);
   transition: transform 0.12s ease;
 }
 .bg-activity.expanded .bg-activity-toggle {
@@ -2739,18 +2725,20 @@ a.chat-row-open {
 
 .bg-panel {
   margin-top: 6px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
   padding: 4px;
   display: flex;
   flex-direction: column;
   gap: 2px;
   max-height: 42vh;
   overflow-y: auto;
+  background: var(--surface);
 }
 .bg-panel-note {
   padding: 6px 8px;
-  font-size: 12px;
+  font-size: 12.5px;
+  color: var(--ink-3);
 }
 .bg-row-head {
   text-decoration: none;
@@ -2758,22 +2746,25 @@ a.chat-row-open {
   -webkit-appearance: none;
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   width: 100%;
   margin: 0;
   padding: 5px 8px;
   border: none;
-  border-radius: 7px;
+  border-radius: var(--radius-sm);
   background: none;
   color: inherit;
   font: inherit;
-  font-size: 12px;
+  font-size: 12.5px;
   text-align: left;
   cursor: pointer;
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
 }
 .bg-row-head:hover {
-  background: color-mix(in srgb, var(--muted-foreground) 10%, transparent);
-  color: var(--foreground);
+  background: var(--hover-2);
+  color: var(--ink);
 }
 .bg-row-head.static {
   cursor: default;
@@ -2787,27 +2778,29 @@ a.chat-row-open {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
+  font-family: var(--font-mono);
+  font-size: 12px;
 }
 .bg-row.watch .bg-row-cmd {
   font-family: inherit;
-  font-size: 12px;
+  font-size: 12.5px;
 }
 .bg-row-meta {
   flex: 0 0 auto;
   margin-left: auto;
   white-space: nowrap;
-  font-size: 11px;
-  opacity: 0.85;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 .bg-row-meta code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 .bg-row-toggle {
   flex: 0 0 auto;
   display: inline-flex;
+  color: var(--ink-3);
   transition: transform 0.12s ease;
 }
 .bg-row.open .bg-row-toggle {
@@ -2816,10 +2809,12 @@ a.chat-row-open {
 .bg-row-output {
   margin: 2px 8px 6px;
   padding: 8px 10px;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--muted-foreground) 8%, transparent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--inset);
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 12px;
   line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
@@ -2837,26 +2832,31 @@ a.chat-row-open {
 .live-work-line {
   appearance: none;
   -webkit-appearance: none;
-  margin: 0;
-  padding: 2px 0;
+  margin: 0 -8px;
+  padding: 3px 8px;
   border: none;
   background: none;
   color: inherit;
   font: inherit;
   text-align: left;
-  width: 100%;
+  width: calc(100% + 16px);
   min-height: 24px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   min-width: 0;
-  font-size: 15px;
+  font-size: 13px;
+  font-weight: 500;
   line-height: 1.4;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
 }
 .live-work-line:not(.static):hover {
-  color: var(--foreground);
+  background: var(--hover-2);
+  color: var(--ink);
 }
 .live-work-line.static,
 .live-work-line:disabled {
@@ -2865,10 +2865,6 @@ a.chat-row-open {
 .live-work-line:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--brand-accent) 60%, transparent);
   outline-offset: 2px;
-}
-.live-work-line .tool-icon {
-  flex: 0 0 auto;
-  color: color-mix(in srgb, var(--muted-foreground) 86%, var(--background));
 }
 .live-work-label {
   flex: 0 1 auto;
@@ -2883,14 +2879,16 @@ a.chat-row-open {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: color-mix(in srgb, var(--muted-foreground) 72%, var(--background));
+  color: var(--ink-3);
+  font-size: 12.5px;
+  font-weight: 400;
 }
 .live-work-toggle {
   flex: 0 0 auto;
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  color: color-mix(in srgb, var(--muted-foreground) 70%, var(--background));
+  color: var(--ink-3);
   transition: transform 0.15s ease;
 }
 
@@ -4248,21 +4246,9 @@ a.chat-row-open {
   align-items: center;
   gap: 10px;
   padding: 24px;
-  color: var(--muted-foreground);
-  font-size: 14px;
-}
-.kc-loading .spinner {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--muted-foreground) 30%, transparent);
-  border-top-color: var(--muted-foreground);
-  animation: chat-spin 0.7s linear infinite;
-}
-@media (prefers-reduced-motion: reduce) {
-  .kc-loading .spinner {
-    animation: none;
-  }
+  color: var(--ink-2);
+  font-size: 13px;
+  font-weight: 500;
 }
 .kc-empty {
   display: flex;
@@ -10594,12 +10580,7 @@ h3.ambient-field-label {
   border-radius: 50%;
   border: 2px solid var(--border);
   border-top-color: var(--foreground);
-  animation: mc-spin 0.7s linear infinite;
-}
-@keyframes mc-spin {
-  to {
-    transform: rotate(360deg);
-  }
+  animation: spin 0.7s linear infinite;
 }
 .mc-close {
   position: absolute;

--- a/plugins/web-ui/src/styles/loading.css
+++ b/plugins/web-ui/src/styles/loading.css
@@ -1,0 +1,44 @@
+.pixel-loader {
+  display: grid;
+  grid-template-columns: repeat(3, 4px);
+  gap: 1.5px;
+  flex: 0 0 auto;
+  color: var(--ink);
+}
+.pixel-loader > i {
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 1px;
+  background: currentColor;
+  opacity: 0.15;
+  animation: pixel-on 650ms ease-in-out infinite;
+}
+.pixel-loader > i:nth-child(1),
+.pixel-loader > i:nth-child(5),
+.pixel-loader > i:nth-child(7) {
+  animation-delay: 90ms;
+}
+.pixel-loader > i:nth-child(2),
+.pixel-loader > i:nth-child(6),
+.pixel-loader > i:nth-child(8) {
+  animation-delay: 180ms;
+}
+.pixel-loader > i:nth-child(3),
+.pixel-loader > i:nth-child(9) {
+  animation-delay: 270ms;
+}
+.live-work-elapsed {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pixel-loader > i {
+    animation: none;
+    opacity: 0.5;
+  }
+}

--- a/plugins/web-ui/src/styles/thinking.css
+++ b/plugins/web-ui/src/styles/thinking.css
@@ -1,0 +1,159 @@
+.work-glyph {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--ink-3);
+}
+.work-glyph.live {
+  color: var(--ink-2);
+}
+.work-glyph > .icon {
+  fill: currentColor;
+  stroke: none;
+}
+.work-glyph-failed {
+  color: var(--red);
+}
+.work-glyph-failed > .icon {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.5;
+}
+.work-title {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.work-body {
+  min-height: 0;
+}
+.trace-item,
+.trace-reason,
+.trace-search-query,
+.trace-search-result,
+.trace-more {
+  animation: fade-up 320ms var(--ease-out-strong) both;
+  animation-delay: calc(var(--i, 0) * 120ms);
+}
+.trace-reason {
+  padding: 4px 6px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+.thinking-body .trace-reason {
+  padding: 2px 0;
+}
+.trace-search {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.trace-search-query {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 24px;
+  padding: 0 6px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+}
+.trace-search-query .icon {
+  flex: none;
+  color: var(--ink-3);
+}
+.trace-search-result {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  color: var(--ink);
+  text-decoration: none;
+  transition: background-color 150ms var(--ease-out-strong);
+}
+.trace-search-result:hover {
+  background: var(--hover);
+}
+.trace-search-result:hover .trace-search-title {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.trace-favicon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--blue);
+  color: #fff;
+}
+.trace-favicon[data-tone="1"] {
+  background: var(--orange);
+}
+.trace-favicon[data-tone="2"] {
+  background: var(--green);
+}
+.trace-favicon .icon {
+  stroke-width: 2.5;
+}
+.trace-search-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+  font-weight: 500;
+}
+.trace-search-host {
+  flex: none;
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+.trace-more {
+  padding: 2px 6px;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+.work-fold::details-content,
+.work-working::details-content,
+.thinking-row::details-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: 0fr;
+  opacity: 0;
+  overflow: clip;
+  transition:
+    grid-template-rows 400ms var(--ease-out-strong),
+    opacity 400ms var(--ease-out-strong),
+    content-visibility 400ms allow-discrete;
+}
+.work-fold[open]::details-content,
+.work-working[open]::details-content,
+.thinking-row[open]::details-content {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  .work-fold::details-content,
+  .work-working::details-content,
+  .thinking-row::details-content {
+    transition: none;
+  }
+  .trace-item,
+  .trace-reason,
+  .trace-search-query,
+  .trace-search-result,
+  .trace-more {
+    animation: none;
+  }
+}

--- a/plugins/web-ui/src/timeline.ts
+++ b/plugins/web-ui/src/timeline.ts
@@ -90,6 +90,16 @@ export function toolRowKind(row: ToolRowModel, status: WorkBlock["status"]): Too
   return failed ? "failed" : "ok";
 }
 
+export type SegmentStatus = "running" | "ok" | "failed" | "stopped";
+
+export function segmentStatus(items: TimelineItem[], status: WorkBlock["status"]): SegmentStatus {
+  if (!isTerminalWorkStatus(status)) return "running";
+  if (status === "failed") return "failed";
+  const kinds = new Set(items.map((it) => (it.kind === "tool" ? toolRowKind(it.row, status) : null)));
+  if (kinds.has("failed")) return "failed";
+  return kinds.has("attempted") ? "stopped" : "ok";
+}
+
 function callIdOf(a: ToolActivity): string | undefined {
   const id = (a.payload as { callId?: unknown } | null)?.callId;
   return typeof id === "string" && id ? id : undefined;

--- a/plugins/web-ui/src/ui.ts
+++ b/plugins/web-ui/src/ui.ts
@@ -36,6 +36,16 @@ export function waveLoader(
   </svg>`;
 }
 
+export function pixelLoader(label?: string): TemplateResult {
+  return html`<span
+    class="pixel-loader"
+    role=${label ? "status" : nothing}
+    aria-label=${label ?? nothing}
+    aria-hidden=${label ? nothing : "true"}
+    ><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i
+  ></span>`;
+}
+
 export function workingWave(): TemplateResult {
   return waveLoader({
     width: 13.6,

--- a/plugins/web-ui/src/work-duration.ts
+++ b/plugins/web-ui/src/work-duration.ts
@@ -1,18 +1,30 @@
 import type { WorkBlock } from "./core-bridge";
 
+function activityTimes(work: WorkBlock): number[] {
+  return work.activity.map((a) => a.createdAt).filter((t): t is number => typeof t === "number" && t > 0);
+}
+
+export function workStartedAt(work: WorkBlock): number | null {
+  if (work.startedAt != null) return work.startedAt;
+  const times = activityTimes(work);
+  return times.length ? Math.min(...times) : null;
+}
+
 export function workSeconds(work: WorkBlock): number {
-  const times = work.activity.map((a) => a.createdAt).filter((t) => typeof t === "number" && t > 0);
-  const start = work.startedAt ?? (times.length ? Math.min(...times) : null);
+  const start = workStartedAt(work);
   if (start == null) return 0;
   const live = work.status === "thinking" || work.status === "working";
-  let end = work.finishedAt;
-  if (end == null) {
-    if (live) end = Date.now();
-    else end = times.length ? Math.max(...times, start) : start;
-  }
+  const end = work.finishedAt ?? (live ? Date.now() : Math.max(start, ...activityTimes(work)));
   return Math.max(0, Math.round((end - start) / 1000));
 }
 
 export function workedLabel(prefix: string, secs: number): string {
   return secs > 0 ? `${prefix} for ${secs}s` : prefix;
+}
+
+export function elapsedLabel(ms: number): string {
+  const tenths = Math.max(0, Math.floor(ms / 100));
+  if (tenths < 600) return `${(tenths / 10).toFixed(1)}s`;
+  const secs = Math.floor(tenths / 10);
+  return `${Math.floor(secs / 60)}m ${String(secs % 60).padStart(2, "0")}s`;
 }

--- a/plugins/web-ui/test/keychain-flow.test.ts
+++ b/plugins/web-ui/test/keychain-flow.test.ts
@@ -196,5 +196,5 @@ test("keychain page renders loading placeholders instead of empty states while l
     /api<\{ providers\?: Record<string, ConnectorProvider> \}>\("\/api\/connectors"\)\.then\(/,
   );
   assert.doesNotMatch(connectorsSource, /drawConnectors\((true|false)\)/);
-  assert.match(shellCssSource, /\.kc-loading \.spinner/);
+  assert.match(connectorsSource, /class="kc-loading">\$\{pixelLoader\(\)\}/);
 });

--- a/plugins/web-ui/test/pixel-loader.test.ts
+++ b/plugins/web-ui/test/pixel-loader.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+import { elapsedLabel } from "../src/work-duration.ts";
+
+test("elapsedLabel shows tenths under a minute and zero-padded seconds after", () => {
+  assert.equal(elapsedLabel(0), "0.0s");
+  assert.equal(elapsedLabel(-500), "0.0s");
+  assert.equal(elapsedLabel(8_240), "8.2s");
+  assert.equal(elapsedLabel(59_960), "59.9s");
+  assert.equal(elapsedLabel(60_000), "1m 00s");
+  assert.equal(elapsedLabel(64_400), "1m 04s");
+  assert.equal(elapsedLabel(3_725_000), "62m 05s");
+});
+
+test("pixelLoader renders a nine-cell grid that announces only when labelled", async () => {
+  const dom = new JSDOM("<main></main>");
+  Object.assign(globalThis, { window: dom.window, document: dom.window.document });
+  const { render } = await import("lit");
+  const { pixelLoader } = await import("../src/ui.ts");
+  const host = dom.window.document.querySelector("main")!;
+
+  render(pixelLoader("Loading"), host);
+  const labelled = host.querySelector(".pixel-loader")!;
+  assert.equal(labelled.querySelectorAll("i").length, 9);
+  assert.equal(labelled.getAttribute("role"), "status");
+  assert.equal(labelled.getAttribute("aria-label"), "Loading");
+  assert.equal(labelled.hasAttribute("aria-hidden"), false);
+  assert.ok([...labelled.querySelectorAll("i")].every((cell) => !cell.hasAttribute("style")));
+
+  const css = readFileSync(new URL("../src/styles/loading.css", import.meta.url), "utf8");
+  const delayOf = (n: number): number =>
+    Number(
+      css.match(new RegExp(`\\.pixel-loader > i:nth-child\\(${n}\\)[^{]*\\{\\s*animation-delay: (\\d+)ms;`))?.[1] ?? 0,
+    );
+  assert.deepEqual([1, 2, 3, 4, 5, 6, 7, 8, 9].map(delayOf), [90, 180, 270, 0, 90, 180, 90, 180, 270]);
+
+  render(pixelLoader(), host);
+  const decorative = host.querySelector(".pixel-loader")!;
+  assert.equal(decorative.getAttribute("aria-hidden"), "true");
+  assert.equal(decorative.hasAttribute("role"), false);
+  assert.equal(decorative.hasAttribute("aria-label"), false);
+});

--- a/plugins/web-ui/test/timeline.test.ts
+++ b/plugins/web-ui/test/timeline.test.ts
@@ -1,7 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { ToolActivity, WorkBlock } from "../src/core-bridge.ts";
-import { buildTimeline, toolCategory, toolRowKind, toolExecutionOutput, type ToolRowModel } from "../src/timeline.ts";
+import {
+  buildTimeline,
+  segmentStatus,
+  toolRowKind,
+  type ToolRowModel,
+  toolCategory,
+  toolExecutionOutput,
+} from "../src/timeline.ts";
 
 function act(seq: number, type: ToolActivity["type"], payload: unknown): ToolActivity {
   return { seq, parentSeq: null, type, payload, createdAt: seq };
@@ -301,71 +308,43 @@ test("memoized output still reflects a mutated-then-replaced work correctly", ()
   assert.equal(items[1]?.kind, "tool");
 });
 
-test("unified sandbox execution keeps legacy failure and display semantics", () => {
-  for (const identity of [{ tool: "execute" }, { tool: "sandbox", action: "exec" }]) {
-    assert.equal(toolCategory(identity), "execute");
-    assert.equal(toolRowKind(row(identity, { ...identity, code: 1, stdout: "failed" }), "complete"), "failed");
-    assert.equal(toolRowKind(row(identity, { ...identity, code: 0, stdout: "ok" }), "complete"), "ok");
-    assert.equal(
-      toolRowKind({ call: null, result: act(1, "tool_result", { ...identity, code: 2 }) }, "complete"),
-      "failed",
-    );
-  }
-  for (const action of [
-    "start_process",
-    "read_process",
-    "write_stdin",
-    "signal_process",
-    "list_processes",
-    "watch_process",
-    "unwatch_process",
-  ])
-    assert.equal(toolCategory({ tool: "sandbox", action }), "background");
-  assert.equal(toolCategory({ tool: "sandbox", action: "status" }), "sandbox");
-});
-
-test("different sandbox actions and process targets do not collapse into one orphan attempt", () => {
-  const actions = [
-    { action: "status", sandbox_id: "box-a" },
-    { action: "restart", sandbox_id: "box-a" },
-    { action: "status", sandbox_id: "box-b" },
-    { action: "read_process", process_id: "job-a" },
-    { action: "read_process", process_id: "job-b" },
+test("a fold's capsule glyph follows its tools: a ring while live, red once any tool failed, neutral when a call never answered, green otherwise", () => {
+  const ok = [
+    act(1, "tool_call", { tool: "execute", command: "ls" }),
+    act(2, "tool_result", { tool: "execute", code: 0 }),
   ];
-  const items = buildTimeline({
-    status: "complete",
-    activity: actions.map((action, index) => act(index, "tool_call", { tool: "sandbox", ...action })),
-  });
-  assert.equal(items.length, actions.length);
+  const crashed = [
+    act(3, "tool_call", { tool: "execute", command: "make" }),
+    act(4, "tool_result", { tool: "execute", code: 2 }),
+  ];
+  const unanswered = [act(5, "tool_call", { tool: "execute", command: "sleep 99" })];
+  const fold = (status: WorkBlock["status"], activity: ToolActivity[]) =>
+    segmentStatus(buildTimeline({ status, activity }), status);
+  assert.equal(fold("working", ok), "running");
+  assert.equal(fold("complete", ok), "ok");
+  assert.equal(fold("complete", [...ok, ...crashed]), "failed", "one non-zero exit turns the whole fold red");
+  assert.equal(fold("failed", ok), "failed", "a failed turn marks its folds even when every tool returned");
+  assert.equal(fold("complete", [act(1, "thinking", { thinking: "hm" })]), "ok");
+  assert.equal(fold("complete", [...ok, ...unanswered]), "stopped", "a call that never reported back is not a success");
+  assert.equal(
+    fold("complete", [...unanswered, ...crashed]),
+    "failed",
+    "a real failure still outranks an unanswered call",
+  );
+  assert.equal(fold("working", unanswered), "running", "mid-turn the same call is simply still running");
 });
 
-test("unscreened execution retains its warning and failure status without parsing command text", () => {
-  const result = {
-    tool: "sandbox",
-    action: "exec",
-    code: 7,
-    timedOut: false,
-    isError: true,
-    unscreened: true,
-    result: "[NOT security-screened]\nQA_EXPECTED_FAILURE\n[exit 7]",
-  };
-  assert.equal(
-    toolRowKind(row({ tool: "sandbox", action: "exec", sandbox_id: "box-a" }, result), "complete"),
-    "failed",
-  );
-  assert.equal(toolExecutionOutput(result), result.result);
-  assert.equal(
-    toolRowKind(row({ tool: "execute" }, { code: 0, stdout: "fake [exit 7]", isError: false }), "complete"),
-    "ok",
-  );
-  assert.equal(toolRowKind(row({ tool: "execute" }, { code: 0, timedOut: true }), "complete"), "failed");
-  assert.equal(toolExecutionOutput({ stdout: "", stderr: "", code: 0 }), "");
-  assert.equal(toolExecutionOutput({ isError: true, result: "[tool output quarantined]" }), null);
-  assert.equal(
-    toolRowKind(
-      row({ tool: "sandbox", action: "exec" }, { isError: true, result: "[tool output quarantined]" }),
-      "complete",
-    ),
-    "failed",
-  );
+test("the unified sandbox tool is categorised by action for labels and failure detection", () => {
+  assert.equal(toolCategory({ tool: "sandbox", action: "exec" }), "execute");
+  assert.equal(toolCategory({ tool: "sandbox", action: "start_process" }), "background");
+  assert.equal(toolCategory({ tool: "sandbox", action: "snapshot" }), "sandbox");
+  assert.equal(toolCategory({ tool: "read" }), "read");
+  const row = {
+    call: { type: "tool_call", payload: { tool: "sandbox", action: "exec", command: "false" } },
+    result: { type: "tool_result", payload: { tool: "sandbox", code: 1 } },
+  } as unknown as ToolRowModel;
+  assert.equal(toolRowKind(row, "complete"), "failed");
+  assert.equal(toolExecutionOutput({ unscreened: true, result: "raw" }), "raw");
+  assert.equal(toolExecutionOutput({ stdout: "ok", stderr: "warn" }), "ok\n[stderr]\nwarn");
+  assert.equal(toolExecutionOutput({}), null);
 });

--- a/plugins/web-ui/test/work-duration-reconciliation.test.ts
+++ b/plugins/web-ui/test/work-duration-reconciliation.test.ts
@@ -89,10 +89,10 @@ test("live and historical rendering consume the same duration helper (source-lev
   const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
   assert.match(
     chat,
-    /import \{ workSeconds, workedLabel \} from "\.\/work-duration"/,
+    /import \{ elapsedLabel, workSeconds, workStartedAt, workedLabel \} from "\.\/work-duration"/,
     "chat renders via the shared helper",
   );
 
-  assert.match(chat, /`Working for \$\{secs\}s` : workedLabel\("Worked", secs\)/);
+  assert.match(chat, /workedLabel\("Thought", secs\)/);
   assert.match(chat, /function segmentSummaryLabel[\s\S]{0,400}?workSeconds\(work\)/);
 });

--- a/plugins/web-ui/test/work-fold-source.test.ts
+++ b/plugins/web-ui/test/work-fold-source.test.ts
@@ -34,8 +34,8 @@ test("the fold chevron rotates when a work-fold is open", () => {
 });
 
 test("expanded tool activity uses a compact log rhythm", () => {
-  assert.match(css, /\.work-divider \{[\s\S]{0,120}?margin: 8px 0 10px;/);
-  assert.match(css, /\.work-rows \{[\s\S]{0,120}?gap: 5px;/);
+  assert.match(css, /\.work-rows \{[\s\S]{0,120}?border-left: 1px solid var\(--line\);/);
+  assert.match(css, /\.work-rows \{[\s\S]{0,120}?gap: 4px;/);
   assert.match(css, /\.tool-row,[\s\S]{0,220}?font-size: 13px;[\s\S]{0,80}?line-height: 1\.35;/);
   assert.match(css, /\.tool-row \.tool-summary \{[\s\S]{0,80}?min-height: 24px;/);
   assert.match(chat, /icon\(meta\.icon, 13\)/);


### PR DESCRIPTION
## Summary

Loading: a 3×3 pixel-grid loader replaces the wave loader on the chat surface,
the working label shimmers, and the live status above the composer shows the
elapsed time of the current tool. Thinking: the streaming assistant row renders
the reference Thinking trace — open while the run is active with a shimmering
"Thinking" / "Searching the web" / "Running tools" header, reasoning
paragraphs, tool rows and search results fading up onto a guide line as they
arrive — and settles to a collapsed "Thought for Ns" / "Searched the web" /
"Ran N tools" header. Tool rows gain the compact label + mono detail layout
the trace relies on. Restores upstream's sandbox tool categorisation helpers in
the timeline so unified sandbox calls keep their labels and output.

## Demo

First: the pixel-grid loader, shimmer label and elapsed counter while a command runs. Second: the trace opens live with "Thinking" then "Running tools", tool rows fade in as they run, and it settles to "Thought for Ns" / "Ran 4 tools".

![02-loading.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/02-loading.gif)

![03-thinking-trace.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/03-thinking-trace.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 (this) | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
