### PR TITLE
web-ui: chat rows, session header and empty state

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -23,6 +23,7 @@ import {
   GitFork,
   Globe,
   type IconNode,
+  Lock,
   Maximize2,
   Paperclip,
   Pause,
@@ -966,7 +967,7 @@ export function createChatSurface(
       render(
         html`
           <div class="custom-chat-shell">
-            ${chatHeader(groupDmTitle(s), surfaceOf(s), true)}
+            ${chatHeader(groupDmTitle(s))}
             <div class="readonly-banner">
               ${
                 surfaceOf(s) === "slack"
@@ -1403,12 +1404,12 @@ export function createChatSurface(
     });
   }
 
-  function chatHeader(title: string | TemplateResult, detail: string, readOnly: boolean): TemplateResult {
+  function chatHeader(title: string | TemplateResult): TemplateResult {
     return html`
-      <header class="chat-topbar">
-        <div class="chat-heading">
-          <div class="chat-title" dir="auto">${title}</div>
-          <div class="chat-subtitle">${readOnly ? "Read-only" : detail}</div>
+      <header class="chat-topbar session-topbar">
+        <div class="session-heading">
+          <span class="session-title" dir="auto">${title}</span>
+          <span class="shared-view-badge">${icon(Lock, 12)}Read-only</span>
         </div>
       </header>
     `;
@@ -1615,7 +1616,7 @@ export function createChatSurface(
                 aria-label="Copy message"
                 @click=${(e: Event) => void copyMessage(text, e.currentTarget as HTMLButtonElement)}
               >
-                ${icon(Copy, 13)}
+                ${icon(Copy, 15)}
               </button>`
             : nothing
         }
@@ -1628,7 +1629,7 @@ export function createChatSurface(
                 aria-label="Fork conversation from here"
                 @click=${() => void forkFromMessage(index)}
               >
-                ${icon(GitFork, 13)}
+                ${icon(GitFork, 15)}
               </button>`
             : nothing
         }
@@ -1690,11 +1691,11 @@ export function createChatSurface(
       return;
     }
     btn.classList.add("copied");
-    btn.replaceChildren(icon(Check, 13));
+    btn.replaceChildren(icon(Check, 15));
     setTimeout(() => {
       if (!btn.isConnected) return;
       btn.classList.remove("copied");
-      btn.replaceChildren(icon(Copy, 13));
+      btn.replaceChildren(icon(Copy, 15));
     }, 1200);
   }
 

--- a/plugins/web-ui/src/session-scope.ts
+++ b/plugins/web-ui/src/session-scope.ts
@@ -99,18 +99,18 @@ export interface SessionTopbarOpts {
 export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
   const crumbTpl = ((): TemplateResult | typeof nothing => {
     if (!o.crumb) return nothing;
-    if (!o.onCrumb) return html`<span class="session-crumb">${o.crumb}</span><span class="session-crumb-sep">/</span>`;
+    if (!o.onCrumb) return html`<span class="session-crumb">${o.crumb}</span>`;
     return html`<button
-        class="session-crumb as-link"
-        type="button"
-        ${tip(`Open the ${o.crumb} project`)}
-        @click=${(e: Event) => {
-          e.stopPropagation();
-          o.onCrumb!();
-        }}
-      >
-        ${o.crumb}</button
-      ><span class="session-crumb-sep">/</span>`;
+      class="session-crumb as-link"
+      type="button"
+      ${tip(`Open the ${o.crumb} project`)}
+      @click=${(e: Event) => {
+        e.stopPropagation();
+        o.onCrumb!();
+      }}
+    >
+      ${o.crumb}
+    </button>`;
   })();
   const heading = html`
     ${crumbTpl} ${o.title ? html`<span class="session-title" dir="auto">${o.title}</span>` : nothing}
@@ -186,7 +186,7 @@ export function sessionTopbarTpl(o: SessionTopbarOpts): TemplateResult {
           aria-expanded="false"
           @click=${toggleFormMenu}
         >
-          ${icon(Ellipsis, 20)}
+          ${icon(Ellipsis, 16)}
         </button>
         <div class="menu-popover" role="menu" hidden>
           <div class="menu-title">This conversation's workspace</div>

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1290,136 +1290,115 @@ a.chat-row-open {
   outline-offset: 2px;
 }
 .chat-topbar {
+  min-width: 0;
   position: relative;
   z-index: 1;
-  height: 56px;
+  height: 40px;
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 16px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
-  background: color-mix(in srgb, var(--background) 94%, var(--secondary));
-}
-.chat-heading {
-  min-width: 0;
-  flex: 1;
-}
-.chat-title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 14px;
-  font-weight: 650;
-  line-height: 1.25;
-}
-.chat-subtitle {
-  color: var(--muted-foreground);
-  font-size: 12px;
-  line-height: 1.25;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  gap: 8px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--line);
+  background: var(--background);
 }
 .topbar-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
-}
-.session-topbar {
-  gap: 12px;
+  gap: 2px;
 }
 .session-heading {
   min-width: 0;
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: 2px;
+  font-size: 13px;
   line-height: 1.25;
 }
-.session-crumb {
-  color: var(--muted-foreground);
+.session-crumb,
+.session-title {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 0 3 auto;
 }
-.session-crumb-sep {
-  color: color-mix(in srgb, var(--muted-foreground) 65%, transparent);
-  flex: none;
+.session-crumb {
+  flex: 0 3 auto;
+  color: var(--ink-2);
 }
 .session-title {
   min-width: 0;
   flex: 0 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  background: var(--field);
+  color: var(--ink);
+  font-weight: 500;
 }
 .session-fork-badge {
   flex: none;
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--muted);
-  color: var(--muted-foreground);
+  margin-left: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-chip);
+  background: var(--surface);
+  color: var(--ink-2);
   font-size: 11.5px;
-  font-weight: 550;
+  font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
 }
 .session-fork-badge:hover:not(:disabled) {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--secondary) 85%, transparent);
+  color: var(--ink);
+  background: var(--hover);
 }
 .session-fork-badge:disabled {
   cursor: default;
 }
 .session-tools {
-  gap: 2px;
   flex: none;
 }
 .session-tool {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  padding: 0;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  height: 30px;
-  padding: 0 10px;
+  justify-content: center;
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--muted-foreground);
-  font-size: 12.5px;
-  font-weight: 550;
+  color: var(--ink-3);
   cursor: pointer;
-  white-space: nowrap;
 }
 .session-tool:hover {
-  background: color-mix(in srgb, var(--secondary) 70%, transparent);
-  color: var(--foreground);
+  background: var(--hover);
+  color: var(--ink);
 }
 .session-tool.active {
-  background: color-mix(in srgb, var(--secondary) 85%, transparent);
-  color: var(--foreground);
+  background: var(--field);
+  color: var(--ink);
 }
 .session-tool-count {
-  min-width: 15px;
-  padding: 0 4px;
+  min-width: 14px;
+  padding: 0 3px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--secondary) 90%, transparent);
-  color: var(--muted-foreground);
-  font-size: 10.5px;
+  background: var(--field);
+  color: var(--ink-2);
+  font-size: 10px;
   font-weight: 600;
-  line-height: 15px;
+  line-height: 14px;
   text-align: center;
+  font-variant-numeric: tabular-nums;
 }
 .session-tool.active .session-tool-count,
 .session-tool:hover .session-tool-count {
-  color: var(--foreground);
+  background: var(--hover-2);
+  color: var(--ink);
 }
 .session-heading.as-link {
   border: 0;
@@ -1431,7 +1410,7 @@ a.chat-row-open {
   font: inherit;
 }
 .session-heading.as-link:hover .session-title {
-  text-decoration: underline;
+  background: var(--hover-2);
 }
 .pane .session-topbar {
   margin: -28px -28px 12px;
@@ -1454,38 +1433,30 @@ a.chat-row-open {
 .session-crumb.as-link {
   border: 0;
   background: transparent;
-  padding: 0;
   font: inherit;
   cursor: pointer;
-  color: var(--muted-foreground);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 0 3 auto;
 }
 .session-crumb.as-link:hover {
-  color: var(--foreground);
-  text-decoration: underline;
+  background: var(--hover);
+  color: var(--ink);
 }
 .icon-btn {
-  width: 34px;
-  height: 34px;
+  width: 28px;
+  height: 28px;
   padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--foreground);
+  color: var(--ink-3);
   cursor: pointer;
   text-decoration: none;
 }
 .icon-btn:hover {
-  background: var(--secondary);
-}
-.icon-btn.subtle {
-  color: var(--muted-foreground);
+  background: var(--hover);
+  color: var(--ink);
 }
 .icon-btn.compact {
   width: 28px;
@@ -1659,9 +1630,6 @@ a.chat-row-open {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-
-  /* The space between blocks lives in each row's reserved meta lane (see .message-row), so the
-     stack adds none of its own — a hover footer can never overhang the block below. */
   gap: 0;
 }
 .empty-stack {
@@ -1672,20 +1640,18 @@ a.chat-row-open {
   width: 100%;
   max-width: var(--content-w);
   margin: 0 0 20px;
-  font-size: 26px;
-  font-weight: 450;
-  letter-spacing: -0.01em;
+  color: var(--ink);
+  font-size: 21px;
+  font-weight: 600;
+  line-height: 1.375;
+  letter-spacing: -0.02em;
   text-align: center;
+  text-wrap: balance;
 }
 @container chat (min-width: 471px) {
   .custom-chat-shell.empty-chat .composer-wrap {
     width: min(calc(var(--content-w) * 0.75), 75%);
     margin-inline: auto;
-  }
-}
-@container chat (max-width: 470px) {
-  .chat-cta {
-    font-size: 22px;
   }
 }
 
@@ -1695,17 +1661,13 @@ a.chat-row-open {
   max-width: var(--content-w);
 }
 .welcome-greeting .assistant-body {
-  font-size: 15px;
+  font-size: 13.5px;
   line-height: 1.55;
 }
 .message-row {
   display: flex;
   min-width: 0;
   position: relative;
-  /* A lane at the bottom of every row that belongs to that row's own hover footer. It doubles
-     as the rhythm between blocks, so reserving it costs almost no height — and because the
-     footer paints inside its own row, it can never overlay the block below (most visibly a
-     collapsed 'Worked for Ns' header). Revealing the footer still changes no layout. */
   padding-bottom: var(--meta-lane);
 }
 .user-row {
@@ -1743,33 +1705,26 @@ a.chat-row-open {
   }
 }
 
-.assistant-row + .user-row {
-  margin-top: 10px;
-}
-
-.steer-label {
-  font-size: 11px;
-  color: var(--muted-foreground);
-  margin: 2px 4px 3px 0;
+.steer-label,
+.speaker-label,
+.revision-badge {
+  font-size: 12px;
+  line-height: 1.3;
+  color: var(--ink-3);
   user-select: none;
+}
+.steer-label,
+.speaker-label {
+  margin: 0 4px 4px 0;
+}
+.speaker-label {
+  font-weight: 500;
 }
 .steered-row .user-bubble {
-  border: 1px dashed var(--border);
+  border: 1px dashed var(--line-strong);
 }
-
-.speaker-label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--muted-foreground);
-  margin: 2px 4px 3px 0;
-  user-select: none;
-}
-
 .revision-badge {
-  font-size: 11px;
-  color: var(--muted-foreground);
   margin-left: 6px;
-  user-select: none;
 }
 
 .deleted-bubble {
@@ -1784,7 +1739,8 @@ a.chat-row-open {
 }
 .system-note {
   font-size: 12px;
-  color: var(--muted-foreground);
+  line-height: 1.3;
+  color: var(--ink-3);
   text-align: center;
   padding: 2px 10px;
 }
@@ -1792,11 +1748,6 @@ a.chat-row-open {
   font-style: italic;
 }
 
-/* The hover footer (timestamp + copy/fork) sits in its row's reserved bottom lane: out of flow,
-   so revealing it never reflows, but inside the row's own box, so it never paints over the next
-   block and needs no opaque backing. The lane is part of the row, so no hover bridge is needed
-   to reach it either. pointer-events (not visibility) gates interaction, so the buttons stay
-   keyboard-focusable while hidden — that is what lets :focus-within reveal the footer. */
 .message-meta {
   position: absolute;
   bottom: 0;
@@ -1806,29 +1757,25 @@ a.chat-row-open {
   align-items: center;
   gap: 8px;
   height: var(--meta-lane);
-  padding: 0 2px;
-  border-radius: 6px;
-  color: var(--muted-foreground);
-  font-size: 11px;
+  padding: 0;
+  color: var(--ink-3);
+  font-size: 12px;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.12s ease;
+  transition: opacity 120ms ease;
 }
 .user-row .message-meta {
   left: auto;
   right: 0;
 }
 .assistant-body .message-meta {
-  margin-left: -2px;
+  margin-left: -4px;
 }
 .message-row:hover .message-meta,
 .message-meta:focus-within {
   opacity: 1;
   pointer-events: auto;
 }
-
-/* Hoverless (touch) devices can't reveal the footer, and a tap can't focus a control that
-   ignores pointer events — so there it simply stays visible in its lane. */
 @media (hover: none) {
   .message-meta {
     opacity: 1;
@@ -1836,8 +1783,10 @@ a.chat-row-open {
   }
 }
 .message-time {
+  padding: 0 4px;
   white-space: nowrap;
-  letter-spacing: 0.01em;
+  font-family: var(--font-mono);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
 .msg-copy {
@@ -1848,20 +1797,24 @@ a.chat-row-open {
   justify-content: center;
   padding: 0;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-chip);
   background: transparent;
-  color: var(--muted-foreground);
+  color: var(--ink-3);
   cursor: pointer;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
 }
 .msg-copy:hover {
-  background: var(--secondary);
-  color: var(--foreground);
+  background: var(--hover-2);
+  color: var(--ink-2);
 }
 .msg-copy.copied {
-  color: var(--foreground);
+  color: var(--green-ink);
 }
 @media (prefers-reduced-motion: reduce) {
-  .message-meta {
+  .message-meta,
+  .msg-copy {
     transition: none;
   }
 }
@@ -1870,9 +1823,9 @@ a.chat-row-open {
 }
 .assistant-body {
   min-width: 0;
-  color: var(--foreground);
-  font-size: 15px;
-  line-height: 1.65;
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.55;
 }
 .assistant-body markdown-block,
 .user-bubble markdown-block {
@@ -1882,17 +1835,7 @@ a.chat-row-open {
   position: relative;
 }
 .streaming-text .tok-in {
-  animation: tok-in 0.42s ease-out both;
-}
-@keyframes tok-in {
-  from {
-    opacity: 0;
-    filter: blur(1.5px);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-  }
+  animation: fade-in 240ms var(--ease-out-strong) both;
 }
 @media (prefers-reduced-motion: reduce) {
   .streaming-text .tok-in {
@@ -1907,9 +1850,6 @@ a.chat-row-open {
 .user-bubble markdown-block > *:last-child {
   margin-bottom: 0;
 }
-/* A streaming reply renders as two stacked blocks (committed prefix + live tail). Restore the
-   paragraph gap at their seam that the edge-trim rules above would otherwise remove; `revert`
-   is the UA-default margin, which is what an uncut paragraph boundary gets. */
 .assistant-body .streaming-text markdown-block:not(:first-of-type) > *:first-child {
   margin-top: revert;
 }
@@ -1918,15 +1858,15 @@ a.chat-row-open {
 }
 .message-bubble {
   min-width: 0;
-  max-width: min(72%, 620px);
+  max-width: min(75%, 620px);
   padding: 10px 14px;
-  border-radius: 18px;
-  font-size: 15px;
-  line-height: 1.55;
+  border-radius: var(--radius-md);
+  font-size: 14px;
+  line-height: 1.5;
 }
 .user-bubble {
-  background: color-mix(in srgb, var(--secondary) 76%, var(--background));
-  color: var(--foreground);
+  background: var(--field);
+  color: var(--ink);
   overflow-wrap: anywhere;
 }
 .message-stack .user-row:not(:has(~ .user-row)) .user-bubble {
@@ -4777,8 +4717,7 @@ summary.work-head:hover {
   .session-tool span {
     display: none;
   }
-  .session-crumb,
-  .session-crumb-sep {
+  .session-crumb {
     display: none;
   }
   .message-stack {
@@ -8528,10 +8467,13 @@ h3.ambient-field-label {
 }
 .inbox-chat-cta {
   margin: 0;
+  color: var(--ink);
   font-size: 19px;
-  font-weight: 450;
-  letter-spacing: -0.01em;
+  font-weight: 600;
+  line-height: 1.375;
+  letter-spacing: -0.02em;
   text-align: center;
+  text-wrap: balance;
 }
 .inbox-chat-log {
   display: flex;
@@ -9622,9 +9564,6 @@ h3.ambient-field-label {
   }
   .session-topbar .session-heading {
     justify-content: center;
-    text-align: center;
-    font-size: 15px;
-    font-weight: 550;
   }
   .session-tools {
     display: none;
@@ -10173,7 +10112,7 @@ h3.ambient-field-label {
 .shared-conversation {
   height: 100dvh;
   display: grid;
-  grid-template-rows: 56px minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 .shared-brand {
   display: flex;

--- a/plugins/web-ui/src/styles/chat.css
+++ b/plugins/web-ui/src/styles/chat.css
@@ -1,0 +1,19 @@
+.assistant-body markdown-block :is(h1, h2, h3, h4, h5, h6) {
+  margin: 18px 0 6px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--ink);
+}
+.assistant-body markdown-block h1 {
+  font-size: 18px;
+}
+.assistant-body markdown-block h2 {
+  font-size: 16px;
+}
+.assistant-body markdown-block h3 {
+  font-size: 15px;
+}
+.assistant-body markdown-block :is(h4, h5, h6) {
+  font-size: 14px;
+}

--- a/plugins/web-ui/src/styles/topbar.css
+++ b/plugins/web-ui/src/styles/topbar.css
@@ -1,0 +1,11 @@
+.session-tool .session-tool-count {
+  position: absolute;
+  top: 0;
+  right: 0;
+  border: 1px solid var(--background);
+}
+@media (max-width: 860px) {
+  .session-topbar .session-title {
+    font-size: 15px;
+  }
+}

--- a/plugins/web-ui/test/session-topbar.test.ts
+++ b/plugins/web-ui/test/session-topbar.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createServer } from "vite";
+import { installDom } from "./dom-harness.ts";
+
+test("the session topbar is a tab strip: ghost crumb, title pill, icon tools with count badges", async () => {
+  installDom('<!doctype html><div id="host"></div>');
+  const vite = await createServer({ server: { middlewareMode: true, hmr: false }, appType: "custom" });
+  try {
+    const { render } = await import("lit");
+    const { sessionTopbarTpl } = (await vite.ssrLoadModule(
+      "/src/session-scope.ts",
+    )) as typeof import("../src/session-scope.ts");
+    const host = document.getElementById("host")!;
+    const clicks: string[] = [];
+    render(
+      sessionTopbarTpl({
+        crumb: "Acme",
+        title: "Q3 plan",
+        onCrumb: () => clicks.push("crumb"),
+        toolCount: (tool) => (tool === "files" ? 3 : 0),
+        onTool: (tool) => clicks.push(tool),
+      }),
+      host,
+    );
+
+    const heading = host.querySelector(".session-heading")!;
+    assert.deepEqual(
+      [...heading.children].map((el) => el.className),
+      ["session-crumb as-link", "session-title"],
+    );
+    assert.equal(heading.querySelector(".session-title")!.getAttribute("dir"), "auto");
+
+    const tools = [...host.querySelectorAll<HTMLElement>(".session-tool")];
+    assert.deepEqual(
+      tools.map((b) => b.getAttribute("aria-label")),
+      ["Crons", "Files", "Apps", "Skills", "Memory", "Your keychain"],
+    );
+    assert.deepEqual(
+      tools.map((b) => b.querySelector(".session-tool-count")?.textContent ?? ""),
+      ["", "3", "", "", "", ""],
+    );
+    assert.equal(host.querySelectorAll('.session-tools-more [role="menuitem"]').length, 6);
+
+    heading.querySelector<HTMLElement>(".session-crumb")!.click();
+    tools[1]!.click();
+    assert.deepEqual(clicks, ["crumb", "files"]);
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
## Summary

User messages become the reference bubble on the field colour, assistant text
takes the 14 px / 1.55 body voice, the message footer is a 24 px action lane, and
the streaming tail fades words in without blur. The session header is a tab
strip — crumb as a ghost tab, title as the active pill, six 28 px tool buttons
with count badges — and the empty chat shows the 21 px headline. Read-only and
shared transcripts share the same bar.

## Demo

Scrolling a conversation: the user bubble, assistant typography, the hover action lane, then the tab-strip header and the empty-state headline.

![04-chat-rows.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/04-chat-rows.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 (this) | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
