### PR TITLE
web-ui: approval card with a pager

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -287,6 +287,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     return composerState.fastMode ?? orgFastModeDefault;
   }
   let fastModeChargeTimer: ReturnType<typeof setTimeout> | null = null;
+  let approvalPage = 0;
 
   function resetComposer(): void {
     composerState.draft = "";
@@ -298,6 +299,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     composerState.openMenu = null;
     slashActiveIndex = 0;
     composerState.slashDismissed = false;
+    approvalPage = 0;
   }
 
   function scopeKey(): string | null {
@@ -816,59 +818,89 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     `;
   }
 
-  function composerApprovalPanel(approvals: PendingApproval[]): TemplateResult {
+  function composerApprovalPanel(approvals: PendingApproval[]): TemplateResult | typeof nothing {
+    if (!approvals.length) return nothing;
     const decide = (decision: ApprovalDecision): void => {
       if (!ctx.chat.state.resolvingApprovals.has(decision.requestId)) ctx.chat.resolveCommandApproval(decision);
     };
+    const page = Math.min(approvalPage, approvals.length - 1);
+    const a = approvals[page];
+    const busy = ctx.chat.state.resolvingApprovals.has(a.requestId);
+    const turnPage = (delta: number): void => {
+      approvalPage = page + delta;
+      ctx.chat.drawActiveChat();
+    };
     return html`<div class="composer-approval-panel" role="group" aria-label="Command approval">
-      ${approvals.map(
-        (a) =>
-          html`<div class="composer-approval">
-            <div class="composer-approval-copy">${ctx.chat.approvalSummaryView(a, true)}</div>
-            <div class="approval-actions">
-              <button
-                class="approval-btn deny"
-                type="button"
-                ?disabled=${ctx.chat.state.resolvingApprovals.has(a.requestId)}
-                @click=${() => decide({ requestId: a.requestId, approved: false })}
-              >
-                Deny
-              </button>
-              <button
-                class="approval-btn"
-                type="button"
-                ?disabled=${ctx.chat.state.resolvingApprovals.has(a.requestId)}
-                @click=${() => decide({ requestId: a.requestId, approved: true, scope: "once" })}
-              >
-                Allow once
-              </button>
-              ${
-                a.grantModes?.session === false
-                  ? nothing
-                  : html`<button
-                      class="approval-btn primary"
-                      type="button"
-                      ?disabled=${ctx.chat.state.resolvingApprovals.has(a.requestId)}
-                      @click=${() => decide({ requestId: a.requestId, approved: true, scope: "session" })}
-                    >
-                      Allow for session
-                    </button>`
-              }
-              ${
-                a.grantModes?.always === false
-                  ? nothing
-                  : html`<button
-                      class="approval-btn"
-                      type="button"
-                      ?disabled=${ctx.chat.state.resolvingApprovals.has(a.requestId)}
-                      @click=${() => decide({ requestId: a.requestId, approved: true, scope: "always" })}
-                    >
-                      Allow always
-                    </button>`
-              }
-            </div>
-          </div>`,
-      )}
+      <div class="composer-approval approval-card">
+        <div class="composer-approval-copy">${ctx.chat.approvalSummaryView(a, true)}</div>
+        <div class="approval-actions">
+          ${
+            approvals.length > 1
+              ? html`<span class="approval-pager">
+                  <button
+                    class="approval-pager-btn"
+                    type="button"
+                    aria-label="Previous approval"
+                    ?disabled=${page === 0}
+                    @click=${() => turnPage(-1)}
+                  >
+                    ‹
+                  </button>
+                  <span class="approval-pager-count" aria-live="polite">${page + 1}/${approvals.length}</span>
+                  <button
+                    class="approval-pager-btn"
+                    type="button"
+                    aria-label="Next approval"
+                    ?disabled=${page === approvals.length - 1}
+                    @click=${() => turnPage(1)}
+                  >
+                    ›
+                  </button>
+                </span>`
+              : nothing
+          }
+          <button
+            class="approval-btn deny"
+            type="button"
+            ?disabled=${busy}
+            @click=${() => decide({ requestId: a.requestId, approved: false })}
+          >
+            Deny
+          </button>
+          <button
+            class="approval-btn"
+            type="button"
+            ?disabled=${busy}
+            @click=${() => decide({ requestId: a.requestId, approved: true, scope: "once" })}
+          >
+            Allow once
+          </button>
+          ${
+            a.grantModes?.session === false
+              ? nothing
+              : html`<button
+                  class="approval-btn primary"
+                  type="button"
+                  ?disabled=${busy}
+                  @click=${() => decide({ requestId: a.requestId, approved: true, scope: "session" })}
+                >
+                  Allow for session
+                </button>`
+          }
+          ${
+            a.grantModes?.always === false
+              ? nothing
+              : html`<button
+                  class="approval-btn"
+                  type="button"
+                  ?disabled=${busy}
+                  @click=${() => decide({ requestId: a.requestId, approved: true, scope: "always" })}
+                >
+                  Allow always
+                </button>`
+          }
+        </div>
+      </div>
     </div>`;
   }
 

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2355,33 +2355,31 @@ summary.work-head:hover {
   gap: 8px;
 }
 .approval-reason-badge {
-  font-size: 12px;
-  font-weight: 600;
-  padding: 2px 9px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--destructive, #c0392b) 13%, var(--background));
-  color: var(--destructive, #c0392b);
-  border: 1px solid color-mix(in srgb, var(--destructive, #c0392b) 30%, transparent);
-}
-.approval-why {
-  font-size: 13px;
-  color: var(--foreground);
+  font-size: 11.5px;
+  font-weight: 500;
   line-height: 1.4;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--red-tint);
+  color: var(--red-ink);
+}
+.approval-why,
+.approval-summary-line {
+  color: var(--ink-2);
+}
+.approval-why-label,
+.approval-match-label,
+.approval-full > summary {
+  font-size: 11.5px;
+  color: var(--ink-3);
 }
 .approval-why-label {
-  font-size: 11px;
-  color: var(--muted-foreground);
   margin-right: 8px;
 }
-.approval-summary-line {
-  font-size: 13px;
-  color: var(--foreground);
-  line-height: 1.4;
-}
 .approval-summary {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 13px;
-  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2394,29 +2392,28 @@ summary.work-head:hover {
   min-width: 0;
 }
 .approval-match-label {
-  font-size: 11px;
-  color: var(--muted-foreground);
   flex: none;
 }
 .approval-match-snippet {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12px;
-  padding: 2px 6px;
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--destructive, #c0392b) 12%, var(--background));
-  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 1px 6px;
+  border-radius: var(--radius-chip);
+  background: var(--red-tint);
+  color: var(--ink);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
 }
 .approval-full > summary {
-  font-size: 12px;
-  color: var(--muted-foreground);
   cursor: pointer;
   user-select: none;
   list-style: none;
   width: fit-content;
+}
+.approval-full > summary:hover {
+  color: var(--ink);
 }
 .approval-full > summary::-webkit-details-marker {
   display: none;
@@ -2435,35 +2432,50 @@ summary.work-head:hover {
 }
 .approval-actions {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 .approval-btn {
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 12px;
+  font: inherit;
+  font-size: 12.5px;
   font-weight: 500;
-  padding: 7px 14px;
-  border-radius: 8px;
-  border: 1px solid var(--border);
-  background: var(--background);
-  color: var(--foreground);
+  line-height: 1;
+  border: 0;
+  border-radius: 999px;
+  background: var(--hover-2);
+  color: var(--ink);
   cursor: pointer;
-  transition: opacity 0.12s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 .approval-btn:hover:not(:disabled) {
-  opacity: 0.85;
+  background: var(--line-strong);
+}
+.approval-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
 }
 .approval-btn.primary {
-  background: var(--cta);
-  color: var(--cta-foreground);
-  border-color: var(--cta);
+  background: var(--blue);
+  color: #fff;
 }
-.approval-btn.deny {
-  color: var(--destructive, #c0392b);
-  border-color: color-mix(in srgb, var(--destructive, #c0392b) 40%, var(--border));
+.approval-btn.primary:hover:not(:disabled) {
+  background: var(--blue-ink);
+}
+.approval-btn.deny:hover:not(:disabled) {
+  color: var(--red-ink);
 }
 .approval-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+  opacity: 0.5;
+  cursor: progress;
 }
 .tool-expandable {
   display: block;
@@ -2999,7 +3011,6 @@ summary.work-head:hover {
   display: grid;
   gap: 10px;
   margin: 0 0 10px;
-
   max-height: calc(100dvh - 130px);
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -3007,20 +3018,12 @@ summary.work-head:hover {
 .composer-approval {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
-  min-height: 48px;
-  padding: 4px 4px 8px;
 }
 .composer-approval-copy {
   display: grid;
   width: 100%;
-  gap: 5px;
+  gap: 6px;
   min-width: 0;
-}
-.composer-approval .approval-title {
-  font-size: 12px;
-  color: var(--muted-foreground);
 }
 .composer-approval .approval-cmd {
   max-width: 100%;
@@ -4733,9 +4736,6 @@ summary.work-head:hover {
   }
   .message-bubble {
     max-width: 88%;
-  }
-  .composer-approval .approval-actions {
-    justify-content: flex-start;
   }
   .composer-toolbar {
     align-items: flex-end;
@@ -9932,16 +9932,6 @@ h3.ambient-field-label {
   .chat-topbar {
     -webkit-user-select: none;
     user-select: none;
-  }
-}
-
-@media (max-width: 560px) {
-  .composer-approval .approval-actions {
-    grid-template-columns: 1fr 1fr;
-    gap: 8px;
-  }
-  .composer-approval .approval-btn {
-    min-height: 48px;
   }
 }
 

--- a/plugins/web-ui/src/styles/approval.css
+++ b/plugins/web-ui/src/styles/approval.css
@@ -1,0 +1,51 @@
+.approval-pager {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-inline-end: auto;
+  color: var(--ink-3);
+}
+.approval-pager-count {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.approval-pager-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+.approval-pager-btn:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--hover);
+}
+.approval-pager-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
+}
+.approval-pager-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+@media (max-width: 560px) {
+  .approval-pager {
+    justify-content: center;
+  }
+  .approval-pager-btn {
+    width: 44px;
+    height: 44px;
+  }
+}

--- a/plugins/web-ui/test/approval-pager.test.ts
+++ b/plugins/web-ui/test/approval-pager.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import type { PendingApproval, SessionEntry } from "../src/core-bridge.ts";
+import { bootConversation, until } from "./dom-harness.ts";
+
+test("the composer pages through pending approvals one card at a time", async () => {
+  const approvals: PendingApproval[] = ["rm -rf build", "git push --force", "npm publish"].map((command, i) => ({
+    requestId: `a${i + 1}`,
+    command,
+    reason: "requires approval",
+  }));
+  const entries: SessionEntry[] = [{ seq: 1, type: "user", createdAt: Date.now(), payload: { text: "ship it" } }];
+  const boot = await bootConversation({ entries, approvals });
+  const { conv, host } = boot;
+  try {
+    boot.mount();
+    await until(() => !!conv.composer.currentModelOption() && !!host.querySelector(".approval-pager-count"));
+
+    const panel = () => host.querySelector(".composer-approval-panel")!;
+    const count = () => panel().querySelector(".approval-pager-count")?.textContent?.trim();
+    const shown = () => [...panel().querySelectorAll(".approval-cmd")].map((el) => el.textContent?.trim());
+    const pagerButton = (label: string) => panel().querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)!;
+
+    assert.equal(count(), "1/3");
+    assert.deepEqual(shown(), ["rm -rf build"]);
+    assert.equal(pagerButton("Previous approval").disabled, true);
+
+    pagerButton("Next approval").click();
+    await until(() => count() === "2/3");
+    assert.deepEqual(shown(), ["git push --force"]);
+    assert.equal(pagerButton("Previous approval").disabled, false);
+
+    pagerButton("Next approval").click();
+    await until(() => count() === "3/3");
+    assert.deepEqual(shown(), ["npm publish"]);
+    assert.equal(pagerButton("Next approval").disabled, true);
+    assert.equal(panel().querySelectorAll(".approval-btn").length, 4);
+  } finally {
+    await boot.dispose();
+  }
+});
+
+test("the pager index resets with the composer so a new conversation opens on its first approval", () => {
+  const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
+  assert.match(composer, /function resetComposer\(\)[\s\S]*?approvalPage = 0;/);
+});


### PR DESCRIPTION
## Summary

The composer's approval panel becomes the reference card — title and reason
badge, summary and purpose, the command in a mono block, a "Show full command"
disclosure — showing one pending approval at a time with a ‹ 1/N › pager when
several are queued, ghost Deny / Allow once / Allow always pills and a primary
Allow for session. The transcript marker is the compact version. The pager
index resets with the conversation.

## Demo

A real pending approval (a pipe-to-shell command): the card with its reason badge, "Triggered by" snippet and the Deny / Allow pills.

![05-approval-card.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/05-approval-card.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 (this) | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
