### PR TITLE
web-ui: tool chips and code blocks

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -57,7 +57,8 @@
         "hljs-real-json",
         "hljs-real-bash",
         "hljs-real-sql",
-        "hljs-real-markdown"
+        "hljs-real-markdown",
+        "hljs-real-diff"
       ]
     }
   }

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -96,6 +96,7 @@ import {
   type ToolRowModel,
   type SegmentStatus,
   segmentStatus,
+  type ToolRowKind,
 } from "./timeline";
 import { CONNECTOR_NAMES, connectorLinksIn, stripConnectorLinks, type ConnectorLink } from "./connector-link";
 import { deepLinkPath, UI_BASE } from "./deep-link";
@@ -2679,15 +2680,21 @@ export function createChatSurface(
     </div>`;
   }
 
+  function toolHead(glyph: SVGElement, kind: ToolRowKind, label: string, detail: string): TemplateResult {
+    const running = kind === "running";
+    const visible = detail || label;
+    const chip = detail ? "tool-chip" : "";
+    const title = detail ? `${label}: ${detail}` : label;
+    return html`<span class="tool-icon">${running ? html`<span class="tool-spinner"></span>` : glyph}</span>
+      ${detail ? html`<span class="tool-name">${running ? sheenLabel(label, true) : label}</span>` : nothing}
+      <span class="tool-label ${chip}" title=${title}>${visible}</span>`;
+  }
+
   function toolRow(row: ToolRowModel, work: WorkBlock, status: WorkBlock["status"], stale = false): TemplateResult {
     if (row.approval) {
       const p = (row.approval.payload ?? {}) as ToolPayload;
       return html`<div class="tool-row tool-approval">
-        <span class="tool-icon">${icon(Wrench, 13)}</span>
-        <span class="tool-label"
-          >Approval
-          needed${p.reason ? html` <span class="tool-detail">${firstLine(p.reason, 90)}</span>` : nothing}</span
-        >
+        ${toolHead(icon(Wrench, 13), "approval", "Approval needed", firstLine(p.reason ?? "", 90))}
       </div>`;
     }
     const call = (row.call?.payload ?? {}) as ToolPayload;
@@ -2709,10 +2716,8 @@ export function createChatSurface(
     const base = kind === "approval" ? "" : toolDetail(tool, call, result);
     const attempts = row.attempts && row.attempts > 1 ? `${row.attempts} attempts` : "";
     const detail = [base, why, attempts].filter(Boolean).join(" · ");
-    const visible = detail || label;
     const classes = ["tool-row", `tool-${kind}`].join(" ");
-    const head = html`<span class="tool-icon">${icon(meta.icon, 13)}</span>
-      <span class="tool-label" title=${detail ? `${label}: ${detail}` : label}>${visible}</span>`;
+    const head = toolHead(icon(meta.icon, 13), kind, label, detail);
     if (!row.call && !row.result) return html`<div class="${classes}">${head}</div>`;
     return html`<details class="${classes} tool-expandable">
       <summary class="tool-summary">${head}${icon(ChevronRight, 14)}</summary>
@@ -2722,11 +2727,14 @@ export function createChatSurface(
 
   function execOutputCard(result: ToolPayload, work: WorkBlock, activity: ToolActivity | null): TemplateResult {
     const out = toolExecutionOutput(result) ?? "";
+    const exitCode = result.code ?? 0;
     return html`<div class="code-card">
-      <div class="code-card-head"><span class="code-card-lang">bash</span></div>
+      <div class="code-card-head">${icon(Terminal, 13)}<span class="code-card-lang">bash</span></div>
       <pre class="code-card-body">${out}</pre>
       <div class="code-card-foot">
-        exit ${result.code ?? "unknown"}${result.timedOut ? " · timed out" : ""}
+        <span class="code-card-exit ${exitCode === 0 && !result.timedOut ? "exit-ok" : "exit-err"}">
+          exit ${exitCode}${result.timedOut ? " · timed out" : ""}
+        </span>
         ${
           activity?.truncated
             ? html`<button class="show-full-btn" type="button" @click=${() => void loadFullEntry(work, activity)}>

--- a/plugins/web-ui/src/lazy-hljs.ts
+++ b/plugins/web-ui/src/lazy-hljs.ts
@@ -9,7 +9,7 @@ type Hljs = {
 let real: Hljs | null = null;
 let loading: Promise<void> | null = null;
 
-const LANGS = ["javascript", "typescript", "python", "xml", "css", "json", "bash", "sql", "markdown"] as const;
+const LANGS = ["javascript", "typescript", "python", "xml", "css", "json", "bash", "sql", "markdown", "diff"] as const;
 const LANG_ALIASES: Record<string, string> = { html: "xml" };
 
 function escapeHtml(text: string): string {
@@ -35,6 +35,7 @@ function ensureLoading(): void {
     import("hljs-real-bash"),
     import("hljs-real-sql"),
     import("hljs-real-markdown"),
+    import("hljs-real-diff"),
   ])
     .then(([core, ...langs]: Array<{ default: unknown }>) => {
       const hljs = core.default as Hljs;

--- a/plugins/web-ui/src/lazy-shims.d.ts
+++ b/plugins/web-ui/src/lazy-shims.d.ts
@@ -6,39 +6,8 @@ declare module "hljs-real" {
   const hljs: unknown;
   export default hljs;
 }
-declare module "hljs-real-javascript" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-typescript" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-python" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-xml" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-css" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-json" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-bash" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-sql" {
-  const lang: unknown;
-  export default lang;
-}
-declare module "hljs-real-markdown" {
-  const lang: unknown;
+declare module "hljs-real-*" {
+  import type { LanguageFn } from "highlight.js";
+  const lang: LanguageFn;
   export default lang;
 }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2256,9 +2256,6 @@ summary.work-head:hover {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.tool-detail {
-  color: color-mix(in srgb, var(--muted-foreground) 70%, var(--background));
-}
 .thinking-row {
   display: block;
   min-width: 0;
@@ -2495,31 +2492,30 @@ summary.work-head:hover {
 .tool-disclosure {
   display: grid;
   gap: 6px;
-  margin: 5px 0 8px 19px;
+  margin: 4px 0 8px 24px;
 }
 .tool-payload-card {
   min-width: 0;
   overflow: hidden;
-  border-radius: 7px;
-  background: var(--secondary);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--inset);
 }
 .tool-payload-label {
-  padding: 7px 10px 3px;
-  color: var(--muted-foreground);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  padding: 6px 10px 0;
+  color: var(--ink-3);
+  font-size: 11.5px;
+  font-weight: 500;
 }
 .tool-payload-body {
   max-height: 320px;
   margin: 0;
-  padding: 3px 10px 9px;
+  padding: 4px 10px 8px;
   overflow: auto;
-  color: var(--foreground);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--ink-2);
+  font-family: var(--font-mono);
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -2529,52 +2525,63 @@ summary.work-head:hover {
 
 .code-card {
   margin: 12px 0 0;
-  border-radius: 8px;
-  background: var(--secondary);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
   overflow: hidden;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 .code-card-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px 6px;
+  gap: 7px;
+  height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-3);
 }
 .code-card-lang {
-  font-size: 13px;
-  color: var(--muted-foreground);
+  font-size: 12px;
+  color: var(--ink);
 }
 .code-card-body {
   margin: 0;
-  padding: 2px 12px 12px;
-  font-size: 15px;
-  line-height: 1.55;
+  padding: 10px 14px;
+  font-size: 12.5px;
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
   max-height: 360px;
   overflow: auto;
-  color: var(--foreground);
+  color: var(--ink-2);
 }
 .code-card-foot {
-  padding: 0 12px 12px;
-  font-size: 13px;
-  color: var(--muted-foreground);
   display: flex;
   align-items: center;
   gap: 10px;
+  min-height: 32px;
+  padding: 0 6px 0 12px;
+  border-top: 1px solid var(--line);
+  font-size: 11.5px;
+  color: var(--ink-3);
 }
 .show-full-btn {
-  border: 1px solid var(--border, #d0d0d0);
-  border-radius: 999px;
-  background: var(--bg, #fff);
-  color: var(--muted-fg, #666);
-  font-size: 12px;
-  padding: 3px 10px;
+  margin-left: auto;
+  height: 24px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: var(--radius-chip);
+  background: transparent;
+  color: var(--ink-3);
+  font: 500 11.5px/1 var(--app-font);
   cursor: pointer;
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
 }
 .show-full-btn:hover {
-  border-color: var(--fg, #333);
-  color: var(--fg, #333);
+  background: var(--hover);
+  color: var(--ink);
 }
 
 .chat-bottom-dock {
@@ -2867,27 +2874,32 @@ summary.work-head:hover {
 
 .assistant-body markdown-block :not(pre) > code,
 .user-bubble markdown-block :not(pre) > code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.92em;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
   padding: 1px 5px;
-  border-radius: 5px;
-  background: var(--secondary);
+  border-radius: 4px;
+  background: var(--field);
 }
 .assistant-body markdown-block pre,
 .user-bubble markdown-block pre {
   margin: 12px 0;
-  padding: 14px 12px;
-  border-radius: 8px;
-  background: var(--secondary);
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
   overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.6em;
 }
 .assistant-body markdown-block pre code,
 .user-bubble markdown-block pre code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 15px;
-  line-height: 1.55;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: inherit;
   background: none;
   padding: 0;
+  color: var(--ink-2);
 }
 .assistant-body code-block[language="text"] pre,
 .user-bubble code-block[language="text"] pre {

--- a/plugins/web-ui/src/styles/code.css
+++ b/plugins/web-ui/src/styles/code.css
@@ -1,0 +1,160 @@
+:root {
+  --syntax-keyword: var(--blue-ink);
+  --syntax-entity: var(--ink);
+  --syntax-constant: var(--ink);
+  --syntax-string: var(--orange-ink);
+  --syntax-variable: var(--ink-2);
+  --syntax-comment: var(--ink-3);
+  --syntax-tag: var(--blue-ink);
+  --syntax-heading: var(--ink);
+  --syntax-list: var(--ink-2);
+  --syntax-addition-fg: var(--green-ink);
+  --syntax-addition-bg: var(--green-tint);
+  --syntax-deletion-fg: var(--red-ink);
+  --syntax-deletion-bg: var(--red-tint);
+}
+
+markdown-block code-block[language] > div {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  overflow: hidden;
+}
+markdown-block code-block[language] pre {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+markdown-block code-block[language] .hljs-title {
+  font-weight: 500;
+}
+
+markdown-block code-block:not([language="text"]) > div > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
+  height: 36px;
+  padding: 0 6px 0 12px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink);
+}
+markdown-block code-block:not([language="text"]) > div > div:first-child::before {
+  content: "";
+  flex: none;
+  width: 15px;
+  height: 15px;
+  background: var(--ink-3);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+}
+markdown-block code-block:not([language="text"]) > div > div:first-child > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+  color: var(--ink);
+}
+markdown-block code-block:not([language="text"]) copy-button {
+  display: inline-flex;
+  margin-left: auto;
+}
+markdown-block code-block:not([language="text"]) copy-button button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 6px;
+  border: 0;
+  border-radius: var(--radius-chip);
+  background: transparent;
+  color: var(--ink-3);
+  font: 500 11.5px/1 var(--app-font);
+  cursor: pointer;
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
+}
+markdown-block code-block:not([language="text"]) copy-button button:hover {
+  background: var(--hover);
+  color: var(--ink);
+}
+markdown-block code-block:not([language="text"]) copy-button button svg {
+  width: 11px;
+  height: 11px;
+}
+markdown-block code-block:not([language="text"]) copy-button button::after {
+  content: "Copy";
+}
+markdown-block code-block:not([language="text"]) copy-button button:has(span)::after {
+  content: none;
+}
+
+markdown-block code-block:not([language="text"]) pre {
+  display: flex;
+  align-items: flex-start;
+  padding: 0;
+}
+markdown-block code-block:not([language="text"]) pre code {
+  display: block;
+  flex: 1 0 auto;
+  min-width: 0;
+  padding: 10px 14px 10px 10px;
+}
+.code-gutter {
+  flex: none;
+  position: sticky;
+  left: 0;
+  box-sizing: border-box;
+  width: 32px;
+  padding: 10px 0;
+  border-right: 1px solid var(--line);
+  background: var(--surface);
+  text-align: right;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-3);
+  user-select: none;
+  -webkit-user-select: none;
+}
+.code-gutter > span {
+  display: block;
+  padding-right: 6px;
+}
+.code-gutter > .code-line-add {
+  background: var(--green-tint);
+  color: var(--green-ink);
+}
+.code-gutter > .code-line-del {
+  background: var(--red-tint);
+  color: var(--red-ink);
+}
+markdown-block code-block:not([language="text"]) pre code .hljs-addition,
+markdown-block code-block:not([language="text"]) pre code .hljs-deletion {
+  display: inline-block;
+  min-width: 100%;
+  margin: 0 -14px 0 -10px;
+  padding: 0 14px 0 10px;
+  color: inherit;
+}
+
+.code-card-head .icon {
+  flex: none;
+}
+.code-card-exit {
+  font-variant-numeric: tabular-nums;
+}
+.code-card-exit.exit-ok {
+  color: var(--green-ink);
+}
+.code-card-exit.exit-err {
+  color: var(--red-ink);
+}

--- a/plugins/web-ui/src/styles/tool-chips.css
+++ b/plugins/web-ui/src/styles/tool-chips.css
@@ -1,0 +1,46 @@
+.tool-row .tool-summary:hover {
+  background: var(--hover-2);
+}
+.tool-name {
+  flex: 0 0 auto;
+  font-weight: 500;
+}
+.tool-label.tool-chip {
+  flex: 0 1 auto;
+  box-sizing: border-box;
+  height: 22px;
+  padding: 0 6px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-chip);
+  background: var(--field);
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 20px;
+}
+.tool-row.tool-failed .tool-chip {
+  background: var(--red-tint);
+  color: var(--red-ink);
+}
+.tool-row.tool-approval .tool-chip {
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+}
+.tool-row.tool-attempted,
+.tool-row.tool-attempted .tool-chip {
+  color: var(--ink-3);
+}
+.tool-spinner {
+  box-sizing: border-box;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--line-strong);
+  border-top-color: var(--ink-2);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .tool-spinner {
+    animation: none;
+  }
+}

--- a/plugins/web-ui/src/text-code.ts
+++ b/plugins/web-ui/src/text-code.ts
@@ -31,25 +31,64 @@ export function normalizePlainTextFences(text: string): string {
 
 export function decorateTextCodeBlocks(root: ParentNode | null): void {
   if (!root) return;
-  for (const block of root.querySelectorAll<HTMLElement>('code-block[language="text"]')) {
-    const body = block.querySelector<HTMLElement>(":scope > div > div:last-child");
-    const footer = block.querySelector<HTMLElement>(":scope > div > div:first-child");
-    const pre = body?.querySelector("pre");
-    if (!body || !footer || !pre) continue;
-    body.classList.add("text-code-body");
-    footer.classList.add("text-code-footer");
-    if (footer.querySelector(".text-code-toggle") || pre.scrollHeight <= 76) continue;
-    const button = block.ownerDocument.createElement("button");
-    button.type = "button";
-    button.className = "text-code-toggle";
-    const update = (expanded: boolean) => {
-      block.dataset.expanded = String(expanded);
-      button.textContent = expanded ? "Show less" : "Show more";
-      button.setAttribute("aria-expanded", String(expanded));
-    };
-    button.addEventListener("click", () => update(block.dataset.expanded !== "true"));
-    footer.insertBefore(button, footer.lastElementChild);
-    block.classList.add("text-code-collapsible");
-    update(block.dataset.expanded === "true");
+  for (const block of root.querySelectorAll<HTMLElement>("code-block")) {
+    if (block.getAttribute("language") === "text") collapsePlainTextBlock(block);
+    else numberCodeLines(block);
   }
+}
+
+function collapsePlainTextBlock(block: HTMLElement): void {
+  const body = block.querySelector<HTMLElement>(":scope > div > div:last-child");
+  const footer = block.querySelector<HTMLElement>(":scope > div > div:first-child");
+  const pre = body?.querySelector("pre");
+  if (!body || !footer || !pre) return;
+  body.classList.add("text-code-body");
+  footer.classList.add("text-code-footer");
+  if (footer.querySelector(".text-code-toggle") || pre.scrollHeight <= 76) return;
+  const button = block.ownerDocument.createElement("button");
+  button.type = "button";
+  button.className = "text-code-toggle";
+  const update = (expanded: boolean) => {
+    block.dataset.expanded = String(expanded);
+    button.textContent = expanded ? "Show less" : "Show more";
+    button.setAttribute("aria-expanded", String(expanded));
+  };
+  button.addEventListener("click", () => update(block.dataset.expanded !== "true"));
+  footer.insertBefore(button, footer.lastElementChild);
+  block.classList.add("text-code-collapsible");
+  update(block.dataset.expanded === "true");
+}
+
+function numberCodeLines(block: HTMLElement): void {
+  const pre = block.querySelector("pre");
+  const code = pre?.querySelector("code");
+  if (!pre || !code) return;
+  const language = block.getAttribute("language") ?? "";
+  const existing = pre.querySelector<HTMLElement>(":scope > .code-gutter");
+  if (existing?.dataset.lang === language && !block.closest(".assistant-row.streaming")) return;
+  const lines = (code.textContent ?? "").replace(/\n$/u, "").split("\n");
+  if (lines.length < 2) return;
+  const diff = /^(?:diff|patch)$/u.test(language);
+  const gutter = existing ?? pre.insertBefore(block.ownerDocument.createElement("span"), code);
+  if (gutter.dataset.lang !== language) {
+    gutter.className = "code-gutter";
+    gutter.setAttribute("aria-hidden", "true");
+    gutter.dataset.lang = language;
+    gutter.replaceChildren();
+  }
+  const cells = gutter.children;
+  while (cells.length > lines.length) gutter.lastElementChild?.remove();
+  for (let i = diff ? Math.max(0, cells.length - 1) : cells.length; i < lines.length; i++) {
+    const cell = cells[i] ?? gutter.appendChild(block.ownerDocument.createElement("span"));
+    const mark = diff ? diffMark(lines[i] ?? "") : "";
+    cell.textContent = diff ? mark || " " : String(i + 1);
+    cell.className = MARK_CLASS[mark] ?? "";
+  }
+}
+
+const MARK_CLASS: Record<string, string> = { "+": "code-line-add", "-": "code-line-del" };
+
+function diffMark(line: string): string {
+  if (/^(?:\+\+\+|---)/u.test(line)) return "";
+  return line[0] === "+" || line[0] === "-" ? line[0] : "";
 }

--- a/plugins/web-ui/test/text-code.test.ts
+++ b/plugins/web-ui/test/text-code.test.ts
@@ -48,3 +48,120 @@ test("text-block expansion is local and preserves rendered code nodes", () => {
   assert.equal(firstButton.textContent, "Show less");
   assert.equal(firstButton.getAttribute("aria-expanded"), "true");
 });
+
+test("source fences get a line gutter and diff fences mark changed rows without touching rendered code", () => {
+  const dom = new JSDOM(`<main>
+    <code-block language="ts"><div><div><span>ts</span><copy-button></copy-button></div><div><pre><code class="hljs">const a = 1;
+const b = 2;
+<!--lit-marker--></code></pre></div></div></code-block>
+    <code-block language="diff"><div><div><span>diff</span><copy-button></copy-button></div><div><pre><code>--- a
++++ b
+ same
+-old
++new
+</code></pre></div></div></code-block>
+    <code-block language="ts"><div><div><span>ts</span><copy-button></copy-button></div><div><pre><code>one</code></pre></div></div></code-block>
+  </main>`);
+  const root = dom.window.document.querySelector("main")!;
+  const [source, diff, single] = Array.from(root.querySelectorAll<HTMLElement>("code-block"));
+  const renderedCode = source!.querySelector("code")!.innerHTML;
+
+  decorateTextCodeBlocks(root);
+  decorateTextCodeBlocks(root);
+
+  const gutters = source!.querySelectorAll(".code-gutter");
+  assert.equal(gutters.length, 1);
+  assert.equal(gutters[0]!.getAttribute("aria-hidden"), "true");
+  assert.equal(source!.querySelector("pre")!.firstElementChild, gutters[0]);
+  assert.deepEqual(
+    Array.from(gutters[0]!.children, (cell) => cell.textContent),
+    ["1", "2"],
+  );
+  assert.equal(source!.querySelector("code")!.innerHTML, renderedCode);
+  assert.deepEqual(
+    Array.from(diff!.querySelectorAll(".code-gutter > span"), (cell) => [cell.className, cell.textContent]),
+    [
+      ["", " "],
+      ["", " "],
+      ["", " "],
+      ["code-line-del", "-"],
+      ["code-line-add", "+"],
+    ],
+  );
+  assert.equal(single!.querySelector(".code-gutter"), null);
+  assert.equal(root.querySelector(".text-code-toggle"), null);
+});
+
+const TS_FENCE = `<code-block language="ts"><div><div><span>ts</span><copy-button></copy-button></div><div><pre><code>const a = 1;
+const b = 2;
+</code></pre></div></div></code-block>`;
+
+test("a settled fence keeps its gutter as-is while a streaming fence grows in place", () => {
+  const dom = new JSDOM(`<main>
+    <article class="message-row assistant-row">${TS_FENCE}</article>
+    <article class="message-row assistant-row streaming">${TS_FENCE}</article>
+  </main>`);
+  const root = dom.window.document.querySelector("main")!;
+  const [settled, streaming] = Array.from(root.querySelectorAll<HTMLElement>("code-block"));
+  const cells = (block: HTMLElement) => Array.from(block.querySelectorAll(".code-gutter > span"));
+
+  decorateTextCodeBlocks(root);
+  const streamingCells = cells(streaming!);
+  for (const block of [settled!, streaming!]) block.querySelector("code")!.textContent += "const c = 3;\n";
+  decorateTextCodeBlocks(root);
+
+  assert.deepEqual(
+    cells(settled!).map((cell) => cell.textContent),
+    ["1", "2"],
+  );
+  const grown = cells(streaming!);
+  assert.deepEqual(
+    grown.map((cell) => cell.textContent),
+    ["1", "2", "3"],
+  );
+  assert.deepEqual(grown.slice(0, 2), streamingCells);
+
+  settled!.setAttribute("language", "diff");
+  decorateTextCodeBlocks(root);
+
+  assert.deepEqual(
+    cells(settled!).map((cell) => cell.textContent),
+    [" ", " ", " "],
+  );
+  assert.equal(settled!.querySelectorAll(".code-gutter").length, 1);
+});
+
+test("a streaming diff fence refreshes its last gutter mark once the line settles", () => {
+  const dom = new JSDOM(`<main><article class="message-row assistant-row streaming">
+    <code-block language="diff"><div><div><span>diff</span><copy-button></copy-button></div><div><pre><code> same
+
+</code></pre></div></div></code-block>
+  </article></main>`);
+  const root = dom.window.document.querySelector("main")!;
+  const code = root.querySelector("code")!;
+  const cells = () =>
+    Array.from(root.querySelectorAll(".code-gutter > span"), (cell) => [cell.className, cell.textContent]);
+
+  decorateTextCodeBlocks(root);
+  assert.deepEqual(cells(), [
+    ["", " "],
+    ["", " "],
+  ]);
+  const first = root.querySelector(".code-gutter > span");
+
+  code.textContent = " same\n-old\n";
+  decorateTextCodeBlocks(root);
+  assert.deepEqual(cells(), [
+    ["", " "],
+    ["code-line-del", "-"],
+  ]);
+
+  code.textContent = " same\n-old\n+new\n";
+  decorateTextCodeBlocks(root);
+  assert.deepEqual(cells(), [
+    ["", " "],
+    ["code-line-del", "-"],
+    ["code-line-add", "+"],
+  ]);
+  assert.equal(root.querySelector(".code-gutter > span"), first);
+});

--- a/plugins/web-ui/test/tool-chips.test.ts
+++ b/plugins/web-ui/test/tool-chips.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { SessionEntry } from "../src/core-bridge.ts";
+import { bootConversation, until } from "./dom-harness.ts";
+
+test("tool rows render their label beside a mono detail chip, tinted by outcome", async () => {
+  const entries: SessionEntry[] = [
+    { seq: 1, type: "user", createdAt: 1, payload: { text: "ship it" } },
+    { seq: 2, parentSeq: 1, type: "tool_call", createdAt: 2, payload: { tool: "execute", command: "npm run freeze" } },
+    { seq: 3, parentSeq: 2, type: "tool_result", createdAt: 3, payload: { tool: "execute", code: 0, stdout: "ok" } },
+    { seq: 4, parentSeq: 1, type: "tool_call", createdAt: 4, payload: { tool: "write", path: "ChurnSchedule.tsx" } },
+    { seq: 5, parentSeq: 4, type: "tool_result", createdAt: 5, payload: { tool: "write", error: "read-only" } },
+    { seq: 6, parentSeq: 1, type: "tool_call", createdAt: 6, payload: { tool: "recall" } },
+    { seq: 7, parentSeq: 6, type: "tool_result", createdAt: 7, payload: { tool: "recall" } },
+    { seq: 8, type: "assistant", createdAt: 8, payload: { text: "done" } },
+  ];
+  const boot = await bootConversation({ entries });
+  const { host } = boot;
+  try {
+    boot.mount();
+    await until(() => host.querySelectorAll(".tool-row").length === 3);
+
+    const ok = host.querySelector(".tool-row.tool-ok")!;
+    assert.equal(ok.querySelector(".tool-name")?.textContent, "Ran command");
+    const chip = ok.querySelector(".tool-label.tool-chip")!;
+    assert.equal(chip.textContent, "npm run freeze");
+    assert.equal(chip.getAttribute("title"), "Ran command: npm run freeze");
+    assert.ok(ok.querySelector(".tool-icon svg"), "settled rows keep their tool glyph");
+
+    const failed = host.querySelector(".tool-row.tool-failed")!;
+    assert.equal(failed.querySelector(".tool-name")?.textContent, "Tried writing file");
+    assert.equal(failed.querySelector(".tool-chip")?.textContent, "ChurnSchedule.tsx · read-only");
+
+    const bare = host.querySelector(".tool-row.tool-ok:has(.tool-label:not(.tool-chip))")!;
+    assert.equal(bare.querySelector(".tool-name"), null, "a row without detail shows only its label");
+    assert.equal(bare.querySelector(".tool-label")?.textContent, "Searched memory");
+  } finally {
+    await boot.dispose();
+  }
+});

--- a/plugins/web-ui/vite.config.ts
+++ b/plugins/web-ui/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
       { find: "hljs-real-bash", replacement: here("node_modules/highlight.js/lib/languages/bash.js") },
       { find: "hljs-real-sql", replacement: here("node_modules/highlight.js/lib/languages/sql.js") },
       { find: "hljs-real-markdown", replacement: here("node_modules/highlight.js/lib/languages/markdown.js") },
+      { find: "hljs-real-diff", replacement: here("node_modules/highlight.js/lib/languages/diff.js") },
       { find: "hljs-real", replacement: here("node_modules/highlight.js/lib/core.js") },
       { find: /^highlight\.js\/lib\/languages\/.*$/, replacement: here("src/hljs-lang-stub.ts") },
     ],


### PR DESCRIPTION
## Summary

Tool rows read as compact chips — a 16 px glyph, the action label, and the
command or path as a mono chip — with running, done, failed and approval
tints; Input and Result payload cards sit on the inset colour. Code blocks get
the reference chrome: a header with the language and a Copy control, a line
number gutter, tinted rows for diff fences (the highlight.js diff grammar is
registered), and the exec output card shows its exit code in green or red.

## Demo

Opening a settled trace, expanding a tool row to its Input and Result cards, then the TypeScript block with its Copy control and gutter and the tinted diff block.

![06-tool-chips-code.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/06-tool-chips-code.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 (this) | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
