### PR TITLE
web-ui: records tables and filter lists

### DIFF
--- a/plugins/web-ui/src/crons.ts
+++ b/plugins/web-ui/src/crons.ts
@@ -240,12 +240,9 @@ function drawCronsPage(): void {
   const ownsAny = all.some(({ mine }) => mine);
   const counts: Record<CronTab, number> = { yours: yours.length, shared: shared.length, archived: archived.length };
 
+  const notice = cronActionNotice ? html`<div class="action-notice">${cronActionNotice}</div>` : nothing;
+  cronActionNotice = "";
   const rows: TemplateResult[] = [];
-  if (cronActionNotice) {
-    rows.push(html`<div class="action-notice">${cronActionNotice}</div>`);
-    cronActionNotice = "";
-  }
-  if (all.length) rows.push(cronTabs(counts));
   if (cronTab === "yours") {
     rows.push(...yoursEnabled.map(({ c }) => cronPageRow(c, true)));
     if (all.length && !yoursEnabled.length)
@@ -279,6 +276,7 @@ function drawCronsPage(): void {
           drawCronsPage();
         },
       },
+      filters: html`${notice}${all.length ? cronTabs(counts) : nothing}`,
       rows,
       empty,
     })}`,
@@ -297,24 +295,24 @@ function toggleDisabledCrons(): void {
 }
 
 function cronEmptyRow(text: string): TemplateResult {
-  return html`<div class="empty compact cron-filter-empty">${text}</div>`;
+  return html`<div class="empty compact">${text}</div>`;
 }
 
 function cronTabs(counts: Record<CronTab, number>): TemplateResult {
   const tabs = CRON_TABS.filter((t) => t.value === "yours" || counts[t.value] > 0 || cronTab === t.value);
   return html`
-    <div class="cron-list-controls" role="tablist" aria-label="Cron view">
+    <div class="resource-tabs" role="tablist" aria-label="Cron view">
       ${tabs.map(
         (t) => html`
           <button
             type="button"
             role="tab"
             aria-selected=${cronTab === t.value}
-            class="cron-filter-chip ${cronTab === t.value ? "active" : ""}"
+            data-status=${t.value}
+            class=${cronTab === t.value ? "active" : ""}
             @click=${() => setCronTab(t.value)}
           >
-            <span>${t.label}</span>
-            <span class="cron-filter-count">${counts[t.value]}</span>
+            ${t.label}<span>${counts[t.value]}</span>
           </button>
         `,
       )}

--- a/plugins/web-ui/src/deploys.ts
+++ b/plugins/web-ui/src/deploys.ts
@@ -110,20 +110,21 @@ function deployTabs(): TemplateResult {
   ) as Record<DeploymentTab, number>;
   const tabs = DEPLOY_TABS.filter((tab) => tab.value === "yours" || counts[tab.value] > 0 || deployTab === tab.value);
   return html`
-    <div class="cron-list-controls" role="tablist" aria-label="App view">
+    <div class="resource-tabs" role="tablist" aria-label="App view">
       ${tabs.map(
         (tab) => html`
           <button
             type="button"
             role="tab"
             aria-selected=${deployTab === tab.value}
-            class="cron-filter-chip ${deployTab === tab.value ? "active" : ""}"
+            data-status=${tab.value}
+            class=${deployTab === tab.value ? "active" : ""}
             @click=${() => {
               deployTab = tab.value;
               drawDeploysPage();
             }}
           >
-            <span>${tab.label}</span><span class="cron-filter-count">${counts[tab.value]}</span>
+            ${tab.label}<span>${counts[tab.value]}</span>
           </button>
         `,
       )}
@@ -191,17 +192,13 @@ function drawDeploysPage(): void {
   else if (deployLoading && deployList.length === 0) empty = "Loading apps…";
   else if (deployQuery && allForTab.length) empty = "No apps match your search.";
   else if (deployScope) empty = "No apps in this context.";
-  const content = deployList.length
-    ? [
-        deployTabs(),
-        ...(deployNotices.list
-          ? [html`<div class="status deploy-list-notice" role="status" aria-live="polite">${deployNotices.list}</div>`]
-          : []),
-        ...(rows.length
-          ? rows.map(deploymentRow)
-          : [html`<div class="empty compact cron-filter-empty">${empty}</div>`]),
-      ]
-    : [];
+  const filters = deployList.length
+    ? html`${deployTabs()}${
+        deployNotices.list
+          ? html`<div class="status deploy-list-notice" role="status" aria-live="polite">${deployNotices.list}</div>`
+          : nothing
+      }`
+    : undefined;
   const scoped = Boolean(scopedSession.active);
   deployPageHost.classList.toggle("scoped-view", scoped);
   render(
@@ -217,7 +214,8 @@ function drawDeploysPage(): void {
             drawDeploysPage();
           },
         },
-        rows: content,
+        filters,
+        rows: rows.map(deploymentRow),
         empty,
       })}
       ${archiveCandidate ? archiveDialog(archiveCandidate) : nothing} ${deployToast ? undoToast(deployToast) : nothing}

--- a/plugins/web-ui/src/markdown-sanitize.ts
+++ b/plugins/web-ui/src/markdown-sanitize.ts
@@ -10,7 +10,7 @@ export const MARKDOWN_SANITIZE_CONFIG: Config = {
 export const SHARED_MARKDOWN_SANITIZE_CONFIG: Config = {
   ...MARKDOWN_SANITIZE_CONFIG,
   FORBID_TAGS: ["img", "video", "audio", "source", "iframe", "object", "embed", "style", "form"],
-  FORBID_ATTR: ["href", "xlink:href", "src", "srcset", "poster", "style", "action"],
+  FORBID_ATTR: ["href", "xlink:href", "src", "srcset", "poster", "style", "action", "background", "bgcolor"],
 };
 
 const SANDBOX_WORKSPACE_LINK = /\shref=(["'])sandbox:\/home\/sprite\/workspace\/([^"']+)\1/gi;

--- a/plugins/web-ui/src/sessions.ts
+++ b/plugins/web-ui/src/sessions.ts
@@ -595,6 +595,7 @@ export function drawChatsPage(): void {
               html`<button
                 role="tab"
                 type="button"
+                data-status=${value}
                 aria-selected=${chatsPageStatus === value}
                 class=${chatsPageStatus === value ? "active" : ""}
                 @click=${() => {
@@ -859,7 +860,7 @@ function sessionRow(s: CoreSession, projectChild = false): TemplateResult {
   const working = sessionWorking(s);
   let titleContent: string | TemplateResult = groupDmTitle(s);
   if (refreshingTitle) {
-    titleContent = html`<span class="sheen-label title-sheen thinking-sheen" data-sheen=${title}>${title}</span>`;
+    titleContent = html`<span class="sheen-label title-sheen thinking-sheen">${title}</span>`;
   } else if (untitledProjectChild) {
     titleContent = title;
   }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -4116,18 +4116,6 @@ summary.work-head:hover {
 .kc-resource-meta {
   margin-top: 3px;
 }
-.kc-state {
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--secondary);
-  color: var(--muted-foreground);
-  font-size: 10px;
-  font-weight: 600;
-}
-.kc-state.warning {
-  background: color-mix(in srgb, var(--warning) 14%, var(--background));
-  color: var(--warning);
-}
 .kc-resource-actions {
   display: flex;
   align-items: center;
@@ -5054,33 +5042,44 @@ summary.work-head:hover {
 }
 .resource-tabs {
   width: min(960px, 100%);
-  margin: 16px auto 0;
+  margin: 12px auto 0;
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
-  border-bottom: 1px solid var(--border);
 }
 .resource-tabs button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 10px;
-  border: 0;
-  border-bottom: 2px solid transparent;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
   background: transparent;
-  color: var(--muted-foreground);
+  color: var(--ink-2);
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
+  font-weight: 500;
+  white-space: nowrap;
   cursor: pointer;
+  transition:
+    background-color 0.2s var(--ease-out-strong),
+    color 0.2s var(--ease-out-strong);
+}
+.resource-tabs button:hover {
+  background: var(--hover);
+  color: var(--ink);
 }
 .resource-tabs button.active {
-  border-bottom-color: var(--foreground);
-  color: var(--foreground);
+  border-color: var(--line-strong);
+  background: var(--field);
+  color: var(--ink);
 }
 .resource-tabs button span {
-  padding: 1px 5px;
-  border-radius: 999px;
-  background: var(--secondary);
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-3);
 }
 .context-resource-heading {
   display: flex;
@@ -5260,7 +5259,7 @@ summary.work-head:hover {
   width: min(960px, 100%);
   margin: 0 auto;
   display: flex;
-  align-items: end;
+  align-items: center;
   gap: 12px;
 }
 .chat-filters .resource-tabs {
@@ -5898,6 +5897,11 @@ summary.work-head:hover {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 500;
   white-space: nowrap;
 }
 .list-page-action svg {
@@ -5919,20 +5923,19 @@ summary.work-head:hover {
   gap: 8px;
   max-width: 960px;
   margin: 12px auto 4px;
-  padding: 0 12px;
-  height: 42px;
+  padding: 0 10px;
+  height: 34px;
   box-sizing: border-box;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--background);
-  color: var(--muted-foreground);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--field);
+  color: var(--ink-3);
 }
 .list-search:focus-within {
-  border-color: color-mix(in srgb, var(--foreground) 30%, var(--border));
+  border-color: var(--blue);
 }
 .list-search svg {
   flex-shrink: 0;
-  opacity: 0.7;
 }
 .list-search input {
   flex: 1;
@@ -5941,15 +5944,19 @@ summary.work-head:hover {
   background: transparent;
   outline: none;
   font: inherit;
-  font-size: 14px;
-  color: var(--foreground);
+  font-size: 13px;
+  color: var(--ink);
 }
 
 .list-rows {
   max-width: 960px;
-  margin: 6px auto 0;
+  margin: 8px auto 0;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
 }
 .list-row {
   display: flex;
@@ -5957,42 +5964,44 @@ summary.work-head:hover {
   justify-content: space-between;
   gap: 12px;
   width: 100%;
+  min-height: 40px;
   box-sizing: border-box;
   text-align: left;
   font: inherit;
-  padding: 12px;
+  font-size: 13px;
+  padding: 8px 12px;
   border: 0;
-  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--foreground);
+  color: var(--ink);
   cursor: pointer;
-  transition: background 0.12s ease;
+  transition: background 0.1s ease;
 }
 .list-row:hover {
-  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  background: var(--hover);
 }
 .list-row.active {
-  background: color-mix(in srgb, var(--foreground) 4%, transparent);
+  background: var(--hover);
 }
 .list-divider {
   flex: 0 0 auto;
   height: 1px;
-  background: color-mix(in srgb, var(--border) 65%, transparent);
+  background: var(--line);
 }
 .list-row-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 500;
 }
 .list-row-meta {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-  font-size: 12px;
-  color: var(--muted-foreground);
+  font-size: 12.5px;
+  color: var(--ink-3);
 }
 .file-row {
   display: grid;
@@ -6007,8 +6016,10 @@ summary.work-head:hover {
   gap: 14px;
 }
 .list-row-date {
-  color: var(--muted-foreground);
-  font-size: 12.5px;
+  color: var(--ink-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 .chat-row .list-row-meta {
@@ -6033,46 +6044,11 @@ summary.work-head:hover {
     flex-wrap: wrap;
   }
 }
-.cron-list-controls {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 0 8px;
-}
-.cron-filter-chip {
-  min-height: 30px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 5px 10px;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 600;
-}
-.cron-filter-chip:hover {
-  background: var(--secondary);
-  color: var(--foreground);
-}
-.cron-filter-chip.active {
-  background: color-mix(in srgb, var(--foreground) 88%, var(--secondary));
-  color: var(--background);
-}
-.cron-filter-count {
-  font-variant-numeric: tabular-nums;
-  opacity: 0.72;
-}
 .deploy-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   cursor: default;
-  min-height: 44px;
   padding: 6px 12px;
 }
 .deploy-row-main {
@@ -6114,32 +6090,52 @@ summary.work-head:hover {
   align-items: center;
   gap: 9px;
 }
-.deploy-row-title .list-row-title {
-  font-size: 13px;
-  font-weight: 500;
-}
-.deploy-status {
+.deploy-status,
+.loop-item-status,
+.kc-state {
   display: inline-flex;
   align-items: center;
   gap: 5px;
   flex-shrink: 0;
-  font-size: 11.5px;
-  color: var(--muted-foreground);
+  height: 22px;
+  padding: 0 7px;
+  box-sizing: border-box;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--field);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
 }
 .deploy-status > span {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 999px;
-  background: var(--muted-foreground);
+  background: currentColor;
 }
-.deploy-status.running > span {
-  background: var(--success);
+.deploy-status.running,
+.loop-item-shipped {
+  border-color: color-mix(in srgb, var(--green) 34%, var(--surface));
+  background: var(--green-tint);
+  color: var(--green-ink);
 }
-.deploy-status.deploying > span {
-  background: var(--warning);
+.deploy-status.deploying,
+.loop-item-in_progress {
+  border-color: color-mix(in srgb, var(--blue-ink) 34%, var(--surface));
+  background: var(--blue-tint);
+  color: var(--blue-ink);
 }
-.deploy-status.archived > span {
-  background: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+.kc-state.warning {
+  border-color: color-mix(in srgb, var(--orange) 34%, var(--surface));
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+}
+.loop-item-failed {
+  border-color: color-mix(in srgb, var(--red) 34%, var(--surface));
+  background: var(--red-tint);
+  color: var(--red-ink);
 }
 .deploy-permission {
   display: inline-flex;
@@ -6456,8 +6452,6 @@ summary.work-head:hover {
   grid-area: title;
   display: flex;
   align-items: center;
-  font-size: 13px;
-  font-weight: 400;
 }
 .cron-title-line span:last-child {
   min-width: 0;
@@ -6474,7 +6468,6 @@ summary.work-head:hover {
 }
 
 .cron-meta-line {
-  color: var(--muted-foreground);
   font-size: 12.5px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -6510,9 +6503,6 @@ summary.work-head:hover {
 }
 .cron-disabled-toggle {
   margin-top: 6px;
-}
-.cron-filter-empty {
-  padding: 16px 0;
 }
 @media (max-width: 620px) {
   .cron-row {
@@ -9085,13 +9075,13 @@ h3.ambient-field-label {
   gap: 10px;
 }
 .loop-row-name {
-  font-weight: 600;
+  font-weight: 500;
   flex: 1;
   text-align: left;
 }
 .loop-row-meta {
-  color: var(--muted-foreground, #667085);
-  font-size: 12px;
+  color: var(--ink-3);
+  font-size: 12.5px;
 }
 .loop-health {
   font-size: 11px;
@@ -9263,16 +9253,9 @@ h3.ambient-field-label {
   border-bottom: 1px solid var(--border, #e4e7ec);
 }
 .loop-item-status {
-  font-size: 11px;
   min-width: 84px;
+  justify-content: center;
   text-transform: capitalize;
-  color: var(--muted-foreground, #667085);
-}
-.loop-item-failed {
-  color: var(--destructive);
-}
-.loop-item-shipped {
-  color: var(--success);
 }
 .loop-item-key {
   font-weight: 600;
@@ -9638,6 +9621,10 @@ h3.ambient-field-label {
   .list-search {
     height: 46px;
     border-radius: 12px;
+  }
+  .list-row,
+  .resource-tabs button {
+    min-height: 44px;
   }
   .pane select {
     min-height: 40px;

--- a/plugins/web-ui/src/skills.ts
+++ b/plugins/web-ui/src/skills.ts
@@ -597,6 +597,7 @@ function drawSkills(loading = false): void {
                 html`<button
                   type="button"
                   aria-pressed=${statusFilter === value}
+                  data-status=${value}
                   class=${statusFilter === value ? "active" : ""}
                   @click=${() => {
                     statusFilter = value;

--- a/plugins/web-ui/src/styles/filter.css
+++ b/plugins/web-ui/src/styles/filter.css
@@ -1,0 +1,28 @@
+.list-page-head .pane-title {
+  font-size: 15px;
+  font-weight: 600;
+}
+.list-page-head .pane-subtitle {
+  margin-top: 2px;
+  color: var(--ink-3);
+  font-size: 12.5px;
+}
+.list-rows > :first-child {
+  border-start-start-radius: inherit;
+  border-start-end-radius: inherit;
+}
+.list-rows > :last-child {
+  border-end-start-radius: inherit;
+  border-end-end-radius: inherit;
+}
+.resource-tabs button[data-status="active"]::before,
+.resource-tabs button[data-status="archived"]::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--ink-3);
+}
+.resource-tabs button[data-status="active"]::before {
+  background: var(--green);
+}

--- a/plugins/web-ui/src/styles/tables.css
+++ b/plugins/web-ui/src/styles/tables.css
@@ -1,0 +1,68 @@
+.markdown-content div:has(> table) {
+  margin: 8px 0;
+  max-height: 438px;
+  overflow: auto;
+  scrollbar-color: var(--line-strong) transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+.markdown-content table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  counter-reset: row;
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+}
+.markdown-content th,
+.markdown-content td,
+.markdown-content tr::before {
+  padding: 8px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+  transition: background-color 0.12s ease-out;
+}
+.markdown-content tbody tr:last-child > *,
+.markdown-content tbody tr:last-child::before {
+  border-bottom: 0;
+}
+.markdown-content thead th,
+.markdown-content thead tr::before {
+  position: sticky;
+  top: 0;
+  background: var(--inset);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.markdown-content tr::before {
+  content: "";
+  display: table-cell;
+  width: 0;
+  padding-right: 0;
+  color: var(--ink-3);
+  font: 500 11px/1.4 var(--font-mono);
+  text-align: right;
+}
+.markdown-content tbody tr::before {
+  counter-increment: row;
+  content: counter(row);
+}
+.markdown-content tbody td:first-child {
+  font-weight: 500;
+}
+.markdown-content tbody tr:hover > td,
+.markdown-content tbody tr:hover::before {
+  background: var(--hover);
+}
+.markdown-content :is(th, td)[align="center"] {
+  text-align: center;
+}
+.markdown-content :is(th, td)[align="right"] {
+  text-align: right;
+}

--- a/plugins/web-ui/test/list-page.test.ts
+++ b/plugins/web-ui/test/list-page.test.ts
@@ -6,3 +6,24 @@ test("list search uses its purpose as an accessible name", () => {
   const source = readFileSync(new URL("../src/list-page.ts", import.meta.url), "utf8");
   assert.equal(source.includes("aria-label=${o.search.placeholder"), true);
 });
+
+test("every list page renders its status tabs as one chip row above the table, never inside it", () => {
+  const read = (file: string) => readFileSync(new URL(`../src/${file}`, import.meta.url), "utf8");
+  const crons = read("crons.ts");
+  const deploys = read("deploys.ts");
+  assert.match(crons, /filters: html`\$\{notice\}\$\{all\.length \? cronTabs\(counts\) : nothing\}`/);
+  assert.doesNotMatch(crons, /rows\.push\(cronTabs/);
+  assert.match(deploys, /filters,\s*rows: rows\.map\(deploymentRow\)/);
+  for (const file of ["crons.ts", "deploys.ts", "skills.ts", "sessions.ts"]) {
+    assert.match(read(file), /class="resource-tabs"/, `${file} uses the shared chip row`);
+  }
+  for (const file of ["crons.ts", "deploys.ts", "skills.ts"]) {
+    assert.match(read(file), /data-status=\$\{/, `${file} tags each chip with the status it filters`);
+  }
+  const css = read("shell.css") + read("styles/filter.css");
+  assert.doesNotMatch(css, /cron-filter-chip|cron-list-controls/);
+  assert.match(css, /\.list-rows \{[^}]*border: 1px solid var\(--line\);[^}]*border-radius: var\(--radius-md\);/);
+  assert.match(css, /\.list-divider \{[^}]*background: var\(--line\);/);
+  assert.match(css, /\.resource-tabs button\.active \{[^}]*background: var\(--field\);/);
+  assert.match(css, /\.resource-tabs button span \{[^}]*font-family: var\(--font-mono\);[^}]*font-size: 11\.5px;/);
+});

--- a/plugins/web-ui/test/markdown-sanitize.test.ts
+++ b/plugins/web-ui/test/markdown-sanitize.test.ts
@@ -55,12 +55,20 @@ test("preserves KaTeX math output (visible render + MathML annotation)", () => {
 
 test("shared Markdown preserves formatting without media or private file links", () => {
   const source =
-    '**Packing list**\n\n- Water\n- Snacks\n\n```js\nconst safe = true;\n```\n![remote](https://example.test/track)\n[private](sandbox:/home/sprite/workspace/secret.txt)\n<img src="/api/files/secret/content"><svg><a xlink:href="/api/sessions/private">hidden link</a></svg>';
+    '**Packing list**\n\n- Water\n- Snacks\n\n| Item | Qty |\n|---|---:|\n| Cones | 12 |\n\n```js\nconst safe = true;\n```\n![remote](https://example.test/track)\n[private](sandbox:/home/sprite/workspace/secret.txt)\n<img src="/api/files/secret/content"><svg><a xlink:href="/api/sessions/private">hidden link</a></svg>';
   const result = DOMPurify.sanitize(marked.parse(source, { async: false }), SHARED_MARKDOWN_SANITIZE_CONFIG) as string;
   assert.ok(result.includes("<strong>Packing list</strong>"));
   assert.ok(result.includes("<li>Water</li>"));
+  assert.ok(result.includes('<td align="right">12</td>'));
   assert.ok(result.includes("const safe = true;"));
   assert.equal(/<img|(?:src|href)=|secret\.txt|api\/files/.test(result), false);
+});
+
+test("shared Markdown drops table-cell attributes that fetch or paint", () => {
+  const cell = '<table><tr><td background="https://x" bgcolor="red" align="right">12</td></tr></table>';
+  const result = DOMPurify.sanitize(cell, SHARED_MARKDOWN_SANITIZE_CONFIG) as string;
+  assert.ok(result.includes('<td align="right">12</td>'));
+  assert.equal(/background|bgcolor/.test(result), false);
 });
 
 test("turns sandbox workspace links into real file-library downloads", () => {

--- a/plugins/web-ui/test/markdown-tables.test.ts
+++ b/plugins/web-ui/test/markdown-tables.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createServer } from "vite";
+import { installDom } from "./dom-harness.ts";
+
+const source = [
+  "| Flavor | Batches | Price |",
+  "|:---|:---:|---:|",
+  "| Rocky Road | 12 | $4.00 |",
+  "| Pistachio | 3 | $1.50 |",
+].join("\n");
+
+test("a markdown table rendered through markdown() keeps its grid and alignment after sanitization", async () => {
+  const dom = installDom('<!doctype html><div id="host"></div>');
+  const vite = await createServer({ server: { middlewareMode: true, hmr: false }, appType: "custom" });
+  try {
+    const { render } = await import("lit");
+    const { markdown } = await vite.ssrLoadModule("/src/message-markdown.ts");
+    const { installMarkdownSanitizer } = await vite.ssrLoadModule("/src/markdown-sanitize.ts");
+    installMarkdownSanitizer();
+    const host = dom.window.document.getElementById("host")!;
+    render(markdown(source), host);
+    const block = host.querySelector("markdown-block") as HTMLElement & { updateComplete: Promise<boolean> };
+    await block.updateComplete;
+
+    const grid = block.querySelector("table")!;
+    assert.equal(grid.querySelectorAll("thead th").length, 3);
+    assert.equal(grid.querySelectorAll("tbody tr").length, 2);
+    assert.equal(grid.querySelector("th:nth-child(2)")!.getAttribute("align"), "center");
+    assert.equal(grid.querySelector("tbody td:nth-child(3)")!.getAttribute("align"), "right");
+    assert.equal(grid.querySelector("tbody td")!.textContent, "Rocky Road");
+    assert.equal(grid.parentElement!.tagName, "DIV");
+  } finally {
+    await vite.close();
+    dom.window.close();
+  }
+});


### PR DESCRIPTION
## Summary

Markdown tables render as the records grid: a rounded hairline container with
horizontal scroll, a sticky inset header, row numbers, hairline dividers, hover
wash and honoured column alignment; the shared sanitizer also forbids the
background and bgcolor cell attributes. Every list page becomes the filter
table: resource tabs are status chips with coloured dots, rows sit in a hairline
table with mono dates, and status pills are tinted by state. Crons and deploys
share the same chip row instead of their own.

## Demo

Hovering the records grid rows, then the Files and Skills list pages with their filter controls and hairline rows.

![07-tables-filters.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/07-tables-filters.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 (this) | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
