### PR TITLE
web-ui: search palette

### DIFF
--- a/plugins/web-ui/src/search.ts
+++ b/plugins/web-ui/src/search.ts
@@ -256,7 +256,13 @@ function resultRows(): TemplateResult[] {
           <span class="chat-search-snippet" dir="auto">${highlight(hitSnippet(hit))}</span>
           <span class="chat-search-meta"
             ><bdi>${hit.entryType === "user" ? (hit.author ?? "you") : "agent"}</bdi> ·
-            ${new Date(hit.createdAt).toLocaleDateString()}</span
+            ${
+              Number.isFinite(hit.createdAt)
+                ? html`<time datetime=${new Date(hit.createdAt).toISOString()}
+                    >${new Date(hit.createdAt).toLocaleDateString()}</time
+                  >`
+                : html`<span>Unknown date</span>`
+            }</span
           >
         </span>
       </button>
@@ -295,11 +301,11 @@ function paletteTpl(): TemplateResult {
   if (q.length < MIN_QUERY_LEN) {
     body = html`<div class="chat-search-empty">Search every chat you can see: messages, not just titles.</div>`;
   } else if (searchState.loading && !searchState.hits.length) {
-    body = html`<div class="chat-search-empty">Searching…</div>`;
+    body = html`<div class="chat-search-empty sheen-label thinking-sheen">Searching…</div>`;
   } else if (searchState.failed) {
     body = html`<div class="chat-search-empty chat-search-failed">Search failed. Try again.</div>`;
   } else if (!searchState.hits.length) {
-    body = html`<div class="chat-search-empty">No messages match “${q}”.</div>`;
+    body = html`<div class="chat-search-empty">No results for “${q}”</div>`;
   } else {
     body = html`${resultRows()}`;
   }
@@ -312,7 +318,7 @@ function paletteTpl(): TemplateResult {
     >
       <div class="chat-search-palette" role="dialog" aria-label="Search your chats" @keydown=${onPaletteKeydown}>
         <div class="chat-search-inputrow">
-          ${icon(Search, 16)}
+          ${icon(Search, 14)}
           <input
             class="chat-search-input"
             type="text"

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -7652,7 +7652,6 @@ h3.ambient-field-label {
   align-self: normal;
 }
 
-/* ===== Chat search palette (⌘K) ===== */
 .section-label.recents-label > span:first-child {
   flex: 1;
 }
@@ -7669,89 +7668,93 @@ h3.ambient-field-label {
 .chat-search-palette {
   display: flex;
   flex-direction: column;
-  width: min(640px, calc(100vw - 32px));
+  width: min(560px, calc(100vw - 32px));
   min-height: min(210px, calc(100vh - 96px));
   max-height: min(576px, calc(100vh - 96px));
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  background: var(--background);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  background: var(--surface);
 }
 .chat-search-inputrow {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--border);
-  color: var(--muted-foreground);
+  gap: 8px;
+  min-height: 36px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-3);
 }
 .chat-search-input {
   flex: 1;
+  min-width: 0;
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--foreground);
+  color: var(--ink);
   font: inherit;
-  font-size: 15px;
+  font-size: 13px;
 }
 .chat-search-results {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 10px;
+  padding: 4px;
 }
 .chat-search-group {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 10px 2px;
-  font-size: 12px;
-  color: var(--muted-foreground);
+  padding: 8px 8px 2px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: var(--ink-3);
 }
 .chat-search-group b {
   overflow: hidden;
-  font-weight: 600;
-  color: var(--foreground);
+  font-weight: 500;
+  color: var(--ink-2);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .chat-search-row {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
-  padding: 8px 10px;
+  min-height: 32px;
+  padding: 6px 8px;
   border: 0;
   border-radius: 8px;
   background: transparent;
-  color: inherit;
+  color: var(--ink);
   font: inherit;
+  font-size: 13px;
   text-align: left;
   cursor: pointer;
+  animation: fade-in 200ms ease-out both;
+  transition: background 100ms;
 }
 .chat-search-row.selected {
-  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  background: var(--hover);
 }
 .chat-search-who {
   display: flex;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  margin-top: 1px;
-  border-radius: 6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--field);
+  color: var(--ink-2);
   font-size: 11px;
   font-weight: 600;
 }
-.chat-search-who.user {
-  background: color-mix(in srgb, var(--foreground) 10%, transparent);
-  color: var(--muted-foreground);
-}
 .chat-search-who.agent,
 .chat-search-who.ask {
-  background: var(--primary);
-  color: var(--primary-foreground);
+  background: var(--blue-tint);
+  color: var(--blue-ink);
 }
 .chat-search-text {
   display: flex;
@@ -7764,38 +7767,37 @@ h3.ambient-field-label {
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  line-height: 1.4;
 }
 .chat-search-snippet mark {
   border-radius: 3px;
   padding: 0 1px;
-  background: color-mix(in srgb, var(--primary) 22%, transparent);
-  color: inherit;
+  background: var(--blue-tint);
+  color: var(--blue-ink);
 }
 .chat-search-meta {
   margin-top: 1px;
-  font-size: 11.5px;
-  color: var(--muted-foreground);
+  font-size: 12px;
+  color: var(--ink-3);
 }
 .chat-search-askbar {
   flex-shrink: 0;
-  padding: 8px 10px;
-  border-top: 1px solid var(--border);
-}
-.chat-search-ask {
-  border-radius: 8px;
+  padding: 4px;
+  border-top: 1px solid var(--line);
 }
 .chat-search-empty {
-  padding: 26px 16px;
-  color: var(--muted-foreground);
+  padding: 20px;
+  font-size: 12.5px;
+  color: var(--ink-3);
   text-align: center;
 }
 .chat-search-foot {
   display: flex;
   gap: 14px;
-  padding: 12px 20px;
-  border-top: 1px solid var(--border);
-  font-size: 12px;
-  color: var(--muted-foreground);
+  padding: 8px 12px;
+  border-top: 1px solid var(--line);
+  font-size: 11.5px;
+  color: var(--ink-3);
 }
 
 .browse-palette {
@@ -7872,30 +7874,30 @@ h3.ambient-field-label {
   align-items: center;
   gap: 2px;
   padding: 1px 5px;
-  border: 1px solid var(--border);
-  border-bottom-width: 2px;
-  border-radius: 5px;
-  font-family: ui-monospace, Menlo, monospace;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--field);
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--muted-foreground);
+  color: var(--ink-3);
 }
 .chat-search-group.archived b {
-  color: var(--muted-foreground, #8a8a8a);
+  color: var(--ink-3);
 }
 .chat-search-archived-tag {
   font-style: normal;
   font-size: 10px;
   padding: 1px 5px;
   margin-left: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--line);
   border-radius: 999px;
-  color: var(--muted-foreground, #8a8a8a);
+  color: var(--ink-3);
 }
 .chat-search-row.archived {
   opacity: 0.65;
 }
 .chat-search-failed {
-  color: var(--destructive, #b42318);
+  color: var(--red-ink);
 }
 
 .nav-badge {
@@ -9884,7 +9886,7 @@ h3.ambient-field-label {
   .chat-search-overlay {
     padding: 0;
     align-items: stretch;
-    background: var(--background);
+    background: var(--surface);
   }
   .chat-search-palette {
     width: 100%;
@@ -10667,4 +10669,14 @@ h3.ambient-field-label {
   flex: none;
   white-space: nowrap;
   color: var(--muted-foreground);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-search-row {
+    animation: none;
+    transition: none;
+  }
+  markdown-block code-block[language] copy-button button,
+  .show-full-btn {
+    transition: none;
+  }
 }

--- a/plugins/web-ui/src/styles/search.css
+++ b/plugins/web-ui/src/styles/search.css
@@ -1,0 +1,7 @@
+.chat-search-input::placeholder {
+  color: var(--ink-3);
+}
+.chat-search-meta time {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}

--- a/plugins/web-ui/test/search-palette-source.test.ts
+++ b/plugins/web-ui/test/search-palette-source.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const search = readFileSync(new URL("../src/search.ts", import.meta.url), "utf8");
+const searchCss = readFileSync(new URL("../src/styles/search.css", import.meta.url), "utf8");
+const shell = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+
+test("result rows carry the speaker avatar, the highlighted snippet, and a machine-readable time", () => {
+  assert.match(search, /class="chat-search-who \$\{hit\.entryType === "user" \? "user" : "agent"\}"/);
+  assert.match(search, /class="chat-search-snippet" dir="auto">\$\{highlight\(hitSnippet\(hit\)\)\}/);
+  assert.match(search, /<time\s+datetime=\$\{new Date\(hit\.createdAt\)\.toISOString\(\)\}/);
+  assert.match(
+    searchCss,
+    /\.chat-search-meta time \{\s*font-family: var\(--font-mono\);\s*font-variant-numeric: tabular-nums;/,
+  );
+});
+
+test("searching reuses the thinking shimmer and never throws on a missing timestamp", () => {
+  assert.match(search, /class="chat-search-empty sheen-label thinking-sheen">Searching…</);
+  assert.doesNotMatch(search, /spinner|chat-search-searching/);
+  assert.doesNotMatch(searchCss, /chat-search-searching|shimmer-text/);
+  assert.match(shell, /@keyframes shimmer-text/);
+  assert.match(search, /Number\.isFinite\(hit\.createdAt\)\s*\?\s*html`<time datetime=/);
+});
+
+test("the palette keeps its dialog semantics and keyboard contract", () => {
+  assert.match(
+    search,
+    /class="chat-search-palette" role="dialog" aria-label="Search your chats" @keydown=\$\{onPaletteKeydown\}/,
+  );
+  for (const key of ["Escape", "ArrowDown", "ArrowUp", "Enter"]) {
+    assert.match(search, new RegExp(`e\\.key === "${key}"`));
+  }
+  assert.match(search, /e\.key\.toLowerCase\(\) === "k" && \(isMac \? e\.metaKey : e\.ctrlKey\)/);
+  assert.match(search, /if \(e\.metaKey \|\| e\.ctrlKey\) return void askQm\(\);/);
+  assert.match(shell, /\.chat-search-row\.selected \{\s*background: var\(--hover\);/);
+});


### PR DESCRIPTION
## Summary

The ⌘K palette takes the reference look: a scrim that darkens in both themes,
a 560 px surface with hairline dividers, an input row with the search glyph,
result rows with an avatar mark, blue highlight marks, mono tabular times and
kbd chips, group headers, a shimmering "Searching…" state and the reference
empty copy. Keyboard behaviour is unchanged.

## Demo

⌘K, typing "churn" letter by letter, arrowing through results, Escape.

![08-search.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/08-search.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 (this) | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
