### PR TITLE
web-ui: settings as inspector cards

### DIFF
--- a/plugins/web-ui/src/settings.ts
+++ b/plugins/web-ui/src/settings.ts
@@ -159,7 +159,7 @@ function themeRow(): TemplateResult {
       </div>
       <div class="settings-theme-controls">
         <div class="settings-choice" role="radiogroup" aria-label="Theme">
-          ${THEME_OPTIONS.map((option) => themeOption(option.value, current, option.label, icon(option.glyph, 15)))}
+          ${THEME_OPTIONS.map((option) => themeOption(option.value, current, option.label, icon(option.glyph, 14)))}
           ${custom ? themeOption("custom", current, custom.name, themeSwatches(custom)) : nothing}
         </div>
         <div class="settings-theme-import">
@@ -241,7 +241,7 @@ function adminRow(): TemplateResult {
         <div class="settings-row-title">Admin</div>
         <div class="settings-row-note">Org settings, people, and policy.</div>
       </div>
-      <a class="btn settings-row-action" href=${ADMIN_HOME_URL}>
+      <a class="settings-row-action" href=${ADMIN_HOME_URL}>
         ${icon(ShieldUser, 15)}<span>Open admin</span>${icon(ExternalLink, 14)}
       </a>
     </div>
@@ -257,7 +257,7 @@ function aboutRow(): TemplateResult {
           Why Y Combinator built this open-source agent harness, and how to run your own.
         </div>
       </div>
-      <a class="btn settings-row-action" href=${QM_ABOUT_URL} target="_blank" rel="noreferrer noopener">
+      <a class="settings-row-action" href=${QM_ABOUT_URL} target="_blank" rel="noreferrer noopener">
         ${icon(BookOpen, 15)}<span>Read the announcement</span>${icon(ExternalLink, 14)}
       </a>
     </div>
@@ -269,13 +269,34 @@ function accountRow(): TemplateResult {
   return html`
     <div class="settings-row">
       <div class="settings-row-copy">
-        <div class="settings-row-title">Account</div>
+        <div class="settings-row-title">Signed in as</div>
         <div class="settings-row-note">${me?.user ?? "Not signed in"}${me?.org ? ` · ${me.org}` : ""}</div>
       </div>
-      <button class="btn settings-row-action" type="button" @click=${() => void signOut()}>
-        ${icon(LogOut, 15)}<span>Sign out</span>
-      </button>
     </div>
+  `;
+}
+
+function signOutAction(): TemplateResult {
+  return html`
+    <button class="settings-group-action" type="button" @click=${() => void signOut()}>
+      ${icon(LogOut, 13)}<span>Sign out</span>
+    </button>
+  `;
+}
+
+function settingsCard(
+  title: string,
+  action: TemplateResult | typeof nothing,
+  rows: Array<TemplateResult | typeof nothing>,
+): TemplateResult {
+  return html`
+    <section class="settings-group">
+      <div class="settings-group-head">
+        <h2 class="settings-group-title">${title}</h2>
+        ${action}
+      </div>
+      ${rows}
+    </section>
   `;
 }
 
@@ -284,9 +305,8 @@ function settingsPane(): TemplateResult {
     <div class="list-page-head">
       <h1 class="pane-title">Settings</h1>
     </div>
-    <div class="settings-group">
-      ${themeRow()} ${sidebarSurfaceRow()} ${can("admin") ? adminRow() : nothing} ${aboutRow()} ${accountRow()}
-    </div>
+    ${settingsCard("Appearance", nothing, [themeRow(), sidebarSurfaceRow()])}
+    ${settingsCard("Account", signOutAction(), [accountRow(), can("admin") ? adminRow() : nothing, aboutRow()])}
   `;
 }
 

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1113,18 +1113,20 @@ a.chat-row-open {
 .settings-group {
   display: flex;
   flex-direction: column;
-  gap: 1px;
   max-width: 960px;
   margin: 12px auto 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
 }
 .settings-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px 16px;
   flex-wrap: wrap;
-  padding: 16px 2px;
-  border-bottom: 1px solid var(--border);
+  padding: 12px;
+  border-bottom: 1px solid var(--line);
 }
 .settings-row:last-child {
   border-bottom: 0;
@@ -1134,49 +1136,72 @@ a.chat-row-open {
   min-width: 0;
 }
 .settings-row-title {
-  font-size: 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink-2);
 }
 .settings-row-note {
   margin-top: 2px;
   font-size: 12.5px;
-  color: var(--muted-foreground);
+  color: var(--ink-3);
 }
 .settings-row-action {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  text-decoration: none;
-}
-.settings-choice {
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--secondary) 55%, var(--background));
-}
-.settings-choice-option {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
-  padding: 6px 11px;
-  border: 0;
-  border-radius: var(--radius-sm);
+  min-height: 28px;
+  padding: 0 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
   background: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
+  color: var(--ink-2);
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
+  text-decoration: none;
+  cursor: pointer;
   transition:
     background 0.12s ease,
     color 0.12s ease;
 }
+.settings-row-action:hover {
+  background: var(--hover);
+  color: var(--ink);
+}
+.settings-choice {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  background: var(--field);
+}
+.settings-choice-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 26px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-chip);
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  white-space: nowrap;
+  transition:
+    background 0.2s var(--ease-out-strong),
+    color 0.2s ease;
+}
 .settings-choice-option:hover {
-  color: var(--foreground);
+  color: var(--ink-2);
 }
 .settings-choice-option.selected {
-  background: var(--background);
-  color: var(--foreground);
+  border-color: var(--line-strong);
+  background: var(--surface);
+  color: var(--blue-ink);
 }
 .settings-theme-controls {
   display: flex;
@@ -1204,7 +1229,7 @@ a.chat-row-open {
   color: var(--foreground);
 }
 .settings-row-error {
-  color: var(--destructive, #c0392b);
+  color: var(--red-ink);
 }
 .theme-swatches {
   display: inline-flex;
@@ -1212,9 +1237,9 @@ a.chat-row-open {
 }
 .theme-swatch {
   width: 8px;
-  height: 14px;
+  height: 8px;
   border-radius: 2px;
-  border: 1px solid color-mix(in srgb, var(--foreground) 25%, transparent);
+  border: 1px solid var(--line-strong);
 }
 
 .main {
@@ -4782,6 +4807,17 @@ summary.work-head:hover {
 }
 
 @media (max-width: 560px) {
+  .settings-choice,
+  .settings-theme-controls {
+    width: 100%;
+  }
+  .settings-theme-controls {
+    justify-content: flex-start;
+  }
+  .settings-row-action,
+  .settings-group-action {
+    min-height: 44px;
+  }
   .pane {
     padding: calc(20px + var(--surface-safe-top)) max(14px, env(safe-area-inset-right))
       calc(32px + env(safe-area-inset-bottom)) max(14px, env(safe-area-inset-left));
@@ -6552,8 +6588,8 @@ summary.work-head:hover {
   height: 34px;
   max-width: min(260px, 50vw);
   padding: 0 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-chip);
   background: var(--background);
   color: var(--foreground);
 }
@@ -6592,7 +6628,7 @@ summary.work-head:hover {
   display: inline-flex;
   align-items: center;
   max-width: 100%;
-  color: var(--foreground);
+  color: var(--ink);
 }
 .field-select > select {
   min-width: 0;
@@ -6601,10 +6637,10 @@ summary.work-head:hover {
   box-sizing: border-box;
   padding: 0 36px 0 10px;
   appearance: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-chip);
   outline: 0;
-  background: var(--background);
+  background: var(--inset);
   color: inherit;
   font: inherit;
   font-size: 13px;
@@ -6613,7 +6649,7 @@ summary.work-head:hover {
 .field-select > .icon {
   position: absolute;
   right: 12px;
-  opacity: 0.55;
+  color: var(--ink-3);
   pointer-events: none;
 }
 .field-select.compact > select {
@@ -6625,11 +6661,11 @@ summary.work-head:hover {
   right: 10px;
 }
 .field-select > select:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--foreground) 30%, var(--border));
+  border-color: var(--ink-3);
 }
 .field-select > select:focus-visible {
-  border-color: var(--foreground);
-  outline: 2px solid color-mix(in srgb, var(--foreground) 65%, transparent);
+  border-color: var(--blue);
+  outline: 2px solid var(--ring);
   outline-offset: 2px;
 }
 .field-select:has(> select:disabled) {

--- a/plugins/web-ui/src/styles/settings.css
+++ b/plugins/web-ui/src/styles/settings.css
@@ -1,0 +1,37 @@
+.settings-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+}
+.settings-group-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+}
+.settings-group-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 0 6px;
+  border: 0;
+  border-radius: var(--radius-chip);
+  background: transparent;
+  color: var(--blue-ink);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.settings-group-action:hover {
+  background: var(--blue-tint);
+}
+.settings-row-copy {
+  flex: 1 1 240px;
+  min-width: 0;
+}

--- a/plugins/web-ui/test/settings-page.test.ts
+++ b/plugins/web-ui/test/settings-page.test.ts
@@ -7,6 +7,7 @@ const shell = readFileSync(new URL("../src/shell.ts", import.meta.url), "utf8");
 const shellState = readFileSync(new URL("../src/shell-state.ts", import.meta.url), "utf8");
 const main = readFileSync(new URL("../src/main.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const settingsCss = readFileSync(new URL("../src/styles/settings.css", import.meta.url), "utf8");
 
 test("settings is a routable view, so /settings survives a reload and a shared link", () => {
   assert.match(shellState, /"settings",?\s*\] as const/);
@@ -91,6 +92,26 @@ test("the imported palette is painted as one style element that applyTheme owns 
   assert.match(apply, /classList\.toggle\("dark", tokens\.dark\)/, "the palette decides dark mode, not the OS");
   assert.match(apply, /styleEl\?\.remove\(\);/, "leaving custom must strip the injected palette");
   assert.match(css, /\.theme-swatch \{/);
+});
+
+test("settings rows live in titled inspector cards, with the radiogroups as segmented controls", () => {
+  assert.match(settings, /settingsCard\("Appearance", nothing, \[themeRow\(\), sidebarSurfaceRow\(\)\]\)/);
+  assert.match(settings, /settingsCard\("Account", signOutAction\(\)/);
+  assert.match(
+    settings,
+    /<section class="settings-group">\s*<div class="settings-group-head">\s*<h2 class="settings-group-title">/,
+  );
+  assert.match(settings, /class="settings-group-action"[^>]*@click=\$\{\(\) => void signOut\(\)\}/);
+  assert.doesNotMatch(settings, /class="btn settings-row-action"/, "row actions are ghost pills, not bordered buttons");
+  assert.match(css, /\.settings-group \{[^}]*border: 1px solid var\(--line\);[^}]*background: var\(--surface\);/);
+  assert.match(css, /\.settings-choice \{[^}]*grid-auto-columns: 1fr;[^}]*background: var\(--field\);/);
+  assert.match(css, /\.settings-choice-option\.selected \{[^}]*background: var\(--surface\);/);
+  assert.match(settingsCss, /\.settings-group-action \{[^}]*color: var\(--blue-ink\);/);
+  assert.match(
+    css,
+    /@media \(max-width: 560px\) \{\s*\.settings-choice,\s*\.settings-theme-controls \{\s*width: 100%;/,
+    "segmented controls span the phone width",
+  );
 });
 
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

The settings page becomes a stack of inspector cards: Appearance (theme and
sidebar conversations as segmented controls, the theme file import as a text
link) and Account (sign-out as the header action; signed-in identity, admin and
about rows). Native selects and the menu-backed filter share one field box.

## Demo

The Appearance card: switching Light / Dark / System and the sidebar conversations segments.

![09-settings.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/09-settings.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 (this) | settings as inspector cards |
| 9 | #1061 | selection actions toolbar |
| 10 | #1062 | recommendation card |
