### PR TITLE
web-ui: selection actions toolbar

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -1249,6 +1249,16 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     return scope ? scope.charAt(0).toUpperCase() + scope.slice(1) : "";
   }
 
+  function insertText(text: string): void {
+    const agent = ctx.chat.state.agent;
+    if (!agent) return;
+    composerState.draft = insertIntoDraft(composerState.draft, text, null).draft;
+    persistDraft();
+    ctx.chat.drawActiveChat(agent);
+    resizeComposer();
+    focusComposerEnd();
+  }
+
   function submitComposer(e: Event, agent: Agent): void {
     e.preventDefault();
     void sendPrompt(agent);
@@ -1947,6 +1957,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     setQueuedRuns,
     resetComposer,
     focusComposerEnd,
+    insertText,
     resizeComposer,
     currentModelOption,
     carryModelPick,

--- a/plugins/web-ui/src/conv-types.ts
+++ b/plugins/web-ui/src/conv-types.ts
@@ -125,6 +125,7 @@ export interface ComposerSurface {
   setQueuedRuns(threadRef: string, runs: QueuedRun[]): void;
   resetComposer(): void;
   focusComposerEnd(): void;
+  insertText(text: string): void;
   resizeComposer(): void;
   currentModelOption(): ModelOption | undefined;
   carryModelPick(fromThreadRef: string | null, toThreadRef: string): void;

--- a/plugins/web-ui/src/main.ts
+++ b/plugins/web-ui/src/main.ts
@@ -3,6 +3,7 @@ import "./shell.css";
 import { bootSafely, closeUserMenu } from "./shell";
 import "./draft-review";
 import { registerChatSearchHotkey } from "./search";
+import { registerSelectionActions } from "./selection-actions";
 import { registerSessionJumpHotkeys } from "./session-jump";
 import { closeFormMenus } from "./ui";
 import { allConversations } from "./conversations";
@@ -105,5 +106,9 @@ document.addEventListener(
 );
 
 registerChatSearchHotkey();
+registerSelectionActions((stack) => {
+  const conv = allConversations().find((c) => c.state.host?.contains(stack));
+  return conv?.state.agent ? conv.composer : null;
+});
 registerSessionJumpHotkeys();
 void bootSafely();

--- a/plugins/web-ui/src/selection-actions.ts
+++ b/plugins/web-ui/src/selection-actions.ts
@@ -1,0 +1,256 @@
+import { html, nothing, render, type TemplateResult } from "lit";
+import { live } from "lit/directives/live.js";
+import { ChevronRight, Copy, MessageCircleQuestionMark, Quote, Sparkle } from "lucide";
+import { copyText, icon } from "./ui.ts";
+
+export interface SelectionComposer {
+  insertText(text: string): void;
+}
+
+interface SelectedPassage {
+  text: string;
+  anchor: Node | null;
+  rect: DOMRect;
+  stack: HTMLElement;
+  composer: SelectionComposer;
+}
+
+interface ShownSelection extends SelectedPassage {
+  returnFocus: HTMLElement | null;
+}
+
+const EDGE = 8;
+
+let host: HTMLDivElement | null = null;
+let shown: ShownSelection | null = null;
+let dismissed: Pick<SelectedPassage, "text" | "anchor"> | null = null;
+let prompt = "";
+let pointerDown = false;
+let composerFor: (stack: HTMLElement) => SelectionComposer | null = () => null;
+
+export function registerSelectionActions(resolve: (stack: HTMLElement) => SelectionComposer | null): void {
+  composerFor = resolve;
+  document.addEventListener("selectionchange", () => {
+    if (!pointerDown && !insideToolbar(document.activeElement)) evaluate();
+  });
+  document.addEventListener("pointerdown", (e) => {
+    if (insideToolbar(e.target)) return;
+    pointerDown = true;
+    dismissed = null;
+    hide();
+  });
+  for (const type of ["pointerup", "pointercancel"] as const) {
+    document.addEventListener(type, (e) => {
+      pointerDown = false;
+      if (!insideToolbar(e.target)) evaluate();
+    });
+  }
+  document.addEventListener("keydown", (e) => {
+    if (!shown) return;
+    if (e.key === "Escape") dismiss();
+    else if (e.key === "Tab") onTab(e, shown.stack);
+  });
+  document.addEventListener(
+    "scroll",
+    (e) => {
+      if (shown && !insideToolbar(e.target) && !insideToolbar(document.activeElement)) evaluate();
+    },
+    { capture: true, passive: true },
+  );
+}
+
+function insideToolbar(target: EventTarget | null): boolean {
+  return Boolean(host && target && host.contains(target as Node));
+}
+
+function stackOf(node: Node | null): HTMLElement | null {
+  const el = node?.nodeType === 1 ? (node as Element) : node?.parentElement;
+  return el?.closest<HTMLElement>(".message-stack") ?? null;
+}
+
+function scrollerOf(stack: HTMLElement): HTMLElement | null {
+  return stack.closest<HTMLElement>(".chat-scroll");
+}
+
+function selectedPassage(): SelectedPassage | null {
+  const sel = document.getSelection();
+  if (!sel || sel.isCollapsed) return null;
+  const text = sel.toString().trim();
+  const stack = stackOf(sel.anchorNode);
+  if (!text || !stack || stack !== stackOf(sel.focusNode)) return null;
+  const composer = composerFor(stack);
+  if (!composer) return null;
+  return { text, anchor: sel.anchorNode, rect: sel.getRangeAt(0).getBoundingClientRect(), stack, composer };
+}
+
+function offscreen({ rect, stack }: SelectedPassage): boolean {
+  const view = scrollerOf(stack)?.getBoundingClientRect();
+  const top = Math.max(0, view?.top ?? 0);
+  const bottom = Math.min(document.documentElement.clientHeight, view?.bottom ?? Infinity);
+  return rect.bottom < top || rect.top > bottom;
+}
+
+function evaluate(): void {
+  const passage = selectedPassage();
+  if (passage && dismissed?.text === passage.text && dismissed.anchor === passage.anchor) return;
+  dismissed = null;
+  if (!passage || offscreen(passage)) {
+    hide();
+    return;
+  }
+  shown = { ...passage, returnFocus: shown?.returnFocus ?? (document.activeElement as HTMLElement | null) };
+  draw();
+  place();
+}
+
+function dismiss(): void {
+  if (shown) dismissed = { text: shown.text, anchor: shown.anchor };
+  hide();
+}
+
+function hide(): void {
+  if (!shown) return;
+  const { stack, returnFocus } = shown;
+  shown = null;
+  prompt = "";
+  if (insideToolbar(document.activeElement)) focusTranscript(stack, returnFocus);
+  draw();
+}
+
+function focusTranscript(stack: HTMLElement, previous: HTMLElement | null): void {
+  const scroller = scrollerOf(stack);
+  if (previous?.isConnected && previous !== document.body && previous !== scroller) {
+    previous.focus({ preventScroll: true });
+    return;
+  }
+  if (!scroller) return;
+  scroller.tabIndex = -1;
+  scroller.setAttribute("data-quiet-focus", "");
+  scroller.addEventListener("blur", () => scroller.removeAttribute("data-quiet-focus"), { once: true });
+  scroller.focus({ preventScroll: true });
+}
+
+function visibleControls(): HTMLElement[] {
+  return [...ensureHost().querySelectorAll<HTMLElement>("input, button:not([disabled])")].filter(
+    (el) => getComputedStyle(el).display !== "none",
+  );
+}
+
+function onTab(e: KeyboardEvent, stack: HTMLElement): void {
+  const active = document.activeElement as HTMLElement | null;
+  const controls = visibleControls();
+  if (insideToolbar(active)) {
+    if (active !== (e.shiftKey ? controls[0] : controls.at(-1))) return;
+    e.preventDefault();
+    hide();
+    return;
+  }
+  if (e.shiftKey || (active !== document.body && active !== scrollerOf(stack))) return;
+  e.preventDefault();
+  controls[0]?.focus();
+}
+
+function ensureHost(): HTMLDivElement {
+  if (!host) {
+    host = document.createElement("div");
+    host.className = "selection-actions-host";
+    document.body.appendChild(host);
+  }
+  return host;
+}
+
+function draw(): void {
+  render(shown ? toolbarTpl(shown) : nothing, ensureHost());
+}
+
+function place(): void {
+  const bar = host?.firstElementChild as HTMLElement | null;
+  if (!bar || !shown) return;
+  const { rect } = shown;
+  const { width, height } = bar.getBoundingClientRect();
+  const viewportWidth = document.documentElement.clientWidth;
+  const viewportHeight = document.documentElement.clientHeight;
+  const centered = rect.left + rect.width / 2 - width / 2;
+  const left = Math.min(Math.max(EDGE, centered), Math.max(EDGE, viewportWidth - width - EDGE));
+  const below = rect.bottom + EDGE;
+  const top = below + height > viewportHeight - EDGE ? rect.top - height - EDGE : below;
+  bar.style.left = `${Math.round(left)}px`;
+  bar.style.top = `${Math.round(Math.max(EDGE, top))}px`;
+}
+
+function quoted(text: string): string {
+  return `> ${text.split("\n").join("\n> ")}\n\n`;
+}
+
+function handOff(text: string): void {
+  if (!shown) return;
+  const { composer } = shown;
+  dismiss();
+  composer.insertText(text);
+}
+
+function copySelection(): void {
+  if (!shown) return;
+  void copyText(shown.text);
+  dismiss();
+}
+
+function submitAsk(): void {
+  const ask = prompt.trim();
+  if (!ask || !shown) return;
+  handOff(`${quoted(shown.text)}${ask}`);
+}
+
+function onPromptInput(e: Event): void {
+  prompt = (e.currentTarget as HTMLInputElement).value;
+  draw();
+}
+
+function onPromptKeydown(e: KeyboardEvent): void {
+  if (e.key !== "Enter") return;
+  e.preventDefault();
+  submitAsk();
+}
+
+function toolbarTpl(s: ShownSelection): TemplateResult {
+  const ask = prompt.trim();
+  return html`<div class="selection-toolbar" role="toolbar" aria-label="Selection actions">
+    <input
+      class="selection-toolbar-input"
+      type="text"
+      placeholder="Describe edits"
+      aria-label="Describe edits"
+      autocomplete="off"
+      .value=${live(prompt)}
+      @input=${onPromptInput}
+      @keydown=${onPromptKeydown}
+    />
+    <span class="selection-toolbar-divider"></span>
+    <button type="button" class="selection-toolbar-btn" data-action="quote" @click=${() => handOff(quoted(s.text))}>
+      ${icon(Quote, 13)}Quote
+    </button>
+    <button
+      type="button"
+      class="selection-toolbar-btn"
+      data-action="explain"
+      @click=${() => handOff(`${quoted(s.text)}Explain this.`)}
+    >
+      ${icon(MessageCircleQuestionMark, 13)}Explain
+    </button>
+    <button type="button" class="selection-toolbar-btn" data-action="ask" ?disabled=${!ask} @click=${submitAsk}>
+      ${icon(Sparkle, 13)}Ask
+    </button>
+    <button type="button" class="selection-toolbar-btn" data-action="copy" @click=${copySelection}>
+      ${icon(Copy, 13)}Copy
+    </button>
+    <button
+      type="button"
+      class="selection-toolbar-btn selection-toolbar-send"
+      aria-label="Ask about the selection"
+      ?disabled=${!ask}
+      @click=${submitAsk}
+    >
+      ${icon(ChevronRight, 13)}
+    </button>
+  </div>`;
+}

--- a/plugins/web-ui/src/styles/selection.css
+++ b/plugins/web-ui/src/styles/selection.css
@@ -1,0 +1,112 @@
+.message-stack ::selection {
+  background: var(--selection, color-mix(in oklch, var(--blue) 28%, transparent));
+}
+.selection-toolbar {
+  position: fixed;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 36px;
+  max-width: calc(100vw - 16px);
+  padding: 4px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--ink);
+  user-select: none;
+  animation: pop-in 160ms var(--ease-out-strong) both;
+}
+.selection-toolbar-input {
+  width: 140px;
+  height: 28px;
+  padding: 0 10px 0 12px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  font-size: 13px;
+}
+.selection-toolbar-input::placeholder {
+  color: var(--ink-3);
+}
+.selection-toolbar-divider {
+  flex: none;
+  width: 1px;
+  height: 16px;
+  margin: 0 4px;
+  background: var(--line-strong);
+}
+.selection-toolbar-btn {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  font-size: 12.5px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease-out,
+    transform 150ms ease-out;
+}
+.selection-toolbar-btn:hover {
+  background: var(--hover);
+}
+.selection-toolbar-btn:active {
+  transform: scale(0.96);
+}
+.selection-toolbar-btn:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.selection-toolbar-send {
+  width: 28px;
+  padding: 0;
+  justify-content: center;
+  background: var(--ink);
+  color: var(--surface);
+}
+.selection-toolbar-send:hover {
+  background: var(--ink-2);
+}
+.selection-toolbar-input:focus-visible,
+.selection-toolbar-btn:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+.chat-scroll[data-quiet-focus]:focus-visible {
+  outline: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .selection-toolbar {
+    animation: none;
+  }
+  .selection-toolbar-btn {
+    transition: none;
+  }
+  .selection-toolbar-btn:active {
+    transform: none;
+  }
+}
+@media (max-width: 560px) {
+  .selection-toolbar {
+    height: 44px;
+  }
+  .selection-toolbar-btn {
+    height: 36px;
+  }
+  .selection-toolbar-input,
+  .selection-toolbar-input + .selection-toolbar-divider,
+  .selection-toolbar-btn[data-action="ask"],
+  .selection-toolbar-send {
+    display: none;
+  }
+}

--- a/plugins/web-ui/test/selection-actions.test.ts
+++ b/plugins/web-ui/test/selection-actions.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { installDom } from "./dom-harness.ts";
+
+const dom = installDom(
+  `<!doctype html><main>
+    <section class="chat-scroll"><div class="message-stack">
+      <p id="inside">Churn it first thing Saturday.</p>
+      <p id="inside2">Fold the pistachios in last.</p>
+    </div></section>
+    <p id="outside">Pistachio holds the top slot.</p>
+    <textarea id="composer"></textarea>
+  </main>`,
+);
+const zeroRect = { x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0, toJSON: () => ({}) };
+dom.window.Range.prototype.getBoundingClientRect = () => zeroRect as DOMRect;
+
+const { registerSelectionActions } = await import("../src/selection-actions.ts");
+const inserted: string[] = [];
+registerSelectionActions(() => ({ insertText: (text) => void inserted.push(text) }));
+
+const selectionChanged = (): boolean => document.dispatchEvent(new window.Event("selectionchange"));
+
+function select(id: string): void {
+  const range = document.createRange();
+  range.selectNodeContents(document.getElementById(id)!);
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selectionChanged();
+  selection.addRange(range);
+  selectionChanged();
+}
+
+function key(type: "keydown" | "keyup", key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const e = new window.KeyboardEvent(type, { key, bubbles: true, cancelable: true, ...init });
+  document.activeElement!.dispatchEvent(e);
+  return e;
+}
+
+const toolbar = (): HTMLElement | null => document.querySelector<HTMLElement>('.selection-toolbar[role="toolbar"]');
+const scroller = document.querySelector<HTMLElement>(".chat-scroll")!;
+const quote = "> Churn it first thing Saturday.\n\n";
+
+test("a selection inside a message stack shows the toolbar", () => {
+  select("inside");
+  assert.ok(toolbar());
+  assert.equal(toolbar()!.getAttribute("aria-label"), "Selection actions");
+  assert.equal(toolbar()!.querySelector("input")!.getAttribute("placeholder"), "Describe edits");
+});
+
+test("a selection outside every message stack shows nothing", () => {
+  select("outside");
+  assert.equal(toolbar(), null);
+});
+
+test("Escape hides the toolbar and the same selection stays dismissed until a new one is made", () => {
+  select("inside");
+  assert.ok(toolbar());
+  key("keydown", "Escape");
+  key("keyup", "Escape");
+  assert.equal(toolbar(), null);
+  selectionChanged();
+  assert.equal(toolbar(), null);
+  select("inside2");
+  assert.ok(toolbar());
+});
+
+test("scrolling keeps the toolbar while the selection is on screen and hides it once the selection is gone", () => {
+  select("inside");
+  scroller.dispatchEvent(new window.Event("scroll"));
+  assert.ok(toolbar());
+  document.getSelection()!.removeAllRanges();
+  scroller.dispatchEvent(new window.Event("scroll"));
+  assert.equal(toolbar(), null);
+});
+
+test("Quote inserts the quoted passage and closes", () => {
+  inserted.length = 0;
+  select("inside");
+  toolbar()!.querySelector<HTMLButtonElement>('[data-action="quote"]')!.click();
+  assert.deepEqual(inserted, [quote]);
+  assert.equal(toolbar(), null);
+});
+
+test("Explain inserts the quote with the prompt beneath it", () => {
+  inserted.length = 0;
+  select("inside");
+  toolbar()!.querySelector<HTMLButtonElement>('[data-action="explain"]')!.click();
+  assert.deepEqual(inserted, [`${quote}Explain this.`]);
+});
+
+test("Ask inserts the typed prompt beneath the quote on Enter or the send button", () => {
+  for (const send of ["enter", "button"]) {
+    inserted.length = 0;
+    select("inside");
+    const input = toolbar()!.querySelector<HTMLInputElement>("input")!;
+    assert.equal(toolbar()!.querySelector<HTMLButtonElement>('[data-action="ask"]')!.disabled, true);
+    input.value = "Make it shorter";
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    if (send === "enter") input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    else toolbar()!.querySelector<HTMLButtonElement>(".selection-toolbar-send")!.click();
+    assert.deepEqual(inserted, [`${quote}Make it shorter`]);
+    assert.equal(toolbar(), null);
+  }
+});
+
+test("Tab enters the toolbar only from the transcript, skips hidden controls, and leaves quietly", () => {
+  const composer = document.getElementById("composer") as HTMLTextAreaElement;
+  select("inside");
+  composer.focus();
+  assert.equal(key("keydown", "Tab").defaultPrevented, false);
+  assert.equal(document.activeElement, composer);
+
+  composer.blur();
+  const style = document.head.appendChild(document.createElement("style"));
+  style.textContent = ".selection-toolbar-input { display: none }";
+  assert.equal(key("keydown", "Tab").defaultPrevented, true);
+  assert.equal(document.activeElement, toolbar()!.querySelector('[data-action="quote"]'));
+  style.remove();
+
+  key("keydown", "Escape");
+  assert.equal(toolbar(), null);
+  assert.equal(document.activeElement, scroller);
+  assert.ok(scroller.hasAttribute("data-quiet-focus"));
+  scroller.blur();
+  assert.equal(scroller.hasAttribute("data-quiet-focus"), false);
+
+  scroller.focus();
+  select("inside2");
+  assert.equal(key("keydown", "Tab").defaultPrevented, true);
+  assert.equal(document.activeElement, toolbar()!.querySelector("input"));
+  toolbar()!.querySelector<HTMLButtonElement>('[data-action="copy"]')!.focus();
+  assert.equal(key("keydown", "Tab").defaultPrevented, true);
+  assert.equal(toolbar(), null);
+  assert.equal(document.activeElement, scroller);
+});


### PR DESCRIPTION
## Summary

Selecting text inside a message shows a floating pill toolbar under the
selection: Quote, Explain and Ask insert the quoted passage (and the typed
question) into the composer and focus it — never auto-submitting — and Copy
copies it. The toolbar survives Escape and the transcript's auto-scroll, resolves
read-only views from state, and the message stack's selection highlight is the
blue tint.

## Demo

Selecting a sentence in a reply: the floating toolbar appears; Quote drops the quoted passage into the composer and focuses it.

![10-selection-actions.gif](https://raw.githubusercontent.com/yc-software/qm/demo/beautiful-ui-screenshots/gifs/10-selection-actions.gif)

## Verification

Typecheck, the full `plugins/web-ui` suite, eslint and prettier pass at this level of the stack (each level is verified on its own, on top of the previous one). Live QA of the finished stack ran in a browser-only `dev-instance` against a seeded conversation (tool run, markdown table, TypeScript and diff fences, a pending approval, ⌘K, list pages, settings), in light and dark and at phone width.

## Stack

Merge in order; each PR is based on the one above it and retargets automatically when its base merges.

| # | PR | Change |
| --- | --- | --- |
| 1 | #1053 | Beautiful UI foundation — tokens, fonts, styles scaffold |
| 2 | #1054 | loading state and the live thinking trace |
| 3 | #1055 | chat rows, session header and empty state |
| 4 | #1056 | approval card with a pager |
| 5 | #1057 | tool chips and code blocks |
| 6 | #1058 | records tables and filter lists |
| 7 | #1059 | search palette |
| 8 | #1060 | settings as inspector cards |
| 9 | #1061 (this) | selection actions toolbar |
| 10 | #1062 | recommendation card |
