### PR TITLE
Route QM browser tasks through Aside Remote Control

### DIFF
--- a/deploy/e2b/e2b.Dockerfile
+++ b/deploy/e2b/e2b.Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates git curl wget jq tar xz-utils unzip zip \
     python3 python3-pip python3-venv \
-    openssh-client gnupg less vim-tiny \
+    openssh-client gnupg less vim-tiny libatomic1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Node 24 (matches the core's runtime major)
@@ -20,3 +20,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # their base images; create it for a stock ubuntu base).
 RUN id user 2>/dev/null || useradd -m -u 1000 -s /bin/bash user || usermod -l user -d /home/user -m ubuntu
 RUN mkdir -p /home/user/workspace && chown -R user:user /home/user
+
+ARG TARGETARCH
+ARG ASIDE_CLI_VERSION=1.26.906.1630
+RUN case "$TARGETARCH" in \
+      amd64) ASIDE_ARCH=x64; ASIDE_SHA=092751c803a3a1c393af5a15b275f07b8663c53eb15851645d80521b170dacf8 ;; \
+      arm64) ASIDE_ARCH=arm64; ASIDE_SHA=0c70914864b8811154d021087419b718a39bee52a7cf948fc73e6f5087f0adf5 ;; \
+      *) exit 1 ;; \
+    esac \
+  && curl -fsSL "https://releases.aside.com/cli/AsideCLI-linux-${ASIDE_ARCH}-${ASIDE_CLI_VERSION}.tar.gz" -o /tmp/aside.tgz \
+  && echo "$ASIDE_SHA  /tmp/aside.tgz" | sha256sum -c - \
+  && tar xzf /tmp/aside.tgz -C /tmp \
+  && install /tmp/aside /usr/local/bin/aside \
+  && rm -f /tmp/aside /tmp/aside.tgz \
+  && aside --version

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git curl wget jq unzip \
       nftables \
       python3 python3-venv python3-pip \
-      ca-certificates gnupg \
+      ca-certificates gnupg libatomic1 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=node-runtime /usr/local/ /usr/local/
@@ -31,6 +31,19 @@ RUN case "$TARGETARCH" in \
   && rm -rf /tmp/gh* \
   && gh --version \
   && rm -rf /root/.local/state/gh
+
+ARG ASIDE_CLI_VERSION=1.26.906.1630
+RUN case "$TARGETARCH" in \
+      amd64) ASIDE_ARCH=x64; ASIDE_SHA=092751c803a3a1c393af5a15b275f07b8663c53eb15851645d80521b170dacf8 ;; \
+      arm64) ASIDE_ARCH=arm64; ASIDE_SHA=0c70914864b8811154d021087419b718a39bee52a7cf948fc73e6f5087f0adf5 ;; \
+      *) exit 1 ;; \
+    esac \
+  && curl -fsSL "https://releases.aside.com/cli/AsideCLI-linux-${ASIDE_ARCH}-${ASIDE_CLI_VERSION}.tar.gz" -o /tmp/aside.tgz \
+  && echo "$ASIDE_SHA  /tmp/aside.tgz" | sha256sum -c - \
+  && tar xzf /tmp/aside.tgz -C /tmp \
+  && install /tmp/aside /usr/local/bin/aside \
+  && rm -f /tmp/aside /tmp/aside.tgz \
+  && aside --version
 
 RUN claude --version \
   && codex --version

--- a/porter/Dockerfile
+++ b/porter/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       bash coreutils findutils grep sed gawk \
       git curl wget jq unzip \
       python3 python3-venv python3-pip \
-      ca-certificates gnupg \
+      ca-certificates gnupg libatomic1 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=node-runtime /usr/local/ /usr/local/
@@ -27,6 +27,19 @@ RUN case "$TARGETARCH" in \
   && rm -rf /tmp/gh* \
   && gh --version \
   && rm -rf /root/.local/state/gh
+
+ARG ASIDE_CLI_VERSION=1.26.906.1630
+RUN case "$TARGETARCH" in \
+      amd64) ASIDE_ARCH=x64; ASIDE_SHA=092751c803a3a1c393af5a15b275f07b8663c53eb15851645d80521b170dacf8 ;; \
+      arm64) ASIDE_ARCH=arm64; ASIDE_SHA=0c70914864b8811154d021087419b718a39bee52a7cf948fc73e6f5087f0adf5 ;; \
+      *) exit 1 ;; \
+    esac \
+  && curl -fsSL "https://releases.aside.com/cli/AsideCLI-linux-${ASIDE_ARCH}-${ASIDE_CLI_VERSION}.tar.gz" -o /tmp/aside.tgz \
+  && echo "$ASIDE_SHA  /tmp/aside.tgz" | sha256sum -c - \
+  && tar xzf /tmp/aside.tgz -C /tmp \
+  && install /tmp/aside /usr/local/bin/aside \
+  && rm -f /tmp/aside /tmp/aside.tgz \
+  && aside --version
 
 ARG AWSCLI_VERSION=2.34.54
 RUN case "$TARGETARCH" in \

--- a/skills-seed/aside-browser/SKILL.md
+++ b/skills-seed/aside-browser/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: aside-browser
+description: Use a person's own logged-in Aside Browser through Remote Control for browser tasks across websites, accounts, files, history, and Aside memory. Also use when the person asks to connect, disconnect, or troubleshoot Aside in QM.
+---
+
+# Aside Browser through Remote Control
+
+Aside Remote Control keeps the browser, cookies, passwords, and website sessions on the person's Mac. QM runs the official Aside CLI on the person's agent computer; the CLI sends the task through Aside's relay, and the selected Mac streams the session result back. Session content crosses the relay while attached, but the browser profile does not leave the Mac.
+
+Use this only in the person's own DM. Never connect or use a personal remote browser from a channel, group, scheduled run, webhook, or unattended trigger.
+
+## Check the connection
+
+Run `aside guide` before using the CLI. Then run:
+
+```bash
+aside host list --json
+```
+
+A usable host has both `remoteControlEnabled: true` and `online: true`. Never target an offline or disabled host. If exactly one host is usable, select it with `aside host use <host-id>`. If several are usable, ask which device to use and show only their device names. Do not show host IDs unless two names are identical.
+
+If `aside` is missing and the person explicitly asked to connect or use Aside, install the official CLI, then re-run `aside guide`:
+
+```bash
+curl -fsSL https://releases.aside.com/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+aside guide
+```
+
+For any other request, ask before installing software.
+
+## Connect once
+
+If `aside host list --json` says to sign in, never ask for or accept an Aside password in chat. On the person's live turn, mint one secure multi-field drop with a one-time grant:
+
+```bash
+curl -fsS -X POST "$AGENT_API_URL/v1/keychain/drops" -H "x-agent-capability: $AGENT_API_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"service":"aside.com","purpose":"sign in the official Aside CLI once, then delete the submitted password","grantMode":"once","fields":[{"key":"ASIDE_EMAIL","label":"Aside email","secret":false},{"key":"ASIDE_PASSWORD","label":"Aside password","secret":true}]}'
+```
+
+Give the returned URL to the person. The conversation wakes when they submit it. Load the one-time grant using the exact `keychain/use` command in the wake message, then sign in without printing either field:
+
+```bash
+printf '%s\n' "$ASIDE_PASSWORD" | aside login --email "$ASIDE_EMAIL"
+unset ASIDE_EMAIL ASIDE_PASSWORD
+rm -f /tmp/keychain.env /tmp/aside-login.env
+```
+
+After sign-in succeeds, immediately delete the temporary `aside.com` credential through `DELETE /v1/keychain/credentials/:id`. The CLI keeps only its revocable access and refresh tokens in its private durable home. Never read, copy, upload, or print `~/.aside/cli/auth.json`.
+
+If the account was created only with Google and direct password sign-in is rejected, explain that the current Aside CLI requires app-backed sign-in for that account. Do not ask for Google credentials or improvise a token transfer.
+
+Run `aside host list --json` again. If no usable host appears, tell the person to open Aside on the Mac, go to Settings → Developers, enable “Allow remote sessions on this machine,” and leave Aside running. Remote Control requires Aside Pro. Recheck only after they confirm it is enabled.
+
+## Run a browser task
+
+Use `aside exec`, not `aside repl`, for normal work. Pass the selected host explicitly even after saving the default, keep Guard on, and shell-quote the person's task as one argument:
+
+```bash
+aside exec --host <host-id> --permission guard "<task>"
+```
+
+Use `--permission full-access` only when the person explicitly authorizes it. For a task likely to run longer than the foreground tool window, start it with the background tool and poll that job instead of launching another copy. Relay the final answer and any artifact paths back to the person.
+
+The CLI prints the Aside session ID. Keep it for follow-ups:
+
+```bash
+aside session resume <session-id> "<follow-up>"
+aside session steer <session-id> "<new direction>"
+aside session queue <session-id> "<next step>"
+aside session stop <session-id>
+```
+
+Resume the same session for follow-ups instead of starting a new one. Never expose relay URLs, bearer tokens, CLI auth files, or host IDs in shared conversations.
+
+## Disconnect
+
+When the person asks to disconnect QM from Aside, run:
+
+```bash
+aside logout
+```
+
+Confirm that `aside host list --json` now requires sign-in. Do not disable Remote Control on the Mac unless the person separately asks for that.

--- a/skills-seed/browse/SKILL.md
+++ b/skills-seed/browse/SKILL.md
@@ -15,6 +15,21 @@ click through a flow — or when a plain fetch is genuinely blocked by heavy JS 
 (To verify a localhost site you built, don't use this at all — a remote browser can't reach
 your loopback; use the local headless `chromium` binary.)
 
+## Prefer a connected Aside Browser
+
+Before paying for a provider browser, check whether this person's own DM already has Aside
+Remote Control connected:
+
+```bash
+command -v aside >/dev/null 2>&1 && aside host list --json
+```
+
+If the command succeeds and at least one host is both online and remote-control enabled, read
+`skills/aside-browser/SKILL.md` and use that path instead. It drives the person's real signed-in
+Aside Browser without copying their browser profile into this computer. If the person explicitly
+asks to connect or use Aside, read that skill even when the check fails. Otherwise continue below;
+do not turn a normal browse request into an Aside setup flow.
+
 ## Pick the provider
 
 Which provider you use is decided by which API key is available in your env (or obtainable

--- a/src/api/agent-api-catalog.ts
+++ b/src/api/agent-api-catalog.ts
@@ -574,7 +574,7 @@ const FAMILIES: AgentApiFamily[] = [
         method: "POST",
         path: "/v1/keychain/drops",
         summary:
-          'mint a single-use, expiring link for someone to drop a credential into the keychain via a browser (no secret in chat; hand the returned url over VERBATIM — it carries a link-bound token, so a reconstructed url will not work; declare the form inputs with fields[], e.g. [{key:"X_EMAIL",label:"Email",secret:false},{key:"X_PASSWORD",label:"Password"}] for a login, or omit for a single token; the link binds to the person who will paste the secret — pass onBehalfOf with their id when that is a teammate who spoke in this conversation rather than the person whose turn this is; refused on trigger-fired turns)',
+          'mint a single-use, expiring link for someone to drop a credential into the keychain via a browser (no secret in chat; hand the returned url over VERBATIM — it carries a link-bound token, so a reconstructed url will not work; declare the form inputs with fields[], e.g. [{key:"X_EMAIL",label:"Email",secret:false},{key:"X_PASSWORD",label:"Password"}] for a login, or omit for a single token; set grantMode:"once" in a personal conversation only when its automatic resume must immediately consume the credential; the link binds to the person who will paste the secret — pass onBehalfOf with their id when that is a teammate who spoke in this conversation rather than the person whose turn this is; refused on trigger-fired turns)',
       },
       {
         method: "POST",

--- a/src/api/routes/secret-drop.ts
+++ b/src/api/routes/secret-drop.ts
@@ -162,7 +162,8 @@ async function mintDrop(ctx: ApiCtx): Promise<void> {
     ownerId = speaker.principalId;
   }
   const scope = parseScopeId(capability.scopeId);
-  const wantsGrant = scope.kind === "channel" || scope.kind === "group";
+  const wantsPersonalGrant = scope.kind === "personal" && samePerson(scope.ref, ownerId) && b.grantMode !== undefined;
+  const wantsGrant = scope.kind === "channel" || scope.kind === "group" || wantsPersonalGrant;
   const dest = resolveCapabilityDestination(capability, undefined);
   const { dropId } = await deps.secretDrops.mint({
     ownerId,

--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -1703,7 +1703,7 @@ export function renderKeychainManifest(input: KeychainManifestInput, now: number
     '   `curl -fsS -X POST "$AGENT_API_URL/v1/keychain/drops" ' +
       CAPABILITY_CURL_AUTH +
       ' -H \'content-type: application/json\' -d \'{"service":"stripe","purpose":"<what the key is for>","envKey":"<ENV_VAR, for a token-style key>"}\'`',
-    "They open it in a browser and paste the secret there; it lands encrypted in their own keychain, and (from a channel or group) is granted to this conversation, which resumes when they submit. Single-use and short-lived.",
+    'They open it in a browser and paste the secret there; it lands encrypted in their own keychain. A channel or group drop is granted to that conversation automatically. In a personal conversation, set `grantMode:"once"` only when the automatic resume must consume the credential immediately. The conversation resumes when they submit. The link is single-use and short-lived.',
   );
 
   const waiting = inDm

--- a/test/aside-remote-integration.test.ts
+++ b/test/aside-remote-integration.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path: string): string => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("every maintained sandbox image installs the pinned Aside CLI with verified architecture checksums", () => {
+  for (const path of ["fly/Dockerfile", "porter/Dockerfile", "deploy/e2b/e2b.Dockerfile"]) {
+    const dockerfile = read(path);
+    assert.match(dockerfile, /ARG ASIDE_CLI_VERSION=1\.26\.906\.1630/, path);
+    assert.match(dockerfile, /AsideCLI-linux-\$\{ASIDE_ARCH\}-\$\{ASIDE_CLI_VERSION\}\.tar\.gz/, path);
+    assert.match(dockerfile, /ASIDE_SHA=.*;;[\s\S]*ASIDE_SHA=.*;;/, path);
+    assert.match(dockerfile, /echo "\$ASIDE_SHA {2}\/tmp\/aside\.tgz" \| sha256sum -c -/, path);
+    assert.match(dockerfile, /install \/tmp\/aside \/usr\/local\/bin\/aside/, path);
+    assert.match(dockerfile, /libatomic1/, path);
+  }
+});
+
+test("the Aside browser skill routes only to an enabled online host and keeps login secrets out of chat", () => {
+  const skill = read("skills-seed/aside-browser/SKILL.md");
+  assert.match(skill, /remoteControlEnabled: true/);
+  assert.match(skill, /online: true/);
+  assert.match(skill, /grantMode":"once/);
+  assert.match(skill, /ASIDE_EMAIL/);
+  assert.match(skill, /ASIDE_PASSWORD/);
+  assert.match(skill, /printf '%s\\n' "\$ASIDE_PASSWORD" \| aside login --email "\$ASIDE_EMAIL"/);
+  assert.match(skill, /DELETE \/v1\/keychain\/credentials\/:id/);
+  assert.match(skill, /aside exec --host <host-id> --permission guard/);
+  assert.doesNotMatch(skill, /cat ~\/\.aside\/cli\/auth\.json/);
+});
+
+test("the generic browse skill prefers a connected Aside remote session without forcing setup", () => {
+  const skill = read("skills-seed/browse/SKILL.md");
+  assert.match(skill, /aside host list --json/);
+  assert.match(skill, /read\s+`skills\/aside-browser\/SKILL\.md`/);
+  assert.match(skill, /do not turn a normal browse request into an Aside setup flow/);
+});

--- a/test/secret-drop.test.ts
+++ b/test/secret-drop.test.ts
@@ -366,6 +366,49 @@ describe("/v1/keychain/drops — mint, form, redeem", async () => {
     );
   });
 
+  it("a personal drop can explicitly grant its automatic resume one-time access", async () => {
+    const minted = await post(
+      "/v1/keychain/drops",
+      {
+        service: "aside.com",
+        purpose: "sign in the Aside CLI once",
+        grantMode: "once",
+        fields: [
+          { key: "ASIDE_EMAIL", label: "Aside email", secret: false },
+          { key: "ASIDE_PASSWORD", label: "Aside password" },
+        ],
+      },
+      await capFor("U_ASIDE"),
+    );
+    assert.equal(minted.status, 200);
+    const { dropId, formPath } = (await minted.json()) as { dropId: string; formPath: string };
+    const redeemRes = await redeem(
+      dropId,
+      { values: { ASIDE_EMAIL: "user@example.com", ASIDE_PASSWORD: "temporary-password" } },
+      "U_ASIDE",
+      linkToken(formPath),
+    );
+    assert.equal(redeemRes.status, 200);
+    const { credential } = (await redeemRes.json()) as { credential: { id: string } };
+
+    const grants = await built.keychain!.grantsForScope(scopeId("personal", "U_ASIDE"));
+    const granted = grants.find((entry) => entry.credential.id === credential.id);
+    assert.equal(granted?.grant.mode, "once");
+    const materialized = await built.keychain!.materialize(
+      granted!.grant.id,
+      scopeId("personal", "U_ASIDE"),
+      "U_ASIDE",
+    );
+    assert.deepEqual(materialized.kind === "env" ? materialized.env : [], [
+      { key: "ASIDE_EMAIL", value: "user@example.com" },
+      { key: "ASIDE_PASSWORD", value: "temporary-password" },
+    ]);
+    await assert.rejects(
+      built.keychain!.materialize(granted!.grant.id, scopeId("personal", "U_ASIDE"), "U_ASIDE"),
+      /already used/,
+    );
+  });
+
   it("a Project roster change invalidates an unredeemed drop", async () => {
     await built.app.upsertDirectory([
       { principalId: "U_PROJECT_OWNER", displayName: "Owner", type: "internal" },

--- a/test/skills-seed.test.ts
+++ b/test/skills-seed.test.ts
@@ -38,6 +38,7 @@ test("installSeedSkills publishes the repository starter catalog into org scope"
   const skills = createSkillStore({ signingSecret: "seed-test-secret" });
   const result = await installSeedSkills(skills, { dir: "skills-seed", scopeId: scopeId("org", "default-org") });
   assert.deepEqual(result.skipped, []);
+  assert.ok(result.installed.includes("aside-browser"));
   assert.ok(result.installed.includes("cloud-cli"));
   assert.ok(result.installed.includes("google-workspace"));
   assert.ok(result.installed.includes("google-drive-sheets"));


### PR DESCRIPTION
## Summary
- bake the official pinned, checksum-verified Aside CLI into Fly, Porter, and E2B agent images
- add a DM-only `aside-browser` skill with host selection, secure sign-in, Guard-mode execution, session continuation, and disconnect flows
- prefer an already-connected Aside Browser before paid provider browsers without forcing setup
- let a personal secret drop explicitly grant its automatic resume one-time access, preserving the existing no-grant default

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run lint:ox`
- `npm run format:check`
- Aside integration, secret-drop, seed-skill, and sandbox-image tests: 39/39 passed
- full root suite: 5,611 passed; two unrelated timing failures passed together on immediate standalone retry (23/23)
- live Remote Control smoke test: selected an enabled online Mac, ran a real `aside exec --host ...` task against Example Domain, and resumed the same session successfully
- independent security/correctness review: clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791605909&installation_model_id=19911&pr_number=1066&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1066&signature=61ce026ad967c6de4180f09b2c61527dcbd3d6bbf804eaa41b4308c80cf5b1be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->