### PR TITLE
fix: preserve attachments in completed chat history

### DIFF
--- a/src/harness/tape-projection.ts
+++ b/src/harness/tape-projection.ts
@@ -313,6 +313,8 @@ export function projectTapeEntries(
         });
       }
     } else if (message.role === "toolResult") {
+      // Attach results carry file references in the transcript, not in the model's text-only tape.
+      if (message.toolName === "attach") return null;
       const draft = toolResultDraft(row);
       if (draft) events.push({ kind: "item", item: draft });
     } else {

--- a/src/harness/tape-projection.ts
+++ b/src/harness/tape-projection.ts
@@ -313,7 +313,6 @@ export function projectTapeEntries(
         });
       }
     } else if (message.role === "toolResult") {
-      // Attach results carry file references in the transcript, not in the model's text-only tape.
       if (message.toolName === "attach") return null;
       const draft = toolResultDraft(row);
       if (draft) events.push({ kind: "item", item: draft });

--- a/test/pi-harness-tape-sync.test.ts
+++ b/test/pi-harness-tape-sync.test.ts
@@ -239,13 +239,14 @@ test("completed Pi attach results retain openable files in viewer history", asyn
     assert.equal(result.reply, "Here are the previews.");
     assert.equal(calls, 2);
     const original = (await store.getEntries(session.id)).find((e) => e.type === "tool_result");
-    assert.deepEqual((original?.payload as { files?: unknown[] }).files, files);
+    assert.ok(original);
+    assert.deepEqual((original.payload as { files?: unknown[] }).files, files);
     const source = createTranscriptSource(store);
     for (const read of [await source.forRender(session.id), await source.forViewer(session.id, "tester")]) {
-      assert.deepEqual(
-        read.entries.find((e) => e.type === "tool_result"),
-        original,
-      );
+      const restored = read.entries.find((e) => e.type === "tool_result");
+      assert.ok(restored);
+      assert.deepEqual((restored.payload as { files?: unknown[] }).files, files);
+      assert.deepEqual(restored, original);
     }
   } finally {
     globalThis.fetch = realFetch;

--- a/test/pi-harness-tape-sync.test.ts
+++ b/test/pi-harness-tape-sync.test.ts
@@ -186,3 +186,69 @@ test("a lease lost mid-turn fails the turn instead of degrading silently", async
     globalThis.fetch = realFetch;
   }
 });
+
+test("completed Pi attach results retain openable files in viewer history", async () => {
+  const { createTranscriptSource } = await import("../src/harness/tape-projection.ts");
+  const store = createMemorySessionStore();
+  const scopeLabel = "personal:tester" as ScopeId;
+  const session = await store.getOrCreateByThread("web:tester:attach-history", "dm", scopeLabel);
+  await store.addParticipant(session.id, "tester", undefined, { includeHistory: true });
+  const { lease } = await store.acquireLease(session.id);
+  assert.ok(lease);
+  const files = [
+    { name: "desktop.png", mimetype: "image/png", sizeBytes: 123, artifactId: "desktop" },
+    { name: "phone.png", mimetype: "image/png", sizeBytes: 456, artifactId: "phone" },
+    { name: "preview.html", mimetype: "text/html", sizeBytes: 789, artifactId: "preview" },
+  ];
+  const harness = createPiHarness({ apiKey: "sk-test" });
+  const realFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    if (calls++ > 0) return sse(textReplyEvents("Here are the previews."));
+    const events = textReplyEvents("");
+    events[1] = {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "attach-preview", name: "attach", input: {} },
+    };
+    events[2] = {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: JSON.stringify({ files: files.map((f) => f.name) }) },
+    };
+    events[4] = { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 3 } };
+    return sse(events);
+  }) as typeof globalThis.fetch;
+  try {
+    const result = await harness.turns.runTurn(
+      turnInput(
+        session.id,
+        { entries: [], tape: [] },
+        {
+          session,
+          tools: {
+            attach: async () => ({ ok: true, files, staged: files.length }),
+          } as unknown as HarnessTurnInput["tools"],
+          emit: (entry) => store.append(lease, entry),
+          tape: async (rec) => {
+            await store.appendTape(lease, rec);
+          },
+        },
+      ),
+    );
+    assert.equal(result.reply, "Here are the previews.");
+    assert.equal(calls, 2);
+    const original = (await store.getEntries(session.id)).find((e) => e.type === "tool_result");
+    assert.deepEqual((original?.payload as { files?: unknown[] }).files, files);
+    const source = createTranscriptSource(store);
+    for (const read of [await source.forRender(session.id), await source.forViewer(session.id, "tester")]) {
+      assert.deepEqual(
+        read.entries.find((e) => e.type === "tool_result"),
+        original,
+      );
+    }
+  } finally {
+    globalThis.fetch = realFetch;
+    await store.releaseLease(lease);
+  }
+});

--- a/test/tape-projection.test.ts
+++ b/test/tape-projection.test.ts
@@ -36,6 +36,7 @@ interface SimCall {
   result: string;
   isError?: boolean;
   resultScope?: ScopeId;
+  resultPayload?: Record<string, unknown>;
 }
 
 interface SimStep {
@@ -128,7 +129,7 @@ async function simTurn(sim: Sim, turn: SimTurn): Promise<void> {
       await emit("tool_call", { ...c.args, tool: c.name, callId: c.id });
       await emit(
         "tool_result",
-        { tool: c.name, callId: c.id, isError: c.isError === true, result: c.result },
+        { ...c.resultPayload, tool: c.name, callId: c.id, isError: c.isError === true, result: c.result },
         c.resultScope ?? scope,
       );
       await tape({
@@ -1072,4 +1073,76 @@ test("model-facing glue user rows (goal notes, env-only nudges) never render", a
   const userRows = projected!.filter((e) => e.type === "user");
   assert.equal(userRows.length, 1);
   assert.equal((userRows[0]!.payload as { text: string }).text, "work on it");
+});
+
+for (const failed of [false, true]) {
+  test(`attach transcript preserves structured results after completion (failed=${failed})`, async () => {
+    const sim = await simSession();
+    await sim.store.addParticipant(sim.session.id, "viewer@example.com", undefined, { includeHistory: true });
+    const files = [
+      { name: "desktop.png", mimetype: "image/png", sizeBytes: 123, artifactId: "desktop" },
+      { name: "phone.png", mimetype: "image/png", sizeBytes: 456, artifactId: "phone" },
+      { name: "preview.html", mimetype: "text/html", sizeBytes: 789, artifactId: "preview" },
+    ];
+    await simTurn(sim, {
+      input: "show the preview",
+      steps: [
+        {
+          calls: [
+            {
+              id: "attach-1",
+              name: "attach",
+              args: { files: files.map((f) => f.name) },
+              result: failed ? "[not attached] file not found" : "[attached] preview files",
+              isError: failed,
+              resultPayload: { ok: !failed, ...(failed ? {} : { files }) },
+            },
+          ],
+        },
+      ],
+      reply: failed ? "the file is missing" : "here is the preview",
+    });
+    const source = createTranscriptSource(sim.store);
+    const expected = await sim.store.getEntries(sim.session.id);
+    assert.deepEqual((await source.forRender(sim.session.id)).entries, expected);
+    assert.deepEqual((await source.forRender(sim.session.id, { limit: 3 })).entries, expected.slice(-3));
+    assert.deepEqual((await source.forRender(sim.session.id, { sinceSeq: 2 })).entries, expected.slice(2));
+    assert.deepEqual((await source.forViewer(sim.session.id, "viewer@example.com", { limit: 3 })).entries, expected);
+    assert.deepEqual((await source.forViewer(sim.session.id, "stranger@example.com")).entries, []);
+  });
+}
+
+test("attachment fallback preserves participant windows and repeated calls in an anchored tail", async () => {
+  const sim = await simSession();
+  await sim.store.addParticipant(sim.session.id, "early", undefined, { includeHistory: true });
+  for (let i = 0; i < 60; i++) await simTurn(sim, { input: `question ${i}`, reply: `answer ${i}` });
+  await sim.store.addParticipant(sim.session.id, "late");
+  await simTurn(sim, {
+    input: "attach twice",
+    steps: [
+      {
+        calls: ["old", "new"].map((artifactId) => ({
+          id: artifactId,
+          name: "attach",
+          args: { files: ["image.png"] },
+          result: "[attached] image.png",
+          resultPayload: { ok: true, files: [{ name: "image.png", mimetype: "image/png", sizeBytes: 12, artifactId }] },
+        })),
+      },
+    ],
+    reply: "latest image",
+  });
+  await sim.store.removeParticipant(sim.session.id, "early");
+  await simTurn(sim, { input: "private follow-up", reply: "later" });
+  const source = createTranscriptSource(sim.store);
+  assert.deepEqual(
+    (await source.forRender(sim.session.id, { limit: 8 })).entries,
+    await sim.store.getEntries(sim.session.id, { limit: 8 }),
+  );
+  for (const viewer of ["early", "late", "stranger"]) {
+    assert.deepEqual(
+      (await source.forViewer(sim.session.id, viewer, { limit: 8 })).entries,
+      await sim.store.visibleEntries(sim.session.id, viewer),
+    );
+  }
 });


### PR DESCRIPTION
Preserve file references when rebuilding chat history so attached images and documents remain visible after completion and reload.

- Use the existing lossless transcript fallback for attachment results; no migration or frontend change.
- Verified the failure and fix through the real Pi harness and a local desktop/mobile browser build with deterministic model responses.
- Regression coverage includes multiple files, failed/repeated attaches, bounded history, and participant visibility.
- 290 focused core tests and 1,018 web tests pass; core typecheck, focused lint, and formatting pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791606397&installation_model_id=19911&pr_number=1068&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1068&signature=d76958ad645d1a06db8abcb982e34aa3176b9beeecfad5d670e52974733d20d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->