### PR TITLE
Preserve gateway and verified CloudFront deployment prerequisites

### DIFF
--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -86,6 +86,11 @@ export const awsDeploymentLayerTransport: DeploymentLayerTransport = httpDeploym
   request: async (config, url, init) => {
     const target = awsPublicFrontDoor(config).dnsName.toLowerCase().replace(/\.$/, "");
     if (!validAlbHostname(target)) throw new CliError("AWS deployment-layer ALB hostname is invalid");
+    if (awsPublicOrigin(config).protocol === "http:") {
+      assertCloudFrontLayerTarget(config, url, target);
+      const response = await fetch(url, init);
+      return { status: response.status, body: await response.text() };
+    }
     return new Promise((resolve, reject) => {
       const request = https.request(
         url,
@@ -3188,6 +3193,57 @@ const validAlbHostname = (value: string): boolean =>
   value
     .split(".")
     .every((label) => label.length > 0 && label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label));
+
+function assertCloudFrontLayerTarget(config: QmConfig, url: URL, target: string): void {
+  interface Distribution {
+    DomainName?: string;
+    Status?: string;
+    Enabled?: boolean;
+    ContinuousDeploymentPolicyId?: string;
+    CacheBehaviors?: { Quantity?: number };
+    DefaultCacheBehavior?: {
+      TargetOriginId?: string;
+      MaxTTL?: number;
+      CachePolicyId?: string;
+      FunctionAssociations?: { Quantity?: number };
+      LambdaFunctionAssociations?: { Quantity?: number };
+    };
+    Origins?: {
+      Items?: Array<{
+        Id?: string;
+        DomainName?: string;
+        OriginPath?: string;
+        CustomOriginConfig?: { OriginProtocolPolicy?: string; HTTPPort?: number };
+      }>;
+    };
+  }
+  const distributions =
+    awsJson<{ DistributionList?: { Items?: Distribution[] } }>(requireAws(config), ["cloudfront", "list-distributions"])
+      .DistributionList?.Items ?? [];
+  const matches = distributions.filter((distribution) => distribution.DomainName === url.hostname);
+  const distribution = matches.length === 1 ? matches[0] : undefined;
+  const behavior = distribution?.DefaultCacheBehavior;
+  const origin = distribution?.Origins?.Items?.find((item) => item.Id === behavior?.TargetOriginId);
+  if (
+    !distribution?.Enabled ||
+    distribution.Status !== "Deployed" ||
+    distribution.ContinuousDeploymentPolicyId ||
+    behavior?.MaxTTL !== 0 ||
+    behavior.CachePolicyId ||
+    distribution.CacheBehaviors?.Quantity !== 0 ||
+    (behavior?.FunctionAssociations?.Quantity ?? 0) !== 0 ||
+    (behavior?.LambdaFunctionAssociations?.Quantity ?? 0) !== 0 ||
+    origin?.DomainName?.toLowerCase().replace(/\.$/, "") !== target ||
+    origin.OriginPath ||
+    origin.CustomOriginConfig?.OriginProtocolPolicy !== "http-only" ||
+    origin.CustomOriginConfig.HTTPPort !== 80 ||
+    (url.port && url.port !== "443")
+  ) {
+    throw new CliError(
+      "AWS deployment-layer HTTPS proxy must be a deployed CloudFront distribution routing directly to the selected ALB without alternate behaviors, origin paths, or edge functions",
+    );
+  }
+}
 
 function awsCoreHostnames(config: QmConfig): string[] {
   const hosts: string[] = [];

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -8,7 +8,9 @@ import { runChecks } from "./check.ts";
 import { hostingProvider } from "../backends/registry.ts";
 
 export function expectedDescriptors(bundle: DeploymentLayerBundle): ToolDescriptor[] {
-  return bundle.tools.map((file) => parseToolDescriptor(file.content, file.path));
+  return bundle.tools
+    .filter((file) => /^tools\/[^/]+\/tool\.json$/.test(file.path))
+    .map((file) => parseToolDescriptor(file.content, file.path));
 }
 
 export interface ConformanceDeployment {

--- a/cli/templates/aws/main.tf
+++ b/cli/templates/aws/main.tf
@@ -347,6 +347,7 @@ resource "aws_iam_role_policy" "github_deploy" {
           "ecs:ListTaskDefinitions",
           "ec2:DescribeSecurityGroups",
           "elasticloadbalancing:Describe*",
+          "cloudfront:ListDistributions",
           "rds:DescribeDBInstances",
           "servicediscovery:ListNamespaces",
           "servicediscovery:ListServices",
@@ -858,7 +859,7 @@ resource "aws_cloudfront_distribution" "portal" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Accept", "Authorization", "CloudFront-Forwarded-Proto", "Content-Type", "Origin", "Referer", "Sec-Fetch-Site"]
+      headers      = ["Accept", "Authorization", "CloudFront-Forwarded-Proto", "Content-Type", "Origin", "Referer", "Sec-Fetch-Site", "X-Timestamp", "X-Signature", "X-Agent-Capability"]
       cookies { forward = "all" }
     }
   }

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -134,6 +134,7 @@ else if (a.includes("lambda-microvms get-microvm-image")) {
   console.log(JSON.stringify({ imageArn }));
 }
 else if (a.includes("lambda-microvms list-microvm-image-versions")) console.log(JSON.stringify({ items: [{ imageVersion: process.env.AWS_FAKE_IMAGE_VERSION || "1", state: process.env.AWS_FAKE_IMAGE_STATE || "SUCCESSFUL", status: process.env.AWS_FAKE_IMAGE_STATUS || "ACTIVE" }] }));
+else if (a.includes("cloudfront list-distributions")) console.log(process.env.AWS_FAKE_CLOUDFRONT || "{}");
 else if (a.includes("elbv2 describe-load-balancers")) console.log(JSON.stringify({ LoadBalancers: [{ LoadBalancerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/test/1", DNSName: process.env.AWS_FAKE_ALB_DNS || "agent.acme.example", State: { Code: "active" } }] }));
 else if (a.includes("elbv2 describe-listeners")) {
   const protocol = process.env.AWS_FAKE_LISTENER_PROTOCOL || "HTTPS";
@@ -4737,6 +4738,113 @@ test("AWS layer GET and PUT bind the selected ALB while retaining API Host, TLS 
     else process.env.CORE_SIGNING_SECRET = priorSecret;
     if (priorAlb === undefined) delete process.env.AWS_FAKE_ALB_DNS;
     else process.env.AWS_FAKE_ALB_DNS = priorAlb;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("AWS layer transport uses the HTTPS front door when an HTTP ALB origin is configured", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-aws-layer-proxy-"));
+  const fake = fakeAws(dir, "console.log('')");
+  const priorSecret = process.env.CORE_SIGNING_SECRET;
+  const priorProtocol = process.env.AWS_FAKE_LISTENER_PROTOCOL;
+  const priorCloudFront = process.env.AWS_FAKE_CLOUDFRONT;
+  const distribution = {
+    DomainName: "test.cloudfront.net",
+    Status: "Deployed",
+    Enabled: true,
+    CacheBehaviors: { Quantity: 0 },
+    DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0 },
+    Origins: {
+      Items: [
+        {
+          Id: "alb",
+          DomainName: "agent.acme.example",
+          OriginPath: "",
+          CustomOriginConfig: { OriginProtocolPolicy: "http-only", HTTPPort: 80 },
+        },
+      ],
+    },
+  };
+  const setDistribution = (value: unknown) => {
+    process.env.AWS_FAKE_CLOUDFRONT = JSON.stringify({ DistributionList: { Items: [value] } });
+  };
+  setDistribution(distribution);
+  process.env.AWS_FAKE_LISTENER_PROTOCOL = "HTTP";
+  process.env.CORE_SIGNING_SECRET = TEST_SECRET_VALUE;
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  t.mock.method(https, "request", () => {
+    throw new Error("must not dial the HTTP origin with TLS");
+  });
+  t.mock.method(globalThis, "fetch", async (url: URL, init: RequestInit) => {
+    calls.push({ url: url.href, init });
+    return new Response("applied", { status: 200 });
+  });
+  try {
+    const configured = {
+      ...config,
+      publicUrl: "https://test.cloudfront.net",
+      env: { ...config.env, core: { ...config.env.core, AWS_PUBLIC_ORIGIN_URL: "http://acme-qm.elb.example" } },
+    };
+    for (const method of ["GET", "PUT"] as const) {
+      const body = method === "PUT" ? '{"contract":1}' : "";
+      assert.equal(
+        (await awsDeploymentLayerTransport({ config: configured, configDir: dir, method, body })).status,
+        200,
+      );
+    }
+    assert.equal(calls.length, 2);
+    for (const { url, init } of calls) {
+      assert.equal(url, "https://test.cloudfront.net/v1/deployment-layer");
+      assert.equal(init.redirect, "error");
+      assert.ok(init.signal instanceof AbortSignal);
+      const headers = init.headers as Record<string, string>;
+      assert.equal(
+        headers["x-signature"],
+        `v0=${createHmac("sha256", TEST_SECRET_VALUE)
+          .update(`v0:${headers["x-timestamp"]}:${init.method}\n/v1/deployment-layer\n${init.body ?? ""}`)
+          .digest("hex")}`,
+      );
+    }
+    for (const invalid of [
+      { ...distribution, DomainName: "another.cloudfront.net" },
+      { ...distribution, Enabled: false },
+      { ...distribution, Status: "InProgress" },
+      { ...distribution, ContinuousDeploymentPolicyId: "staging-policy" },
+      { ...distribution, DomainName: "other.cloudfront.net", Aliases: { Items: ["test.cloudfront.net"] } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 60 } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, CachePolicyId: "managed" } },
+      { ...distribution, CacheBehaviors: { Quantity: 1 } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "other", MaxTTL: 0 } },
+      {
+        ...distribution,
+        DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, FunctionAssociations: { Quantity: 1 } },
+      },
+      {
+        ...distribution,
+        DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, LambdaFunctionAssociations: { Quantity: 1 } },
+      },
+      ...[
+        { DomainName: "other-stack.elb.example" },
+        { OriginPath: "/prefix" },
+        { CustomOriginConfig: { OriginProtocolPolicy: "match-viewer", HTTPPort: 80 } },
+      ].map((change) => ({ ...distribution, Origins: { Items: [{ ...distribution.Origins.Items[0], ...change }] } })),
+    ]) {
+      setDistribution(invalid);
+      await assert.rejects(
+        () => awsDeploymentLayerTransport({ config: configured, configDir: dir, method: "PUT", body: "{}" }),
+        /routing directly to the selected ALB/,
+      );
+    }
+    assert.equal(calls.length, 2);
+  } finally {
+    if (priorCloudFront === undefined) delete process.env.AWS_FAKE_CLOUDFRONT;
+    else process.env.AWS_FAKE_CLOUDFRONT = priorCloudFront;
+    t.mock.restoreAll();
+    fake.restore();
+    if (priorSecret === undefined) delete process.env.CORE_SIGNING_SECRET;
+    else process.env.CORE_SIGNING_SECRET = priorSecret;
+    if (priorProtocol === undefined) delete process.env.AWS_FAKE_LISTENER_PROTOCOL;
+    else process.env.AWS_FAKE_LISTENER_PROTOCOL = priorProtocol;
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -246,10 +246,24 @@ test("the docker sync PUTs the bundle to the base port with verifiable v0 HMAC s
 test("conformance passes against a live core: base-port override, signed request, canonical hash + descriptors", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-conf-"));
   const captured: CapturedRequest[] = [];
+  const descriptor = {
+    id: "t",
+    advertise: "runs t",
+    install: {
+      binary: "t",
+      files: [
+        { from: "t", to: "/usr/local/bin/t", mode: "0755" },
+        { from: "release.json", to: "/usr/local/lib/t/release.json", mode: "0644" },
+      ],
+    },
+  };
   const bundle = (() => {
     writeLayer(dir);
+    writeFileSync(join(dir, "sandbox", "tools", "t", "tool.json"), JSON.stringify(descriptor));
+    writeFileSync(join(dir, "sandbox", "tools", "t", "release.json"), JSON.stringify({ version: "1.0.0" }));
     return deploymentLayerBundle(join(dir, "sandbox"));
   })();
+  assert.equal(bundle.tools.length, 3);
   const contentHash = createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
   const { server, port } = await startCoreStub(
     () => ({
@@ -257,7 +271,7 @@ test("conformance passes against a live core: base-port override, signed request
         contentHash,
         status: "applied",
         runtimeContentHash: contentHash,
-        resolved: { tools: [{ install: { binary: "t" }, advertise: "runs t", id: "t" }] },
+        resolved: { tools: [descriptor] },
       }),
     }),
     captured,

--- a/cli/test/terraform.test.ts
+++ b/cli/test/terraform.test.ts
@@ -593,6 +593,7 @@ test("AWS module supports CloudFront TLS or a direct HTTPS ALB without mixing th
   assert.match(edge, /domain_name\s*=\s*aws_lb\.this\.dns_name/);
   assert.match(edge, /origin_protocol_policy\s*=\s*var\.certificate_arn == "" \? "http-only" : "https-only"/);
   assert.match(edge, /cloudfront_default_certificate\s*=\s*true/);
+  for (const header of ["X-Timestamp", "X-Signature", "X-Agent-Capability"]) assert.ok(edge.includes(`"${header}"`));
 });
 
 test("AWS module reuses account OIDC, guards account and passes configured task roles", () => {

--- a/deploy/core/Dockerfile
+++ b/deploy/core/Dockerfile
@@ -23,5 +23,6 @@ ENV GIT_SHA=$GIT_SHA
 RUN mkdir -p /data && chown node:node /data
 EXPOSE 8080
 
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "src/index.ts"]

--- a/deploy/portal/Dockerfile
+++ b/deploy/portal/Dockerfile
@@ -14,5 +14,6 @@ COPY plugins/portal/tsconfig.json ./
 ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "src/index.ts"]

--- a/deploy/web-ui/Dockerfile
+++ b/deploy/web-ui/Dockerfile
@@ -23,5 +23,6 @@ COPY --from=build /app/dist-web ./dist-web
 ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "server/index.ts"]

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -1141,6 +1141,27 @@ async function buildModelRuntime(
   for (const [provider, apiKey] of Object.entries(k)) {
     if (apiKey) await runtime.setRuntimeApiKey(provider, apiKey, { allowNetwork: false });
   }
+  if (modelGateway) {
+    const providers = new Set(
+      Object.keys(modelGateway.models).flatMap((id) => {
+        const model = resolveModel(id);
+        return model ? [model.provider] : [];
+      }),
+    );
+    const hasConfiguredAuth = runtime.hasConfiguredAuth.bind(runtime);
+    runtime.hasConfiguredAuth = (provider) => providers.has(provider) || hasConfiguredAuth(provider);
+    const getAuth = runtime.getAuth.bind(runtime);
+    runtime.getAuth = (async (model, overrides) => {
+      if (typeof model === "string") return getAuth(model, overrides);
+      const request = modelGatewayRequest(modelGateway, model);
+      if (request)
+        return {
+          auth: { apiKey: request.apiKey, headers: { ...model.headers, ...request.headers } },
+          source: "model gateway",
+        };
+      return getAuth(model, overrides);
+    }) as typeof runtime.getAuth;
+  }
   const retained = <T extends object | undefined>(options: T): T =>
     cacheRetention ? ({ ...options, cacheRetention } as T) : options;
   const stream = runtime.stream.bind(runtime);

--- a/test/pi-harness-oneshot.test.ts
+++ b/test/pi-harness-oneshot.test.ts
@@ -281,7 +281,7 @@ test("oneShot completes an authenticated Pi 0.82 turn", async (t) => {
 });
 
 test("oneShot routes configured models through the model gateway without mutating transport metadata", async (t) => {
-  const requests: Array<{ gatewayKey?: string; providerKey?: string; model?: string }> = [];
+  const requests: Array<{ gatewayKey?: string; providerKey?: string; model?: string; marker?: string }> = [];
   const server = createServer((request, response) => {
     let body = "";
     request.setEncoding("utf8");
@@ -294,6 +294,7 @@ test("oneShot routes configured models through the model gateway without mutatin
         ...(request.headers["api-key"] ? { gatewayKey: String(request.headers["api-key"]) } : {}),
         ...(request.headers["x-api-key"] ? { providerKey: String(request.headers["x-api-key"]) } : {}),
         ...(requestModel ? { model: requestModel } : {}),
+        ...(request.headers["x-model-marker"] ? { marker: String(request.headers["x-model-marker"]) } : {}),
       });
       response.writeHead(200, { "content-type": "text/event-stream" });
       for (const event of [
@@ -340,23 +341,31 @@ test("oneShot routes configured models through the model gateway without mutatin
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "gateway-secret",
     apiKeyHeader: "api-key",
-    models: { "claude-haiku-4-5": "router/haiku" },
+    models: { "claude-haiku-4-5": "router/haiku", "retired-model-name": "router/retired" },
   };
-  const model = getRequiredModel("claude-haiku-4-5");
+  const model = { ...getRequiredModel("claude-haiku-4-5"), headers: { "x-model-marker": "preserved" } };
+  assert.equal(await oneShot("pi-gateway-test", model, {}, "system", "hello", { modelGateway }), "gateway");
+  const directModel = { ...getRequiredModel("claude-opus-4-8"), baseUrl: modelGateway.url };
+  await assert.rejects(
+    oneShot("pi-unmapped-test", directModel, {}, "system", "hello", { modelGateway }),
+    /No API key found|Provider is not configured/,
+  );
+
   assert.equal(
-    await oneShot("pi-gateway-test", model, "direct-provider-key", "system", "hello", { modelGateway }),
+    await oneShot("pi-direct-test", directModel, "direct-provider-key", "system", "hello", { modelGateway }),
     "gateway",
   );
-  const directModel = { ...getRequiredModel("claude-opus-4-8"), baseUrl: modelGateway.url };
-  assert.equal(await oneShot("pi-direct-test", directModel, "direct-provider-key", "system", "hello"), "gateway");
   assert.deepEqual(requests, [
-    { gatewayKey: "gateway-secret", providerKey: "gateway-secret", model: "router/haiku" },
+    { gatewayKey: "gateway-secret", providerKey: "gateway-secret", model: "router/haiku", marker: "preserved" },
     { providerKey: "direct-provider-key", model: "claude-opus-4-8" },
   ]);
   const routed = modelGatewayRequest(modelGateway, model);
   assert.equal(routed?.model.id, "claude-haiku-4-5");
   assert.equal(routed?.target, "router/haiku");
-  assert.deepEqual(transportFromModel(model), { modelId: "claude-haiku-4-5" });
+  assert.deepEqual(transportFromModel(model), {
+    modelId: "claude-haiku-4-5",
+    headers: { "x-model-marker": "preserved" },
+  });
 });
 
 test("Pi assistant error messages fail the turn instead of becoming a blank reply", () => {


### PR DESCRIPTION
Preserve gateway-only Pi authentication and packaged deployment-layer support when moving existing AWS HTTPS-proxy deployments onto current main. These prerequisites were previously carried by a candidate branch; this change brings just those prerequisites forward without its separate database-pooling work.

For HTTP ALB origins, signed layer requests use the native HTTPS CloudFront endpoint only after verifying the distribution belongs to the current account and directly targets the selected ALB. Reject alternate behaviors, edge functions, origin paths, continuous-deployment policies, and cached behaviors. Direct HTTPS-ALB binding, TLS verification, signatures, deadlines and redirect rejection remain intact. Generated deployment roles gain cloudfront:ListDistributions; existing roles need that read permission before using the proxy path.

Validation: 215 focused gateway/CLI/template tests pass, including four transport regressions; core and CLI typechecks and focused lint pass. Read-only live CloudFront transport returned the expected applied layer and runtime hashes. Independent adversarial review is clear.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791651644&installation_model_id=19911&pr_number=1073&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1073&signature=99357316df21cf8e854508f01fa61a8c3d9350df9186d31880d82b6c40c6ee28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Preserve the operator audit utility in all three runtime images by including util-linux while retaining USER node. Rebuilt exact-head images all pass an actual script/cat audit-command probe; the packaging delta received independent review.