### PR TITLE
fix: attach live activity to the floating composer

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1286,8 +1286,8 @@ export function createChatSurface(
             </div>
           </section>
           <div class="chat-bottom-dock">
-            ${goalStrip(agent)} ${ctx.composer.queuedStrip(agent)} ${liveWorkStatus(agent)}
-            ${ctx.composer.composerForm(agent, backgroundActivityStrip())}
+            ${goalStrip(agent)} ${ctx.composer.queuedStrip(agent)}
+            ${ctx.composer.composerForm(agent, html`${glanceTier ? nothing : liveWorkStatus(agent)} ${backgroundActivityStrip()}`)}
           </div>
         </div>
       `,

--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -386,7 +386,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
         (ctx.chat.state.threadRef ? threadModelPicks.get(ctx.chat.state.threadRef) : undefined) ??
         defaultModelValue(scopeKey());
       return html`<div class="composer-wrap">
-        ${composerApprovalPanel(ctx.chat.activePendingApprovals())}
+        ${header} ${composerApprovalPanel(ctx.chat.activePendingApprovals())}
         <p role="status">
           ${composerState.error || activeRuntimeConfig?.unavailableReason || "Selected model is unavailable. Choose a replacement to continue."}
           ${selected}

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1814,9 +1814,6 @@ a.chat-row-open {
   width: min(calc(var(--content-w) - 24px), calc(100% - 56px));
   margin: 0 auto -10px;
 }
-.queued-strip:has(+ .live-work-status) {
-  margin-bottom: 6px;
-}
 .queued-chip {
   display: flex;
   align-items: center;
@@ -2511,6 +2508,7 @@ a.chat-row-open {
   color: var(--muted-foreground);
   font-size: 12.5px;
 }
+.composer-wrap > .live-work-status,
 .composer-wrap > .bg-activity {
   flex: 0 0 calc(100% + var(--composer-pad-inline) + var(--composer-pad-end));
   width: auto;
@@ -2523,6 +2521,13 @@ a.chat-row-open {
   border-bottom-right-radius: 0;
   border-bottom: 1px solid var(--border);
   background: color-mix(in srgb, var(--secondary) 40%, var(--background));
+}
+.composer-wrap > .live-work-status:has(+ .bg-activity) {
+  margin-bottom: 0;
+}
+.composer-wrap > .live-work-status + .bg-activity {
+  margin-top: 0;
+  border-radius: 0;
 }
 .readonly-chat .bg-activity {
   margin-top: 8px;
@@ -2652,10 +2657,7 @@ a.chat-row-open {
 }
 
 .live-work-status {
-  width: min(var(--content-w), calc(100% - 32px));
   min-width: 0;
-  margin: 0 auto 8px;
-  padding: 0 12px;
   color: var(--muted-foreground);
 }
 .live-work-line {
@@ -7299,7 +7301,6 @@ h3.ambient-field-label {
   /* Mid-width surfaces: the floating composer/dock hug the full-width column with 16px
      side margins, but must still clear the device safe areas — the 10px variant below
      only kicks in at <=470px, so the insets need a floor here too. */
-  .live-work-status,
   .composer-wrap {
     width: auto;
     margin-right: max(16px, calc(10px + env(safe-area-inset-right)));
@@ -7322,10 +7323,6 @@ h3.ambient-field-label {
   }
   /* The floating composer/dock margins pair with the full-bleed 14px chat pad and must
      follow the surface's width too, or a window resize misaligns them with the column. */
-  .live-work-status {
-    margin-right: calc(10px + env(safe-area-inset-right));
-    margin-left: calc(10px + env(safe-area-inset-left));
-  }
   .composer-wrap {
     margin-right: calc(10px + env(safe-area-inset-right));
     margin-bottom: calc(10px + env(safe-area-inset-bottom));
@@ -9565,11 +9562,6 @@ h3.ambient-field-label {
     max-width: 86%;
   }
 
-  .live-work-status {
-    width: calc(100% - 16px);
-    margin-right: auto;
-    margin-left: auto;
-  }
   .composer-wrap {
     width: calc(100% - 16px);
     margin: 0 auto calc(8px + env(safe-area-inset-bottom));

--- a/plugins/web-ui/test/pinned-composer-polish.test.ts
+++ b/plugins/web-ui/test/pinned-composer-polish.test.ts
@@ -15,7 +15,10 @@ test("transcript top spacing and prompt gap stay compact at every density", () =
 });
 
 test("editable background activity is rendered inside the composer surface", () => {
-  assert.match(chat, /composerForm\(agent, backgroundActivityStrip\(\)\)/);
+  assert.match(
+    chat,
+    /composerForm\(agent, html`\$\{glanceTier \? nothing : liveWorkStatus\(agent\)\} \$\{backgroundActivityStrip\(\)\}`\)/,
+  );
   assert.match(composer, /<form class="composer-wrap[^]*?\$\{header\}/);
   assert.match(
     css,

--- a/plugins/web-ui/test/queue-by-default.test.ts
+++ b/plugins/web-ui/test/queue-by-default.test.ts
@@ -186,7 +186,7 @@ test("the strip renders core's queue, refreshed from the same read that names th
 test("the queued strip sits behind and outside the composer form", () => {
   assert.match(
     chat,
-    /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent, backgroundActivityStrip\(\)\)/,
+    /ctx\.composer\.queuedStrip\(agent\)[\s\S]*?ctx\.composer\.composerForm\(agent, html`\$\{glanceTier \? nothing : liveWorkStatus\(agent\)\} \$\{backgroundActivityStrip\(\)\}`\)/,
   );
   const composerMarkup = composer.slice(composer.indexOf('<form class="composer-wrap"'), composer.indexOf("</form>"));
   assert.doesNotMatch(composerMarkup, /queuedStrip\(agent\)/);

--- a/plugins/web-ui/test/thinking-placement.test.ts
+++ b/plugins/web-ui/test/thinking-placement.test.ts
@@ -3,36 +3,29 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
+const composer = readFileSync(new URL("../src/composer.ts", import.meta.url), "utf8");
 
-test("live thinking and tool activity stay above the composer and background tasks", () => {
-  const draw = chat.slice(
-    chat.indexOf("  function drawActiveChat("),
-    chat.indexOf("  function decorateStreamingTail("),
-  );
-  const transcript = draw.slice(
-    draw.indexOf('<section class="chat-scroll">'),
-    draw.indexOf('<div class="chat-bottom-dock">'),
-  );
-  const dock = draw.slice(draw.indexOf('<div class="chat-bottom-dock">'));
-  assert.doesNotMatch(transcript, /liveWorkStatus\(agent\)/);
-  assert.match(dock, /\$\{liveWorkStatus\(agent\)\}/);
-  assert.ok(dock.indexOf("liveWorkStatus(agent)") < dock.indexOf("composerForm(agent, backgroundActivityStrip())"));
-  assert.match(dock, /composerForm\(agent, backgroundActivityStrip\(\)\)/);
-});
-
-test("the live-work row uses the floating composer column", () => {
-  const rule = css.match(/\.live-work-status \{[^}]*\}/)?.[0] ?? "";
-  assert.match(rule, /width: min\(var\(--content-w\), calc\(100% - 32px\)\);/);
-  assert.match(rule, /margin: 0 auto 8px;/);
-  assert.doesNotMatch(css, /live-work-dock/);
-});
-
-test("goal and queued messages precede thinking without the queue's composer overlap", () => {
+test("thinking is the composer header above background activity, not a transparent dock sibling", () => {
   const dock = chat.slice(chat.indexOf('<div class="chat-bottom-dock">'));
-  const goal = dock.indexOf("goalStrip(agent)");
-  const queue = dock.indexOf("ctx.composer.queuedStrip(agent)");
-  const thinking = dock.indexOf("liveWorkStatus(agent)");
-  assert.ok(goal >= 0 && goal < queue && queue < thinking);
-  const spacing = css.match(/\.queued-strip:has\(\+ \.live-work-status\) \{[^}]*\}/)?.[0] ?? "";
-  assert.match(spacing, /margin-bottom: 6px;/);
+  assert.match(
+    dock,
+    /composerForm\(agent, html`\$\{glanceTier \? nothing : liveWorkStatus\(agent\)\} \$\{backgroundActivityStrip\(\)\}`\)/,
+  );
+  assert.ok(dock.indexOf("goalStrip(agent)") < dock.indexOf("ctx.composer.queuedStrip(agent)"));
+  assert.ok(dock.indexOf("ctx.composer.queuedStrip(agent)") < dock.indexOf("composerForm(agent"));
+  assert.doesNotMatch(css, /\.queued-strip:has\(\+ \.live-work-status\)/);
+});
+
+test("stacked composer headers share a solid surface without double negative margins", () => {
+  assert.match(
+    css,
+    /\.composer-wrap > \.live-work-status,\s*\.composer-wrap > \.bg-activity \{[^}]*background: color-mix/,
+  );
+  assert.match(css, /\.composer-wrap > \.live-work-status:has\(\+ \.bg-activity\) \{\s*margin-bottom: 0;/);
+  assert.match(css, /\.composer-wrap > \.live-work-status \+ \.bg-activity \{\s*margin-top: 0;\s*border-radius: 0;/);
+  assert.doesNotMatch(css, /\.live-work-status \{[^}]*width: min/);
+});
+
+test("model-unavailable composer retains the activity header and approvals", () => {
+  assert.match(composer, /<div class="composer-wrap">\s*\$\{header\} \$\{composerApprovalPanel/);
 });


### PR DESCRIPTION
Render thinking and current activity inside the floating composer above background jobs, while keeping goals and queued messages independent.

- Verification: 1,018 web UI tests passed; typecheck, focused ESLint, Prettier, and whitespace checks passed.
- Browser verification: 177 assertions passed against the real development UI with synthetic state, covering desktop/mobile, split panes, goals, queues, expanded activity, approvals, and unavailable models.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791651704&installation_model_id=19911&pr_number=1074&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1074&signature=5e967ff1b777e0728a73929fc3f98e8317b173cb6bc66e8727df72302f4073ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->