### PR TITLE
Accept retained AWS coordinates for bundled service hosts

### DIFF
--- a/cli/src/backends/registry.ts
+++ b/cli/src/backends/registry.ts
@@ -329,7 +329,7 @@ const aws: HostingProvider = {
       }
     }
     for (const name of Object.keys(config.aws.services)) {
-      if (!workloads.has(name)) {
+      if (!workloads.has(name) && !workloads.has(serviceHost(name))) {
         errors.push({
           clause: "config.v1",
           message: `contract aws.services.${name}: coordinates do not match an enabled service or discovered plugin`,

--- a/cli/test/check.test.ts
+++ b/cli/test/check.test.ts
@@ -219,6 +219,42 @@ test("AWS requires exact ECS/ECR coordinates for discovered plugins", () => {
   }
 });
 
+test("AWS accepts retained bundled coordinates only when their host is enabled", () => {
+  const d = deployment(() => {}, {
+    target: "aws",
+    services: ["core", "web-ui", "admin", "portal", "auth"],
+    aws: {
+      accountId: "123456789012",
+      region: "us-west-2",
+      cluster: "acme",
+      deployRoleArn: "arn:aws:iam::123456789012:role/deploy",
+      secretsPrefix: "acme/",
+      imageLabel: "release",
+      networking: { cloudMapNamespace: "acme.internal" },
+      services: Object.fromEntries(
+        ["core", "web-ui", "admin", "portal", "auth"].map((name) => [
+          name,
+          { ecrRepository: name, ecsService: `acme-${name}`, cpu: 512, memory: 1024 },
+        ]),
+      ),
+    },
+  });
+  try {
+    assert.doesNotThrow(() => check(d));
+    delete d.config.aws!.services["web-ui"];
+    assert.throws(() => check(d), /aws\.services\.web-ui/);
+    d.config.services = ["core"];
+    delete d.config.aws!.services.portal;
+    assert.throws(() => check(d), /aws\.services\.(admin|auth)/);
+    delete d.config.aws!.services.admin;
+    delete d.config.aws!.services.auth;
+    d.config.aws!.services.unused = { ecrRepository: "unused", ecsService: "unused", cpu: 512, memory: 1024 };
+    assert.throws(() => check(d), /aws\.services\.unused/);
+  } finally {
+    rmSync(d.dir, { recursive: true, force: true });
+  }
+});
+
 test("optional plugin secrets remain in the computed contract without becoming required", () => {
   const optional: QmConfig = {
     ...CONFIG,


### PR DESCRIPTION
When an AWS deployment retains the old admin or auth Terraform resources for rollback, its config must retain their coordinates for `doctor` to verify the infrastructure contract. The deployer already accepts these bundled coordinates and deploys only their physical hosts, but the static validator rejects the same config before doctor runs.

Align the validator with the existing deployment topology check: retained component coordinates are valid only when their host is an enabled workload. Missing host coordinates and unrelated or disabled workloads remain errors. This changes CLI validation only; workload selection and runtime images are unchanged.

Validation: 58 focused check, Terraform, and provider tests; CLI typecheck; focused ESLint and formatting checks. Independent adversarial review found no issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791654603&installation_model_id=19911&pr_number=1075&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1075&signature=1bc9a64427614ec8d39d5e4b11c06b39866e179d2af79d9ecb2321c638bb761c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->