### PR TITLE
Preserve optional fields in unified sandbox tool schemas

### DIFF
--- a/src/harness/agent-tools.ts
+++ b/src/harness/agent-tools.ts
@@ -2,7 +2,7 @@ import { createGrindMeter, grindState } from "./grind.ts";
 import type { RuntimeHandoff, RuntimeRequest } from "./runtime-types.ts";
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type, type TSchema } from "typebox";
-import { Check } from "typebox/value";
+import { Check, Clone } from "typebox/value";
 import { CONFIG_DEFAULTS, type Config } from "../config.ts";
 import type { CronFireLogEntry, EntryType, ScopeId } from "../types.ts";
 import type { ToolContext, PublishInput, PublishAudienceDescriptor, ShareDirective } from "../tools/primitives.ts";
@@ -1716,7 +1716,10 @@ export function createAgentTools(ref: ToolContextRef, opts?: AgentToolsOptions):
     ...Object.fromEntries(
       Object.entries(schemas(background)).map(([key, schema]) => {
         const description = (schema as TSchema & { description?: string }).description;
-        return [key, description ? { ...schema, description: processFieldDescription(description) } : schema];
+        return [
+          key,
+          description ? Object.assign(Clone(schema), { description: processFieldDescription(description) }) : schema,
+        ];
       }),
     ),
     ...schemas(execute),

--- a/test/agent-tools.test.ts
+++ b/test/agent-tools.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { Check } from "typebox/value";
 import { createAgentTools, pauseStampAfterToolCall, type ToolContextRef } from "../src/harness/agent-tools.ts";
 import { filterHistoryForAudience } from "../src/resolution/context-filter.ts";
 import { CommandDenied, NeedsApproval, type ToolContext } from "../src/tools/primitives.ts";
@@ -2741,6 +2742,37 @@ test("unified sandbox dispatches every process action and preserves cursors, sig
     screens.slice(0, 2).map((s) => s.provenance),
     ["external", "external"],
   );
+});
+
+test("unified sandbox advertised schemas and handlers accept minimal arguments for every action", async () => {
+  const actions = [
+    { action: "status", purpose: "Check health" },
+    { action: "restart", purpose: "Recover the computer" },
+    { action: "list", purpose: "List computers" },
+    { action: "create", backend: "modal", purpose: "Create a computer" },
+    { action: "set_default", sandbox_id: null, purpose: "Clear the default" },
+    { action: "retire", sandbox_id: "box-a", purpose: "Retire a computer" },
+    { action: "exec", command: "echo ok", purpose: "Check execution" },
+    { action: "start_process", command: "echo ok" },
+    { action: "read_process", process_id: "bg-1" },
+    { action: "write_stdin", process_id: "bg-1", data: "" },
+    { action: "signal_process", process_id: "bg-1" },
+    { action: "list_processes" },
+    { action: "watch_process", process_id: "bg-1" },
+    { action: "unwatch_process", monitor_id: "mon-1" },
+  ];
+  for (const options of [{}, { scratchExec: true }, { ownerAuthExec: true }, { reachExec: true }]) {
+    const tool = createAgentTools(
+      { current: { ...fakeToolContext(), sandboxResources: async () => ({ ok: true }) }, scopeLabel: "personal:U1" },
+      { ...options, sandboxResources: true },
+    ).find((t) => t.name === "sandbox")!;
+    const advertised = JSON.parse(JSON.stringify(tool.parameters));
+    assert.deepEqual(advertised.required, ["action"]);
+    for (const input of actions) {
+      assert.equal(Check(advertised, input), true, `${JSON.stringify(options)}: ${input.action}`);
+      assert.doesNotMatch(textOut(await call(tool, input)), /\[error\]/, input.action);
+    }
+  }
 });
 
 test("unified sandbox rejects missing, mistyped and unrelated action fields before dispatch", async () => {


### PR DESCRIPTION
The unified sandbox tool advertised process-only fields as required because spreading a TypeBox schema discarded its non-enumerable optional metadata. Ordinary exec/status/restart calls failed schema validation, while supplying the process fields made action validation reject them as unrelated.

Clone schemas with TypeBox's metadata-preserving clone before updating descriptions. Add a regression test that serializes the advertised schema and validates minimal arguments for every sandbox action before dispatching through its handler, across all four execution configurations. Existing invalid-argument rejection tests remain unchanged.

Validation: the new test failed before the fix with nine spurious required fields; all 105 agent-tool tests pass after the fix. Typecheck and lint passed. Independent adversarial review found no blockers. This is a schema-construction logic fix; it changes no sandbox state or routing.
