### PR TITLE
Qualify transaction pooling with combined runtime deployment prerequisites

### DIFF
--- a/.github/workflows/pgbouncer.yml
+++ b/.github/workflows/pgbouncer.yml
@@ -1,0 +1,19 @@
+name: PgBouncer compatibility
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  transaction-pooling:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.18.1"
+          cache: npm
+      - run: npm ci
+      - run: bash scripts/test-pgbouncer.sh

--- a/cli/src/backends/aws.ts
+++ b/cli/src/backends/aws.ts
@@ -86,6 +86,11 @@ export const awsDeploymentLayerTransport: DeploymentLayerTransport = httpDeploym
   request: async (config, url, init) => {
     const target = awsPublicFrontDoor(config).dnsName.toLowerCase().replace(/\.$/, "");
     if (!validAlbHostname(target)) throw new CliError("AWS deployment-layer ALB hostname is invalid");
+    if (awsPublicOrigin(config).protocol === "http:") {
+      assertCloudFrontLayerTarget(config, url, target);
+      const response = await fetch(url, init);
+      return { status: response.status, body: await response.text() };
+    }
     return new Promise((resolve, reject) => {
       const request = https.request(
         url,
@@ -3188,6 +3193,57 @@ const validAlbHostname = (value: string): boolean =>
   value
     .split(".")
     .every((label) => label.length > 0 && label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label));
+
+function assertCloudFrontLayerTarget(config: QmConfig, url: URL, target: string): void {
+  interface Distribution {
+    DomainName?: string;
+    Status?: string;
+    Enabled?: boolean;
+    ContinuousDeploymentPolicyId?: string;
+    CacheBehaviors?: { Quantity?: number };
+    DefaultCacheBehavior?: {
+      TargetOriginId?: string;
+      MaxTTL?: number;
+      CachePolicyId?: string;
+      FunctionAssociations?: { Quantity?: number };
+      LambdaFunctionAssociations?: { Quantity?: number };
+    };
+    Origins?: {
+      Items?: Array<{
+        Id?: string;
+        DomainName?: string;
+        OriginPath?: string;
+        CustomOriginConfig?: { OriginProtocolPolicy?: string; HTTPPort?: number };
+      }>;
+    };
+  }
+  const distributions =
+    awsJson<{ DistributionList?: { Items?: Distribution[] } }>(requireAws(config), ["cloudfront", "list-distributions"])
+      .DistributionList?.Items ?? [];
+  const matches = distributions.filter((distribution) => distribution.DomainName === url.hostname);
+  const distribution = matches.length === 1 ? matches[0] : undefined;
+  const behavior = distribution?.DefaultCacheBehavior;
+  const origin = distribution?.Origins?.Items?.find((item) => item.Id === behavior?.TargetOriginId);
+  if (
+    !distribution?.Enabled ||
+    distribution.Status !== "Deployed" ||
+    distribution.ContinuousDeploymentPolicyId ||
+    behavior?.MaxTTL !== 0 ||
+    behavior.CachePolicyId ||
+    distribution.CacheBehaviors?.Quantity !== 0 ||
+    (behavior?.FunctionAssociations?.Quantity ?? 0) !== 0 ||
+    (behavior?.LambdaFunctionAssociations?.Quantity ?? 0) !== 0 ||
+    origin?.DomainName?.toLowerCase().replace(/\.$/, "") !== target ||
+    origin.OriginPath ||
+    origin.CustomOriginConfig?.OriginProtocolPolicy !== "http-only" ||
+    origin.CustomOriginConfig.HTTPPort !== 80 ||
+    (url.port && url.port !== "443")
+  ) {
+    throw new CliError(
+      "AWS deployment-layer HTTPS proxy must be a deployed CloudFront distribution routing directly to the selected ALB without alternate behaviors, origin paths, or edge functions",
+    );
+  }
+}
 
 function awsCoreHostnames(config: QmConfig): string[] {
   const hosts: string[] = [];

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -8,7 +8,9 @@ import { runChecks } from "./check.ts";
 import { hostingProvider } from "../backends/registry.ts";
 
 export function expectedDescriptors(bundle: DeploymentLayerBundle): ToolDescriptor[] {
-  return bundle.tools.map((file) => parseToolDescriptor(file.content, file.path));
+  return bundle.tools
+    .filter((file) => /^tools\/[^/]+\/tool\.json$/.test(file.path))
+    .map((file) => parseToolDescriptor(file.content, file.path));
 }
 
 export interface ConformanceDeployment {

--- a/cli/src/secrets.ts
+++ b/cli/src/secrets.ts
@@ -191,6 +191,18 @@ export const FIRST_PARTY_SECRET_SPECS: readonly SecretSpec[] = [
     managedBy: "terraform",
   },
   {
+    name: "DATABASE_POOL_URL",
+    service: "core",
+    required: false,
+    description: "Transaction-mode PgBouncer URL using the direct database's company credentials and database name.",
+  },
+  {
+    name: "DATABASE_POOL_CA_CERT",
+    service: "core",
+    required: false,
+    description: "PEM CA certificate used to verify the transaction pooler's TLS identity.",
+  },
+  {
     name: "DATABASE_CA_CERT",
     service: "core",
     required: false,

--- a/cli/templates/aws/main.tf
+++ b/cli/templates/aws/main.tf
@@ -347,6 +347,7 @@ resource "aws_iam_role_policy" "github_deploy" {
           "ecs:ListTaskDefinitions",
           "ec2:DescribeSecurityGroups",
           "elasticloadbalancing:Describe*",
+          "cloudfront:ListDistributions",
           "rds:DescribeDBInstances",
           "servicediscovery:ListNamespaces",
           "servicediscovery:ListServices",
@@ -858,7 +859,7 @@ resource "aws_cloudfront_distribution" "portal" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Accept", "Authorization", "CloudFront-Forwarded-Proto", "Content-Type", "Origin", "Referer", "Sec-Fetch-Site"]
+      headers      = ["Accept", "Authorization", "CloudFront-Forwarded-Proto", "Content-Type", "Origin", "Referer", "Sec-Fetch-Site", "X-Timestamp", "X-Signature", "X-Agent-Capability"]
       cookies { forward = "all" }
     }
   }

--- a/cli/test/aws.test.ts
+++ b/cli/test/aws.test.ts
@@ -134,6 +134,7 @@ else if (a.includes("lambda-microvms get-microvm-image")) {
   console.log(JSON.stringify({ imageArn }));
 }
 else if (a.includes("lambda-microvms list-microvm-image-versions")) console.log(JSON.stringify({ items: [{ imageVersion: process.env.AWS_FAKE_IMAGE_VERSION || "1", state: process.env.AWS_FAKE_IMAGE_STATE || "SUCCESSFUL", status: process.env.AWS_FAKE_IMAGE_STATUS || "ACTIVE" }] }));
+else if (a.includes("cloudfront list-distributions")) console.log(process.env.AWS_FAKE_CLOUDFRONT || "{}");
 else if (a.includes("elbv2 describe-load-balancers")) console.log(JSON.stringify({ LoadBalancers: [{ LoadBalancerArn: "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/test/1", DNSName: process.env.AWS_FAKE_ALB_DNS || "agent.acme.example", State: { Code: "active" } }] }));
 else if (a.includes("elbv2 describe-listeners")) {
   const protocol = process.env.AWS_FAKE_LISTENER_PROTOCOL || "HTTPS";
@@ -4737,6 +4738,113 @@ test("AWS layer GET and PUT bind the selected ALB while retaining API Host, TLS 
     else process.env.CORE_SIGNING_SECRET = priorSecret;
     if (priorAlb === undefined) delete process.env.AWS_FAKE_ALB_DNS;
     else process.env.AWS_FAKE_ALB_DNS = priorAlb;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("AWS layer transport uses the HTTPS front door when an HTTP ALB origin is configured", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "qm-aws-layer-proxy-"));
+  const fake = fakeAws(dir, "console.log('')");
+  const priorSecret = process.env.CORE_SIGNING_SECRET;
+  const priorProtocol = process.env.AWS_FAKE_LISTENER_PROTOCOL;
+  const priorCloudFront = process.env.AWS_FAKE_CLOUDFRONT;
+  const distribution = {
+    DomainName: "test.cloudfront.net",
+    Status: "Deployed",
+    Enabled: true,
+    CacheBehaviors: { Quantity: 0 },
+    DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0 },
+    Origins: {
+      Items: [
+        {
+          Id: "alb",
+          DomainName: "agent.acme.example",
+          OriginPath: "",
+          CustomOriginConfig: { OriginProtocolPolicy: "http-only", HTTPPort: 80 },
+        },
+      ],
+    },
+  };
+  const setDistribution = (value: unknown) => {
+    process.env.AWS_FAKE_CLOUDFRONT = JSON.stringify({ DistributionList: { Items: [value] } });
+  };
+  setDistribution(distribution);
+  process.env.AWS_FAKE_LISTENER_PROTOCOL = "HTTP";
+  process.env.CORE_SIGNING_SECRET = TEST_SECRET_VALUE;
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  t.mock.method(https, "request", () => {
+    throw new Error("must not dial the HTTP origin with TLS");
+  });
+  t.mock.method(globalThis, "fetch", async (url: URL, init: RequestInit) => {
+    calls.push({ url: url.href, init });
+    return new Response("applied", { status: 200 });
+  });
+  try {
+    const configured = {
+      ...config,
+      publicUrl: "https://test.cloudfront.net",
+      env: { ...config.env, core: { ...config.env.core, AWS_PUBLIC_ORIGIN_URL: "http://acme-qm.elb.example" } },
+    };
+    for (const method of ["GET", "PUT"] as const) {
+      const body = method === "PUT" ? '{"contract":1}' : "";
+      assert.equal(
+        (await awsDeploymentLayerTransport({ config: configured, configDir: dir, method, body })).status,
+        200,
+      );
+    }
+    assert.equal(calls.length, 2);
+    for (const { url, init } of calls) {
+      assert.equal(url, "https://test.cloudfront.net/v1/deployment-layer");
+      assert.equal(init.redirect, "error");
+      assert.ok(init.signal instanceof AbortSignal);
+      const headers = init.headers as Record<string, string>;
+      assert.equal(
+        headers["x-signature"],
+        `v0=${createHmac("sha256", TEST_SECRET_VALUE)
+          .update(`v0:${headers["x-timestamp"]}:${init.method}\n/v1/deployment-layer\n${init.body ?? ""}`)
+          .digest("hex")}`,
+      );
+    }
+    for (const invalid of [
+      { ...distribution, DomainName: "another.cloudfront.net" },
+      { ...distribution, Enabled: false },
+      { ...distribution, Status: "InProgress" },
+      { ...distribution, ContinuousDeploymentPolicyId: "staging-policy" },
+      { ...distribution, DomainName: "other.cloudfront.net", Aliases: { Items: ["test.cloudfront.net"] } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 60 } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, CachePolicyId: "managed" } },
+      { ...distribution, CacheBehaviors: { Quantity: 1 } },
+      { ...distribution, DefaultCacheBehavior: { TargetOriginId: "other", MaxTTL: 0 } },
+      {
+        ...distribution,
+        DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, FunctionAssociations: { Quantity: 1 } },
+      },
+      {
+        ...distribution,
+        DefaultCacheBehavior: { TargetOriginId: "alb", MaxTTL: 0, LambdaFunctionAssociations: { Quantity: 1 } },
+      },
+      ...[
+        { DomainName: "other-stack.elb.example" },
+        { OriginPath: "/prefix" },
+        { CustomOriginConfig: { OriginProtocolPolicy: "match-viewer", HTTPPort: 80 } },
+      ].map((change) => ({ ...distribution, Origins: { Items: [{ ...distribution.Origins.Items[0], ...change }] } })),
+    ]) {
+      setDistribution(invalid);
+      await assert.rejects(
+        () => awsDeploymentLayerTransport({ config: configured, configDir: dir, method: "PUT", body: "{}" }),
+        /routing directly to the selected ALB/,
+      );
+    }
+    assert.equal(calls.length, 2);
+  } finally {
+    if (priorCloudFront === undefined) delete process.env.AWS_FAKE_CLOUDFRONT;
+    else process.env.AWS_FAKE_CLOUDFRONT = priorCloudFront;
+    t.mock.restoreAll();
+    fake.restore();
+    if (priorSecret === undefined) delete process.env.CORE_SIGNING_SECRET;
+    else process.env.CORE_SIGNING_SECRET = priorSecret;
+    if (priorProtocol === undefined) delete process.env.AWS_FAKE_LISTENER_PROTOCOL;
+    else process.env.AWS_FAKE_LISTENER_PROTOCOL = priorProtocol;
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/cli/test/deployment-layer.test.ts
+++ b/cli/test/deployment-layer.test.ts
@@ -246,10 +246,24 @@ test("the docker sync PUTs the bundle to the base port with verifiable v0 HMAC s
 test("conformance passes against a live core: base-port override, signed request, canonical hash + descriptors", async () => {
   const dir = mkdtempSync(join(tmpdir(), "qm-conf-"));
   const captured: CapturedRequest[] = [];
+  const descriptor = {
+    id: "t",
+    advertise: "runs t",
+    install: {
+      binary: "t",
+      files: [
+        { from: "t", to: "/usr/local/bin/t", mode: "0755" },
+        { from: "release.json", to: "/usr/local/lib/t/release.json", mode: "0644" },
+      ],
+    },
+  };
   const bundle = (() => {
     writeLayer(dir);
+    writeFileSync(join(dir, "sandbox", "tools", "t", "tool.json"), JSON.stringify(descriptor));
+    writeFileSync(join(dir, "sandbox", "tools", "t", "release.json"), JSON.stringify({ version: "1.0.0" }));
     return deploymentLayerBundle(join(dir, "sandbox"));
   })();
+  assert.equal(bundle.tools.length, 3);
   const contentHash = createHash("sha256").update(JSON.stringify(bundle)).digest("hex");
   const { server, port } = await startCoreStub(
     () => ({
@@ -257,7 +271,7 @@ test("conformance passes against a live core: base-port override, signed request
         contentHash,
         status: "applied",
         runtimeContentHash: contentHash,
-        resolved: { tools: [{ install: { binary: "t" }, advertise: "runs t", id: "t" }] },
+        resolved: { tools: [descriptor] },
       }),
     }),
     captured,

--- a/cli/test/terraform.test.ts
+++ b/cli/test/terraform.test.ts
@@ -593,6 +593,7 @@ test("AWS module supports CloudFront TLS or a direct HTTPS ALB without mixing th
   assert.match(edge, /domain_name\s*=\s*aws_lb\.this\.dns_name/);
   assert.match(edge, /origin_protocol_policy\s*=\s*var\.certificate_arn == "" \? "http-only" : "https-only"/);
   assert.match(edge, /cloudfront_default_certificate\s*=\s*true/);
+  for (const header of ["X-Timestamp", "X-Signature", "X-Agent-Capability"]) assert.ok(edge.includes(`"${header}"`));
 });
 
 test("AWS module reuses account OIDC, guards account and passes configured task roles", () => {

--- a/deploy/core/Dockerfile
+++ b/deploy/core/Dockerfile
@@ -23,5 +23,6 @@ ENV GIT_SHA=$GIT_SHA
 RUN mkdir -p /data && chown node:node /data
 EXPOSE 8080
 
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "src/index.ts"]

--- a/deploy/portal/Dockerfile
+++ b/deploy/portal/Dockerfile
@@ -14,5 +14,6 @@ COPY plugins/portal/tsconfig.json ./
 ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "src/index.ts"]

--- a/deploy/web-ui/Dockerfile
+++ b/deploy/web-ui/Dockerfile
@@ -23,5 +23,6 @@ COPY --from=build /app/dist-web ./dist-web
 ENV NODE_ENV=production
 ENV PORT=8080
 EXPOSE 8080
+RUN apk add --no-cache util-linux
 USER node
 CMD ["node", "server/index.ts"]

--- a/docs/pgbouncer.md
+++ b/docs/pgbouncer.md
@@ -1,0 +1,15 @@
+# PostgreSQL transaction pooling
+
+Keep DATABASE_URL pointed at PostgreSQL. Set DATABASE_POOL_URL to a transaction-mode PgBouncer endpoint with the same database and credentials. Set DATABASE_POOL_CA_CERT to the PEM CA certificate for that endpoint to verify its TLS identity independently of the direct database's configured trust.
+
+Ordinary queries and transactions use the pooled endpoint. Session advisory locks and LISTEN subscriptions use separate direct connections. Schema initialization and dynamic migrations use a separate direct migration pool. pg-boss retains its existing direct endpoint, including its notification connection.
+
+DATABASE_POOL_MAX bounds each process's shared query pool (default 10). DATABASE_DIRECT_POOL_MAX bounds its separate shared session pool (default 32). Both accept integers from 1 to 100. Migrations use a shared one-connection pool. Count every process, database and pooler replica when calculating database capacity; PgBouncer limits are per database/user and per pooler process.
+
+Without DATABASE_POOL_URL, queries and sessions use separate pools to the direct database. Stores sharing a URL share the corresponding underlying pool, with reference-counted close. A closed store cannot reopen itself.
+
+Use PgPool.pool() for ordinary transactions and PgPool.sessionPool() only when the PostgreSQL session must remain pinned, such as session locks and subscriptions. Register migrations through the helper; never run session-lock-based migrations through the transaction endpoint. Query-specific timeouts execute inside a transaction using SET LOCAL, preventing timeout state from leaking between PgBouncer borrowers.
+
+Run scripts/test-pgbouncer.sh to create isolated PostgreSQL and TLS-enabled PgBouncer containers and exercise pooling, lock-held writes, timeout cleanup, migration ordering and shutdown races. The fixture uses a single backend connection to verify multiplexing and a single direct session slot to catch connection starvation. The PgBouncer compatibility workflow runs it on every pull request.
+
+Before enabling pooling on a deployment, verify schema initialization, notifications, job scheduling, TLS failures, cross-database access denial and application reconnect behavior. Roll back routing by removing DATABASE_POOL_URL and restarting the application; database contents do not change.

--- a/scripts/test-pgbouncer.sh
+++ b/scripts/test-pgbouncer.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+name="qm-pgbouncer-test-$$"
+fixture=$(mktemp -d)
+cleanup() {
+  docker rm -f "$name-pool" "$name-db" >/dev/null 2>&1 || true
+  docker network rm "$name" >/dev/null 2>&1 || true
+  rm -rf "$fixture"
+}
+trap cleanup EXIT
+docker network create "$name" >/dev/null
+docker run -d --name "$name-db" --network "$name" -e POSTGRES_PASSWORD=test-password -p 127.0.0.1::5432 postgres:16-alpine >/dev/null
+for attempt in $(seq 1 60); do
+  if docker exec "$name-db" pg_isready -U postgres >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+openssl req -x509 -newkey rsa:2048 -nodes -keyout "$fixture/server.key" -out "$fixture/server.crt" -days 1 -subj /CN=localhost -addext subjectAltName=DNS:localhost,IP:127.0.0.1 >/dev/null 2>&1
+cat > "$fixture/pgbouncer.ini" <<CONFIG
+[databases]
+postgres = host=$name-db port=5432 dbname=postgres pool_size=1
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+unix_socket_dir = /tmp
+pool_mode = transaction
+auth_type = scram-sha-256
+auth_file = /fixture/users.txt
+client_tls_sslmode = require
+client_tls_cert_file = /fixture/server.crt
+client_tls_key_file = /fixture/server.key
+server_tls_sslmode = disable
+max_client_conn = 100
+default_pool_size = 1
+query_wait_timeout = 10
+CONFIG
+printf '"postgres" "test-password"\n' > "$fixture/users.txt"
+chmod 755 "$fixture"
+chmod 644 "$fixture"/*
+docker create --name "$name-pool" --network "$name" -p 127.0.0.1::6432 alpine:3.22 sh -c 'apk add --no-cache pgbouncer >/dev/null && adduser -D pool && exec su pool -s /bin/sh -c "pgbouncer /fixture/pgbouncer.ini"' >/dev/null
+docker cp "$fixture" "$name-pool:/fixture"
+docker start "$name-pool" >/dev/null
+direct_port=$(docker port "$name-db" 5432/tcp | sed 's/.*://')
+pooled_port=$(docker port "$name-pool" 6432/tcp | sed 's/.*://')
+export DATABASE_URL="postgres://postgres:test-password@127.0.0.1:$direct_port/postgres"
+export DATABASE_POOL_URL="postgres://postgres:test-password@127.0.0.1:$pooled_port/postgres"
+export DATABASE_POOL_CA_CERT
+DATABASE_POOL_CA_CERT=$(cat "$fixture/server.crt")
+export DATABASE_DIRECT_POOL_MAX=1 DATABASE_POOL_MAX=4
+for attempt in $(seq 1 60); do
+  if docker logs "$name-pool" 2>&1 | grep -q 'process up'; then break; fi
+  sleep 1
+done
+node --test test/pg-pool-routing.test.ts

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,10 @@ export interface Config {
   databaseUrl?: string;
   databaseCaCert?: string;
   databaseCaCertFile?: string;
+  databasePoolUrl?: string;
+  databasePoolCaCert?: string;
+  databasePoolMax?: number;
+  databaseDirectPoolMax?: number;
   harness: "mock" | "pi" | "opencode" | "codex" | "claude";
   securityPosture: SecurityPosture;
   sandboxResourcesEnabled: boolean;
@@ -1192,6 +1196,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     orgId: env.ORG_ID ?? DEFAULT_ORG_ID,
     sessionStore: env.SESSION_STORE === "postgres" ? "postgres" : "memory",
     ...(env.DATABASE_URL ? { databaseUrl: env.DATABASE_URL } : {}),
+    ...(env.DATABASE_POOL_URL ? { databasePoolUrl: env.DATABASE_POOL_URL } : {}),
+    ...(env.DATABASE_POOL_CA_CERT ? { databasePoolCaCert: env.DATABASE_POOL_CA_CERT } : {}),
+    ...(env.DATABASE_POOL_MAX ? { databasePoolMax: numEnvStrict("DATABASE_POOL_MAX", env.DATABASE_POOL_MAX) } : {}),
+    ...(env.DATABASE_DIRECT_POOL_MAX
+      ? { databaseDirectPoolMax: numEnvStrict("DATABASE_DIRECT_POOL_MAX", env.DATABASE_DIRECT_POOL_MAX) }
+      : {}),
     ...(env.DATABASE_CA_CERT ? { databaseCaCert: env.DATABASE_CA_CERT } : {}),
     ...(env.DATABASE_CA_CERT_FILE ? { databaseCaCertFile: env.DATABASE_CA_CERT_FILE } : {}),
     harness,

--- a/src/harness/pi-harness.ts
+++ b/src/harness/pi-harness.ts
@@ -1141,6 +1141,27 @@ async function buildModelRuntime(
   for (const [provider, apiKey] of Object.entries(k)) {
     if (apiKey) await runtime.setRuntimeApiKey(provider, apiKey, { allowNetwork: false });
   }
+  if (modelGateway) {
+    const providers = new Set(
+      Object.keys(modelGateway.models).flatMap((id) => {
+        const model = resolveModel(id);
+        return model ? [model.provider] : [];
+      }),
+    );
+    const hasConfiguredAuth = runtime.hasConfiguredAuth.bind(runtime);
+    runtime.hasConfiguredAuth = (provider) => providers.has(provider) || hasConfiguredAuth(provider);
+    const getAuth = runtime.getAuth.bind(runtime);
+    runtime.getAuth = (async (model, overrides) => {
+      if (typeof model === "string") return getAuth(model, overrides);
+      const request = modelGatewayRequest(modelGateway, model);
+      if (request)
+        return {
+          auth: { apiKey: request.apiKey, headers: { ...model.headers, ...request.headers } },
+          source: "model gateway",
+        };
+      return getAuth(model, overrides);
+    }) as typeof runtime.getAuth;
+  }
   const retained = <T extends object | undefined>(options: T): T =>
     cacheRetention ? ({ ...options, cacheRetention } as T) : options;
   const stream = runtime.stream.bind(runtime);

--- a/src/persistence/advisory-lock.ts
+++ b/src/persistence/advisory-lock.ts
@@ -51,7 +51,7 @@ export function createPostgresAdvisoryLock(
   return {
     async withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
       const deadline = Date.now() + timeoutMs;
-      const pool = await pg.pool();
+      const pool = await pg.sessionPool();
       for (;;) {
         const client = await pool.connect();
         try {
@@ -76,7 +76,7 @@ export function createPostgresAdvisoryLock(
     },
 
     async tryWithLock<T>(key: string, fn: () => Promise<T>): Promise<T | null> {
-      const pool = await pg.pool();
+      const pool = await pg.sessionPool();
       const client = await pool.connect();
       try {
         const res = await client.query<{ locked: boolean }>(

--- a/src/persistence/leader-lease.ts
+++ b/src/persistence/leader-lease.ts
@@ -41,7 +41,7 @@ export function createPostgresLeaderLease(pg: PgPool): LeaderLease {
     if (!conn) {
       const entry: Conn = { cp: undefined as unknown as Promise<PoolClient>, onError: () => {}, lost: new Set() };
       entry.cp = (async () => {
-        const c = await (await pg.pool()).connect();
+        const c = await (await pg.sessionPool()).connect();
         entry.onError = (e: unknown) => {
           swallow("leader-lease: lock connection died (its locks auto-released)", e);
           drop(entry, c, true);

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -7,6 +7,63 @@ export type { Pool, PoolClient };
 
 export type Rows = Record<string, unknown>[];
 
+const sharedPools = new Map<string, { pool: Pool; users: number }>();
+
+async function retainPool(connectionString: string, kind: "query" | "session" | "migration"): Promise<Pool> {
+  const pg = (await import("pg")).default;
+  const key = `${kind}:${connectionString}`;
+  const existing = sharedPools.get(key);
+  if (existing) {
+    existing.users++;
+    return existing.pool;
+  }
+  const setting = kind === "query" ? "DATABASE_POOL_MAX" : "DATABASE_DIRECT_POOL_MAX";
+  const max = kind === "migration" ? 1 : Number(process.env[setting] ?? (kind === "query" ? 10 : 32));
+  if (!Number.isInteger(max) || max < 1 || max > 100)
+    throw new Error(`${setting} must be an integer between 1 and 100`);
+  let url = connectionString;
+  let ssl = pgCaOptions();
+  if (kind === "query" && connectionString === process.env.DATABASE_POOL_URL && process.env.DATABASE_POOL_CA_CERT) {
+    const parsed = new URL(connectionString);
+    for (const key of ["sslmode", "sslcert", "sslkey", "sslrootcert"]) parsed.searchParams.delete(key);
+    url = parsed.toString();
+    ssl = { ssl: { ca: process.env.DATABASE_POOL_CA_CERT } };
+  }
+  const pool = new pg.Pool({ connectionString: url, ...ssl, max, connectionTimeoutMillis: 10_000 });
+  pool.on("error", (error) => console.error("[pg] idle client error:", errMessage(error)));
+  sharedPools.set(key, { pool, users: 1 });
+  return pool;
+}
+
+async function releasePool(
+  connectionString: string,
+  pool: Pool,
+  kind: "query" | "session" | "migration",
+): Promise<void> {
+  const key = `${kind}:${connectionString}`;
+  const entry = sharedPools.get(key);
+  if (!entry || entry.pool !== pool) return;
+  if (--entry.users === 0) {
+    sharedPools.delete(key);
+    await pool.end();
+  }
+}
+
+function pooledDatabaseUrl(connectionString: string): string {
+  const pooled = process.env.DATABASE_POOL_URL;
+  if (!pooled || connectionString !== process.env.DATABASE_URL) return connectionString;
+  const directUrl = new URL(connectionString);
+  const pooledUrl = new URL(pooled);
+  if (
+    directUrl.username !== pooledUrl.username ||
+    directUrl.password !== pooledUrl.password ||
+    directUrl.pathname !== pooledUrl.pathname
+  ) {
+    throw new Error("DATABASE_POOL_URL must preserve the DATABASE_URL database and credentials");
+  }
+  return pooled;
+}
+
 export const PG_MIGRATIONS_TABLE = "qm_schema_migrations";
 
 export interface PgMigrationDefinition {
@@ -31,6 +88,7 @@ export interface PgQueryOptions {
 
 export interface PgPool {
   pool(): Promise<Pool>;
+  sessionPool(): Promise<Pool>;
   q(text: string, params?: unknown[], options?: PgQueryOptions): Promise<Rows>;
   query(text: string, params?: unknown[], options?: PgQueryOptions): Promise<{ rows: Rows; rowCount: number }>;
   registerMigration(migration: PgMigrationDefinition): void;
@@ -44,11 +102,16 @@ async function withStatementTimeout<T>(
   run: () => Promise<T>,
 ): Promise<T> {
   if (timeoutMs === undefined) return run();
-  await client.query(`SET statement_timeout = ${Math.max(1, Math.round(timeoutMs))}`);
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 1) throw new Error("Query timeout must be a positive finite number");
+  await client.query("BEGIN");
   try {
-    return await run();
-  } finally {
-    await client.query("RESET statement_timeout").catch(swallowAs("pg-pool: reset statement_timeout", undefined));
+    await client.query(`SET LOCAL statement_timeout = ${Math.round(timeoutMs)}`);
+    const result = await run();
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK").catch(swallowAs("pg-pool: rollback query timeout", undefined));
+    throw error;
   }
 }
 
@@ -302,28 +365,40 @@ export function createPgPool(
   const postMigrationMaintenance = maintenanceSource
     .filter((definition) => !definition.beforeMigrations)
     .map((definition) => definePgMigration(definition.id, definition.statements));
-  let poolP: Promise<Pool> | null = null;
-  function pool(): Promise<Pool> {
-    if (!poolP) {
-      poolP = (async () => {
-        const pg = (await import("pg")).default;
-        const instance = new pg.Pool({ connectionString, ...pgCaOptions() });
-        instance.on("error", (error) => console.error("[pg] idle client error:", errMessage(error)));
-        try {
-          await applyPgMaintenance(instance, preMigrationMaintenance);
-          await applyPgMigrations(instance, migrations);
-          await applyPgMaintenance(instance, postMigrationMaintenance);
-        } catch (error) {
-          await instance.end().catch(swallowAs("pg-pool: close after schema failure", undefined));
-          throw error;
-        }
-        return instance;
-      })().catch((error) => {
-        poolP = null;
-        throw error;
-      });
+  let readyP: Promise<void> | null = null;
+  let sessionPoolP: Promise<Pool> | null = null;
+  let queryPoolP: Promise<Pool> | null = null;
+  let closed = false;
+  const queryUrl = pooledDatabaseUrl(connectionString);
+  async function withMigrationPool<T>(fn: (pool: Pool) => Promise<T>): Promise<T> {
+    const instance = await retainPool(connectionString, "migration");
+    try {
+      return await fn(instance);
+    } finally {
+      await releasePool(connectionString, instance, "migration");
     }
-    return poolP;
+  }
+  async function ready(): Promise<void> {
+    if (closed) throw new Error("Postgres store is closed");
+    await (readyP ??= withMigrationPool(async (instance) => {
+      await applyPgMaintenance(instance, preMigrationMaintenance);
+      await applyPgMigrations(instance, migrations);
+      await applyPgMaintenance(instance, postMigrationMaintenance);
+    }).catch((error) => {
+      readyP = null;
+      throw error;
+    }));
+    if (closed) throw new Error("Postgres store is closed");
+  }
+  async function pool(): Promise<Pool> {
+    await ready();
+    if (closed) throw new Error("Postgres store is closed");
+    return (queryPoolP ??= retainPool(queryUrl, "query"));
+  }
+  async function sessionPool(): Promise<Pool> {
+    await ready();
+    if (closed) throw new Error("Postgres store is closed");
+    return (sessionPoolP ??= retainPool(connectionString, "session"));
   }
   async function query(
     text: string,
@@ -397,7 +472,13 @@ export function createPgPool(
     return (await query(text, params, options)).rows;
   }
   async function close(): Promise<void> {
-    if (poolP) await (await poolP).end();
+    if (closed) return;
+    closed = true;
+    await readyP?.catch(() => {});
+    await Promise.all([
+      queryPoolP?.then((instance) => releasePool(queryUrl, instance, "query")),
+      sessionPoolP?.then((instance) => releasePool(connectionString, instance, "session")),
+    ]);
   }
   async function migrate(definition: PgMigrationDefinition): Promise<void> {
     const migration = definePgMigration(
@@ -407,7 +488,8 @@ export function createPgPool(
       definition.legacyId,
     );
     registerPgMigration(connectionString, migration);
-    await applyPgMigrations(await pool(), [migration]);
+    if (closed) throw new Error("Postgres store is closed");
+    await withMigrationPool((instance) => applyPgMigrations(instance, [migration]));
   }
   function registerMigration(definition: PgMigrationDefinition): void {
     registerPgMigration(
@@ -415,5 +497,5 @@ export function createPgPool(
       definePgMigration(definition.id, definition.statements, definition.expectedChecksum, definition.legacyId),
     );
   }
-  return { pool, q, query, registerMigration, migrate, close };
+  return { pool, sessionPool, q, query, registerMigration, migrate, close };
 }

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -7,7 +7,7 @@ export type { Pool, PoolClient };
 
 export type Rows = Record<string, unknown>[];
 
-export interface PgPoolingConfig {
+interface PgPoolingConfig {
   databaseUrl?: string;
   poolUrl?: string;
   caCert?: string;
@@ -41,8 +41,7 @@ async function retainPool(connectionString: string, kind: "query" | "session" | 
     return existing.pool;
   }
   const setting = kind === "query" ? "DATABASE_POOL_MAX" : "DATABASE_DIRECT_POOL_MAX";
-  const max =
-    kind === "migration" ? 1 : kind === "query" ? (poolingConfig.queryMax ?? 10) : (poolingConfig.sessionMax ?? 32);
+  const max = { query: poolingConfig.queryMax ?? 10, session: poolingConfig.sessionMax ?? 32, migration: 1 }[kind];
   if (!Number.isInteger(max) || max < 1 || max > 100)
     throw new Error(`${setting} must be an integer between 1 and 100`);
   let url = connectionString;

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -489,6 +489,7 @@ export function createPgPool(
     );
     registerPgMigration(connectionString, migration);
     if (closed) throw new Error("Postgres store is closed");
+    await ready();
     await withMigrationPool((instance) => applyPgMigrations(instance, [migration]));
   }
   function registerMigration(definition: PgMigrationDefinition): void {

--- a/src/persistence/pg-pool.ts
+++ b/src/persistence/pg-pool.ts
@@ -7,6 +7,29 @@ export type { Pool, PoolClient };
 
 export type Rows = Record<string, unknown>[];
 
+export interface PgPoolingConfig {
+  databaseUrl?: string;
+  poolUrl?: string;
+  caCert?: string;
+  queryMax?: number;
+  sessionMax?: number;
+}
+
+let poolingConfig: PgPoolingConfig = {};
+
+export function configurePgPooling(config: PgPoolingConfig): void {
+  if (config.poolUrl && !config.databaseUrl) throw new Error("DATABASE_POOL_URL requires DATABASE_URL");
+  for (const [name, value] of [
+    ["DATABASE_POOL_MAX", config.queryMax],
+    ["DATABASE_DIRECT_POOL_MAX", config.sessionMax],
+  ] as const) {
+    if (value !== undefined && (!Number.isInteger(value) || value < 1 || value > 100)) {
+      throw new Error(`${name} must be an integer between 1 and 100`);
+    }
+  }
+  poolingConfig = { ...config };
+}
+
 const sharedPools = new Map<string, { pool: Pool; users: number }>();
 
 async function retainPool(connectionString: string, kind: "query" | "session" | "migration"): Promise<Pool> {
@@ -18,16 +41,17 @@ async function retainPool(connectionString: string, kind: "query" | "session" | 
     return existing.pool;
   }
   const setting = kind === "query" ? "DATABASE_POOL_MAX" : "DATABASE_DIRECT_POOL_MAX";
-  const max = kind === "migration" ? 1 : Number(process.env[setting] ?? (kind === "query" ? 10 : 32));
+  const max =
+    kind === "migration" ? 1 : kind === "query" ? (poolingConfig.queryMax ?? 10) : (poolingConfig.sessionMax ?? 32);
   if (!Number.isInteger(max) || max < 1 || max > 100)
     throw new Error(`${setting} must be an integer between 1 and 100`);
   let url = connectionString;
   let ssl = pgCaOptions();
-  if (kind === "query" && connectionString === process.env.DATABASE_POOL_URL && process.env.DATABASE_POOL_CA_CERT) {
+  if (kind === "query" && connectionString === poolingConfig.poolUrl && poolingConfig.caCert) {
     const parsed = new URL(connectionString);
     for (const key of ["sslmode", "sslcert", "sslkey", "sslrootcert"]) parsed.searchParams.delete(key);
     url = parsed.toString();
-    ssl = { ssl: { ca: process.env.DATABASE_POOL_CA_CERT } };
+    ssl = { ssl: { ca: poolingConfig.caCert } };
   }
   const pool = new pg.Pool({ connectionString: url, ...ssl, max, connectionTimeoutMillis: 10_000 });
   pool.on("error", (error) => console.error("[pg] idle client error:", errMessage(error)));
@@ -50,8 +74,8 @@ async function releasePool(
 }
 
 function pooledDatabaseUrl(connectionString: string): string {
-  const pooled = process.env.DATABASE_POOL_URL;
-  if (!pooled || connectionString !== process.env.DATABASE_URL) return connectionString;
+  const pooled = poolingConfig.poolUrl;
+  if (!pooled || connectionString !== poolingConfig.databaseUrl) return connectionString;
   const directUrl = new URL(connectionString);
   const pooledUrl = new URL(pooled);
   if (

--- a/src/persistence/postgres-notify-bus.ts
+++ b/src/persistence/postgres-notify-bus.ts
@@ -34,7 +34,7 @@ export function createPostgresNotifyBus<T>(
     if (closed || connecting || listenClient || local.size() === 0) return;
     connecting = true;
     void (async () => {
-      const client = await (await pg.pool()).connect();
+      const client = await (await pg.sessionPool()).connect();
       client.on("notification", (msg) => {
         if (msg.channel !== channel || !msg.payload) return;
         try {

--- a/src/runs/postgres-run-signal-store.ts
+++ b/src/runs/postgres-run-signal-store.ts
@@ -65,7 +65,7 @@ export function createPostgresRunSignalStore(connectionString: string): RunSigna
     if (closed || connecting || listenClient || listeners.size === 0) return;
     connecting = true;
     void (async () => {
-      const client = await (await pg.pool()).connect();
+      const client = await (await pg.sessionPool()).connect();
       client.on("notification", (msg) => {
         if (msg.channel === CHANNEL && msg.payload) ring(msg.payload);
       });

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -70,7 +70,7 @@ import { installSeedSkills } from "./skills/seed.ts";
 import { createMemoryMap, createPostgresMapFactory, type DurableMap } from "./persistence/durable-map.ts";
 import type { PersistedUiState, UiStateStore } from "./surfaces/ui-state.ts";
 import { slackUserClientFactory } from "./loops/sources/slack.ts";
-import { configurePgCaTrust } from "./persistence/pg-pool.ts";
+import { configurePgCaTrust, configurePgPooling } from "./persistence/pg-pool.ts";
 import { createPostgresLeaderLease, createNoopLeaderLease, type LeaderLease } from "./persistence/leader-lease.ts";
 import {
   createMemoryAdvisoryLock,
@@ -492,6 +492,13 @@ export function buildApp(
   if (config.databaseUrl && !config.connectorSecretKey) {
     throw new Error("CONNECTOR_SECRET_KEY is required with durable storage");
   }
+  configurePgPooling({
+    ...(config.databaseUrl ? { databaseUrl: config.databaseUrl } : {}),
+    ...(config.databasePoolUrl ? { poolUrl: config.databasePoolUrl } : {}),
+    ...(config.databasePoolCaCert ? { caCert: config.databasePoolCaCert } : {}),
+    ...(config.databasePoolMax !== undefined ? { queryMax: config.databasePoolMax } : {}),
+    ...(config.databaseDirectPoolMax !== undefined ? { sessionMax: config.databaseDirectPoolMax } : {}),
+  });
   configurePgCaTrust({
     ...(config.databaseCaCert ? { cert: config.databaseCaCert } : {}),
     ...(config.databaseCaCertFile ? { certFile: config.databaseCaCertFile } : {}),

--- a/test/persistence-init-retry.test.ts
+++ b/test/persistence-init-retry.test.ts
@@ -15,9 +15,13 @@ function flakyPgPool(failures: number): PgPool {
       remaining--;
       throw new Error("transient pg failure");
     }
-    return { rows: [{ token: "t", json: { n: 1 } }], rowCount: 1 };
+    return {
+      rows: [{ token: "t", json: { n: 1 } }],
+      rowCount: 1,
+    };
   }
   return {
+    sessionPool: () => Promise.reject(new Error("not backed by a real pool")),
     pool: () => Promise.reject(new Error("not backed by a real pool")),
     query,
     q: async (text, params) => (await query(text, params ?? [])).rows,

--- a/test/pg-pool-routing.test.ts
+++ b/test/pg-pool-routing.test.ts
@@ -71,7 +71,7 @@ test("one session slot can hold a lock while a transaction uses the query pool",
   const map = createPostgresMap<{ n: number }>(a, "pgbouncer_lock_write_test");
   try {
     await lock.withLock("pgbouncer-write", async () => {
-      await map.set("one", { n: 42 });
+      await map.put("one", { n: 42 });
       assert.deepEqual(await map.get("one"), { n: 42 });
     });
   } finally {
@@ -102,5 +102,23 @@ test("closing during initialization rejects pending queries and leaves other sto
     assert.equal((await b.q("SELECT 42 AS answer"))[0]!.answer, 42);
   } finally {
     await b.close();
+  }
+});
+
+test("dynamic migration waits for its prerequisite schema on a fresh database", { skip }, async () => {
+  const a = createPgPool(direct!, "pool-routing/prerequisite/0001", [
+    "CREATE TABLE IF NOT EXISTS pool_routing_prerequisite(id INTEGER PRIMARY KEY)",
+  ]);
+  try {
+    await a.migrate({
+      id: "pool-routing/prerequisite/0002",
+      statements: ["ALTER TABLE pool_routing_prerequisite ADD COLUMN IF NOT EXISTS value TEXT"],
+    });
+    await a.q(
+      "INSERT INTO pool_routing_prerequisite(id, value) VALUES (1, 'ready') ON CONFLICT (id) DO UPDATE SET value=EXCLUDED.value",
+    );
+    assert.equal((await a.q("SELECT value FROM pool_routing_prerequisite WHERE id=1"))[0]!.value, "ready");
+  } finally {
+    await a.close();
   }
 });

--- a/test/pg-pool-routing.test.ts
+++ b/test/pg-pool-routing.test.ts
@@ -2,10 +2,18 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createPostgresAdvisoryLock } from "../src/persistence/advisory-lock.ts";
 import { createPostgresMap } from "../src/persistence/durable-map.ts";
-import { createPgPool } from "../src/persistence/pg-pool.ts";
+import { createPgPool, configurePgPooling } from "../src/persistence/pg-pool.ts";
 
 const direct = process.env.DATABASE_URL;
 const pooled = process.env.DATABASE_POOL_URL;
+const pooling = {
+  ...(direct ? { databaseUrl: direct } : {}),
+  ...(pooled ? { poolUrl: pooled } : {}),
+  ...(process.env.DATABASE_POOL_CA_CERT ? { caCert: process.env.DATABASE_POOL_CA_CERT } : {}),
+  queryMax: Number(process.env.DATABASE_POOL_MAX ?? 4),
+  sessionMax: Number(process.env.DATABASE_DIRECT_POOL_MAX ?? 1),
+};
+configurePgPooling(pooling);
 const skip = !direct || !pooled ? "requires direct Postgres and transaction PgBouncer URLs" : false;
 
 test("stores share the query pool and closing one does not close another", { skip }, async () => {
@@ -57,11 +65,11 @@ test("pooled credentials cannot silently change company identity", { skip }, () 
   const previous = process.env.DATABASE_POOL_URL;
   const url = new URL(previous!);
   url.pathname = "/another_company";
-  process.env.DATABASE_POOL_URL = url.toString();
+  configurePgPooling({ ...pooling, poolUrl: url.toString() });
   try {
     assert.throws(() => createPgPool(direct!), /preserve.*database and credentials/);
   } finally {
-    process.env.DATABASE_POOL_URL = previous;
+    configurePgPooling(pooling);
   }
 });
 

--- a/test/pg-pool-routing.test.ts
+++ b/test/pg-pool-routing.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createPostgresAdvisoryLock } from "../src/persistence/advisory-lock.ts";
+import { createPostgresMap } from "../src/persistence/durable-map.ts";
+import { createPgPool } from "../src/persistence/pg-pool.ts";
+
+const direct = process.env.DATABASE_URL;
+const pooled = process.env.DATABASE_POOL_URL;
+const skip = !direct || !pooled ? "requires direct Postgres and transaction PgBouncer URLs" : false;
+
+test("stores share the query pool and closing one does not close another", { skip }, async () => {
+  const a = createPgPool(direct!);
+  const b = createPgPool(direct!);
+  try {
+    assert.equal(await a.pool(), await b.pool());
+    await a.close();
+    assert.equal((await b.q("SELECT 42 AS answer"))[0]!.answer, 42);
+  } finally {
+    await a.close();
+    await b.close();
+  }
+});
+
+test("pooled query timeout rolls back without contaminating the next borrower", { skip }, async () => {
+  const a = createPgPool(direct!);
+  try {
+    await assert.rejects(a.q("SELECT pg_sleep(0.2)", [], { timeoutMs: 20 }), { code: "57014" });
+    assert.equal((await a.q("SHOW statement_timeout"))[0]!.statement_timeout, "0");
+    await a.q("SELECT pg_sleep(0.05)");
+    assert.equal((await a.q("SELECT 42 AS answer", [], { timeoutMs: 1000 }))[0]!.answer, 42);
+    assert.equal((await a.q("SHOW statement_timeout"))[0]!.statement_timeout, "0");
+  } finally {
+    await a.close();
+  }
+});
+
+test("session operations remain direct while ordinary queries use another backend", { skip }, async () => {
+  const a = createPgPool(direct!);
+  const client = await (await a.sessionPool()).connect();
+  try {
+    assert.equal(new URL((await a.pool()).options.connectionString!).port, new URL(pooled!).port);
+    const directPid = (await client.query("SELECT pg_backend_pid() AS pid")).rows[0]!.pid;
+    await client.query("LISTEN qm_pool_routing_test");
+    await client.query("SELECT pg_advisory_lock(827360194)");
+    const result = await a.q("SELECT pg_backend_pid() AS pid, pg_try_advisory_xact_lock(827360194) AS acquired");
+    assert.notEqual(result[0]!.pid, directPid);
+    assert.equal(result[0]!.acquired, false);
+  } finally {
+    await client.query("SELECT pg_advisory_unlock(827360194)");
+    await client.query("UNLISTEN qm_pool_routing_test");
+    client.release();
+    await a.close();
+  }
+});
+
+test("pooled credentials cannot silently change company identity", { skip }, () => {
+  const previous = process.env.DATABASE_POOL_URL;
+  const url = new URL(previous!);
+  url.pathname = "/another_company";
+  process.env.DATABASE_POOL_URL = url.toString();
+  try {
+    assert.throws(() => createPgPool(direct!), /preserve.*database and credentials/);
+  } finally {
+    process.env.DATABASE_POOL_URL = previous;
+  }
+});
+
+test("one session slot can hold a lock while a transaction uses the query pool", { skip }, async () => {
+  const a = createPgPool(direct!);
+  const lock = createPostgresAdvisoryLock(a);
+  const map = createPostgresMap<{ n: number }>(a, "pgbouncer_lock_write_test");
+  try {
+    await lock.withLock("pgbouncer-write", async () => {
+      await map.set("one", { n: 42 });
+      assert.deepEqual(await map.get("one"), { n: 42 });
+    });
+  } finally {
+    await a.close();
+  }
+});
+
+test("concurrent client queries multiplex onto one configured server connection", { skip }, async () => {
+  const a = createPgPool(direct!);
+  try {
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => a.q("SELECT pg_backend_pid() AS pid, pg_sleep(0.01)")),
+    );
+    assert.equal(new Set(results.map((rows) => rows[0]!.pid)).size, 1);
+  } finally {
+    await a.close();
+  }
+});
+
+test("closing during initialization rejects pending queries and leaves other stores usable", { skip }, async () => {
+  const a = createPgPool(direct!);
+  const b = createPgPool(direct!);
+  const pending = assert.rejects(a.q("SELECT 1"), /closed/);
+  await a.close();
+  await pending;
+  await assert.rejects(a.pool(), /closed/);
+  try {
+    assert.equal((await b.q("SELECT 42 AS answer"))[0]!.answer, 42);
+  } finally {
+    await b.close();
+  }
+});

--- a/test/pi-harness-oneshot.test.ts
+++ b/test/pi-harness-oneshot.test.ts
@@ -281,7 +281,7 @@ test("oneShot completes an authenticated Pi 0.82 turn", async (t) => {
 });
 
 test("oneShot routes configured models through the model gateway without mutating transport metadata", async (t) => {
-  const requests: Array<{ gatewayKey?: string; providerKey?: string; model?: string }> = [];
+  const requests: Array<{ gatewayKey?: string; providerKey?: string; model?: string; marker?: string }> = [];
   const server = createServer((request, response) => {
     let body = "";
     request.setEncoding("utf8");
@@ -294,6 +294,7 @@ test("oneShot routes configured models through the model gateway without mutatin
         ...(request.headers["api-key"] ? { gatewayKey: String(request.headers["api-key"]) } : {}),
         ...(request.headers["x-api-key"] ? { providerKey: String(request.headers["x-api-key"]) } : {}),
         ...(requestModel ? { model: requestModel } : {}),
+        ...(request.headers["x-model-marker"] ? { marker: String(request.headers["x-model-marker"]) } : {}),
       });
       response.writeHead(200, { "content-type": "text/event-stream" });
       for (const event of [
@@ -340,23 +341,31 @@ test("oneShot routes configured models through the model gateway without mutatin
     url: `http://127.0.0.1:${address.port}`,
     apiKey: "gateway-secret",
     apiKeyHeader: "api-key",
-    models: { "claude-haiku-4-5": "router/haiku" },
+    models: { "claude-haiku-4-5": "router/haiku", "retired-model-name": "router/retired" },
   };
-  const model = getRequiredModel("claude-haiku-4-5");
+  const model = { ...getRequiredModel("claude-haiku-4-5"), headers: { "x-model-marker": "preserved" } };
+  assert.equal(await oneShot("pi-gateway-test", model, {}, "system", "hello", { modelGateway }), "gateway");
+  const directModel = { ...getRequiredModel("claude-opus-4-8"), baseUrl: modelGateway.url };
+  await assert.rejects(
+    oneShot("pi-unmapped-test", directModel, {}, "system", "hello", { modelGateway }),
+    /No API key found|Provider is not configured/,
+  );
+
   assert.equal(
-    await oneShot("pi-gateway-test", model, "direct-provider-key", "system", "hello", { modelGateway }),
+    await oneShot("pi-direct-test", directModel, "direct-provider-key", "system", "hello", { modelGateway }),
     "gateway",
   );
-  const directModel = { ...getRequiredModel("claude-opus-4-8"), baseUrl: modelGateway.url };
-  assert.equal(await oneShot("pi-direct-test", directModel, "direct-provider-key", "system", "hello"), "gateway");
   assert.deepEqual(requests, [
-    { gatewayKey: "gateway-secret", providerKey: "gateway-secret", model: "router/haiku" },
+    { gatewayKey: "gateway-secret", providerKey: "gateway-secret", model: "router/haiku", marker: "preserved" },
     { providerKey: "direct-provider-key", model: "claude-opus-4-8" },
   ]);
   const routed = modelGatewayRequest(modelGateway, model);
   assert.equal(routed?.model.id, "claude-haiku-4-5");
   assert.equal(routed?.target, "router/haiku");
-  assert.deepEqual(transportFromModel(model), { modelId: "claude-haiku-4-5" });
+  assert.deepEqual(transportFromModel(model), {
+    modelId: "claude-haiku-4-5",
+    headers: { "x-model-marker": "preserved" },
+  });
 });
 
 test("Pi assistant error messages fail the turn instead of becoming a blank reply", () => {


### PR DESCRIPTION
Combines the reviewed transaction-pooling runtime with the existing combined-runtime deployment candidate, preserving gateway authentication, packaged-layer deployment, verified CloudFront routing, and ECS Exec utilities. This candidate enables exact-source CI qualification without introducing unrelated runtime upgrades. Pooling adds no schema migrations; direct database connectivity remains available for session operations and rollback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791660343&installation_model_id=19911&pr_number=1077&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1077&signature=8ff0beceb7be3b7692d874e8fd5417877b486ff438482108cee9d089177e2a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->