### PR TITLE
Reject ignored Docker sandbox environment settings

### DIFF
--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1479,6 +1479,14 @@ function validateSandbox(raw: unknown, path: string, target: Target): SandboxCon
       );
     }
   }
+  if (target === "docker" && (out.backend === undefined || out.backend === "sprites")) {
+    const stray = (["env", "secretEnv"] as const).filter((key) => out[key] !== undefined);
+    if (stray.length) {
+      throw new CliError(
+        `${path}: target "docker" does not support ${stray.map((key) => `"sandbox.${key}"`).join(", ")} — nothing on this path delivers them to the sandbox; remove them and add an org service credential with "delivery": "env" instead`,
+      );
+    }
+  }
   if (out.image && !out.app && out.backend !== "local") {
     throw new CliError(`${path}: "sandbox.image" requires "sandbox.app" unless "sandbox.backend" is "local"`);
   }

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -822,10 +822,23 @@ test("AWS rejects coordinates that its Terraform-derived resources cannot accept
   );
 });
 
-test("sandbox.env (literals) + sandbox.secretEnv (resolved) become FLY_RESIDENT_ENV_<KEY>", () => {
+test("sandbox.env (literals) + sandbox.secretEnv (resolved) become FLY_RESIDENT_ENV_<KEY> (aws target, sprites backend)", () => {
+  const aws = {
+    accountId: "123456789012",
+    region: "us-west-2",
+    cluster: "acme",
+    deployRoleArn: "arn:aws:iam::123456789012:role/deploy",
+    secretsPrefix: "acme/",
+    imageLabel: "release",
+    networking: { cloudMapNamespace: "acme.internal" },
+    services: { core: { ecrRepository: "core", ecsService: "acme-core", cpu: 512, memory: 1024 } },
+  };
   withConfig(
     {
+      target: "aws",
+      aws,
       sandbox: {
+        backend: "sprites",
         app: "acme-sandboxes",
         env: { TZ: "America/Los_Angeles" },
         secretEnv: ["COMPANY_API_TOKEN"],
@@ -843,6 +856,35 @@ test("sandbox.env (literals) + sandbox.secretEnv (resolved) become FLY_RESIDENT_
       assert.equal(missing.env.FLY_RESIDENT_ENV_TZ, "America/Los_Angeles");
     },
   );
+});
+
+test('target "docker" rejects sandbox.env/secretEnv on the default and sprites backends (dead Fly resident-env writes)', () => {
+  const cases: unknown[] = [
+    { app: "acme-sandboxes", env: { TZ: "UTC" } },
+    { app: "acme-sandboxes", secretEnv: ["COMPANY_API_TOKEN"] },
+    { app: "acme-sandboxes", env: { TZ: "UTC" }, secretEnv: ["COMPANY_API_TOKEN"] },
+    { app: "acme-sandboxes", secretEnv: [] },
+    { backend: "sprites", app: "acme-sandboxes", env: { TZ: "UTC" } },
+    { backend: "sprites", app: "acme-sandboxes", secretEnv: ["COMPANY_API_TOKEN"] },
+  ];
+  for (const sandbox of cases) {
+    withConfig({ sandbox }, ({ path }) =>
+      assert.throws(
+        () => loadConfigAt(path),
+        /target "docker" does not support .*org service credential.*"delivery": "env"/,
+        `expected ${JSON.stringify(sandbox)} rejected`,
+      ),
+    );
+  }
+});
+
+test('target "docker" still deploys sandbox.app-only configs (default and explicit sprites backend)', () => {
+  withConfig({ sandbox: { app: "acme-sandboxes" } }, ({ path }) => {
+    assert.equal(loadConfigAt(path).config.sandbox?.app, "acme-sandboxes");
+  });
+  withConfig({ sandbox: { backend: "sprites", app: "acme-sandboxes" } }, ({ path }) => {
+    assert.equal(loadConfigAt(path).config.sandbox?.backend, "sprites");
+  });
 });
 
 test("no sandbox block → no injected env, lenient undefined app", () => {

--- a/cli/test/docker-secrets.test.ts
+++ b/cli/test/docker-secrets.test.ts
@@ -13,7 +13,6 @@ const SECRETS = {
   CORE_SIGNING_SECRET: "core-signing-supersecret".repeat(2),
   PORTAL_IDENTITY_SECRET: "portal-identity-supersecret",
   SKILL_SIGNING_SECRET: "skill-signing-supersecret".repeat(2),
-  SB_TOKEN: "sandbox-forwarded-supersecret",
   PLUG_TOKEN: "plugin-supersecret",
   SLACK_BOT_TOKEN: "xoxb-dual-role-supersecret",
   SLACK_APP_TOKEN: "xapp-supersecret",
@@ -88,8 +87,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
         ],
         sandbox: {
           app: "sekrit-sandboxes",
-          env: { TZ: "UTC" },
-          secretEnv: ["SB_TOKEN", "SLACK_BOT_TOKEN"],
         },
         securityScreen: {
           backend: "proxy",
@@ -110,7 +107,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
             CORE_SIGNING_SECRET: "config-placeholder",
             DATABASE_URL: "postgres://config/placeholder",
             PUBLIC_API_URL: "https://config-placeholder.invalid",
-            FLY_RESIDENT_ENV_SB_TOKEN: "config-placeholder",
           },
           slack: { WEB_UI_PUBLIC_URL: "http://folded.example.com/web-ui", CORE_SIGNING_SECRET: "config-placeholder" },
         },
@@ -147,7 +143,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
     );
     assert.ok(!argv.includes("config-placeholder"), "non-secret config env cannot shadow or expose secret values");
     assert.ok(argv.includes("--env-file"), "secrets travel via --env-file");
-    assert.ok(argv.includes("FLY_RESIDENT_ENV_TZ=UTC"), "sandbox.env literals are not secrets");
     assert.ok(argv.includes("LINEAR_REGION=us"), "undeclared plugin env still flows as -e");
     const signerArgs = argv
       .split("\n")
@@ -170,10 +165,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       lines.some((l) => /\.env keys not forwarded/.test(l) && l.includes("HARNESS")),
       "unforwarded .env keys are warned about",
     );
-    assert.ok(
-      !lines.some((l) => /\.env keys not forwarded/.test(l) && l.includes("SB_TOKEN")),
-      "consumed secret names are not warned about",
-    );
 
     const envFiles = readFileSync(fake.envCopy, "utf8");
     assert.ok(envFiles.includes(`CORE_SIGNING_SECRET=${SECRETS.CORE_SIGNING_SECRET}`));
@@ -182,10 +173,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       "secret-store values win over colliding config env on services and plugins",
     );
     assert.ok(envFiles.includes("DATABASE_URL=postgres://external/db"), "DATABASE_URL routes through the env-file");
-    assert.ok(
-      envFiles.includes(`FLY_RESIDENT_ENV_SB_TOKEN=${SECRETS.SB_TOKEN}`),
-      "secretEnv values route through the file",
-    );
     assert.ok(envFiles.includes(`PLUG_TOKEN=${SECRETS.PLUG_TOKEN}`), "plugin secrets route through the file");
     assert.match(
       envFiles,
@@ -197,14 +184,10 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       envFiles.includes(`PUBLIC_API_URL=${SECRETS.PUBLIC_API_URL}`),
       "the sandbox-reachable self-API URL reaches core",
     );
-    assert.ok(
-      envFiles.includes(`FLY_RESIDENT_ENV_SLACK_BOT_TOKEN=${SECRETS.SLACK_BOT_TOKEN}`),
-      "dual-role secret is forwarded into sandboxes",
-    );
     assert.match(
       envFiles,
       new RegExp(`^SLACK_BOT_TOKEN=${SECRETS.SLACK_BOT_TOKEN}$`, "m"),
-      "dual-role secret keeps its plain name for the in-process slack surface",
+      "the slack service secret keeps its plain name for the in-process slack surface",
     );
     assert.match(
       envFiles,
@@ -217,7 +200,6 @@ test("docker up delivers secrets via a 0600 env-file, never on the docker argv",
       "a secretEnv alias delivers the stored value under its declared env name",
     );
     assert.match(envFiles, new RegExp(`^SECURITY_SCREEN_PROXY_TOKEN=${SECRETS.EXAMPLE_SCREEN_TOKEN}$`, "m"));
-    assert.ok(!envFiles.includes("FLY_RESIDENT_ENV_TZ"), "literal sandbox env is not in the secret file");
     for (const mode of envFiles.match(/^mode=.*$/gm) ?? []) assert.equal(mode, "mode=600");
 
     for (const line of readFileSync(fake.argvLog, "utf8").split("\n").filter(Boolean)) {

--- a/cli/test/layer-wiring.test.ts
+++ b/cli/test/layer-wiring.test.ts
@@ -108,7 +108,7 @@ test("--sandbox-dir sources the layer from a shared dir while config stays in th
   }
 });
 
-test("sandbox.app/env/secretEnv become the core's FLY_* + FLY_RESIDENT_ENV_* env", async () => {
+test("sandbox.env + sandbox.secretEnv are rejected before planning a docker deployment (dead Fly resident-env path)", async () => {
   const dir = makeDeployment(
     {
       sandbox: {
@@ -120,15 +120,13 @@ test("sandbox.app/env/secretEnv become the core's FLY_* + FLY_RESIDENT_ENV_* env
     (d) => writeFileSync(join(d, ".env"), "COMPANY_API_TOKEN=sek-ret\n"),
   );
   try {
-    const out = await plan(dir);
-    assert.match(out, /FLY_RESIDENT_ENV_TZ/);
-    assert.match(out, /FLY_RESIDENT_ENV_COMPANY_API_TOKEN/);
+    await assert.rejects(() => plan(dir), /target "docker" does not support "sandbox.env", "sandbox.secretEnv"/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("a missing secretEnv value is warned, not invented", async () => {
+test("sandbox.secretEnv alone is also rejected on the default docker backend", async () => {
   const dir = makeDeployment({
     sandbox: {
       app: "s",
@@ -136,8 +134,7 @@ test("a missing secretEnv value is warned, not invented", async () => {
     },
   });
   try {
-    const out = await plan(dir);
-    assert.match(out, /sandbox.secretEnv "NOPE_TOKEN" has no value/);
+    await assert.rejects(() => plan(dir), /target "docker" does not support "sandbox.secretEnv"/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #351 (reported by @shekharkadyan).

`sandbox.env` / `sandbox.secretEnv` are written onto the core container as
`FLY_RESIDENT_ENV_*`, but nothing in core reads that prefix, so the setting is
silently accepted and then dropped. The `local`, `aws`, and `agent37` sandbox
backends already reject these fields with a clear error. The `docker` target's
default (backend omitted) and explicit `sprites` backend were the only two
paths left silently accepting them.

This adds one validator check (8 production lines in `cli/src/config.ts`) that
rejects `sandbox.env`/`sandbox.secretEnv` on those two remaining `docker`-target
paths, naming the unsupported fields only (never their values) and pointing at
an org service credential with `"delivery": "env"` as the supported
alternative. `sandbox.app`/`sandbox.baseImage` configs are unaffected. Other
targets (`fly`, `aws`) are left unaffected by this change — this only says the
fields are unsupported for `docker`; whether they work elsewhere is a separate
audit, not something this PR verifies either way.

Three test files build a `docker`-target config through the JSON loader with
`sandbox.env`/`secretEnv` and no rejecting backend, so they needed updating:
`cli/test/config.test.ts` (moved the existing `sandboxCoreEnv()` mapping test
onto an unaffected `aws`+`sprites` config, added rejection coverage for each
field alone/together/empty-array and both docker paths, added a still-works
app-only check), `cli/test/docker-secrets.test.ts` and
`cli/test/layer-wiring.test.ts` (dropped the now-invalid docker+env/secretEnv
fixtures and their forwarding-specific assertions, kept every unrelated
secret-handling assertion in both files unchanged).

**Tests:** `config.test.ts`, `docker-secrets.test.ts`, `layer-wiring.test.ts`,
`fly-sandbox.test.ts`, `secrets.test.ts`, `stack-configs.test.ts` — 112/112
pass. Typecheck and lint clean. Fail-before/pass-after verified by reverting
the validator change and confirming the new tests fail, then restoring it.

Independently reviewed prior to this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791669661&installation_model_id=19911&pr_number=1080&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1080&signature=2af42cd031ceebd8f7f3f10ab3adc005f401f3149a3ca04c9109a5452914ee10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->