### PR TITLE
Correct the Admin ambient-policy default guidance

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -5418,10 +5418,11 @@
                     <label for="ambient-enabled">Ambient behavior</label>
                     <p class="hint" style="margin: 2px 0 6px">
                       When off, the agent never wakes on overheard messages in this channel; it only responds to direct
-                      @mentions. Default: on for channels with 8 or fewer members, off for larger ones.
+                      @mentions. Default: on when this channel has a standing order or an action-marked bot, off
+                      otherwise.
                     </p>
                     <select id="ambient-enabled" style="margin-bottom: 14px">
-                      <option value="default">Default (by channel size)</option>
+                      <option value="default">Default (standing order or action bot)</option>
                       <option value="on">On</option>
                       <option value="off">Off</option>
                     </select>
@@ -5553,8 +5554,8 @@
                       <span class="setting-copy"
                         ><strong>Allow ambient behavior</strong
                         ><small
-                          >Channels choose per-channel; without a choice, ambient defaults off in channels with more
-                          than 8 members.</small
+                          >Channels choose per-channel; without a choice, ambient defaults on only where there's a
+                          standing order or an action-bot trigger, off otherwise.</small
                         ></span
                       >
                     </label>

--- a/plugins/admin/test/ambient-policy-copy.test.ts
+++ b/plugins/admin/test/ambient-policy-copy.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+
+test("ambient policy copy: per-channel default explains the real gate — standing orders or an action bot, not channel size", () => {
+  assert.match(html, /Default: on when this channel has a standing order or an action-marked bot,\s+off\s+otherwise\./);
+  assert.match(html, /<option value="default">Default \(standing order or action bot\)<\/option>/);
+});
+
+test("ambient policy copy: org-wide toggle explains the same default and that it overrides an explicit per-channel On", () => {
+  assert.match(
+    html,
+    /Org-wide, default on\. When off, the agent never acts on overheard messages in any channel,\s+regardless of per-channel settings; it only responds to direct @mentions\./,
+  );
+  assert.match(
+    html,
+    /ambient defaults on only where there's a\s+standing order or an action-bot trigger, off otherwise\./,
+  );
+});
+
+test("ambient policy copy: no stale channel-size language remains anywhere in the admin UI", () => {
+  assert.doesNotMatch(html, /8 or fewer members/);
+  assert.doesNotMatch(html, /by channel size/);
+  assert.doesNotMatch(html, /more\s+than 8 members/);
+  assert.doesNotMatch(html, /channels with more/);
+});

--- a/test/surface-cache.test.ts
+++ b/test/surface-cache.test.ts
@@ -169,7 +169,11 @@ test("channel policy store: bot ledger round-trips and an omitted `bots` leaves 
 test("channel policy store: ambientEnabled is tri-state — unset by default, round-trips, omitted leaves it, null clears it", async () => {
   const store = createMemoryChannelPolicyStore();
   await store.set("C1", "watch the launch", { setBy: "U-admin" });
-  assert.equal((await store.get("C1"))?.ambientEnabled, undefined, "unset by default — the size rule decides");
+  assert.equal(
+    (await store.get("C1"))?.ambientEnabled,
+    undefined,
+    "unset by default — a standing order or action-bot trigger decides",
+  );
   await store.set("C1", "watch the launch", { setBy: "U-admin", ambientEnabled: false });
   assert.equal((await store.get("C1"))?.ambientEnabled, false, "off persists");
   await store.set("C1", "watch the launch harder", { setBy: "U-admin" });


### PR DESCRIPTION
Fixes #270.

## Summary
- Correct the three admin-UI copy strings claiming the ambient reply default is decided by channel size (an "8 or fewer members" / "more than 8 members" cutoff that doesn't exist in the runtime). The actual default (`src/api/app-ambient.ts`, `judgeAmbientContainer`) opts an unset per-channel policy into ambient only when there's a non-empty standing order or a bot ledger entry with mode `"action"`; an org-wide off always wins, including over an explicit per-channel On.
- Fix the matching stale assertion message in the channel-policy-store tri-state test (the asserted value was already correct; only the description text repeated the size-rule framing).
- Add an admin copy-regression test asserting the corrected strings and the absence of any remaining "8 members" / "channel size" language.

No runtime/behavior change. Reported by @ianTPE in #270 (a 5-member Slack channel that the Admin UI promised automatic ambient behavior for, but that never engaged — the real gate is standing orders/action bots, not member count). Same underlying stale-copy issue as the earlier, unmerged #825.

## Coordination with #1042
#1042 restructures the same `card-ambient-policy` HTML block (for web-project applicability) but its diff leaves this stale copy text itself unchanged, and it doesn't touch the org-wide card or either test file here. Not modifying #1042. Recommend landing #1042 first and rebasing this on top of it — the two per-channel-card string edits move into #1042's new wrapper markup, and the org-card edit plus both test files carry over with no conflict either order.

## Test plan
- `node --test test/surface-cache.test.ts` — 21/21 pass
- `node --test test/surface-cache-ambient.test.ts` (full ambient policy matrix: org-off precedence, per-channel off, standing-orders-opts-in regardless of size, action-bot opts-in, explicit-on opts-in, bot ledger semantics) — 40/40 pass
- `plugins/admin`: `node --test` (full plugin suite incl. new copy test) — 130/130 pass
- Root typecheck, admin plugin typecheck, eslint, oxlint, prettier --check, git diff --check — all clean
- Confirmed the new copy-regression test actually catches the regression: fails against the pre-fix HTML, passes against the fix
- Independently reviewed against a fresh-context pass per repo convention
- Demoed against the actual Admin UI running locally against a mock harness with in-memory data (before/after screenshots to follow in review)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791670164&installation_model_id=19911&pr_number=1081&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1081&signature=197399c99aec0bd7dc74df189f3eb05b402694d8af8b2b07d448e1d3626605a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
