### PR TITLE
Exercise runtime discovery and correct dev socket diagnostics

### DIFF
--- a/.codex/skills/dev-instance/SKILL.md
+++ b/.codex/skills/dev-instance/SKILL.md
@@ -45,9 +45,10 @@ heartbeat so slot reclaim can tell "actively in use" from "abandoned".
 **`up` only prints success after proving the bot is reachable**: the Slack socket must be
 the app's _only_ connection (`num_connections == 1`, read from the hello frame) and — when
 the slot has a `CANARY_CHANNEL` — a posted canary message must arrive back over that same
-socket. If another machine/worktree holds a connection to the app (the classic "boots LIVE
-but deaf" failure), `up` detects it, flags the slot for 30 minutes, and auto-rotates to the
-next one, reporting the thief's hello host. A canary that never returns on a clean socket
+socket. If Slack reports multiple connections, `up` flags the slot for 30 minutes and
+auto-rotates to the next one. The count is a snapshot from the last hello frame, not
+a continuously refreshed inventory. Its `debug_info.host` identifies Slack's server,
+not another client's machine; it cannot locate a competing instance. A canary that never returns on a clean socket
 means a stale Slack app; `up` flags and rotates past that too.
 
 **Re-running `up` on a live instance is a reload, not a no-op**: it re-reads your shell
@@ -185,8 +186,11 @@ port squatters, machine-wide token orphans, Docker daemon — and prints a ranke
 with a remedy per finding. `doctor --fix` applies the safe ones (child restarts).
 
 **Bot never replies to a DM (silent bot).** The new `up` catches the two big causes at
-boot: another live connection to the same app (auto-rotates, names the thief's host) and a
-stale Slack app whose events never arrive (canary fails → flags the slot and rotates). If
+boot: multiple reported connections to the same app (flags the slot and auto-rotates)
+and a Slack app whose events never arrive (canary fails → flags the slot and rotates).
+Check local processes and other deployments before attributing a connection count to
+a live competitor. After cleanup, reconnect to obtain a fresh hello count; rereading
+health alone returns the previous snapshot. If
 deafness appears mid-session, the 10s health probe logs `DEGRADED: num_connections=N` in
 `supervisor.log` and the periodic canary flags delivery loss; `dev canary` gives you an
 on-demand proof either way. `dev up --rotate` moves to a fresh slot.

--- a/.codex/skills/dev-instance/SKILL.md
+++ b/.codex/skills/dev-instance/SKILL.md
@@ -48,8 +48,8 @@ the slot has a `CANARY_CHANNEL` — a posted canary message must arrive back ove
 socket. If Slack reports multiple connections, `up` flags the slot for 30 minutes and
 auto-rotates to the next one. The count is a snapshot from the last hello frame, not
 a continuously refreshed inventory. Its `debug_info.host` identifies Slack's server,
-not another client's machine; it cannot locate a competing instance. A canary that never returns on a clean socket
-means a stale Slack app; `up` flags and rotates past that too.
+not another client's machine; it cannot locate a competing instance. A canary that
+never returns leaves delivery unverified; `up` flags and rotates past that too.
 
 **Re-running `up` on a live instance is a reload, not a no-op**: it re-reads your shell
 env, dev.env, and `.env`, diffs against what the children are running, and does a rolling
@@ -190,19 +190,22 @@ boot: multiple reported connections to the same app (flags the slot and auto-rot
 and a Slack app whose events never arrive (canary fails → flags the slot and rotates).
 Check local processes and other deployments before attributing a connection count to
 a live competitor. After cleanup, reconnect to obtain a fresh hello count; rereading
-health alone returns the previous snapshot. If
-deafness appears mid-session, the 10s health probe logs `DEGRADED: num_connections=N` in
-`supervisor.log` and the periodic canary flags delivery loss; `dev canary` gives you an
-on-demand proof either way. `dev up --rotate` moves to a fresh slot.
+health alone returns the previous snapshot. The 10s health probe logs
+`DEGRADED: num_connections=N` in `supervisor.log` when it observes a count transition
+above one, but cannot detect a new competitor while the hello snapshot is unchanged.
+Periodic canaries can detect delivery loss; `dev canary` tests delivery on demand.
+A successful canary does not establish exclusivity. `dev up --rotate` moves to a fresh slot.
 
-For a slot flagged `canary-failed`, the app itself is stale and needs rebuilding (~5 min):
-at api.slack.com **signed into the example workspace** (the dev console is
+For a slot flagged `canary-failed`, check networking, event subscriptions, permissions,
+and competing connections first. If the app configuration needs rebuilding, use
+api.slack.com **signed into the example workspace** (the dev console is
 per-workspace-identity — use "Sign in to another workspace" if it lists the wrong one):
 Create New App → From a manifest → paste `src/slack/manifest.json` (give it a unique
 `name` and bot `display_name`; old handles stay taken) → Install to Workspace → Basic
 Information → App-Level Tokens → Generate with the `connections:write` scope. Write the Bot
 token (`xoxb-…`) and app-level token (`xapp-…`) into `poolN.env`, delete `poolN.flag.json`,
-then run `up` again. (If you own the existing app, just reinstalling it also works.)
+then run `up` again to verify the replacement. Reinstalling an existing app may also
+resolve configuration drift; verify delivery afterward.
 
 Two smaller gotchas: a freshly-created bot isn't in Slack's "New message" people search for a
 minute or two — open its DM deterministically via `conversations.open` (bot token + your user

--- a/scripts/dev/cli.ts
+++ b/scripts/dev/cli.ts
@@ -403,12 +403,12 @@ async function cmdUp(): Promise<number> {
         {
           reason: "stolen",
           at: nowEpoch(),
-          detail: `num_connections=${result.numConnections} host=${result.helloHost ?? "?"}`,
+          detail: `num_connections=${result.numConnections} slack_server=${result.helloHost ?? "?"}`,
         },
         store,
       );
       out(
-        `[!] slot ${slot} is STOLEN: ${result.numConnections} connections open to its Slack app (another machine/worktree holds one; hello host: ${result.helloHost ?? "?"}).`,
+        `[!] slot ${slot}: Slack reported ${result.numConnections} connections at the last hello; exclusivity is unverified (Slack server: ${result.helloHost ?? "?"}, not a client host).`,
       );
       out(`    flagged ${slot} for 30min and rotating to the next slot...`);
       excluded.add(slot);

--- a/scripts/dev/commands/doctor.ts
+++ b/scripts/dev/commands/doctor.ts
@@ -99,9 +99,11 @@ export async function runDoctor(opts: { json: boolean; fix: boolean; store: stri
           detail:
             conns === null
               ? "num_connections unknown (introspection tap degraded)"
-              : `num_connections=${conns}${slack?.helloHost ? ` (hello host ${slack.helloHost})` : ""}`,
+              : `num_connections=${conns} at last hello${slack?.helloHost ? ` (Slack server ${slack.helloHost})` : ""}`,
           remedy:
-            conns !== null && conns > 1 ? "another live connection is stealing events: dev up --rotate" : undefined,
+            conns !== null && conns > 1
+              ? "check for other instances; reconnect and verify with dev up --rotate"
+              : undefined,
         });
         const canary = (await supervisorRequest(sock, "POST", "/canary", {}, 40_000)).body as {
           ok: boolean;

--- a/scripts/dev/supervisor/main.ts
+++ b/scripts/dev/supervisor/main.ts
@@ -534,7 +534,7 @@ function startLoops(): void {
       }
       if ((slackHealth.numConnections ?? 1) > 1 && (lastSlackHealth?.numConnections ?? 1) <= 1) {
         log(
-          `DEGRADED: num_connections=${slackHealth.numConnections} -- another connection to this Slack app is stealing events (host: ${slackHealth.helloHost ?? "?"})`,
+          `DEGRADED: num_connections=${slackHealth.numConnections} at last hello -- Slack socket exclusivity is unverified (Slack server: ${slackHealth.helloHost ?? "?"}, not a client host)`,
         );
       }
       lastSlackHealth = slackHealth;

--- a/test/live-slack/scenarios.ts
+++ b/test/live-slack/scenarios.ts
@@ -28,7 +28,7 @@ export const scenarios: Scenario[] = [
       const ch = await ctx.freshChannel();
       const marker = ctx.marker();
       const root = await ch.mention(
-        `Use the runtime tool to inspect your active runtime and available models, then switch to a different available Anthropic model for this task only. Keep the pi harness, set effort to auto and fastMode to false. After the handoff, inspect runtime again and calculate 17 × 23. Only after completing these steps, reply with the exact token ${marker}, your active model and the answer.`,
+        `Can you switch your model to a different available Anthropic model for this request and then calculate 17 × 23? Keep using pi with automatic reasoning effort and fast mode off. Once you have switched, verify which model you are actually running on. Include ${marker}, that model and the answer in your final reply.`,
       );
       const reply = await ch.waitForBotReply(root, { match: new RegExp(marker), timeoutMs: 4 * 60_000 });
       assert.match(reply.text ?? "", /\b391\b/);


### PR DESCRIPTION
The live runtime scenario previously named the tool and its parameter values, so it did not test whether the agent could discover runtime control from a normal model-switch request. Use natural language while retaining the durable handoff, post-switch inspection, distinct-model invocation, and answer assertions.

Dev Socket Mode diagnostics also called Slack's `debug_info.host` a competing client's host and asserted that another machine was stealing events. Label it as Slack's server and describe `num_connections` as a last-hello snapshot. Keep the exclusivity gate, slot flags, and rotation behavior unchanged.

Validation: live Firefox Slack QA discovered runtime control, switched Sol to Astra within the same request, verified Astra, and returned 391. A follow-up request used Sol again; durable model records and tool results confirmed the switch and task-only lifetime. Normal dev startup passed socket exclusivity and a live canary. All 30 focused dev CLI, supervisor-child, and Slack introspection tests passed, along with typecheck and lint.

Diagnostic example: `Slack reported 3 connections at the last hello; exclusivity is unverified (Slack server: applink-12, not a client host).`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791675539&installation_model_id=19911&pr_number=1084&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1084&signature=aab7a19f327f8a8a63e74457bd95740eccf032f3aafd0952d1b7bbdc981f6e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->