### PR TITLE
Link quarantine refusals to authorized review history

### DIFF
--- a/plugins/chassis/src/failure-copy.ts
+++ b/plugins/chassis/src/failure-copy.ts
@@ -1,4 +1,4 @@
-import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "./security-quarantine.ts";
+import { quarantineRefusalText } from "./security-quarantine.ts";
 
 export const GENERIC_FAILURE_CLAUSE = "something went wrong on my end";
 
@@ -8,10 +8,11 @@ export interface FailureLike {
   status?: string;
   reason?: string;
   refusalKind?: string;
+  adminUrl?: string;
 }
 
 export function userFacingFailureText(result: FailureLike): string {
-  if (result.refusalKind === "security_quarantine") return SECURITY_QUARANTINE_REFUSAL_TEXT;
+  if (result.refusalKind === "security_quarantine") return quarantineRefusalText(result.adminUrl);
   if (result.status === "refused" && result.reason) return result.reason;
   return GENERIC_FAILURE_TEXT;
 }

--- a/plugins/chassis/src/security-quarantine.ts
+++ b/plugins/chassis/src/security-quarantine.ts
@@ -1,2 +1,19 @@
-export const SECURITY_QUARANTINE_REFUSAL_TEXT =
-  "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review the quarantine.";
+const SECURITY_QUARANTINE_REFUSAL_INTRO =
+  "I couldn't act because my security screen flagged part of this message or its conversation context.";
+
+export const SECURITY_QUARANTINE_REFUSAL_TEXT = `${SECURITY_QUARANTINE_REFUSAL_INTRO} Please retry without the flagged context.`;
+
+export function quarantineRefusalText(adminUrl?: string): string {
+  if (!adminUrl || /[\u0000-\u001f\u007f]/.test(adminUrl)) return SECURITY_QUARANTINE_REFUSAL_TEXT;
+  const reviewUrl = adminUrl.trim();
+  if (!reviewUrl || /[\s<>"']/.test(reviewUrl) || !/^https?:\/\//i.test(reviewUrl))
+    return SECURITY_QUARANTINE_REFUSAL_TEXT;
+  try {
+    const url = new URL(reviewUrl);
+    if ((url.protocol !== "http:" && url.protocol !== "https:") || !url.hostname)
+      return SECURITY_QUARANTINE_REFUSAL_TEXT;
+    return `${SECURITY_QUARANTINE_REFUSAL_INTRO} Please retry without the flagged context, or ask an admin to review this quarantine in session history: ${url.href}`;
+  } catch {
+    return SECURITY_QUARANTINE_REFUSAL_TEXT;
+  }
+}

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -95,7 +95,7 @@ import { deepLinkPath, UI_BASE } from "./deep-link";
 import type { ChatSurface, ConvCtx } from "./conv-types";
 import { errMessage, swallow } from "../../chassis/src/errors";
 import { showStateError } from "./error-banner";
-import { splitLinks } from "./linkify";
+import { linkifiedText } from "./linkified-text";
 import { escapeLoneDollars } from "./markdown-dollars";
 import { slackWireToPlain, splitSlackWire, stripSlackDirectives } from "./slack-text";
 import { splitStreamingMarkdown } from "./streaming-markdown";
@@ -1077,16 +1077,6 @@ export function createChatSurface(
     else readonlyRedraw?.();
   }
 
-  function linkifiedText(text: string): TemplateResult {
-    return html`${splitLinks(text).map((seg) =>
-      seg.kind === "link"
-        ? html`<a href=${seg.href} target="_blank" rel="noreferrer noopener" @click=${(e: Event) => e.stopPropagation()}
-            >${seg.href}</a
-          >`
-        : seg.text,
-    )}`;
-  }
-
   function pinnedStrip(): TemplateResult | typeof nothing {
     const pins = chatState.pins;
     if (!pins.length) return nothing;
@@ -1282,7 +1272,7 @@ export function createChatSurface(
             <div class="message-stack ${emptyChat ? "empty-stack" : ""}">
               ${inheritedHeader()} ${chatState.earlierCount > 0 ? earlierNotice(agent) : nothing} ${messageContent}
               ${emptyChat ? html`<h1 class="chat-cta">${chatCta()}</h1>` : nothing}
-              ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${agent.state.errorMessage}</div>` : nothing}
+              ${showStateError(messages, agent.state.errorMessage) ? html`<div class="composer-error inline">${linkifiedText(agent.state.errorMessage ?? "")}</div>` : nothing}
             </div>
           </section>
           <div class="chat-bottom-dock">
@@ -1540,7 +1530,7 @@ export function createChatSurface(
           <div class="assistant-body">
             ${showWork ? workBlock(work, isStreaming) : nothing} ${assistantContent(msg, isStreaming, showWork)}
             ${assistantFileList(deliveredFiles)}
-            ${msg.stopReason === "error" && msg.errorMessage ? html`<div class="composer-error inline">${msg.errorMessage}</div>` : nothing}
+            ${msg.stopReason === "error" && msg.errorMessage ? html`<div class="composer-error inline">${linkifiedText(msg.errorMessage)}</div>` : nothing}
             ${msg.stopReason === "aborted" ? html`<div class="stopped-note">${icon(Ban, 13)}<span>Stopped</span></div>` : nothing}
             ${isStreaming ? nothing : messageMeta(msg, index)}
           </div>

--- a/plugins/web-ui/src/linkified-text.ts
+++ b/plugins/web-ui/src/linkified-text.ts
@@ -1,0 +1,12 @@
+import { html, type TemplateResult } from "lit";
+import { splitLinks } from "./linkify.ts";
+
+export function linkifiedText(text: string): TemplateResult {
+  return html`${splitLinks(text).map((seg) =>
+    seg.kind === "link"
+      ? html`<a href=${seg.href} target="_blank" rel="noreferrer noopener" @click=${(e: Event) => e.stopPropagation()}
+          >${seg.href}</a
+        >`
+      : seg.text,
+  )}`;
+}

--- a/plugins/web-ui/test/core-bridge-idle.test.ts
+++ b/plugins/web-ui/test/core-bridge-idle.test.ts
@@ -396,13 +396,18 @@ test("a refused run still shows its authored, user-facing reason", async () => {
   assert.equal(final.errorMessage, "you're not a member of that context");
 });
 
-test("a stored quarantine refusal renders the canned copy on the web, never the internal verdict", async () => {
+test("a stored quarantine refusal renders its admin history link on the web, never the internal verdict", async () => {
   setClock(() => 1_000_000);
   instantSleep();
   stubRuns([
     {
       status: "done",
-      result: { status: "refused", refusalKind: "security_quarantine", reason: "internal screening details" },
+      result: {
+        status: "refused",
+        refusalKind: "security_quarantine",
+        reason: "internal screening details",
+        adminUrl: "https://portal.example.com/admin/history/s/s-1",
+      },
       partial: "",
     },
   ]);
@@ -414,4 +419,5 @@ test("a stored quarantine refusal renders the canned copy on the web, never the 
   assert.equal(final.stopReason, "error");
   assert.doesNotMatch(final.errorMessage ?? "", /internal screening details/);
   assert.match(final.errorMessage ?? "", /security screen flagged/);
+  assert.match(final.errorMessage ?? "", /admin\/history\/s\/s-1/);
 });

--- a/plugins/web-ui/test/error-link.test.ts
+++ b/plugins/web-ui/test/error-link.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { JSDOM } from "jsdom";
+
+test("web quarantine copy canonicalizes a safe review link and rejects delimiter-bearing URLs", async () => {
+  const dom = new JSDOM('<!doctype html><main id="host"></main>');
+  Object.defineProperty(globalThis, "document", { configurable: true, value: dom.window.document });
+  const [{ render }, { linkifiedText }, { userFacingFailureText }] = await Promise.all([
+    import("lit"),
+    import("../src/linkified-text.ts"),
+    import("../../chassis/src/failure-copy.ts"),
+  ]);
+  const host = dom.window.document.querySelector<HTMLElement>("#host")!;
+  const canonicalUrl = "https://portal.example.com/admin/history/s/session-574";
+  const quarantine = {
+    status: "refused",
+    refusalKind: "security_quarantine",
+    reason: "internal screening details",
+  };
+  const linkedCopy = userFacingFailureText({
+    ...quarantine,
+    adminUrl: "HTTPS://PORTAL.EXAMPLE.COM/admin/history/s/session-574",
+  });
+  render(linkifiedText(linkedCopy), host);
+
+  const anchors = host.querySelectorAll<HTMLAnchorElement>("a");
+  assert.equal(anchors.length, 1);
+  assert.equal(anchors[0]!.href, canonicalUrl);
+  assert.equal(anchors[0]!.textContent, canonicalUrl);
+  assert.equal(anchors[0]!.target, "_blank");
+  assert.equal(anchors[0]!.rel, "noreferrer noopener");
+  assert.doesNotMatch(host.textContent ?? "", /internal screening details/);
+
+  for (const adminUrl of [
+    "https://portal.example.com/admin/history/s/<session-574>",
+    'https://portal.example.com/admin/history/s/"session-574"',
+    "https://portal.example.com/admin/history/s/'session-574'",
+  ]) {
+    const fallbackCopy = userFacingFailureText({ ...quarantine, adminUrl });
+    render(linkifiedText(fallbackCopy), host);
+    assert.equal(host.querySelectorAll("a").length, 0);
+    assert.doesNotMatch(host.textContent ?? "", /admin|review|internal screening details/i);
+  }
+  dom.window.close();
+});
+
+test("both live and settled web error renderers use the safe linkified renderer", () => {
+  const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+  assert.equal(chat.match(/composer-error inline">\$\{linkifiedText\(/g)?.length, 2);
+});

--- a/plugins/web-ui/test/linkify.test.ts
+++ b/plugins/web-ui/test/linkify.test.ts
@@ -80,6 +80,7 @@ test("a lone @ is left as text", () => {
 });
 
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
+const linkified = readFileSync(new URL("../src/linkified-text.ts", import.meta.url), "utf8");
 
 test("expanded pinned items render text and preview through the linkifier", () => {
   assert.match(
@@ -100,7 +101,7 @@ test("the collapsed peek is linkified and lives outside the toggle button", () =
 });
 
 test("pin links stop propagation so a click follows the link instead of toggling", () => {
-  assert.match(chat, /@click=\$\{\(e: Event\) => e\.stopPropagation\(\)\}/);
+  assert.match(linkified, /@click=\$\{\(e: Event\) => e\.stopPropagation\(\)\}/);
 });
 
 const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");

--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -161,7 +161,8 @@ export const ADMIN_RESOURCES: readonly AdminResource[] = [
     id: "security-posture",
     kind: "enum",
     target: "any",
-    label: "Harness security posture. The org value is a minimum; narrower scopes may tighten it but cannot weaken it.",
+    label:
+      "Harness security posture. The org value is a floor in the posture ordering. Strict pauses every harness tool call for human approval except the two no-effect turn enders. Auto screens provenance-labelled external data and tool results before they reach the model. Dangerous has no content screening or posture-level pauses. The predeclared command policy's approval rules and hard denials apply in every posture. Moving Auto to Strict replaces content screening with per-tool approvals. Narrower scopes may select a higher-ranked posture but cannot select one below the org floor.",
     readKey: "securityPosture",
     enumValues: SECURITY_POSTURES,
     get: (deps, scope) => deps.config!.getSecurityPostureDurable(scope),

--- a/src/core/failure-copy.ts
+++ b/src/core/failure-copy.ts
@@ -1,5 +1,4 @@
 import type { TurnResult } from "../types.ts";
-import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../../plugins/chassis/src/security-quarantine.ts";
 import { GENERIC_FAILURE_CLAUSE, userFacingFailureText } from "../../plugins/chassis/src/failure-copy.ts";
 
 export { userFacingFailureText } from "../../plugins/chassis/src/failure-copy.ts";
@@ -16,6 +15,7 @@ interface FailureShape {
   status?: string;
   reason?: string;
   refusalKind?: TurnResult["refusalKind"];
+  adminUrl?: string;
 }
 
 export function standaloneFailureText(result: FailureShape): string | undefined {
@@ -23,7 +23,7 @@ export function standaloneFailureText(result: FailureShape): string | undefined 
 }
 
 export function userFacingFailureClause(result: FailureShape): string {
-  if (result.refusalKind === "security_quarantine") return SECURITY_QUARANTINE_REFUSAL_TEXT;
+  if (result.refusalKind === "security_quarantine") return userFacingFailureText(result);
   if (result.refusalKind === "session_busy") return SESSION_BUSY_CLAUSE;
   if (result.status === "failed" || !result.reason) return GENERIC_FAILURE_CLAUSE;
   return result.reason;

--- a/src/delivery/run-result-delivery.ts
+++ b/src/delivery/run-result-delivery.ts
@@ -72,7 +72,13 @@ export function runResultDelivery(
     run.result.refusalKind === "security_quarantine" &&
     run.request.addressed
   ) {
-    return { destination, text: standaloneFailureText(run.result)!, provenance, idempotencyKey };
+    const adminUrl = run.result.sessionId ? adminUrlFor?.(run.result.sessionId) : undefined;
+    return {
+      destination,
+      text: standaloneFailureText({ ...run.result, ...(adminUrl ? { adminUrl } : {}) })!,
+      provenance,
+      idempotencyKey,
+    };
   }
   if (run.request.surfaceTools && run.result?.status !== "failed" && !run.result?.attachments?.length) return null;
   if (failed) {
@@ -95,7 +101,7 @@ export function runResultDelivery(
 }
 
 export type TurnFailureSessions = TranscriptAppendSessions &
-  Pick<SessionStore, "getByThread" | "acquireLease" | "peekLease" | "releaseLease" | "getEntries">;
+  Pick<SessionStore, "get" | "getByThread" | "acquireLease" | "peekLease" | "releaseLease" | "getEntries">;
 
 const FAILURE_RECORD_SCAN_LIMIT = 200;
 const FAILURE_RECORD_WAIT_MS = 10 * 60_000;
@@ -145,7 +151,15 @@ export function wireRunResultDeliveries(
     }
     void (async () => {
       const taskList = tasks ? await tasks.list({ originRunId: run.id }) : [];
-      const delivery = runResultDelivery(run, taskList, adminUrlFor);
+      let deliveryRun = run;
+      if (sessions && run.result?.sessionId) {
+        const session =
+          (await sessions.getByThread(run.result.sessionId)) ?? (await sessions.get(run.result.sessionId));
+        if (session && session.id !== run.result.sessionId) {
+          deliveryRun = { ...run, result: { ...run.result, sessionId: session.id } };
+        }
+      }
+      const delivery = runResultDelivery(deliveryRun, taskList, adminUrlFor);
       if (!delivery) return;
       await deliveries.enqueue(delivery);
     })().catch((err) =>

--- a/src/slack/approvals.ts
+++ b/src/slack/approvals.ts
@@ -32,7 +32,7 @@ import { resolveAgentRequestTarget } from "./approval-context.ts";
 import { parseBlockAction, parseInteractionBody } from "./payloads.ts";
 import type { SlackAgentRequestContext, SlackCoreClient } from "../api/slack-core-client.ts";
 import type { TurnResult } from "../types.ts";
-import { userFacingFailureClause } from "../core/failure-copy.ts";
+import { standaloneFailureText, userFacingFailureClause } from "../core/failure-copy.ts";
 import { GENERIC_FAILURE_CLAUSE } from "../../plugins/chassis/src/failure-copy.ts";
 import type { CoreTurnBody, TurnFlow } from "./turn-flow.ts";
 import type { BotIdentity, Directory } from "./directory.ts";
@@ -822,14 +822,11 @@ export function createApprovals(deps: {
         return;
       }
 
+      const standalone = standaloneFailureText(result);
       const failLink = isBoundaryRefusal(result.reason) ? null : (result.adminUrl ?? null);
       const failDetail = failLink ? ` Full error: ${failLink}` : "";
-      await updateSlackMessage(
-        client,
-        cardChannel,
-        messageTs,
-        `I can't continue — ${userFacingFailureClause(result)}.${failDetail}`,
-      );
+      const failureText = standalone ?? `${userFacingFailureClause(result)}.${failDetail}`;
+      await updateSlackMessage(client, cardChannel, messageTs, `I can't continue — ${failureText}`);
       ackConveyedQuarantine(outcome);
     } catch (err) {
       console.error("%s", `[slack] approval ${requestId} action failed:`, errMessage(err));

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -125,6 +125,19 @@ test("GET /v1/admin/resources returns a manifest entry for every registered reso
     assert.ok((byId.get("base-model")?.enumValues?.length ?? 0) > 0);
     assert.deepEqual(byId.get("security-posture")?.enumValues, ["dangerous", "auto", "strict"]);
     assert.deepEqual(byId.get("sharing-posture")?.enumValues, ["isolated", "open"]);
+    const postureLabel = (byId.get("security-posture") as { label?: string } | undefined)?.label ?? "";
+    assert.match(
+      postureLabel,
+      /Strict pauses every harness tool call for human approval except the two no-effect turn enders/,
+    );
+    assert.match(
+      postureLabel,
+      /Auto screens provenance-labelled external data and tool results before they reach the model/,
+    );
+    assert.match(postureLabel, /Dangerous has no content screening or posture-level pauses/);
+    assert.match(postureLabel, /predeclared command policy's approval rules and hard denials apply in every posture/);
+    assert.match(postureLabel, /Moving Auto to Strict replaces content screening with per-tool approvals/);
+    assert.doesNotMatch(postureLabel, /cannot weaken it|effectful harness tool/i);
     assert.equal(byId.get("service-credentials")?.target, "org");
     assert.equal(byId.get("service-credentials")?.secret, true);
     assert.equal(byId.has("import"), false);

--- a/test/failure-copy.test.ts
+++ b/test/failure-copy.test.ts
@@ -18,8 +18,39 @@ test("the shared failure policy renders quarantine canned, refused reasons verba
   } as const;
   assert.equal(userFacingFailureText(quarantine), SECURITY_QUARANTINE_REFUSAL_TEXT);
   assert.doesNotMatch(userFacingFailureText(quarantine), /internal screening details/);
+  assert.doesNotMatch(userFacingFailureText(quarantine), /ask an admin/i);
   assert.equal(userFacingFailureClause(quarantine), SECURITY_QUARANTINE_REFUSAL_TEXT);
   assert.equal(standaloneFailureText(quarantine), SECURITY_QUARANTINE_REFUSAL_TEXT);
+
+  const linkedQuarantine = { ...quarantine, adminUrl: "https://portal.example.com/admin/history/s/s-1" };
+  assert.equal(
+    userFacingFailureText(linkedQuarantine),
+    "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review this quarantine in session history: https://portal.example.com/admin/history/s/s-1",
+  );
+  assert.doesNotMatch(userFacingFailureText(linkedQuarantine), /internal screening details/);
+  assert.equal(userFacingFailureText(linkedQuarantine).match(/https:\/\//g)?.length, 1);
+  assert.match(
+    userFacingFailureText({
+      ...quarantine,
+      adminUrl: "HTTPS://PORTAL.EXAMPLE.COM/admin/history/s/s-1",
+    }),
+    /https:\/\/portal\.example\.com\/admin\/history\/s\/s-1$/,
+  );
+  for (const adminUrl of [
+    "javascript:alert(1)",
+    "ftp://portal.example.com/admin/history/s/s-1",
+    "not a URL",
+    "http:portal.example.com/admin/history/s/s-1",
+    "\nhttps://portal.example.com/admin/history/s/s-1",
+    "https://portal.example.com/admin/history/s/s-1\nspoofed",
+    "https://portal.example.com/admin/history/s/<s-1>",
+    'https://portal.example.com/admin/history/s/"s-1"',
+    "https://portal.example.com/admin/history/s/'s-1'",
+  ]) {
+    const text = userFacingFailureText({ ...quarantine, adminUrl });
+    assert.equal(text, SECURITY_QUARANTINE_REFUSAL_TEXT);
+    assert.doesNotMatch(text, /admin|review|internal screening details/i);
+  }
 
   const busy = { status: "refused", refusalKind: "session_busy", reason: SESSION_BUSY_USER_TEXT } as const;
   assert.equal(userFacingFailureText(busy), SESSION_BUSY_USER_TEXT);

--- a/test/refusal-admin-link-integration.test.ts
+++ b/test/refusal-admin-link-integration.test.ts
@@ -122,3 +122,53 @@ test("a failed turn surfaces a refusal whose admin link points at the real sessi
   assert.doesNotMatch(note, /ch:C_UUID_FIXTURE/, "the link must not contain the threadRef");
   assert.doesNotMatch(note, /fully-internal/, "a turn failure is not a boundary refusal");
 });
+
+test("a quarantine refusal links the authorized viewer to the session holding the captured screen request", async () => {
+  const sessions = createMemorySessionStore();
+  const { runs } = createMemoryRunStore();
+  const threadRef = "dm:U1:quarantine";
+  const session = await sessions.getOrCreateByThread(threadRef, "dm", "personal:U1");
+  await sessions.recordLlmRequest(session.id, {
+    turnSeq: 0,
+    step: -1,
+    model: "mock-security",
+    scopeLabel: session.scopeId,
+    promptEnvelope: { messages: [{ role: "user", content: "screened payload" }] },
+  });
+  const { run } = await runs.enqueue({
+    sessionId: threadRef,
+    request: {
+      surface: "slack",
+      actor,
+      conversation: { kind: "dm", threadRef, audience: [actor] },
+      origin: { kind: "direct" },
+      text: "review this",
+      addressed: true,
+    },
+  });
+  const claimed = await runs.claimById(run.id, "w1", 60_000);
+  assert.ok(claimed?.leaseToken);
+  assert.equal(
+    await runs.complete(run.id, claimed.leaseToken, {
+      status: "refused",
+      refusalKind: "security_quarantine",
+      reason: "internal screening details",
+      sessionId: session.id,
+    }),
+    true,
+  );
+
+  const app = createApp({ sessions, runs, publicWebUrl: ADMIN } as unknown as AppDeps);
+  const visible = await app.getRun(run.id, "U1");
+  assert.equal(visible?.result?.adminUrl, `${ADMIN}/admin/history/s/${session.id}`);
+  assert.equal(await app.getRun(run.id, "U2"), null, "another DM participant cannot read the result or its link");
+  const linkedId = new URL(visible!.result!.adminUrl!).pathname.split("/").at(-1);
+  assert.equal(linkedId, session.id);
+  const captured = await sessions.listLlmRequests(linkedId!, { turnSeqs: [0] });
+  assert.equal(captured[0]?.step, -1);
+  assert.match(JSON.stringify(captured[0]?.promptEnvelope), /screened payload/);
+
+  const note = refusalNote(visible!.result!, "dm");
+  assert.match(note, new RegExp(`${ADMIN}/admin/history/s/${session.id}`));
+  assert.doesNotMatch(note, /internal screening details/);
+});

--- a/test/run-result-delivery.test.ts
+++ b/test/run-result-delivery.test.ts
@@ -101,7 +101,8 @@ test("runResultDelivery still posts a surface-spine turn's FAILURE note", () => 
   assert.equal(runResultDelivery(spine)?.text, "⚠️ I couldn't finish that turn: something went wrong on my end");
 });
 
-test("runResultDelivery recovers a security quarantine without exposing its internal reason", () => {
+test("runResultDelivery recovers a security quarantine with its admin history link", () => {
+  const sessionId = "b6f3f9e2-0000-4000-8000-000000000001";
   const d = runResultDelivery(
     run({
       request: { ...turn("hi", "C9:171.001"), addressed: true },
@@ -109,11 +110,36 @@ test("runResultDelivery recovers a security quarantine without exposing its inte
         status: "refused",
         refusalKind: "security_quarantine",
         reason: "internal screening details",
+        sessionId,
       },
     }),
+    [],
+    (id) => `https://portal.example.com/admin/history/s/${id}`,
+  );
+  assert.equal(
+    d?.text,
+    `I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review this quarantine in session history: https://portal.example.com/admin/history/s/${sessionId}`,
+  );
+  assert.doesNotMatch(d?.text ?? "", /internal screening details/);
+  assert.equal(d?.text.match(/https:\/\//g)?.length, 1);
+});
+
+test("runResultDelivery does not promise unreachable quarantine review without an admin history link", () => {
+  const d = runResultDelivery(
+    run({
+      request: { ...turn("hi", "C9:171.001"), addressed: true },
+      result: {
+        status: "refused",
+        refusalKind: "security_quarantine",
+        reason: "internal screening details",
+        sessionId: "legacy-thread-ref",
+      },
+    }),
+    [],
+    () => undefined,
   );
   assert.equal(d?.text, SECURITY_QUARANTINE_REFUSAL_TEXT);
-  assert.doesNotMatch(d?.text ?? "", /internal screening details/);
+  assert.doesNotMatch(d?.text ?? "", /admin|review|internal screening details/i);
 });
 
 test("runResultDelivery keeps an unprompted quarantine silent — a replay has no live handler to suppress it", () => {
@@ -258,6 +284,41 @@ const failureSessions = async () => {
   const session = await sessions.getOrCreateByThread("slack:D1", "dm", scope, undefined, "slack");
   return { sessions, session };
 };
+
+test("wired quarantine recovery resolves a stored thread ref to the canonical session history URL", async () => {
+  const { sessions, session } = await failureSessions();
+  const { runs } = createMemoryRunStore();
+  const deliveries = createDeliveryStore();
+  wireRunResultDeliveries(
+    runs,
+    deliveries,
+    undefined,
+    (sessionId) => `https://portal.example.com/admin/history/s/${sessionId}`,
+    sessions,
+  );
+  const queued = (
+    await runs.enqueue({
+      sessionId: "slack:D1",
+      request: { ...turn("review", "D1:171.001"), addressed: true },
+    })
+  ).run;
+  const claimed = await runs.claimById(queued.id, "w1", 5_000);
+  await runs.complete(queued.id, claimed?.leaseToken ?? "", {
+    status: "refused",
+    refusalKind: "security_quarantine",
+    reason: "internal screening details",
+    sessionId: "slack:D1",
+  });
+
+  let pending = await deliveries.pending("slack");
+  for (let i = 0; i < 50 && pending.length === 0; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    pending = await deliveries.pending("slack");
+  }
+  assert.equal(pending.length, 1);
+  assert.match(pending[0]!.text, new RegExp(`/admin/history/s/${session.id}$`));
+  assert.doesNotMatch(pending[0]!.text, /slack:D1|internal screening details/);
+});
 
 const failedRun = (over: Partial<Run> = {}): Run =>
   run({

--- a/test/slack-approvals-quarantine.test.ts
+++ b/test/slack-approvals-quarantine.test.ts
@@ -64,9 +64,15 @@ function fixture(results: { submit: TurnResult; wait: TurnResult | null }) {
 }
 
 test("an approved resume that comes back security-quarantined acks the delivery after the card conveys it", async () => {
+  const adminUrl = "https://portal.example.com/admin/history/s/session-1";
   const f = fixture({
     submit: { status: "queued", runId: "R1" },
-    wait: { status: "refused", refusalKind: "security_quarantine", reason: "quarantined" },
+    wait: {
+      status: "refused",
+      refusalKind: "security_quarantine",
+      reason: "internal screening details",
+      adminUrl,
+    },
   });
   await f.clickApprove();
   await new Promise((resolve) => setImmediate(resolve));
@@ -76,6 +82,10 @@ test("an approved resume that comes back security-quarantined acks the delivery 
   assert.notEqual(cardIndex, -1, "the card conveys the refusal");
   assert.notEqual(ackIndex, -1, "the delivery row is acked so the poller does not re-post the notice");
   assert.ok(ackIndex > cardIndex, "the ack lands only after the card conveys the refusal (post-then-ack)");
+  const card = String(f.updates.at(-1)?.text ?? "");
+  assert.equal(card.split(adminUrl).length - 1, 1);
+  assert.doesNotMatch(card, /internal screening details/);
+  assert.match(card, /review this quarantine in session history/);
   assert.equal(f.flow.inFlightRuns.has("R1"), false, "the pin is released, so nothing leaks until restart");
 });
 

--- a/test/slack-refusals.test.ts
+++ b/test/slack-refusals.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { refusalNote, refusalDelivery, postThenAckRunDelivery, isBoundaryRefusal } from "../src/slack/lib.ts";
 import { SESSION_BUSY_USER_TEXT } from "../src/core/failure-copy.ts";
+import { SECURITY_QUARANTINE_REFUSAL_TEXT } from "../plugins/chassis/src/security-quarantine.ts";
 
 const ADMIN_URL = "https://portal.example.com/admin/?view=history&session=s-1";
 
@@ -59,9 +60,24 @@ test("refusalNote: a security quarantine is human-safe and hides the internal re
 
   assert.equal(
     note,
-    "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review the quarantine.",
+    "I couldn't act because my security screen flagged part of this message or its conversation context. Please retry without the flagged context, or ask an admin to review this quarantine in session history: https://portal.example.com/admin/?view=history&session=s-1",
   );
   assert.doesNotMatch(note, /Auto quarantined|unscreenable|Full error/);
+  assert.equal(note.match(/https:\/\//g)?.length, 1);
+});
+
+test("refusalNote: a quarantine without an admin URL gives retry guidance without promising review", () => {
+  const note = refusalNote(
+    {
+      refusalKind: "security_quarantine",
+      reason: "internal screening details",
+    },
+    "dm",
+  );
+
+  assert.equal(note, SECURITY_QUARANTINE_REFUSAL_TEXT);
+  assert.match(note, /Please retry without the flagged context/);
+  assert.doesNotMatch(note, /admin|review|internal screening details/i);
 });
 
 test("refusalDelivery: quarantine posts in-thread only when addressed; every unprompted refusal stays silent", () => {


### PR DESCRIPTION
## Summary

- link quarantine refusals to authorized session history across direct Slack, web, approval-resume, and addressed async-recovery paths
- canonicalize and validate HTTP(S) review URLs, resolve legacy recovery thread references, and render safe web links without exposing internal screening reasons
- accurately describe Auto, Strict, Dangerous, and command-policy behavior

Security enforcement is unchanged; this only corrects user-facing copy, review handoff wiring, safe rendering, and posture documentation.

Fixes #574, reported by @ianTPE.

## Verification

- 104 affected root tests passed
- 30 affected web tests passed
- root, contract, and web typechecks passed
- ESLint, oxlint, Prettier, and diff checks passed
- independently reviewed and approved after two review passes

Real Slack QA was not performed because the full dev instance was blocked by unavailable local Docker/Sprites infrastructure. A synthetic browser demo using the branch's actual shared formatters, resource registry, and safe Lit link renderer was completed instead; no production data or credentials were used.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791675811&installation_model_id=19911&pr_number=1085&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1085&signature=32e78f9b5f19bc821e02a5355c594e7dffbac5ea9453ac62e2c16fc47124e1aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
