### PR TITLE
Give the factory sandbox the credentials and identity the wrapper needs

### DIFF
--- a/src/loops/factory/credentials.ts
+++ b/src/loops/factory/credentials.ts
@@ -3,9 +3,11 @@ import type { ScopeId } from "../../types.ts";
 
 export const FACTORY_LINEAR_SLUG = "factory-linear";
 export const FACTORY_GITHUB_SLUG = "factory-github";
+// The wrapper runs `claude -p` inside the sandbox, so the model key must travel with the other two.
+export const FACTORY_ANTHROPIC_SLUG = "factory-anthropic";
 
 export type FactoryCredentials =
-  { ok: true; linearApiKey: string; githubToken: string } | { ok: false; missing: string[] };
+  { ok: true; linearApiKey: string; githubToken: string; anthropicApiKey: string } | { ok: false; missing: string[] };
 
 function usableSecret(rec: DecryptedServiceCredential | null): string | null {
   if (!rec || !rec.enabled) return null;
@@ -17,17 +19,20 @@ export async function readFactoryCredentials(
   reader: ServiceCredentialReader,
   orgScopeId: ScopeId,
 ): Promise<FactoryCredentials> {
-  const [linearRec, githubRec] = await Promise.all([
+  const [linearRec, githubRec, anthropicRec] = await Promise.all([
     reader.getServiceCredentialSecret(orgScopeId, FACTORY_LINEAR_SLUG),
     reader.getServiceCredentialSecret(orgScopeId, FACTORY_GITHUB_SLUG),
+    reader.getServiceCredentialSecret(orgScopeId, FACTORY_ANTHROPIC_SLUG),
   ]);
   const linearApiKey = usableSecret(linearRec);
   const githubToken = usableSecret(githubRec);
-  if (linearApiKey === null || githubToken === null) {
+  const anthropicApiKey = usableSecret(anthropicRec);
+  if (linearApiKey === null || githubToken === null || anthropicApiKey === null) {
     const missing: string[] = [];
     if (linearApiKey === null) missing.push(FACTORY_LINEAR_SLUG);
     if (githubToken === null) missing.push(FACTORY_GITHUB_SLUG);
+    if (anthropicApiKey === null) missing.push(FACTORY_ANTHROPIC_SLUG);
     return { ok: false, missing };
   }
-  return { ok: true, linearApiKey, githubToken };
+  return { ok: true, linearApiKey, githubToken, anthropicApiKey };
 }

--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -68,6 +68,7 @@ export interface FactoryContext {
   config: FactoryConfig;
   linearApiKey: string;
   githubToken: string;
+  anthropicApiKey: string;
 }
 
 export type FactoryWorkEffects = Pick<LoopRunnerEffects, "enumerate" | "work" | "captureOutputs" | "evaluate">;
@@ -126,7 +127,12 @@ export async function loadFactoryContext(deps: FactoryEffectsDeps): Promise<Fact
   if (!config) throw new Error("factory_config_missing");
   const credentials = await readFactoryCredentials(deps.credentials, deps.orgScopeId);
   if (!credentials.ok) throw new Error(`factory_credentials_missing: ${credentials.missing.join(", ")}`);
-  return { config, linearApiKey: credentials.linearApiKey, githubToken: credentials.githubToken };
+  return {
+    config,
+    linearApiKey: credentials.linearApiKey,
+    githubToken: credentials.githubToken,
+    anthropicApiKey: credentials.anthropicApiKey,
+  };
 }
 
 export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkEffects {
@@ -158,7 +164,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
     },
 
     async work({ loop, item, guidance }) {
-      const { config, linearApiKey, githubToken } = await loadFactoryContext(deps);
+      const { config, linearApiKey, githubToken, anthropicApiKey } = await loadFactoryContext(deps);
 
       const preflightHandle = await provisionWorkspace(loop.ownerScopeId);
       let preflight: PreflightResult;
@@ -175,6 +181,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
         guidance,
         linearApiKey,
         githubToken,
+        anthropicApiKey,
         repoDir,
         factorySourceDir: FACTORY_SOURCE_DIR,
       });

--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -44,6 +44,17 @@ const FACTORY_SOURCE_BOOTSTRAP_SCRIPT = [
 
 export const FACTORY_LOOP_SURFACE = "factory";
 
+// The wrapper's ownership marker and session branch need a positive integer that is stable for one run
+// and distinct across runs; a loop has no ECS session, so the run id is hashed into one.
+export function factorySessionIdFor(runId: string): number {
+  let hash = 0x811c9dc5;
+  for (const ch of runId) {
+    hash ^= ch.charCodeAt(0);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return (hash % 2_000_000_000) + 1;
+}
+
 export const isFactoryLoop = (loop: Loop): boolean => loop.surface === FACTORY_LOOP_SURFACE;
 
 export const factoryForgeRef = (config: FactoryConfig, externalRef: string | undefined): ForgeRef | null => {
@@ -176,12 +187,15 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
       }
       if (!preflight.ok) throw new Error(`factory_preflight_failed: ${preflightDetail(preflight)}`);
 
+      const itemPrefix = `factory:${loop.id}:${item.id}:`;
+      const runId = `${itemPrefix}${item.attempts + 1}`;
       const env = renderFactoryEnv({
         config,
         guidance,
         linearApiKey,
         githubToken,
         anthropicApiKey,
+        factorySessionId: factorySessionIdFor(runId),
         repoDir,
         factorySourceDir: FACTORY_SOURCE_DIR,
       });
@@ -214,9 +228,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
       }
       if (result.aborted) throw new Error("factory_run_aborted");
 
-      const itemPrefix = `factory:${loop.id}:${item.id}:`;
       for (const key of runs.keys()) if (key.startsWith(itemPrefix)) runs.delete(key);
-      const runId = `${itemPrefix}${item.attempts + 1}`;
       runs.set(runId, { result, config });
       return { runId };
     },

--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -15,16 +15,18 @@ export interface FactoryEnvInput {
   guidance?: string;
   linearApiKey: string;
   githubToken: string;
+  anthropicApiKey: string;
   repoDir: string;
   factorySourceDir: string;
 }
 
 export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string> {
-  const { config, guidance, linearApiKey, githubToken, repoDir, factorySourceDir } = input;
+  const { config, guidance, linearApiKey, githubToken, anthropicApiKey, repoDir, factorySourceDir } = input;
   return {
     ...(guidance !== undefined ? { IO_FEEDBACK: guidance } : {}),
     IO_LINEAR_API_KEY: linearApiKey,
     IO_GITHUB_TOKEN: githubToken,
+    ANTHROPIC_API_KEY: anthropicApiKey,
     IO_PUBLISH_FORGE: config.forge,
     IO_PUBLISH_PROJECT: config.publishProject,
     IO_PUBLISH_TARGET: config.targetBranch,

--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -16,12 +16,14 @@ export interface FactoryEnvInput {
   linearApiKey: string;
   githubToken: string;
   anthropicApiKey: string;
+  factorySessionId: number;
   repoDir: string;
   factorySourceDir: string;
 }
 
 export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string> {
-  const { config, guidance, linearApiKey, githubToken, anthropicApiKey, repoDir, factorySourceDir } = input;
+  const { config, guidance, linearApiKey, githubToken, anthropicApiKey, factorySessionId, repoDir, factorySourceDir } =
+    input;
   return {
     ...(guidance !== undefined ? { IO_FEEDBACK: guidance } : {}),
     IO_LINEAR_API_KEY: linearApiKey,
@@ -40,6 +42,7 @@ export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string>
     IO_VERIFY_LINT_CMD: config.verifyLintCmd,
     IO_REPO_DIR: repoDir,
     IO_FACTORY_SOURCE_DIR: factorySourceDir,
+    IO_FACTORY_SESSION_ID: String(factorySessionId),
     IO_REPO_CLONE_URL: config.repoCloneUrl,
     ...(config.repoSetupCmd !== undefined ? { IO_REPO_SETUP_CMD: config.repoSetupCmd } : {}),
     ...(config.proofStartCmd !== undefined ? { IO_PROOF_START_CMD: config.proofStartCmd } : {}),

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -1117,7 +1117,7 @@ test("applying a factory config mints one factory loop owned by the acting admin
 
     const fired = await srv.built.loops.fire!.fire(loop.id, "apply-fire-1");
     assert.equal(fired.status, "failed");
-    assert.match(fired.note ?? "", /factory_credentials_missing: factory-linear, factory-github/);
+    assert.match(fired.note ?? "", /factory_credentials_missing: factory-linear, factory-github, factory-anthropic/);
   } finally {
     await srv.close();
   }

--- a/test/loop-factory-credentials.test.ts
+++ b/test/loop-factory-credentials.test.ts
@@ -12,6 +12,11 @@ import {
 const LINEAR_SECRET = "lin_FAKE_SECRET_1";
 const GITHUB_SECRET = "ghp_FAKE_SECRET_2";
 const ANTHROPIC_SECRET = "sk-ant-FAKE_SECRET_3";
+const SECRET_BY_SLUG: Record<string, string> = {
+  [FACTORY_LINEAR_SLUG]: LINEAR_SECRET,
+  [FACTORY_GITHUB_SLUG]: GITHUB_SECRET,
+  [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_SECRET,
+};
 const ORG = "org:acme";
 
 function record(slug: string, over: Partial<DecryptedServiceCredential> = {}): DecryptedServiceCredential {

--- a/test/loop-factory-credentials.test.ts
+++ b/test/loop-factory-credentials.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { DecryptedServiceCredential, ServiceCredentialReader } from "../src/credentials/keychain.ts";
 import {
+  FACTORY_ANTHROPIC_SLUG,
   FACTORY_GITHUB_SLUG,
   FACTORY_LINEAR_SLUG,
   readFactoryCredentials,
@@ -10,13 +11,15 @@ import {
 
 const LINEAR_SECRET = "lin_FAKE_SECRET_1";
 const GITHUB_SECRET = "ghp_FAKE_SECRET_2";
+const ANTHROPIC_SECRET = "sk-ant-FAKE_SECRET_3";
 const ORG = "org:acme";
 
 function record(slug: string, over: Partial<DecryptedServiceCredential> = {}): DecryptedServiceCredential {
   return {
     slug,
     name: slug,
-    secret: slug === FACTORY_LINEAR_SLUG ? LINEAR_SECRET : GITHUB_SECRET,
+    secret:
+      slug === FACTORY_LINEAR_SLUG ? LINEAR_SECRET : slug === FACTORY_GITHUB_SLUG ? GITHUB_SECRET : ANTHROPIC_SECRET,
     delivery: "broker",
     host: "api.example.com",
     deployments: false,
@@ -46,14 +49,21 @@ test("returns each trimmed secret in its own field whatever the delivery mode", 
   const { reader, calls } = fakeReader([
     record(FACTORY_LINEAR_SLUG, { secret: `  ${LINEAR_SECRET}\n`, delivery: "env", envKey: "FACTORY_LINEAR_ENV_KEY" }),
     record(FACTORY_GITHUB_SLUG),
+    record(FACTORY_ANTHROPIC_SLUG),
   ]);
 
   const result = await readFactoryCredentials(reader, ORG);
 
-  assert.deepEqual(result, { ok: true, linearApiKey: LINEAR_SECRET, githubToken: GITHUB_SECRET });
+  assert.deepEqual(result, {
+    ok: true,
+    linearApiKey: LINEAR_SECRET,
+    githubToken: GITHUB_SECRET,
+    anthropicApiKey: ANTHROPIC_SECRET,
+  });
   assert.deepEqual(calls, [
     [ORG, "factory-linear"],
     [ORG, "factory-github"],
+    [ORG, "factory-anthropic"],
   ]);
 });
 
@@ -65,13 +75,11 @@ const unusable: { label: string; over: Partial<DecryptedServiceCredential> | nul
 ];
 
 for (const { label, over } of unusable) {
-  test(`${label} credential is reported missing by slug, alone or alongside the other`, async () => {
-    const sides: [string, string][] = [
-      [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG],
-      [FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG],
-    ];
-    for (const [broken, healthy] of sides) {
-      const { reader } = fakeReader(over ? [record(broken, over), record(healthy)] : [record(healthy)]);
+  test(`${label} credential is reported missing by slug, alone or alongside the others`, async () => {
+    const slugs = [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG];
+    for (const broken of slugs) {
+      const healthy = slugs.filter((slug) => slug !== broken).map((slug) => record(slug));
+      const { reader } = fakeReader(over ? [record(broken, over), ...healthy] : healthy);
 
       const result = await readFactoryCredentials(reader, ORG);
 
@@ -79,19 +87,20 @@ for (const { label, over } of unusable) {
       assert.deepEqual(Object.keys(result), ["ok", "missing"]);
     }
 
-    const { reader } = fakeReader(over ? [record(FACTORY_LINEAR_SLUG, over), record(FACTORY_GITHUB_SLUG, over)] : []);
+    const { reader } = fakeReader(over ? slugs.map((slug) => record(slug, over)) : []);
 
     assert.deepEqual(await readFactoryCredentials(reader, ORG), {
       ok: false,
-      missing: [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG],
+      missing: slugs,
     });
   });
 }
 
-test("both credentials unusable names both slugs and carries no secret material", async () => {
+test("every credential unusable names every slug and carries no secret material", async () => {
   const { reader } = fakeReader([
     record(FACTORY_LINEAR_SLUG, { enabled: false }),
     record(FACTORY_GITHUB_SLUG, { enabled: false }),
+    record(FACTORY_ANTHROPIC_SLUG, { enabled: false }),
   ]);
   const levels = ["log", "warn", "error", "info", "debug"] as const;
   const original = levels.map((level) => [level, console[level]] as const);
@@ -108,7 +117,7 @@ test("both credentials unusable names both slugs and carries no secret material"
     for (const [level, fn] of original) console[level] = fn;
   }
 
-  assert.deepEqual(result, { ok: false, missing: [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG] });
+  assert.deepEqual(result, { ok: false, missing: [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG] });
   const serialized = JSON.stringify(result);
   assert.ok(!serialized.includes(LINEAR_SECRET) && !serialized.includes(GITHUB_SECRET), "result carries a secret");
   assert.deepEqual(logged, []);

--- a/test/loop-factory-credentials.test.ts
+++ b/test/loop-factory-credentials.test.ts
@@ -23,8 +23,7 @@ function record(slug: string, over: Partial<DecryptedServiceCredential> = {}): D
   return {
     slug,
     name: slug,
-    secret:
-      slug === FACTORY_LINEAR_SLUG ? LINEAR_SECRET : slug === FACTORY_GITHUB_SLUG ? GITHUB_SECRET : ANTHROPIC_SECRET,
+    secret: SECRET_BY_SLUG[slug] ?? "",
     delivery: "broker",
     host: "api.example.com",
     deployments: false,

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -14,7 +14,7 @@ import {
   type FactoryWorkEffects,
 } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
-import { FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
+import { FACTORY_ANTHROPIC_SLUG, FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
 import { FACTORY_WRAPPER, renderFactoryEnv } from "../src/loops/factory/process-work.ts";
 import { shq } from "../src/util/shell.ts";
 import { LINEAR_GRAPHQL_URL } from "../src/loops/factory/linear-intake.ts";
@@ -34,6 +34,7 @@ import type { Loop, LoopItem, LoopState, WorkspaceLayer } from "../src/types.ts"
 const ORG_SCOPE = "org:acme";
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
+const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
 const REPO_DIR = "/workspace/repo";
 const CLONE_DIR = "/workspace/qm-yc";
 const CLONE_URL = "https://github.com/yc-software/qm-yc.git";
@@ -272,7 +273,7 @@ const credentialRecord = (
 ): DecryptedServiceCredential => ({
   slug,
   name: slug,
-  secret: slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : GITHUB_TOKEN,
+  secret: slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : slug === FACTORY_GITHUB_SLUG ? GITHUB_TOKEN : ANTHROPIC_KEY,
   delivery: "broker",
   host: "api.example.com",
   deployments: false,
@@ -286,7 +287,11 @@ function fakeCredentials(records: (DecryptedServiceCredential | null)[]): Servic
 }
 
 const healthyCredentials = (): ServiceCredentialReader =>
-  fakeCredentials([credentialRecord(FACTORY_LINEAR_SLUG), credentialRecord(FACTORY_GITHUB_SLUG)]);
+  fakeCredentials([
+    credentialRecord(FACTORY_LINEAR_SLUG),
+    credentialRecord(FACTORY_GITHUB_SLUG),
+    credentialRecord(FACTORY_ANTHROPIC_SLUG),
+  ]);
 
 function fakeLoops(states: (LoopState | null)[]): { loops: FactoryEffectsDeps["loops"]; ids: string[] } {
   const ids: string[] = [];
@@ -429,7 +434,12 @@ test("a Linear failure propagates unwrapped out of enumerate", async () => {
 
 test("loadFactoryContext resolves the org config and both credentials", async () => {
   const context: FactoryContext = await loadFactoryContext(deps());
-  assert.deepEqual(context, { config: CONFIG, linearApiKey: LINEAR_KEY, githubToken: GITHUB_TOKEN });
+  assert.deepEqual(context, {
+    config: CONFIG,
+    linearApiKey: LINEAR_KEY,
+    githubToken: GITHUB_TOKEN,
+    anthropicApiKey: ANTHROPIC_KEY,
+  });
 });
 
 test("a missing factory config fails every entry point before any sandbox or network call", async () => {
@@ -449,7 +459,7 @@ test("missing credentials name every absent slug, linear first, without leaking 
   const fake = fakeSandbox();
   const base = deps({
     sandbox: fake.sandbox,
-    credentials: fakeCredentials([credentialRecord(FACTORY_GITHUB_SLUG)]),
+    credentials: fakeCredentials([credentialRecord(FACTORY_GITHUB_SLUG), credentialRecord(FACTORY_ANTHROPIC_SLUG)]),
   });
   const effects = createFactoryLoopEffects(base);
   for (const promise of [loadFactoryContext(base), effects.enumerate(LOOP), workedRunId(effects)]) {
@@ -464,6 +474,7 @@ test("missing credentials name every absent slug, linear first, without leaking 
       credentials: fakeCredentials([
         credentialRecord(FACTORY_LINEAR_SLUG, { secret: "   " }),
         credentialRecord(FACTORY_GITHUB_SLUG, { enabled: false }),
+        credentialRecord(FACTORY_ANTHROPIC_SLUG),
       ]),
     }),
   );
@@ -509,6 +520,7 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
       guidance: "smaller diff please",
       linearApiKey: LINEAR_KEY,
       githubToken: GITHUB_TOKEN,
+      anthropicApiKey: ANTHROPIC_KEY,
       repoDir: REPO_DIR,
       factorySourceDir: FACTORY_SOURCE_DIR,
     }),

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -35,6 +35,11 @@ const ORG_SCOPE = "org:acme";
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
 const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
+const SECRET_BY_SLUG: Record<string, string> = {
+  [FACTORY_LINEAR_SLUG]: LINEAR_KEY,
+  [FACTORY_GITHUB_SLUG]: GITHUB_TOKEN,
+  [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_KEY,
+};
 const REPO_DIR = "/workspace/repo";
 const CLONE_DIR = "/workspace/qm-yc";
 const CLONE_URL = "https://github.com/yc-software/qm-yc.git";
@@ -273,7 +278,7 @@ const credentialRecord = (
 ): DecryptedServiceCredential => ({
   slug,
   name: slug,
-  secret: slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : slug === FACTORY_GITHUB_SLUG ? GITHUB_TOKEN : ANTHROPIC_KEY,
+  secret: SECRET_BY_SLUG[slug] ?? "",
   delivery: "broker",
   host: "api.example.com",
   deployments: false,

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -12,6 +12,7 @@ import {
   type FactoryContext,
   type FactoryEffectsDeps,
   type FactoryWorkEffects,
+  factorySessionIdFor,
 } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
 import { FACTORY_ANTHROPIC_SLUG, FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
@@ -526,6 +527,7 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
       linearApiKey: LINEAR_KEY,
       githubToken: GITHUB_TOKEN,
       anthropicApiKey: ANTHROPIC_KEY,
+      factorySessionId: factorySessionIdFor("factory:loop-1:item-1:1"),
       repoDir: REPO_DIR,
       factorySourceDir: FACTORY_SOURCE_DIR,
     }),
@@ -546,6 +548,14 @@ test("work omits IO_FEEDBACK without guidance, honours repoDir, and numbers the 
   assert.equal(started.opts?.env?.IO_FACTORY_SOURCE_DIR, FACTORY_SOURCE_DIR);
   assert.notEqual(started.opts?.env?.IO_FACTORY_SOURCE_DIR, started.opts?.env?.IO_REPO_DIR);
   assert.equal(runId, "factory:loop-1:item-1:3");
+});
+
+test("factorySessionIdFor is a stable positive integer that differs across runs", () => {
+  const a = factorySessionIdFor("factory:loop-1:item-1:1");
+  assert.equal(a, factorySessionIdFor("factory:loop-1:item-1:1"));
+  assert.ok(Number.isInteger(a) && a > 0 && a <= 2_000_000_000);
+  assert.notEqual(a, factorySessionIdFor("factory:loop-1:item-1:2"));
+  assert.notEqual(a, factorySessionIdFor("factory:loop-1:item-2:1"));
 });
 
 test("work bootstraps the factory control plane on the preflight handle before the wrapper, once per call", async () => {

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -71,6 +71,7 @@ const ENV_INPUT: FactoryEnvInput = {
   guidance: "reviewer asked for a smaller diff",
   linearApiKey: "lin_api_secret",
   githubToken: "ghp_secret",
+  anthropicApiKey: "sk-ant-secret",
   repoDir: REPO_DIR,
   factorySourceDir: SOURCE_DIR,
 };
@@ -209,6 +210,7 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
     IO_FEEDBACK: "reviewer asked for a smaller diff",
     IO_LINEAR_API_KEY: "lin_api_secret",
     IO_GITHUB_TOKEN: "ghp_secret",
+    ANTHROPIC_API_KEY: "sk-ant-secret",
     IO_PUBLISH_FORGE: "github",
     IO_PUBLISH_PROJECT: "acme/widgets",
     IO_PUBLISH_TARGET: "main",
@@ -245,6 +247,7 @@ test("renderFactoryEnv omits every optional key whose source is absent", () => {
     config: MINIMAL_CONFIG,
     linearApiKey: "lin_min",
     githubToken: "ghp_min",
+    anthropicApiKey: "sk-ant-min",
     repoDir: "/srv/repo",
     factorySourceDir: SOURCE_DIR,
   });
@@ -521,7 +524,12 @@ test("a signal aborted before the call terminates on the first pass and the defa
 });
 
 test("no path logs to the console or puts a credential in an error", async () => {
-  const env = renderFactoryEnv({ ...ENV_INPUT, linearApiKey: "LEAK-LINEAR", githubToken: "LEAK-GITHUB" });
+  const env = renderFactoryEnv({
+    ...ENV_INPUT,
+    linearApiKey: "LEAK-LINEAR",
+    githubToken: "LEAK-GITHUB",
+    anthropicApiKey: "LEAK-ANTHROPIC",
+  });
   const failures: Array<() => Promise<unknown>> = [
     () => runFactoryProcess(baseInput(fakeSandbox({}), { env, ticketId: "QM-12; rm -rf /" })),
     () => runFactoryProcess(baseInput(fakeSandbox({ processSessions: false }), { env })),
@@ -547,7 +555,7 @@ test("no path logs to the console or puts a credential in an error", async () =>
     for (const run of failures) {
       const error = await rejection(run());
       const rendered = [error.message, error.stack ?? "", JSON.stringify(Object.entries(error))].join("\n");
-      for (const sentinel of ["LEAK-LINEAR", "LEAK-GITHUB"]) {
+      for (const sentinel of ["LEAK-LINEAR", "LEAK-GITHUB", "LEAK-ANTHROPIC"]) {
         assert.equal(rendered.includes(sentinel), false, `${error.message} leaked ${sentinel}`);
       }
     }

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -72,6 +72,7 @@ const ENV_INPUT: FactoryEnvInput = {
   linearApiKey: "lin_api_secret",
   githubToken: "ghp_secret",
   anthropicApiKey: "sk-ant-secret",
+  factorySessionId: 4242,
   repoDir: REPO_DIR,
   factorySourceDir: SOURCE_DIR,
 };
@@ -224,6 +225,7 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
     IO_VERIFY_LINT_CMD: "npm run lint",
     IO_REPO_DIR: REPO_DIR,
     IO_FACTORY_SOURCE_DIR: SOURCE_DIR,
+    IO_FACTORY_SESSION_ID: "4242",
     IO_REPO_CLONE_URL: "https://github.com/acme/widgets.git",
     IO_REPO_SETUP_CMD: "npm ci",
     IO_PROOF_START_CMD: "npm run dev",
@@ -248,6 +250,7 @@ test("renderFactoryEnv omits every optional key whose source is absent", () => {
     linearApiKey: "lin_min",
     githubToken: "ghp_min",
     anthropicApiKey: "sk-ant-min",
+    factorySessionId: 7,
     repoDir: "/srv/repo",
     factorySourceDir: SOURCE_DIR,
   });

--- a/test/loop-factory-wiring.test.ts
+++ b/test/loop-factory-wiring.test.ts
@@ -41,5 +41,8 @@ test("a booted instance drives a factory loop through the factory dependencies i
 
   const uncredentialed = await built.loops.fire!.fire(loop.id, "f2");
   assert.equal(uncredentialed.status, "failed");
-  assert.match(uncredentialed.note ?? "", /factory_credentials_missing: factory-linear, factory-github/);
+  assert.match(
+    uncredentialed.note ?? "",
+    /factory_credentials_missing: factory-linear, factory-github, factory-anthropic/,
+  );
 });

--- a/test/loop-fire.test.ts
+++ b/test/loop-fire.test.ts
@@ -9,7 +9,7 @@ import { buildShipGrant } from "../src/loops/ship-gate.ts";
 import { createIdempotencyStore } from "../src/idempotency/idempotency-store.ts";
 import { FACTORY_LOOP_SURFACE, type FactoryEffectsDeps } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
-import { FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
+import { FACTORY_ANTHROPIC_SLUG, FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
 import { FACTORY_WRAPPER } from "../src/loops/factory/process-work.ts";
 import type { FactoryConfig } from "../src/resolution/config-store.ts";
 import type { ServiceCredentialReader } from "../src/credentials/keychain.ts";
@@ -565,6 +565,7 @@ const GH_REPO = "https://api.github.com/repos/acme/app";
 const HEAD_SHA = "1".repeat(40);
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
+const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
 const WRAPPER_STDOUT = `working\nBRANCH:${FACTORY_BRANCH}\nMR:42\n`;
 const ALREADY_FIXED_STDOUT = "ALREADY_FIXED:true\nALREADY_FIXED_EVIDENCE:fixed by #40\n";
 
@@ -757,7 +758,8 @@ function factoryCredentials(missing: string[] = []): ServiceCredentialReader {
         : {
             slug,
             name: slug,
-            secret: slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : GITHUB_TOKEN,
+            secret:
+              slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : slug === FACTORY_GITHUB_SLUG ? GITHUB_TOKEN : ANTHROPIC_KEY,
             delivery: "broker",
             host: "api.example.com",
             deployments: false,
@@ -922,8 +924,8 @@ test("factory surface: a missing config or credential fails the fire before the 
     ["config", /factory_config_missing/, { config: null }],
     [
       "credential",
-      /factory_credentials_missing: factory-github/,
-      { credentials: factoryCredentials([FACTORY_GITHUB_SLUG]) },
+      /factory_credentials_missing: factory-github, factory-anthropic/,
+      { credentials: factoryCredentials([FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG]) },
     ],
   ];
   for (const [name, expected, over] of cases) {

--- a/test/loop-fire.test.ts
+++ b/test/loop-fire.test.ts
@@ -566,6 +566,11 @@ const HEAD_SHA = "1".repeat(40);
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
 const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
+const SECRET_BY_SLUG: Record<string, string> = {
+  [FACTORY_LINEAR_SLUG]: LINEAR_KEY,
+  [FACTORY_GITHUB_SLUG]: GITHUB_TOKEN,
+  [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_KEY,
+};
 const WRAPPER_STDOUT = `working\nBRANCH:${FACTORY_BRANCH}\nMR:42\n`;
 const ALREADY_FIXED_STDOUT = "ALREADY_FIXED:true\nALREADY_FIXED_EVIDENCE:fixed by #40\n";
 
@@ -758,8 +763,7 @@ function factoryCredentials(missing: string[] = []): ServiceCredentialReader {
         : {
             slug,
             name: slug,
-            secret:
-              slug === FACTORY_LINEAR_SLUG ? LINEAR_KEY : slug === FACTORY_GITHUB_SLUG ? GITHUB_TOKEN : ANTHROPIC_KEY,
+            secret: SECRET_BY_SLUG[slug] ?? "",
             delivery: "broker",
             host: "api.example.com",
             deployments: false,


### PR DESCRIPTION
The factory wrapper runs `claude -p` inside the sandbox, but `renderFactoryEnv` carried only the Linear key and the GitHub token, so the first model call had nothing to authenticate with. Normal QM sessions run `claude` on the server through the harness; the factory does not.

- `credentials.ts`: a third org service credential, `factory-anthropic`, read alongside `factory-linear` and `factory-github`. A missing or disabled one is reported by slug and fails the fire before the sandbox, as the other two do.
- `effects.ts`: `FactoryContext` and `loadFactoryContext` carry `anthropicApiKey`; `work` passes it to `renderFactoryEnv`.
- `process-work.ts`: `ANTHROPIC_API_KEY` in the sandbox process env, next to the two `IO_*` secrets.
- Tests: the credential suite covers three slugs in every unusable combination; the env suite pins the new key and includes it in the leak sentinels; the fixtures in the effects, loop-fire, wiring, and admin-resources suites carry the third credential.

Verification: targeted suites 147 pass; `npm run test:all` 5896 tests, 0 failures; typecheck, eslint, oxlint, prettier clean. Removing the `ANTHROPIC_API_KEY` env line fails the process-work test.

Targets the integration branch, not `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791676280&installation_model_id=19911&pr_number=1086&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1086&signature=a34ff10d7d61340cd66406a88aceff505c1f8600f3a72299941105f6f17ce7e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


**Second gap found on the first local run:** the wrapper refused to start without a numeric ECS session id. `factorySessionIdFor(runId)` hashes the run id into a stable positive integer and `renderFactoryEnv` passes it as `IO_FACTORY_SESSION_ID`; the `layer/factory` wrapper on `qm-30-s18477` reads it when no session URL is present.