### PR TITLE
Mark the factory wrapper's environment as a sandbox

### DIFF
--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -43,6 +43,8 @@ export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string>
     IO_REPO_DIR: repoDir,
     IO_FACTORY_SOURCE_DIR: factorySourceDir,
     IO_FACTORY_SESSION_ID: String(factorySessionId),
+    // The sandbox runs the wrapper as root, and claude refuses --dangerously-skip-permissions as root unless this is set.
+    IS_SANDBOX: "1",
     IO_REPO_CLONE_URL: config.repoCloneUrl,
     ...(config.repoSetupCmd !== undefined ? { IO_REPO_SETUP_CMD: config.repoSetupCmd } : {}),
     ...(config.proofStartCmd !== undefined ? { IO_PROOF_START_CMD: config.proofStartCmd } : {}),

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -226,6 +226,7 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
     IO_REPO_DIR: REPO_DIR,
     IO_FACTORY_SOURCE_DIR: SOURCE_DIR,
     IO_FACTORY_SESSION_ID: "4242",
+    IS_SANDBOX: "1",
     IO_REPO_CLONE_URL: "https://github.com/acme/widgets.git",
     IO_REPO_SETUP_CMD: "npm ci",
     IO_PROOF_START_CMD: "npm run dev",


### PR DESCRIPTION
The sandbox runs the wrapper as root, and `claude` refuses `--dangerously-skip-permissions` under root unless `IS_SANDBOX=1` is set. The first local end-to-end run stopped at that check before its first model call. One env entry in `renderFactoryEnv`, pinned by the env test. Targets the integration branch, not `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791677533&installation_model_id=19911&pr_number=1087&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1087&signature=322130f6c5a0d46e3fa737efb8c6ad8cb447992a43911529687c88bc65eed8b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->