### PR TITLE
test(live-slack): send a signed portal identity on admin API calls

### DIFF
--- a/test/live-slack/core.ts
+++ b/test/live-slack/core.ts
@@ -1,7 +1,8 @@
 import { signedRequestHeaders } from "../../src/auth/source-auth-sign.ts";
 import { mintCapabilityToken } from "../../src/auth/capability-token.ts";
+import { mintPortalIdentity, PORTAL_IDENTITY_HEADER } from "../../src/auth/portal-identity.ts";
 
-const ADMIN_PRINCIPAL = "admin-alice";
+const ADMIN_PRINCIPAL = process.env.LIVE_E2E_ADMIN_PRINCIPAL || "admin-alice";
 
 export interface SessionSummary {
   id: string;
@@ -39,9 +40,14 @@ export class CoreClient {
     return data;
   }
 
-  private admin(method: string, pathWithQuery: string): Promise<any> {
+  private async admin(method: string, pathWithQuery: string): Promise<any> {
     const orgId = this.orgScope.split(":")[1] ?? "acme";
-    return this.request(method, pathWithQuery, undefined, { "x-admin-actor": `${ADMIN_PRINCIPAL}@${orgId}` });
+    const portalSecret = process.env.PORTAL_IDENTITY_SECRET || this.signingSecret;
+    const identity = await mintPortalIdentity({ p: ADMIN_PRINCIPAL, exp: Date.now() + 60_000 }, portalSecret);
+    return this.request(method, pathWithQuery, undefined, {
+      "x-admin-actor": `${ADMIN_PRINCIPAL}@${orgId}`,
+      [PORTAL_IDENTITY_HEADER]: identity,
+    });
   }
 
   listSessions(): Promise<{ sessions: SessionSummary[] }> {

--- a/test/live-slack/run.ts
+++ b/test/live-slack/run.ts
@@ -28,7 +28,11 @@ function requireEnv(name: string): string {
 async function buildEnv(): Promise<Env> {
   const qa = new SlackClient(requireEnv("SLACK_QA_USER_TOKEN"));
   const bot = new SlackClient(requireEnv("SLACK_BOT_TOKEN"));
-  const core = new CoreClient(requireEnv("CORE_API_URL"), requireEnv("CORE_SIGNING_SECRET"));
+  const core = new CoreClient(
+    requireEnv("CORE_API_URL"),
+    requireEnv("CORE_SIGNING_SECRET"),
+    process.env.LIVE_E2E_ORG_SCOPE || undefined,
+  );
   const [qaAuth, botAuth] = await Promise.all([
     qa.authTest(),
     process.env.LIVE_E2E_BOT_USER_ID ? undefined : bot.authTest(),


### PR DESCRIPTION
Production-mode cores require a signed `x-portal-identity` on `/v1/admin/*` routes. The live-E2E `CoreClient` sent only a source-auth signature plus `x-admin-actor`, so the `runtime-model-handoff` release scenario fails with 401 (`portal identity required`) against a production-posture staging deployment.

- Mint the portal identity in `CoreClient.admin()` from `PORTAL_IDENTITY_SECRET`, falling back to the signing secret (matching `scripts/google-oauth-smoke.ts` and `postdeploy-smoke`).
- Add `LIVE_E2E_ADMIN_PRINCIPAL` and `LIVE_E2E_ORG_SCOPE` env overrides so deployments with a different admin principal/org can run the release gate.

No product code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791684725&installation_model_id=19911&pr_number=1092&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1092&signature=02800850a4eacf585c24166b13680bc2cdd7b6c99b0c2595a9ae0d45b9e62ff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->