### PR TITLE
Verify projected sandbox results in cloud qualification

### DIFF
--- a/test/live-slack-sandbox-providers.test.ts
+++ b/test/live-slack-sandbox-providers.test.ts
@@ -38,6 +38,28 @@ test("provider execution requires correlated success on the exact sandbox", () =
   assert.throws(() => assertSandboxExecution([{ type: "assistant", payload: { text: "nonce" } }], "box", "nonce\n"));
 });
 
+test("projected sandbox results require exact successful execution evidence", () => {
+  const entries = evidence() as Array<{ type: string; payload: Record<string, unknown> }>;
+  entries[1]!.payload = { tool: "sandbox", callId: "call", isError: false, result: "nonce\n\n[exit 0]" };
+  assert.doesNotThrow(() => assertSandboxExecution(entries, "box", "nonce\n"));
+  for (const patch of [
+    { result: "nonce\n" },
+    { result: "nonce\n\n[exit 1]" },
+    { result: "nonce\n\n[exit 0 timed-out]" },
+    { result: "wrong\n\n[exit 0]" },
+    { result: "nonce\n\n[stderr]\nfailed\n[exit 0]" },
+    { isError: true },
+    { callId: "unrelated" },
+    { code: 1 },
+    { timedOut: true },
+    { action: "start_process" },
+  ]) {
+    const changed = [entries[0], { ...entries[1], payload: { ...entries[1]!.payload, ...patch } }];
+    assert.throws(() => assertSandboxExecution(changed, "box", "nonce\n"));
+  }
+  assert.throws(() => assertSandboxExecution(entries.toReversed(), "box", "nonce\n"));
+});
+
 test("every provider has its own parallel execution scenario", () => {
   assert.deepEqual(sandboxProviders.toSorted(), [
     "agent37",

--- a/test/live-slack/scenarios-sandbox-providers.ts
+++ b/test/live-slack/scenarios-sandbox-providers.ts
@@ -18,33 +18,26 @@ const providerCoverage: Record<SandboxBackendName, true> = {
 export const sandboxProviders = Object.keys(providerCoverage) as SandboxBackendName[];
 
 export function assertSandboxExecution(entries: readonly unknown[], sandboxId: string, stdout: string): void {
-  const calls = new Set(
-    entries.flatMap((entry) => {
-      if (!isObj(entry) || entry.type !== "tool_call" || !isObj(entry.payload)) return [];
-      const p = entry.payload;
-      return p.tool === "sandbox" && p.action === "exec" && p.sandbox_id === sandboxId && typeof p.callId === "string"
-        ? [p.callId]
-        : [];
-    }),
-  );
+  const calls = new Set<string>();
+  let executed = false;
+  for (const entry of entries) {
+    if (!isObj(entry) || !isObj(entry.payload)) continue;
+    const p = entry.payload;
+    if (p.tool !== "sandbox" || typeof p.callId !== "string") continue;
+    if (entry.type === "tool_call" && p.action === "exec" && p.sandbox_id === sandboxId) {
+      calls.add(p.callId);
+      continue;
+    }
+    if (entry.type !== "tool_result" || !calls.has(p.callId) || p.isError !== false) continue;
+    const structured = "code" in p || "timedOut" in p || "stdout" in p || "action" in p;
+    if (
+      structured
+        ? p.action === "exec" && p.code === 0 && p.timedOut === false && p.stdout === stdout
+        : p.result === `${stdout}\n[exit 0]`
+    ) executed = true;
+  }
   assert.ok(calls.size, `no sandbox exec call targeted ${sandboxId}`);
-  assert.ok(
-    entries.some((entry) => {
-      if (!isObj(entry) || entry.type !== "tool_result" || !isObj(entry.payload)) return false;
-      const p = entry.payload;
-      return (
-        p.tool === "sandbox" &&
-        p.action === "exec" &&
-        typeof p.callId === "string" &&
-        calls.has(p.callId) &&
-        p.isError === false &&
-        p.code === 0 &&
-        p.timedOut === false &&
-        p.stdout === stdout
-      );
-    }),
-    `no successful sandbox exec result with exact stdout on ${sandboxId}`,
-  );
+  assert.ok(executed, `no successful sandbox exec result with exact stdout on ${sandboxId}`);
 }
 
 export const sandboxProviderScenarios: Scenario[] = sandboxProviders.map((backend) => ({

--- a/test/live-slack/scenarios-sandbox-providers.ts
+++ b/test/live-slack/scenarios-sandbox-providers.ts
@@ -34,7 +34,8 @@ export function assertSandboxExecution(entries: readonly unknown[], sandboxId: s
       structured
         ? p.action === "exec" && p.code === 0 && p.timedOut === false && p.stdout === stdout
         : p.result === `${stdout}\n[exit 0]`
-    ) executed = true;
+    )
+      executed = true;
   }
   assert.ok(calls.size, `no sandbox exec call targeted ${sandboxId}`);
   assert.ok(executed, `no successful sandbox exec result with exact stdout on ${sandboxId}`);


### PR DESCRIPTION
Cloud sandbox qualification rejected successful execution because the admin transcript projection omits structured result metadata. Accept its exact rendered stdout and successful exit marker, correlated with a preceding exec call targeting the required sandbox. Raw local execution still uses strict structured fields; partial or contradictory metadata cannot enter the projected fallback.

Validation: all 14 affected tests, typecheck, lint, and independent review pass. Both real AWS and Sprites transcripts from the failed qualification pass with nonces extracted from their commands. Negative cases reject prose, wrong output, errors, nonzero exits, timeouts, stderr, unrelated calls, and results preceding calls. Provider availability, first-attempt requirements, and cleanup gates remain unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791693288&installation_model_id=19911&pr_number=1099&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1099&signature=01eaa797a5a29608eee2290b7d30a17fd6efc726cce06c3b07f06cf5dd6aea3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->