### PR TITLE
Preserve existing volume-backed Fly deployments during provider upgrades

### DIFF
--- a/docs/fly-legacy-deployments.md
+++ b/docs/fly-legacy-deployments.md
@@ -1,0 +1,21 @@
+# Upgrading legacy Fly deployments
+
+The Fly provider uses isolated app networks and creates a new Machine before replacing a healthy release. Instances previously running the volume-backed Fly provider can retain their existing apps while new deployments use the current provider.
+
+Set `FLY_LEGACY_DEPLOYMENT_IDS` to a comma-separated list of existing deployment UUIDs. This is an explicit, fixed compatibility inventory, including archived deployments. It is not a creation-date cutoff and must not be regenerated on startup. With an empty list, all deployments use the current provider.
+
+The listed deployments retain their shortened Fly app names, `/data` volumes, Git reconciliation, automatic sleep/wake, and volume-preserving archive/restore. New deployments use the current Fly provider's full UUID app names, isolated networks, bundle limits, and idle cleanup. The current provider does not provision persistent app volumes.
+
+## Cutover
+
+1. Preserve the current image digests, application configuration, signing keys, database backup, Fly volume snapshots, and object-store release and Git archives. Validate recovery separately from the agent development instance.
+2. Quiesce publication and inventory every deployment row, including archived and stopped rows. Verify that shortened IDs do not collide and match the existing Fly resources. Record the explicit UUID list in durable deployment configuration.
+3. Preserve `FLY_DEPLOY_APP_PREFIX`, `FLY_ORG`, `FLY_REGION`, `FLY_DEPLOY_BASE_IMAGE`, `PUBLIC_API_URL`, `CAPABILITY_SECRET`, and the release bucket and prefix. Existing Machines download their release on every boot from `/v1/deploy-releases/:id`; the endpoint and old signatures must remain usable. Release objects live under the existing `deploy-releases/transfer/` prefix and are not ordinary expiring transfer blobs.
+4. Stop the old core from accepting publication before the final inventory and replacement. Do not allow old and new cores to publish concurrently during this transition.
+5. Verify an existing app wakes without republishing; then verify volume preservation, Git updates, rollback, and archive/restore with an isolated legacy test app. Verify a newly created app uses the current provider and never enters the legacy list.
+
+## Retirement
+
+Migrate each legacy app's persistent data and boot dependencies before removing its UUID from the list. Removing an ID does not move volumes, rename Fly apps, or delete old resources. New provider app names are different. Keep rollback resources until the migrated app has been validated, then retire them explicitly.
+
+The legacy provider retains the earlier shared-network model; it is a compatibility path, not the default for newly published code. Do not add newly created deployment IDs to the legacy list merely to bypass current-provider bundle limits.

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -175,4 +175,5 @@ export interface ServerDeps {
   secretDrops?: SecretDropStore;
   fireDropResolution?: (drop: DropResolution) => Promise<unknown>;
   blobTransfer?: BlobTransferStore;
+  deployReleaseTransfer?: BlobTransferStore;
 }

--- a/src/api/routes/deploy-releases.ts
+++ b/src/api/routes/deploy-releases.ts
@@ -1,0 +1,27 @@
+import { DEPLOY_RELEASE_AUD, verifyDeployReleaseCapability } from "../../auth/capability-token.ts";
+import { CAPABILITY_HEADER } from "../contract.ts";
+import { headerValue, pipeToResponse, sendJson } from "../http.ts";
+import type { BaseCtx, Route } from "./route.ts";
+
+async function getDeployRelease(ctx: BaseCtx): Promise<void> {
+  const { req, res, deps, params, secret } = ctx;
+  if (!deps.deployReleaseTransfer) {
+    req.resume();
+    return sendJson(res, 501, { error: "not_configured", message: "no deploy release store wired" });
+  }
+  const id = params.id!;
+  const capSecret = deps.capabilitySecret ?? secret;
+  const capToken = headerValue(req, CAPABILITY_HEADER);
+  if (!capSecret || !capToken || !(await verifyDeployReleaseCapability(capToken, capSecret, id))) {
+    req.resume();
+    return sendJson(res, 403, { error: "forbidden", message: "deploy release capability is not valid" });
+  }
+  const release = await deps.deployReleaseTransfer.open(id);
+  if (!release) return sendJson(res, 404, { error: "not_found" });
+  res.writeHead(200, { "content-type": "application/octet-stream", "content-length": String(release.sizeBytes) });
+  pipeToResponse(res, release.stream, "deploy release read failed");
+}
+
+export const deployReleaseRoutes: ReadonlyArray<Route<BaseCtx>> = [
+  { method: "GET", path: "/v1/deploy-releases/:id", auth: { aud: DEPLOY_RELEASE_AUD }, handle: getDeployRelease },
+];

--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -2,6 +2,7 @@ import { sendJson } from "../http.ts";
 import { type ApiCtx, type BaseCtx, type Route } from "./route.ts";
 import { connectorRawRoutes, connectorRoutes } from "./connectors.ts";
 import { deploymentRawRoutes, deploymentRoutes } from "./deployments.ts";
+import { deployReleaseRoutes } from "./deploy-releases.ts";
 import { blobRoutes } from "./blobs.ts";
 import { sessionStateRawRoutes } from "./session-state.ts";
 import { loopItemEventsRawRoutes } from "./loop-item-events.ts";
@@ -46,6 +47,7 @@ export const rawRoutes: ReadonlyArray<Route<BaseCtx>> = [
   ...connectorRawRoutes,
   ...deploymentRawRoutes,
   ...blobRoutes,
+  ...deployReleaseRoutes,
   ...sessionStateRawRoutes,
   ...loopItemEventsRawRoutes,
   ...webhookRawRoutes,

--- a/src/auth/capability-token.ts
+++ b/src/auth/capability-token.ts
@@ -10,6 +10,7 @@ export const OAUTH_CONSENT_AUD = "oauth-consent";
 export const CREDENTIAL_BROKER_AUD = "credential-broker";
 export const EGRESS_PROXY_AUD = "egress-proxy";
 export const BLOB_TRANSFER_AUD = "blob-transfer";
+export const DEPLOY_RELEASE_AUD = "deploy-release";
 export const SECRET_DROP_AUD = "secret-drop";
 
 interface BlobGrant {
@@ -112,4 +113,23 @@ export async function verifyBlobTransferCapability(
   if (grant.id !== undefined && (typeof grant.id !== "string" || !BLOB_ID.test(grant.id))) return null;
   if (expected.dir === "read" ? grant.id !== expected.id : grant.id !== undefined) return null;
   return claims as BlobTransferClaims;
+}
+
+export async function verifyDeployReleaseCapability(
+  token: string,
+  secret: string | string[],
+  blobId: string,
+  now: number = Date.now(),
+): Promise<CapabilityClaims | null> {
+  const claims = await verifyCapabilityToken(token, secret, now);
+  if (
+    !claims ||
+    claims.aud !== DEPLOY_RELEASE_AUD ||
+    claims.blob?.dir !== "read" ||
+    claims.blob.id !== blobId ||
+    !BLOB_ID.test(blobId)
+  ) {
+    return null;
+  }
+  return claims;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,6 +180,7 @@ export interface Config {
   awsDeploy: AwsDeployEnv;
   deployAppsDomain?: string;
   flyDeploy: FlyDeployEnv;
+  flyLegacyDeploymentIds: string[];
 }
 
 export function configuredModelForHarness(config: Config, harness: string): string | undefined {
@@ -730,6 +731,22 @@ interface FlyDeployEnv {
   baseImage: string;
   org: string;
   region?: string;
+}
+
+function flyLegacyDeploymentIds(env: NodeJS.ProcessEnv): string[] {
+  const ids = (env.FLY_LEGACY_DEPLOYMENT_IDS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (
+    ids.some((id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(id)) ||
+    new Set(ids).size !== ids.length
+  ) {
+    throw new Error("FLY_LEGACY_DEPLOYMENT_IDS must contain unique lowercase deployment UUIDs separated by commas");
+  }
+  if (ids.length && env.DEPLOY_PROVIDER !== "fly")
+    throw new Error("FLY_LEGACY_DEPLOYMENT_IDS requires DEPLOY_PROVIDER=fly");
+  return ids;
 }
 
 function flyDeployEnv(env: NodeJS.ProcessEnv): FlyDeployEnv {
@@ -1410,5 +1427,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     },
     ...(deployAppsDomain ? { deployAppsDomain } : {}),
     flyDeploy: flyDeployEnv(env),
+    flyLegacyDeploymentIds: flyLegacyDeploymentIds(env),
   };
 }

--- a/src/deploy/deploy-service.ts
+++ b/src/deploy/deploy-service.ts
@@ -63,6 +63,7 @@ export interface ReachOptions {
 
 export interface DeployService {
   readonly providerProfile: DeployProfile;
+  providerProfileFor?(deployment: Deployment): DeployProfile;
   deploy(input: DeployInput): Promise<Deployment>;
   redeploy(
     id: string,
@@ -108,6 +109,7 @@ export interface DeploymentGrantee {
 export interface DeployServiceDeps {
   deployStore: DeployStore;
   provider: DeployProvider;
+  providerFor?: (deployment: Deployment) => DeployProvider;
   deployDir: string;
   auditLog: AuditLog;
   acl: AclStore;
@@ -152,6 +154,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
   const leaderLease = deps.leaderLease ?? createNoopLeaderLease();
   const advisoryLock = deps.advisoryLock ?? createNoopAdvisoryLock();
   const deployQueue = createKeyedQueue();
+  const providerFor = (deployment: Deployment): DeployProvider => deps.providerFor?.(deployment) ?? deps.provider;
   function withDeployLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     return deployQueue(id, () => advisoryLock.withLock(`deploy:${id}`, fn));
   }
@@ -162,15 +165,16 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
     fromVersion?: number,
   ): Promise<DeployEndpoint> => {
     const d = (await deps.deployStore.get(id))!;
+    const provider = providerFor(d);
     const deploymentEnv = await deps.deploymentEnv?.(d);
     if (deploymentEnv && Object.keys(deploymentEnv).length)
       version = { ...version, env: { ...version.env, ...deploymentEnv } };
     let endpoint: DeployEndpoint;
-    if (deps.provider.reconcile && version.commit) {
+    if (provider.reconcile && version.commit) {
       const diff = await deps.deployStore.diffVersions(id, fromVersion, version.version);
       const allPaths = ((await deps.deployStore.treeOf(id, version.version)) ?? []).map((f) => f.path);
       const gitBundle = await deps.deployStore.bundleOf(id, version.version);
-      endpoint = await deps.provider.reconcile(d, version, {
+      endpoint = await provider.reconcile(d, version, {
         ...(gitBundle ? { gitBundle } : {}),
         changedPaths: diff ? [...diff.added, ...diff.modified].map((f) => f.path) : allPaths,
         deletedPaths: diff?.deleted.map((f) => f.path) ?? [],
@@ -183,7 +187,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
         if (files == null) throw new Error(`cannot materialize deployment ${id} version ${version.version}`);
         materialized = { ...version, snapshotDir: await snapshotFiles(deps.deployDir, files) };
       }
-      endpoint = await deps.provider.apply(d, materialized);
+      endpoint = await provider.apply(d, materialized);
     }
     if (endpoint.image && endpoint.image !== version.image) {
       await deps.deployStore.setVersionImage(id, version.version, endpoint.image);
@@ -198,10 +202,11 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
   };
 
   const liveEndpoint = async (d: Deployment): Promise<DeployEndpoint> => {
-    if (!deps.provider.resolveEndpoint || d.endpoint == null) return d.endpoint!;
+    const provider = providerFor(d);
+    if (!provider.resolveEndpoint || d.endpoint == null) return d.endpoint!;
     const version = d.versions.find((v) => v.version === d.currentVersion);
     if (!version) return d.endpoint;
-    const resolved = await deps.provider.resolveEndpoint(d, version);
+    const resolved = await provider.resolveEndpoint(d, version);
     if (resolved) {
       if (!endpointsEqual(resolved, d.endpoint)) await deps.deployStore.setEndpoint(d.id, resolved);
       return resolved;
@@ -209,7 +214,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
     return withDeployLock(d.id, async () => {
       const cur = (await deps.deployStore.get(d.id)) ?? d;
       const v = cur.versions.find((x) => x.version === cur.currentVersion) ?? version;
-      const again = await deps.provider.resolveEndpoint!(cur, v);
+      const again = await providerFor(cur).resolveEndpoint?.(cur, v);
       if (again) {
         if (!endpointsEqual(again, cur.endpoint)) await deps.deployStore.setEndpoint(cur.id, again);
         return again;
@@ -343,6 +348,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
 
   return {
     providerProfile: deps.provider.profile,
+    providerProfileFor: (deployment) => providerFor(deployment).profile,
 
     async deploy(input) {
       if (input.name !== undefined) {
@@ -433,7 +439,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
       return withDeployLock(id, async () => {
         const d = await deps.deployStore.get(id);
         if (!d) return;
-        await deps.provider.destroy(d);
+        await providerFor(d).destroy(d);
         await deps.deployStore.setStatus(id, "archived");
         await deps.deployStore.setEndpoint(id, null);
       });
@@ -451,7 +457,7 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
           const endpoint = await applyVersion(id, version, d.appliedVersion);
           await markVersionRunning(id, version.version, endpoint);
         } catch (error) {
-          await deps.provider
+          await providerFor(d)
             .destroy(d)
             .catch((cleanupError) => swallow("deploy restore runtime cleanup", cleanupError));
           await deps.deployStore
@@ -554,10 +560,9 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
     },
 
     async deploymentLogs(idOrName, opts): Promise<string | null> {
-      if (!deps.provider.logs) return null;
       const d = (await deps.deployStore.get(idOrName)) ?? (await deps.deployStore.getByName(idOrName));
       if (!d || d.status !== "running") return null;
-      return deps.provider.logs(d, opts);
+      return (await providerFor(d).logs?.(d, opts)) ?? null;
     },
 
     async gitRepoPath(idOrName) {
@@ -604,17 +609,18 @@ export function createDeployService(deps: DeployServiceDeps): DeployService {
 
     async reapIdleDeployments(ttlMs, now = Date.now()) {
       const result = await leaderLease.hold("deployments:reaper", async () => {
-        if (deps.provider.profile.managedScaleToZero) return 0;
         let stopped = 0;
         for (const d of await deps.deployStore.list()) {
-          if (d.status !== "running") continue;
+          if (d.status !== "running" || providerFor(d).profile.managedScaleToZero) continue;
           if (d.alwaysOn) continue;
           const last = d.lastAccessAt ?? d.versions[d.versions.length - 1]?.createdAt ?? 0;
           if (now - last < ttlMs) continue;
           await withDeployLock(d.id, async () => {
             const cur = await deps.deployStore.get(d.id);
             if (!cur || cur.status !== "running" || cur.alwaysOn) return;
-            await deps.provider.destroy(cur);
+            const provider = providerFor(cur);
+            if (provider.profile.managedScaleToZero) return;
+            await provider.destroy(cur);
             await deps.deployStore.setStatus(d.id, "stopped");
             await deps.deployStore.setEndpoint(d.id, null);
             stopped++;

--- a/src/deploy/legacy-fly-deploy-provider.ts
+++ b/src/deploy/legacy-fly-deploy-provider.ts
@@ -1,0 +1,517 @@
+import { pack } from "tar-stream";
+import type { Deployment, DeploymentVersion } from "./deploy-store.ts";
+import type { DeployEndpoint, DeployProvider, DeployReconcileInput } from "./deploy-provider.ts";
+import { normalizeRelPath, readTree } from "./deploy-fs.ts";
+import { swallow } from "../util/errors.ts";
+import { sleep } from "../util/async.ts";
+import { shq } from "../util/shell.ts";
+import { DEPLOY_RELEASE_AUD, mintCapabilityToken } from "../auth/capability-token.ts";
+import { CAPABILITY_HEADER } from "../api/contract.ts";
+import { MAX_BLOB_BYTES, type BlobTransferStore } from "../persistence/blob-transfer.ts";
+
+const APP_PORT = 8080;
+const DATA_DIR = "/data";
+const VOLUME_NAME = "qm_data";
+const OWNER_KEY = "qm_deployment_id";
+const VERSION_KEY = "qm_deployment_version";
+const RELEASE_KEY = "qm_deployment_release";
+const RELEASE_EXPIRY = Date.UTC(2100, 0, 1);
+const MACHINE_WAIT_SLICE_SECONDS = 60;
+const MACHINE_WAIT_ATTEMPTS = 5;
+
+export interface FlyApp {
+  name: string;
+  organization?: { slug?: string };
+}
+
+export interface FlyVolume {
+  id: string;
+  name: string;
+  state?: string;
+  attached_machine_id?: string | null;
+  region?: string;
+}
+
+export interface FlyMachine {
+  id: string;
+  instance_id?: string;
+  state?: string;
+  config?: FlyMachineConfig;
+}
+
+export interface FlyMachineConfig {
+  image: string;
+  env?: Record<string, string>;
+  metadata?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface FlyDeployApi {
+  getApp(name: string): Promise<FlyApp | null>;
+  createApp(name: string, org: string): Promise<void>;
+  ensureFlycast(name: string): Promise<void>;
+  listVolumes(name: string): Promise<FlyVolume[]>;
+  createVolume(name: string, region: string): Promise<FlyVolume>;
+  listMachines(name: string): Promise<FlyMachine[]>;
+  createMachine(name: string, region: string, config: FlyMachineConfig): Promise<FlyMachine>;
+  updateMachine(name: string, id: string, config: FlyMachineConfig): Promise<FlyMachine>;
+  startMachine(name: string, id: string): Promise<void>;
+  waitMachineStopped(name: string, id: string, instanceId: string): Promise<void>;
+  waitMachine(name: string, id: string): Promise<void>;
+  deleteMachine(name: string, id: string): Promise<void>;
+}
+
+export interface FlyDeployProviderOptions {
+  token: string;
+  org: string;
+  region: string;
+  image: string;
+  appPrefix: string;
+  apiBaseUrl: string;
+  capabilitySecret: string;
+  releaseStore: BlobTransferStore;
+  api?: FlyDeployApi;
+  fetchImpl?: typeof fetch;
+  probe?: (endpoint: DeployEndpoint) => Promise<void>;
+  readyTimeoutMs?: number;
+  now?: () => number;
+}
+
+class FlyApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export function createFlyDeployApi(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+  machinesBaseUrl = "https://api.machines.dev",
+  graphqlUrl = "https://api.fly.io/graphql",
+): FlyDeployApi {
+  const authorization = token.startsWith("Bearer ") ? token : `Bearer ${token}`;
+  const request = async <T>(path: string, init: RequestInit = {}): Promise<T> => {
+    const response = await fetchImpl(`${machinesBaseUrl}${path}`, {
+      ...init,
+      signal: AbortSignal.timeout(70_000),
+      headers: { authorization, "content-type": "application/json", ...init.headers },
+    });
+    const body = await response.text();
+    if (!response.ok)
+      throw new FlyApiError(
+        `Fly API ${init.method ?? "GET"} ${path} failed (${response.status}): ${body.slice(0, 300)}`,
+        response.status,
+      );
+    return body ? (JSON.parse(body) as T) : (undefined as T);
+  };
+  const graphql = async <T>(query: string, variables: Record<string, unknown>): Promise<T> => {
+    const response = await fetchImpl(graphqlUrl, {
+      method: "POST",
+      signal: AbortSignal.timeout(30_000),
+      headers: { authorization, "content-type": "application/json" },
+      body: JSON.stringify({ query, variables }),
+    });
+    const body = await response.text();
+    if (!response.ok)
+      throw new FlyApiError(`Fly GraphQL failed (${response.status}): ${body.slice(0, 300)}`, response.status);
+    const parsed = JSON.parse(body) as { data?: T; errors?: Array<{ message?: string }> };
+    if (parsed.errors?.length)
+      throw new Error(`Fly GraphQL failed: ${parsed.errors.map((e) => e.message ?? "unknown error").join("; ")}`);
+    if (!parsed.data) throw new Error("Fly GraphQL returned no data");
+    return parsed.data;
+  };
+  return {
+    async getApp(name) {
+      try {
+        return await request<FlyApp>(`/v1/apps/${encodeURIComponent(name)}`);
+      } catch (error) {
+        if (error instanceof FlyApiError && error.status === 404) return null;
+        throw error;
+      }
+    },
+    async createApp(name, org) {
+      await request("/v1/apps", { method: "POST", body: JSON.stringify({ app_name: name, org_slug: org }) });
+    },
+    async ensureFlycast(name) {
+      const query = `query ($appName: String!) { app(name: $appName) { ipAddresses { nodes { type } } } }`;
+      const found = await graphql<{ app: { ipAddresses: { nodes: Array<{ type: string }> } } }>(query, {
+        appName: name,
+      });
+      const publicTypes = found.app.ipAddresses.nodes.map((ip) => ip.type).filter((type) => type !== "private_v6");
+      if (publicTypes.length) {
+        throw new Error(`Fly app ${name} has public IP addresses (${publicTypes.join(", ")}); refusing deployment`);
+      }
+      if (found.app.ipAddresses.nodes.some((ip) => ip.type === "private_v6")) return;
+      const mutation = `mutation ($input: AllocateIPAddressInput!) { allocateIpAddress(input: $input) { ipAddress { id } } }`;
+      await graphql(mutation, { input: { appId: name, type: "private_v6", region: "" } });
+    },
+    listVolumes(name) {
+      return request<FlyVolume[]>(`/v1/apps/${encodeURIComponent(name)}/volumes`);
+    },
+    createVolume(name, region) {
+      return request<FlyVolume>(`/v1/apps/${encodeURIComponent(name)}/volumes`, {
+        method: "POST",
+        body: JSON.stringify({ name: VOLUME_NAME, region, size_gb: 1, auto_backup_enabled: true }),
+      });
+    },
+    listMachines(name) {
+      return request<FlyMachine[]>(`/v1/apps/${encodeURIComponent(name)}/machines`);
+    },
+    createMachine(name, region, config) {
+      return request<FlyMachine>(`/v1/apps/${encodeURIComponent(name)}/machines`, {
+        method: "POST",
+        body: JSON.stringify({ region, config }),
+      });
+    },
+    updateMachine(name, id, config) {
+      return request<FlyMachine>(`/v1/apps/${encodeURIComponent(name)}/machines/${encodeURIComponent(id)}`, {
+        method: "POST",
+        body: JSON.stringify({ config, skip_launch: true }),
+      });
+    },
+    async startMachine(name, id) {
+      await request(`/v1/apps/${encodeURIComponent(name)}/machines/${encodeURIComponent(id)}/start`, {
+        method: "POST",
+      });
+    },
+    async waitMachineStopped(name, id, instanceId) {
+      await request(
+        `/v1/apps/${encodeURIComponent(name)}/machines/${encodeURIComponent(id)}` +
+          `/wait?state=stopped&instance_id=${encodeURIComponent(instanceId)}&timeout=${MACHINE_WAIT_SLICE_SECONDS}`,
+      );
+    },
+    async waitMachine(name, id) {
+      const path =
+        `/v1/apps/${encodeURIComponent(name)}/machines/${encodeURIComponent(id)}` +
+        `/wait?state=started&timeout=${MACHINE_WAIT_SLICE_SECONDS}`;
+      for (let attempt = 1; attempt <= MACHINE_WAIT_ATTEMPTS; attempt++) {
+        try {
+          await request(path);
+          return;
+        } catch (error) {
+          if (!(error instanceof FlyApiError) || error.status !== 408 || attempt === MACHINE_WAIT_ATTEMPTS) throw error;
+        }
+      }
+    },
+    async deleteMachine(name, id) {
+      await request(`/v1/apps/${encodeURIComponent(name)}/machines/${encodeURIComponent(id)}?force=true`, {
+        method: "DELETE",
+      });
+    },
+  };
+}
+
+async function tarBytes(files: Array<{ path: string; data: Uint8Array }>): Promise<Buffer | null> {
+  if (!files.length) return null;
+  const archive = pack();
+  const chunks: Buffer[] = [];
+  const complete = new Promise<Buffer>((resolve, reject) => {
+    archive.on("data", (chunk: Buffer) => chunks.push(chunk));
+    archive.on("end", () => resolve(Buffer.concat(chunks)));
+    archive.on("error", reject);
+  });
+  for (const file of files) {
+    await new Promise<void>((resolve, reject) => {
+      archive.entry({ name: normalizeRelPath(file.path), mode: 0o600 }, Buffer.from(file.data), (error) =>
+        error ? reject(error) : resolve(),
+      );
+    });
+  }
+  archive.finalize();
+  return complete;
+}
+
+function liveMachines(machines: FlyMachine[]): FlyMachine[] {
+  return machines.filter((machine) => machine.state !== "destroyed" && machine.state !== "destroying");
+}
+
+export function createLegacyFlyDeployProvider(opts: FlyDeployProviderOptions): DeployProvider {
+  const api = opts.api ?? createFlyDeployApi(opts.token, opts.fetchImpl);
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 60_000;
+  const endpointFor = (name: string): DeployEndpoint => ({ host: `${name}.flycast`, port: 80 });
+  const appName = (d: Deployment): string => {
+    const suffix = d.id.replaceAll("-", "").slice(0, 16).toLowerCase();
+    const name = `${opts.appPrefix}-${suffix}`;
+    if (name.length > 63 || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(name)) {
+      throw new Error(`invalid Fly deploy app name ${JSON.stringify(name)}; check FLY_DEPLOY_APP_PREFIX`);
+    }
+    return name;
+  };
+  const ensureConfigured = (): void => {
+    if (!opts.token) throw new Error("FLY_DEPLOY_API_TOKEN not set (DEPLOY_PROVIDER=fly)");
+    if (!opts.org) throw new Error("FLY_ORG not set (DEPLOY_PROVIDER=fly)");
+    if (!opts.region) throw new Error("FLY_REGION not set (DEPLOY_PROVIDER=fly)");
+    if (!opts.image) throw new Error("FLY_DEPLOY_BASE_IMAGE not set (DEPLOY_PROVIDER=fly)");
+    if (!opts.apiBaseUrl) throw new Error("PUBLIC_API_URL not set (DEPLOY_PROVIDER=fly)");
+    if (!opts.capabilitySecret) throw new Error("CAPABILITY_SECRET not set (DEPLOY_PROVIDER=fly)");
+  };
+  const ensureApp = async (name: string): Promise<void> => {
+    let app = await api.getApp(name);
+    if (!app) {
+      try {
+        await api.createApp(name, opts.org);
+      } catch (error) {
+        app = await api.getApp(name);
+        if (!app) throw error;
+      }
+      app = await api.getApp(name);
+    }
+    if (!app) throw new Error(`Fly app ${name} was not found after creation`);
+    if (app.organization?.slug !== opts.org) {
+      throw new Error(
+        `Fly app ${name} belongs to organization ${app.organization?.slug ?? "unknown"}, expected ${opts.org}`,
+      );
+    }
+    await api.ensureFlycast(name);
+  };
+  const machineFor = async (name: string, deploymentId: string): Promise<FlyMachine | null> => {
+    const machines = liveMachines(await api.listMachines(name));
+    const owned = machines.filter((machine) => machine.config?.metadata?.[OWNER_KEY] === deploymentId);
+    if (machines.length !== owned.length)
+      throw new Error(`Fly app ${name} contains a Machine not owned by deployment ${deploymentId}`);
+    if (owned.length > 1) throw new Error(`Fly app ${name} contains multiple Machines for deployment ${deploymentId}`);
+    return owned[0] ?? null;
+  };
+  const volumeFor = async (name: string, machine: FlyMachine | null): Promise<FlyVolume> => {
+    const volumes = (await api.listVolumes(name)).filter(
+      (volume) => volume.name === VOLUME_NAME && volume.state !== "destroyed",
+    );
+    if (volumes.length > 1) throw new Error(`Fly app ${name} contains multiple ${VOLUME_NAME} volumes`);
+    const volume = volumes[0] ?? (await api.createVolume(name, opts.region));
+    if (volume.attached_machine_id && volume.attached_machine_id !== machine?.id) {
+      throw new Error(`Fly app ${name} data volume is attached to unexpected Machine ${volume.attached_machine_id}`);
+    }
+    return volume;
+  };
+  const defaultProbe = async (endpoint: DeployEndpoint): Promise<void> => {
+    const deadline = Date.now() + readyTimeoutMs;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      try {
+        const remaining = Math.max(1, deadline - Date.now());
+        const response = await (opts.fetchImpl ?? fetch)(`http://${endpoint.host}:${endpoint.port}/`, {
+          signal: AbortSignal.timeout(Math.min(5_000, remaining)),
+          redirect: "manual",
+        });
+        await response.body?.cancel();
+        if (response.status === 502 || response.status === 503 || response.status === 504) {
+          throw new Error(`Fly proxy returned ${response.status}`);
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        await sleep(Math.min(500, Math.max(1, deadline - Date.now())));
+      }
+    }
+    throw new Error(`Fly deployment did not become reachable within ${readyTimeoutMs}ms`, { cause: lastError });
+  };
+  const buildConfig = async (
+    d: Deployment,
+    version: DeploymentVersion,
+    volume: FlyVolume,
+    input?: DeployReconcileInput,
+  ): Promise<{ config: FlyMachineConfig; blobId: string }> => {
+    const home = version.homeDir
+      ? (await readTree(version.homeDir, { tolerateMissing: true })).map((file) => ({
+          path: `root/${normalizeRelPath(file.path)}`,
+          data: file.data,
+        }))
+      : [];
+    let payloadFiles: Array<{ path: string; data: Uint8Array }>;
+    let materialize: string;
+    if (input?.gitBundle && version.commit) {
+      if (!/^[0-9a-f]{40}$/i.test(version.commit)) throw new Error(`invalid deploy commit: ${version.commit}`);
+      payloadFiles = [
+        { path: "bundle", data: input.gitBundle },
+        ...home.map((file) => ({ ...file, path: file.path.replace(/^root\//, "home/") })),
+      ];
+      const ref = `refs/deploy-commits/${version.commit}`;
+      materialize = [
+        "rm -rf /app",
+        "mkdir -p /app /root",
+        `git -C /app init -q`,
+        `git -C /app fetch -q /tmp/qm-release/bundle ${shq(ref)}`,
+        "git -C /app checkout -q --detach FETCH_HEAD",
+        "[ ! -d /tmp/qm-release/home ] || cp -a /tmp/qm-release/home/. /root/",
+      ].join(" && ");
+    } else {
+      const app = (await readTree(version.snapshotDir, { tolerateMissing: true })).map((file) => ({
+        path: `app/${normalizeRelPath(file.path)}`,
+        data: file.data,
+      }));
+      payloadFiles = [...app, ...home.map((file) => ({ ...file, path: file.path.replace(/^root\//, "home/") }))];
+      materialize = [
+        "rm -rf /app",
+        "mv /tmp/qm-release/app /app",
+        "mkdir -p /root",
+        "[ ! -d /tmp/qm-release/home ] || cp -a /tmp/qm-release/home/. /root/",
+      ].join(" && ");
+    }
+    const archive = await tarBytes(payloadFiles);
+    if (!archive) throw new Error("Fly deployment snapshot is empty");
+    const blob = await opts.releaseStore.put(archive, { maxBytes: MAX_BLOB_BYTES });
+    const token = await mintCapabilityToken(
+      {
+        actorId: d.createdBy,
+        scopeId: d.ownerScopeId,
+        aud: DEPLOY_RELEASE_AUD,
+        blob: { dir: "read", id: blob.blobId },
+        exp: Math.max((opts.now ?? Date.now)() + 1, RELEASE_EXPIRY),
+      },
+      opts.capabilitySecret,
+    );
+    const base = opts.apiBaseUrl.replace(/\/$/, "");
+    const url = `${base}/v1/deploy-releases/${blob.blobId}`;
+    const download = [
+      `curl -fSsL -H ${shq(`${CAPABILITY_HEADER}: ${token}`)} ${shq(url)} -o /tmp/qm-release.tar`,
+      "rm -rf /tmp/qm-release",
+      "mkdir -p /tmp/qm-release",
+      "tar -xf /tmp/qm-release.tar -C /tmp/qm-release",
+    ].join(" && ");
+    const start = `${download} && ${materialize} && cd /app && exec sh -c ${shq(version.entrypoint)}`;
+    return {
+      config: {
+        image: opts.image,
+        env: { ...version.env, HOME: "/root", PORT: String(APP_PORT), DATA_DIR },
+        metadata: {
+          [OWNER_KEY]: d.id,
+          [VERSION_KEY]: String(version.version),
+          [RELEASE_KEY]: blob.blobId,
+          fly_process_group: "app",
+        },
+        init: { exec: ["/bin/sh", "-lc", start] },
+        mounts: [{ volume: volume.id, path: DATA_DIR }],
+        guest: { cpu_kind: "shared", cpus: 1, memory_mb: 512 },
+        restart: { policy: "always" },
+        services: [
+          {
+            protocol: "tcp",
+            internal_port: APP_PORT,
+            autostop: "stop",
+            autostart: true,
+            min_machines_running: 0,
+            ports: [{ port: 80, handlers: ["http"] }],
+          },
+        ],
+      },
+      blobId: blob.blobId,
+    };
+  };
+  const place = async (
+    d: Deployment,
+    version: DeploymentVersion,
+    input?: DeployReconcileInput,
+  ): Promise<DeployEndpoint> => {
+    ensureConfigured();
+    const name = appName(d);
+    const app = await api.getApp(name);
+    if (!app) await ensureApp(name);
+    else if (app.organization?.slug !== opts.org)
+      throw new Error(
+        `Fly app ${name} belongs to organization ${app.organization?.slug ?? "unknown"}, expected ${opts.org}`,
+      );
+    const machine = await machineFor(name, d.id);
+    if (app) await api.ensureFlycast(name);
+    const volume = await volumeFor(name, machine);
+    const { config, blobId } = await buildConfig(d, version, volume, input);
+    let placed: FlyMachine | null = null;
+    let completed = false;
+    let discardFailedRelease = false;
+    const updateAndStart = async (current: FlyMachine, nextConfig: FlyMachineConfig): Promise<FlyMachine> => {
+      const updated = await api.updateMachine(name, current.id, nextConfig);
+      if (!updated.instance_id) throw new Error(`Fly update for Machine ${updated.id} returned no instance_id`);
+      await api.waitMachineStopped(name, updated.id, updated.instance_id);
+      await api.startMachine(name, updated.id);
+      await api.waitMachine(name, updated.id);
+      return updated;
+    };
+    try {
+      if (machine) {
+        placed = await updateAndStart(machine, config);
+      } else {
+        placed = await api.createMachine(name, volume.region ?? opts.region, config);
+        await api.waitMachine(name, placed.id);
+      }
+      const endpoint = endpointFor(name);
+      await (opts.probe ?? defaultProbe)(endpoint);
+      completed = true;
+      const previousRelease = machine?.config?.metadata?.[RELEASE_KEY];
+      if (previousRelease && previousRelease !== blobId) {
+        await opts.releaseStore
+          .delete(previousRelease)
+          .catch((cleanupError: unknown) =>
+            swallow("legacy fly deploy: previous release cleanup failed", cleanupError),
+          );
+      }
+      return { ...endpoint, image: opts.image };
+    } catch (error) {
+      let recoveryError: unknown;
+      if (machine?.config) {
+        try {
+          await updateAndStart(machine, machine.config);
+          discardFailedRelease = true;
+        } catch (rollbackError) {
+          recoveryError = rollbackError;
+        }
+      } else if (!machine) {
+        try {
+          const accepted = placed ?? (await machineFor(name, d.id));
+          if (accepted) await api.deleteMachine(name, accepted.id);
+          discardFailedRelease = true;
+        } catch (cleanupError) {
+          recoveryError = cleanupError;
+        }
+      }
+      if (recoveryError) {
+        throw new AggregateError([error, recoveryError], "Fly deployment failed and recovery failed", { cause: error });
+      }
+      throw error;
+    } finally {
+      if (!completed && discardFailedRelease) {
+        await opts.releaseStore
+          .delete(blobId)
+          .catch((cleanupError: unknown) => swallow("legacy fly deploy: failed release cleanup failed", cleanupError));
+      }
+    }
+  };
+  return {
+    profile: { managedScaleToZero: true, inPlaceReconcile: true, dataDir: DATA_DIR },
+    apply: (d, version) => place(d, version),
+    reconcile: (d, version, input) => place(d, version, input),
+    async resolveEndpoint(d): Promise<DeployEndpoint | null> {
+      ensureConfigured();
+      const name = appName(d);
+      const app = await api.getApp(name);
+      if (!app) return null;
+      if (app.organization?.slug !== opts.org) return null;
+      const machine = await machineFor(name, d.id);
+      if (!machine) return null;
+      const endpoint = endpointFor(name);
+      if (d.alwaysOn) await (opts.probe ?? defaultProbe)(endpoint);
+      return endpoint;
+    },
+    async destroy(d): Promise<void> {
+      ensureConfigured();
+      const name = appName(d);
+      const app = await api.getApp(name);
+      if (!app) return;
+      if (app.organization?.slug !== opts.org)
+        throw new Error(`Fly app ${name} is not owned by the configured organization`);
+      const machine = await machineFor(name, d.id);
+      if (machine) {
+        await api.deleteMachine(name, machine.id);
+        const release = machine.config?.metadata?.[RELEASE_KEY];
+        if (release) {
+          await opts.releaseStore
+            .delete(release)
+            .catch((cleanupError: unknown) =>
+              swallow("legacy fly deploy: archived release cleanup failed", cleanupError),
+            );
+        }
+      }
+    },
+  };
+}

--- a/src/tools/primitives.ts
+++ b/src/tools/primitives.ts
@@ -1045,7 +1045,9 @@ export function createToolContext(deps: ToolContextDeps): ToolContext {
             : base;
         const urlBase = deps.publicWebUrl?.replace(/\/$/, "") ?? "";
         const url = publicUrlOf(d.endpoint) ?? `${urlBase}/d/${ref}/`;
-        const dataDir = effectiveEntrypoint ? deps.deploy.providerProfile?.dataDir : undefined;
+        const dataDir = effectiveEntrypoint
+          ? (deps.deploy.providerProfileFor?.(d) ?? deps.deploy.providerProfile)?.dataDir
+          : undefined;
         return {
           id: d.id,
           ...(d.name ? { name: d.name } : {}),

--- a/src/wiring.ts
+++ b/src/wiring.ts
@@ -135,6 +135,7 @@ import { viewerIdentityKey } from "./deploy/access-token.ts";
 import { deploymentCredentialSlugs } from "./deploy/deployment-credentials.ts";
 import { createDockerDeployProvider } from "./deploy/docker-deploy-provider.ts";
 import { createAwsDeployProvider, type StoredDeployBody } from "./deploy/aws-deploy-provider.ts";
+import { createLegacyFlyDeployProvider } from "./deploy/legacy-fly-deploy-provider.ts";
 import { createFlyDeployProvider } from "./deploy/fly-deploy-provider.ts";
 import { createPorterDeployProvider, type StoredPorterDeployBody } from "./deploy/porter-deploy-provider.ts";
 import type { DeployProvider } from "./deploy/deploy-provider.ts";
@@ -456,6 +457,7 @@ export interface BuiltApp {
   sandboxMigration: SandboxMigrationRunner;
   sandboxResources: SandboxResources;
   blobTransfer: BlobTransferStore;
+  deployReleaseTransfer: BlobTransferStore;
   files: FileArtifactStore;
   fileUploads?: DirectFileUploads;
   livenessCache: LivenessCache;
@@ -704,6 +706,14 @@ export function buildApp(
           ...(config.s3Prefix ? { prefix: config.s3Prefix } : {}),
         })
       : createLocalBlobTransferStore(join(config.dataDir, "transfer"));
+  const deployReleaseTransfer: BlobTransferStore =
+    config.transferStore === "s3" && config.s3Bucket
+      ? createS3BlobTransferStore({
+          bucket: config.s3Bucket,
+          ...(config.s3Region ? { region: config.s3Region } : {}),
+          prefix: `${config.s3Prefix ?? ""}deploy-releases/`,
+        })
+      : createLocalBlobTransferStore(join(config.dataDir, "deploy-releases"));
   const fileBytes: DurableByteStore =
     config.snapshotStore === "s3" && config.s3Bucket
       ? createS3DurableByteStore({
@@ -1314,6 +1324,17 @@ export function buildApp(
       }),
   };
   const deployProvider: DeployProvider = buildDeployProvider[config.deployProvider]();
+  const legacyDeploymentIds = new Set(config.flyLegacyDeploymentIds);
+  const legacyFlyProvider = legacyDeploymentIds.size
+    ? createLegacyFlyDeployProvider({
+        ...config.flyDeploy,
+        image: config.flyDeploy.baseImage,
+        region: config.flyDeploy.region ?? "lhr",
+        apiBaseUrl: config.apiBaseUrl ?? "",
+        capabilitySecret: config.capabilitySecret ?? "",
+        releaseStore: deployReleaseTransfer,
+      })
+    : undefined;
   if (config.deployProvider === "aws" && !config.awsDeploy.dataBucket && !config.awsSandbox.s3Bucket) {
     console.warn(
       "[wiring] aws deploy: no data bucket resolved (AWS_DEPLOY_DATA_BUCKET unset, sandbox is not aws) — deployed apps have NO durable /data",
@@ -1357,6 +1378,12 @@ export function buildApp(
   const deployGitSecret = config.signingSecret;
   const deployGitBase = config.apiBaseUrl;
   const deployService = createDeployService({
+    ...(legacyFlyProvider
+      ? {
+          providerFor: (deployment: Deployment) =>
+            legacyDeploymentIds.has(deployment.id) ? legacyFlyProvider : deployProvider,
+        }
+      : {}),
     deployStore,
     provider: deployProvider,
     deployDir: join(config.dataDir, "deployments"),
@@ -2132,6 +2159,7 @@ export function buildApp(
     sandboxResources,
     advisoryLock,
     blobTransfer,
+    deployReleaseTransfer,
     files,
     ...(fileUploads ? { fileUploads } : {}),
     livenessCache,
@@ -2251,6 +2279,7 @@ export function serverDeps(
     filesDirectUploadsEnabled: config.filesDirectUploadsEnabled,
     memory: built.memory,
     blobTransfer: built.blobTransfer,
+    deployReleaseTransfer: built.deployReleaseTransfer,
     sandboxBackend: built.sandbox.profile.backend,
     egressDeclaredEnforcement: built.sandbox.profile.egressEnforcement ?? "none",
     egressEnforcement: effectiveEgressEnforcement(built.sandbox.profile, {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -702,3 +702,14 @@ test("sandbox resource rollout requires explicit activation", () => {
     /not a recognized boolean/,
   );
 });
+
+test("legacy Fly routing accepts only an explicit unique deployment allowlist", () => {
+  const env = { DEPLOY_PROVIDER: "fly", FLY_DEPLOY_API_TOKEN: "test-token" };
+  const id = "00000000-0000-4000-8000-000000000001";
+  assert.deepEqual(loadConfig(env).flyLegacyDeploymentIds, []);
+  assert.deepEqual(loadConfig({ ...env, FLY_LEGACY_DEPLOYMENT_IDS: id }).flyLegacyDeploymentIds, [id]);
+  for (const value of ["*", "existing", `${id},${id}`, "00000000-0000-4000-8000-00000000000A"]) {
+    assert.throws(() => loadConfig({ ...env, FLY_LEGACY_DEPLOYMENT_IDS: value }), /FLY_LEGACY_DEPLOYMENT_IDS/);
+  }
+  assert.throws(() => loadConfig({ FLY_LEGACY_DEPLOYMENT_IDS: id }), /requires DEPLOY_PROVIDER=fly/);
+});

--- a/test/deploy-provider-selection.test.ts
+++ b/test/deploy-provider-selection.test.ts
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDeployStore } from "../src/deploy/deploy-store.ts";
+import { createDeployService } from "../src/deploy/deploy-service.ts";
+import type { DeployProvider } from "../src/deploy/deploy-provider.ts";
+import { createAclStore } from "../src/acl/acl-store.ts";
+import { scopeId } from "../src/types.ts";
+
+test("mixed deployment providers preserve Git updates, restore, reach, profiles and idle policies", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "provider-selection-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const store = createDeployStore({ git: { repoRoot: join(root, "repos") } });
+  const old = await store.create({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "node server.js",
+    snapshotDir: "/missing-legacy-snapshot",
+    files: [{ path: "server.js", data: "old" }],
+  });
+  await store.setStatus(old.id, "archived");
+  const legacyIds = new Set([old.id]);
+  const applied: string[] = [];
+  const destroyed: string[] = [];
+  let reconciles = 0;
+  let resolutions = 0;
+  const modern: DeployProvider = {
+    profile: { managedScaleToZero: false },
+    apply: async (_d, v) => {
+      applied.push(readFileSync(join(v.snapshotDir, "server.js"), "utf8"));
+      return { host: "modern.flycast", port: 8080 };
+    },
+    destroy: async (d) => {
+      destroyed.push(`modern:${d.id}`);
+    },
+    logs: async () => "modern logs",
+  };
+  const legacy: DeployProvider = {
+    profile: { managedScaleToZero: true, inPlaceReconcile: true, dataDir: "/data" },
+    apply: async () => {
+      throw new Error("legacy Git version must reconcile");
+    },
+    reconcile: async (_d, _v, input) => {
+      assert.ok(input.gitBundle?.length);
+      reconciles++;
+      return { host: "legacy.flycast", port: 80 };
+    },
+    resolveEndpoint: async () => {
+      resolutions++;
+      return { host: "legacy.flycast", port: 80 };
+    },
+    destroy: async (d) => {
+      destroyed.push(`legacy:${d.id}`);
+    },
+  };
+  const service = createDeployService({
+    deployStore: store,
+    provider: modern,
+    providerFor: (d) => (legacyIds.has(d.id) ? legacy : modern),
+    deployDir: join(root, "snapshots"),
+    acl: createAclStore(),
+    auditLog: { record() {}, events: async () => [], tail: async () => [] },
+  });
+  await service.restoreDeployment(old.id);
+  assert.equal(reconciles, 1);
+  const fresh = await service.deploy({
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    entrypoint: "node server.js",
+    files: [{ path: "server.js", data: "v1" }],
+  });
+  assert.equal(service.providerProfileFor!(old).dataDir, "/data");
+  assert.equal(service.providerProfileFor!(fresh).dataDir, undefined);
+  assert.equal((await service.reachDeployment(fresh.id, "U1", { bypassAcl: true })).status, "ok");
+  assert.deepEqual(applied, ["v1"]);
+  assert.equal(resolutions, 0);
+  assert.equal((await service.reachDeployment(old.id, "U1", { bypassAcl: true })).status, "ok");
+  assert.equal(resolutions, 1);
+  assert.equal(await service.deploymentLogs(old.id, { tailLines: 10 }), null);
+  assert.equal(await service.deploymentLogs(fresh.id, { tailLines: 10 }), "modern logs");
+  const work = join(root, "work");
+  const repo = (await service.gitRepoPath(fresh.id))!;
+  execFileSync("git", ["clone", "--quiet", repo, work]);
+  writeFileSync(join(work, "server.js"), "v2");
+  execFileSync("git", ["-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-aqm", "v2"], { cwd: work });
+  execFileSync("git", ["push", "--quiet", repo, "HEAD:current"], { cwd: work });
+  await service.pushGit(fresh.id, async () => ({ result: true, ok: true }));
+  assert.deepEqual(applied, ["v1", "v2"]);
+  await service.rollbackDeployment(fresh.id, 1);
+  assert.deepEqual(applied, ["v1", "v2", "v1"]);
+  assert.equal(await service.reapIdleDeployments(60_000, Date.now() + 1_000_000), 1);
+  assert.deepEqual(destroyed, [`modern:${fresh.id}`]);
+  assert.equal((await store.get(old.id))!.status, "running");
+  await service.archiveDeployment(old.id);
+  assert.equal((await store.get(old.id))!.endpoint, null);
+  assert.deepEqual(destroyed, [`modern:${fresh.id}`, `legacy:${old.id}`]);
+  await service.restoreDeployment(old.id);
+  assert.equal(reconciles, 2);
+  assert.equal((await store.get(old.id))!.endpoint!.host, "legacy.flycast");
+});

--- a/test/deploy-release-endpoint.test.ts
+++ b/test/deploy-release-endpoint.test.ts
@@ -1,0 +1,51 @@
+import "./support/auto-fake-sprites.ts";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../src/api/server.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
+import { DEPLOY_RELEASE_AUD, mintCapabilityToken } from "../src/auth/capability-token.ts";
+import { CAPABILITY_HEADER } from "../src/api/contract.ts";
+import { scopeId } from "../src/types.ts";
+
+const SECRET = "deploy-release-secret".repeat(3);
+
+test("deploy release endpoint serves only the release pinned by its capability", async () => {
+  const built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "deploy-release-")) }));
+  const stored = await built.deployReleaseTransfer.put(Buffer.from("release payload"));
+  const token = await mintCapabilityToken(
+    {
+      actorId: "publisher",
+      scopeId: scopeId("group", "project-that-may-change"),
+      aud: DEPLOY_RELEASE_AUD,
+      blob: { dir: "read", id: stored.blobId },
+      exp: Date.now() + 60_000,
+    },
+    SECRET,
+  );
+  const server = createServer(built.app, {
+    signingSecret: SECRET,
+    deployReleaseTransfer: built.deployReleaseTransfer,
+  });
+  server.listen(0);
+  const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+  try {
+    const ok = await fetch(`${base}/v1/deploy-releases/${stored.blobId}`, {
+      headers: { [CAPABILITY_HEADER]: token },
+    });
+    assert.equal(ok.status, 200);
+    assert.equal(await ok.text(), "release payload");
+    const wrong = "f".repeat(32);
+    const denied = await fetch(`${base}/v1/deploy-releases/${wrong}`, {
+      headers: { [CAPABILITY_HEADER]: token },
+    });
+    assert.equal(denied.status, 403);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/test/legacy-fly-deploy-provider.test.ts
+++ b/test/legacy-fly-deploy-provider.test.ts
@@ -1,0 +1,656 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extract } from "tar-stream";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  createFlyDeployApi,
+  createLegacyFlyDeployProvider,
+  type FlyApp,
+  type FlyDeployApi,
+  type FlyMachine,
+  type FlyMachineConfig,
+  type FlyVolume,
+} from "../src/deploy/legacy-fly-deploy-provider.ts";
+import type { Deployment, DeploymentVersion } from "../src/deploy/deploy-store.ts";
+import type { BlobTransferStore } from "../src/persistence/blob-transfer.ts";
+import { Readable } from "node:stream";
+import { asChunks } from "../src/util/bytes.ts";
+import { scopeId } from "../src/types.ts";
+
+const ID = "550e8400-e29b-41d4-a716-446655440000";
+const APP = "example-d-550e8400e29b41d4";
+const IMAGE = "registry.fly.io/example-sandboxes@sha256:abc";
+
+function deployment(): Deployment {
+  return {
+    id: ID,
+    ownerScopeId: scopeId("personal", "U1"),
+    createdBy: "U1",
+    currentVersion: 1,
+    status: "stopped",
+    endpoint: null,
+    versions: [],
+  };
+}
+
+function snapshot(file: string, contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), "fly-deploy-"));
+  const target = join(root, file);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, contents);
+  return root;
+}
+
+function version(number: number, root: string, over: Partial<DeploymentVersion> = {}): DeploymentVersion {
+  return {
+    version: number,
+    createdAt: 0,
+    entrypoint: "node server.js",
+    snapshotDir: root,
+    env: { API_KEY: "secret", PORT: "9999", DATA_DIR: "/wrong" },
+    ...over,
+  };
+}
+
+function fakeApi() {
+  const apps = new Map<string, FlyApp>();
+  const volumes = new Map<string, FlyVolume[]>();
+  const machines = new Map<string, FlyMachine[]>();
+  const configs: FlyMachineConfig[] = [];
+  const machineRegions: string[] = [];
+  const calls = {
+    createApp: 0,
+    flycast: 0,
+    createVolume: 0,
+    createMachine: 0,
+    updateMachine: 0,
+    start: 0,
+    waitStopped: 0,
+    wait: 0,
+    delete: 0,
+  };
+  let machineNumber = 0;
+  const api: FlyDeployApi = {
+    async getApp(name) {
+      return apps.get(name) ?? null;
+    },
+    async createApp(name, org) {
+      calls.createApp++;
+      apps.set(name, { name, organization: { slug: org } });
+    },
+    async ensureFlycast() {
+      calls.flycast++;
+    },
+    async listVolumes(name) {
+      return volumes.get(name) ?? [];
+    },
+    async createVolume(name) {
+      calls.createVolume++;
+      const volume = { id: `vol-${calls.createVolume}`, name: "qm_data", state: "created", region: "sjc" };
+      volumes.set(name, [volume]);
+      return volume;
+    },
+    async listMachines(name) {
+      return machines.get(name) ?? [];
+    },
+    async createMachine(name, region, config) {
+      calls.createMachine++;
+      machineRegions.push(region);
+      configs.push(config);
+      const machine = {
+        id: `machine-${++machineNumber}`,
+        instance_id: `instance-${machineNumber}`,
+        state: "created",
+        config,
+      };
+      machines.set(name, [machine]);
+      const volume = volumes.get(name)?.[0];
+      if (volume) volume.attached_machine_id = machine.id;
+      return machine;
+    },
+    async updateMachine(name, id, config) {
+      calls.updateMachine++;
+      configs.push(config);
+      const machine = { id, instance_id: `instance-${++machineNumber}`, state: "created", config };
+      machines.set(name, [machine]);
+      return machine;
+    },
+    async startMachine(name, id) {
+      calls.start++;
+      const machine = machines.get(name)?.find((candidate) => candidate.id === id);
+      assert.equal(machine?.state, "stopped");
+      if (machine) machine.state = "started";
+    },
+    async waitMachineStopped(name, id, instanceId) {
+      calls.waitStopped++;
+      const machine = machines.get(name)?.find((candidate) => candidate.id === id);
+      assert.equal(machine?.instance_id, instanceId);
+      assert.equal(machine?.state, "created");
+      machine!.state = "stopped";
+    },
+    async waitMachine(name, id) {
+      calls.wait++;
+      const machine = machines.get(name)?.find((candidate) => candidate.id === id);
+      if (machine) machine.state = "started";
+    },
+    async deleteMachine(name, id) {
+      calls.delete++;
+      machines.set(
+        name,
+        (machines.get(name) ?? []).filter((machine) => machine.id !== id),
+      );
+      const volume = volumes.get(name)?.[0];
+      if (volume?.attached_machine_id === id) volume.attached_machine_id = null;
+    },
+  };
+  return { api, apps, volumes, machines, configs, machineRegions, calls };
+}
+
+function recordingBlobs() {
+  const payloads = new Map<string, Buffer>();
+  const deleted: string[] = [];
+  let sequence = 0;
+  const store: BlobTransferStore = {
+    async put(source) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of asChunks(source)) chunks.push(Buffer.from(chunk));
+      const data = Buffer.concat(chunks);
+      const blobId = (++sequence).toString(16).padStart(32, "0");
+      payloads.set(blobId, data);
+      return { blobId, sizeBytes: data.length, sha256: "a".repeat(63) + sequence };
+    },
+    async open(blobId) {
+      const data = payloads.get(blobId);
+      return data ? { sizeBytes: data.length, stream: Readable.from(data) } : null;
+    },
+    async delete(blobId) {
+      deleted.push(blobId);
+    },
+    async sweep() {
+      return 0;
+    },
+  };
+  return { store, payloads, deleted };
+}
+
+function provider(api: FlyDeployApi, probes: Array<{ host: string; port: number }>, blobs = recordingBlobs()) {
+  return createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api,
+    probe: async (endpoint) => void probes.push(endpoint),
+  });
+}
+
+async function untar(raw: Uint8Array): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  const unpack = extract();
+  const complete = new Promise<Map<string, string>>((resolve, reject) => {
+    unpack.on("finish", () => resolve(files));
+    unpack.on("error", reject);
+  });
+  unpack.on("entry", (header, stream, next) => {
+    const chunks: Buffer[] = [];
+    stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+    stream.on("end", () => {
+      files.set(header.name, Buffer.concat(chunks).toString());
+      next();
+    });
+    stream.resume();
+  });
+  unpack.end(Buffer.from(raw));
+  return complete;
+}
+
+test("apply creates a private Fly app, persistent volume, and one owned Machine", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const probes: Array<{ host: string; port: number }> = [];
+  const endpoint = await provider(fake.api, probes, blobs).apply(
+    deployment(),
+    version(1, snapshot("public/index.html", "<h1>hello</h1>")),
+  );
+
+  assert.deepEqual(endpoint, { host: `${APP}.flycast`, port: 80, image: IMAGE });
+  assert.deepEqual(probes, [{ host: `${APP}.flycast`, port: 80 }]);
+  assert.equal(fake.calls.createApp, 1);
+  assert.equal(fake.calls.flycast, 1);
+  assert.equal(fake.calls.createVolume, 1);
+  assert.equal(fake.calls.createMachine, 1);
+  assert.equal(fake.calls.start, 0);
+  assert.equal(fake.calls.wait, 1);
+  const config = fake.configs[0]!;
+  assert.equal(config.metadata?.qm_deployment_id, ID);
+  assert.equal(config.metadata?.qm_deployment_version, "1");
+  assert.deepEqual(config.env, { API_KEY: "secret", PORT: "8080", DATA_DIR: "/data", HOME: "/root" });
+  assert.deepEqual(config.mounts, [{ volume: "vol-1", path: "/data" }]);
+  assert.deepEqual(config.services, [
+    {
+      protocol: "tcp",
+      internal_port: 8080,
+      autostop: "stop",
+      autostart: true,
+      min_machines_running: 0,
+      ports: [{ port: 80, handlers: ["http"] }],
+    },
+  ]);
+  assert.equal(config.files, undefined);
+  assert.match(
+    JSON.stringify(config.init),
+    /https:\/\/example-core\.fly\.dev\/v1\/deploy-releases\/00000000000000000000000000000001/,
+  );
+  assert.doesNotMatch(JSON.stringify(config.init), /\/data\/\.qm\/releases/);
+  const archived = await untar(blobs.payloads.values().next().value!);
+  assert.equal(archived.get("app/public/index.html"), "<h1>hello</h1>");
+  assert.deepEqual(blobs.deleted, []);
+});
+
+test("large snapshots stay in the durable release store rather than Machine config", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const root = snapshot("public/bundle.js", "x".repeat(2 * 1024 * 1024));
+  await provider(fake.api, [], blobs).apply(deployment(), version(1, root));
+
+  assert.ok(blobs.payloads.values().next().value!.length > 2 * 1024 * 1024);
+  assert.ok(JSON.stringify(fake.configs[0]).length < 10_000);
+  assert.equal(fake.configs[0]!.files, undefined);
+});
+
+test("redeploy updates the existing Machine and preserves its data volume", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const p = provider(fake.api, [], blobs);
+  const d = deployment();
+  await p.apply(d, version(1, snapshot("server.js", "v1")));
+  await p.apply(d, version(2, snapshot("server.js", "v2")));
+
+  assert.equal(fake.calls.createApp, 1);
+  assert.equal(fake.calls.createVolume, 1);
+  assert.equal(fake.calls.createMachine, 1);
+  assert.equal(fake.calls.updateMachine, 1);
+  assert.deepEqual(fake.configs[1]!.mounts, [{ volume: "vol-1", path: "/data" }]);
+  assert.equal(fake.configs[1]!.metadata?.qm_deployment_version, "2");
+  assert.deepEqual(blobs.deleted, ["00000000000000000000000000000001"]);
+});
+
+test("redeploy waits for a stopped Machine update version before explicitly starting it", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const p = provider(fake.api, [], blobs);
+  const d = deployment();
+  await p.apply(d, version(1, snapshot("server.js", "v1")));
+  fake.machines.get(APP)![0]!.state = "stopped";
+
+  await p.apply(d, version(2, snapshot("server.js", "v2")));
+
+  assert.equal(fake.calls.updateMachine, 1);
+  assert.equal(fake.calls.waitStopped, 1);
+  assert.equal(fake.calls.start, 1);
+  assert.equal(fake.calls.wait, 2);
+  assert.equal(fake.machines.get(APP)?.[0]?.state, "started");
+});
+
+test("archive removes only the Machine and restore reattaches the retained volume", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const p = provider(fake.api, [], blobs);
+  const d = deployment();
+  const v = version(1, snapshot("server.js", "v1"));
+  await p.apply(d, v);
+  await p.destroy(d);
+
+  assert.equal(fake.calls.delete, 1);
+  assert.deepEqual(blobs.deleted, ["00000000000000000000000000000001"]);
+  assert.ok(fake.apps.has(APP));
+  assert.equal(fake.volumes.get(APP)?.[0]?.id, "vol-1");
+  assert.equal(await p.resolveEndpoint!(d, v), null);
+
+  await p.apply(d, v);
+  assert.equal(fake.calls.createVolume, 1);
+  assert.equal(fake.calls.createMachine, 2);
+  assert.deepEqual(fake.configs[1]!.mounts, [{ volume: "vol-1", path: "/data" }]);
+});
+
+test("restore creates the replacement Machine in the retained volume region", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const d = deployment();
+  const v = version(1, snapshot("server.js", "v1"));
+  await provider(fake.api, [], blobs).apply(d, v);
+  await provider(fake.api, [], blobs).destroy(d);
+  await createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "iad",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api: fake.api,
+    probe: async () => undefined,
+  }).apply(d, v);
+
+  assert.deepEqual(fake.machineRegions, ["sjc", "sjc"]);
+});
+
+test("reconcile stages the durable git bundle instead of a stale snapshot", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const p = provider(fake.api, [], blobs);
+  const d = deployment();
+  const commit = "a".repeat(40);
+  await p.reconcile!(d, version(2, "/unused", { commit }), {
+    gitBundle: Buffer.from("bundle"),
+    changedPaths: ["server.js"],
+    deletedPaths: [],
+    allPaths: ["server.js"],
+  });
+
+  const config = fake.configs[0]!;
+  assert.equal(config.files, undefined);
+  const archived = await untar(blobs.payloads.values().next().value!);
+  assert.equal(archived.get("bundle"), "bundle");
+  assert.match(JSON.stringify(config.init), new RegExp(`refs/deploy-commits/${commit}`));
+});
+
+test("an existing foreign Machine is refused without deleting it", async () => {
+  const fake = fakeApi();
+  fake.apps.set(APP, { name: APP, organization: { slug: "personal" } });
+  fake.machines.set(APP, [
+    { id: "foreign", state: "started", config: { image: IMAGE, metadata: { qm_deployment_id: "other" } } },
+  ]);
+  await assert.rejects(
+    () => provider(fake.api, []).apply(deployment(), version(1, snapshot("server.js", "v1"))),
+    /not owned by deployment/,
+  );
+  assert.equal(fake.calls.delete, 0);
+  assert.equal(fake.calls.flycast, 0);
+  assert.equal(fake.machines.get(APP)?.[0]?.id, "foreign");
+});
+
+test("readiness retries Fly proxy startup responses before accepting the endpoint", async () => {
+  const fake = fakeApi();
+  let attempts = 0;
+  const p = createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: recordingBlobs().store,
+    api: fake.api,
+    fetchImpl: (async () => new Response(null, { status: ++attempts === 1 ? 503 : 200 })) as typeof fetch,
+    readyTimeoutMs: 2_000,
+  });
+
+  await p.apply(deployment(), version(1, snapshot("server.js", "v1")));
+  assert.equal(attempts, 2);
+});
+
+test("failed redeploy restores the previous Machine config and removes the failed release", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const d = deployment();
+  await provider(fake.api, [], blobs).apply(d, version(1, snapshot("server.js", "v1")));
+  const prior = fake.machines.get(APP)?.[0]?.config;
+  const failing = createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api: fake.api,
+    probe: async () => {
+      throw new Error("not ready");
+    },
+  });
+
+  await assert.rejects(() => failing.apply(d, version(2, snapshot("server.js", "v2"))), /not ready/);
+  assert.equal(fake.calls.updateMachine, 2);
+  assert.deepEqual(fake.machines.get(APP)?.[0]?.config, prior);
+  assert.deepEqual(blobs.deleted, ["00000000000000000000000000000002"]);
+});
+
+test("failed redeploy of a stopped Machine restarts the restored version", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const d = deployment();
+  await provider(fake.api, [], blobs).apply(d, version(1, snapshot("server.js", "v1")));
+  fake.machines.get(APP)![0]!.state = "stopped";
+  const failing = createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api: fake.api,
+    probe: async () => {
+      throw new Error("not ready");
+    },
+  });
+
+  await assert.rejects(() => failing.apply(d, version(2, snapshot("server.js", "v2"))), /not ready/);
+  assert.equal(fake.calls.waitStopped, 2);
+  assert.equal(fake.calls.start, 2);
+  assert.equal(fake.machines.get(APP)?.[0]?.state, "started");
+  assert.deepEqual(blobs.deleted, ["00000000000000000000000000000002"]);
+});
+
+test("an accepted update with a lost API response is rolled back", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const d = deployment();
+  const p = provider(fake.api, [], blobs);
+  await p.apply(d, version(1, snapshot("server.js", "v1")));
+  const prior = fake.machines.get(APP)?.[0]?.config;
+  const update = fake.api.updateMachine.bind(fake.api);
+  let loseResponse = true;
+  fake.api.updateMachine = async (name, id, config) => {
+    const result = await update(name, id, config);
+    if (loseResponse) {
+      loseResponse = false;
+      throw new Error("response lost");
+    }
+    return result;
+  };
+
+  await assert.rejects(() => p.apply(d, version(2, snapshot("server.js", "v2"))), /response lost/);
+  assert.equal(fake.calls.updateMachine, 2);
+  assert.deepEqual(fake.machines.get(APP)?.[0]?.config, prior);
+});
+
+test("an accepted create with a lost API response is cleaned up", async () => {
+  const fake = fakeApi();
+  const create = fake.api.createMachine.bind(fake.api);
+  fake.api.createMachine = async (name, region, config) => {
+    await create(name, region, config);
+    throw new Error("response lost");
+  };
+
+  await assert.rejects(
+    () => provider(fake.api, []).apply(deployment(), version(1, snapshot("server.js", "v1"))),
+    /response lost/,
+  );
+  assert.equal(fake.calls.delete, 1);
+  assert.deepEqual(fake.machines.get(APP), []);
+});
+
+test("rollback failure is surfaced and keeps the release needed by the accepted config", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  const d = deployment();
+  await provider(fake.api, [], blobs).apply(d, version(1, snapshot("server.js", "v1")));
+  const update = fake.api.updateMachine.bind(fake.api);
+  fake.api.updateMachine = async (name, id, config) => {
+    if (config.metadata?.qm_deployment_version === "1") throw new Error("rollback rejected");
+    return update(name, id, config);
+  };
+  const failing = createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://example-core.fly.dev",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api: fake.api,
+    probe: async () => {
+      throw new Error("not ready");
+    },
+  });
+
+  await assert.rejects(
+    () => failing.apply(d, version(2, snapshot("server.js", "v2"))),
+    /deployment failed and recovery failed/,
+  );
+  assert.deepEqual(blobs.deleted, []);
+});
+
+test("Fly API refuses an app with a public IP address", async () => {
+  const fetchImpl = (async () =>
+    new Response(
+      JSON.stringify({ data: { app: { ipAddresses: { nodes: [{ type: "shared_v4" }] } } } }),
+    )) as typeof fetch;
+  const api = createFlyDeployApi("FlyV1-test", fetchImpl, "https://machines.test", "https://graphql.test");
+  await assert.rejects(() => api.ensureFlycast(APP), /public IP addresses \(shared_v4\)/);
+});
+
+test("Fly API client uses the Machines REST API and allocates only a private Flycast address", async () => {
+  const requests: Array<{ url: string; method: string; authorization: string; body?: unknown }> = [];
+  let waitAttempts = 0;
+  const fetchImpl = (async (input: string | URL | Request, init: RequestInit = {}) => {
+    const url = String(input);
+    const method = init.method ?? "GET";
+    const headers = new Headers(init.headers);
+    const body = typeof init.body === "string" ? (JSON.parse(init.body) as unknown) : undefined;
+    requests.push({ url, method, authorization: headers.get("authorization") ?? "", ...(body ? { body } : {}) });
+    if (url === "https://graphql.test") {
+      const operation = body as { query: string };
+      return operation.query.startsWith("query")
+        ? new Response(JSON.stringify({ data: { app: { ipAddresses: { nodes: [] } } } }))
+        : new Response(JSON.stringify({ data: { allocateIpAddress: { ipAddress: { id: "private" } } } }));
+    }
+    if (url.endsWith("/v1/apps/missing")) return new Response("not found", { status: 404 });
+    if (url.endsWith("/volumes") && method === "POST") {
+      return new Response(JSON.stringify({ id: "vol-1", name: "qm_data", state: "created" }));
+    }
+    if (url.endsWith("/machines") && method === "POST") {
+      return new Response(JSON.stringify({ id: "machine-1", state: "created", config: { image: IMAGE } }));
+    }
+    if (url.includes("/wait?state=started&timeout=60")) {
+      waitAttempts++;
+      return waitAttempts === 1 ? new Response("timed out", { status: 408 }) : new Response(null, { status: 200 });
+    }
+    if (url.includes("/machines/machine-1") && method === "POST") {
+      return new Response(JSON.stringify({ id: "machine-1", state: "started", config: { image: IMAGE } }));
+    }
+    return new Response(null, { status: method === "POST" && url.endsWith("/v1/apps") ? 201 : 200 });
+  }) as typeof fetch;
+  const api = createFlyDeployApi("FlyV1-test", fetchImpl, "https://machines.test", "https://graphql.test");
+
+  assert.equal(await api.getApp("missing"), null);
+  await api.createApp(APP, "personal");
+  await api.ensureFlycast(APP);
+  await api.createVolume(APP, "sjc");
+  await api.createMachine(APP, "sjc", { image: IMAGE });
+  await api.updateMachine(APP, "machine-1", { image: IMAGE });
+  await api.waitMachineStopped(APP, "machine-1", "instance-2");
+  await api.startMachine(APP, "machine-1");
+  await api.waitMachine(APP, "machine-1");
+  await api.deleteMachine(APP, "machine-1");
+
+  assert.ok(requests.every((request) => request.authorization === "Bearer FlyV1-test"));
+  assert.deepEqual(
+    requests.filter((request) => request.url === "https://graphql.test").map((request) => request.body),
+    [
+      {
+        query: "query ($appName: String!) { app(name: $appName) { ipAddresses { nodes { type } } } }",
+        variables: { appName: APP },
+      },
+      {
+        query: "mutation ($input: AllocateIPAddressInput!) { allocateIpAddress(input: $input) { ipAddress { id } } }",
+        variables: { input: { appId: APP, type: "private_v6", region: "" } },
+      },
+    ],
+  );
+  assert.ok(requests.some((request) => request.url.endsWith("/machines/machine-1/start")));
+  assert.deepEqual(
+    requests.find((request) => request.url.endsWith("/machines/machine-1") && request.method === "POST")?.body,
+    { config: { image: IMAGE }, skip_launch: true },
+  );
+  assert.ok(
+    requests.some((request) =>
+      request.url.endsWith("/machines/machine-1/wait?state=stopped&instance_id=instance-2&timeout=60"),
+    ),
+  );
+  assert.equal(requests.filter((request) => request.url.endsWith("/wait?state=started&timeout=60")).length, 2);
+  assert.ok(requests.some((request) => request.url.endsWith("/machines/machine-1?force=true")));
+});
+
+test("readiness does not follow application redirects into core networks", async () => {
+  const fake = fakeApi();
+  const blobs = recordingBlobs();
+  let checked = false;
+  const p = createLegacyFlyDeployProvider({
+    token: "FlyV1-test",
+    org: "personal",
+    region: "sjc",
+    image: IMAGE,
+    appPrefix: "example-d",
+    apiBaseUrl: "https://core.example.com",
+    capabilitySecret: "test-capability-secret",
+    releaseStore: blobs.store,
+    api: fake.api,
+    fetchImpl: (async (_input, init) => {
+      assert.equal(init?.redirect, "manual");
+      checked = true;
+      return new Response(null, { status: 302, headers: { location: "http://127.0.0.1/private" } });
+    }) as typeof fetch,
+  });
+  await p.apply(deployment(), version(1, snapshot("server.js", "v1")));
+  assert.ok(checked);
+});
+
+test("legacy destroy refuses unknown or foreign organization ownership", async () => {
+  for (const organization of [undefined, { slug: "another-org" }]) {
+    const fake = fakeApi();
+    fake.apps.set(APP, { name: APP, ...(organization ? { organization } : {}) });
+    await assert.rejects(provider(fake.api, [], recordingBlobs()).destroy(deployment()), /not owned/);
+    assert.equal(fake.calls.delete, 0);
+  }
+});
+
+test("legacy warming probes only while always-on is enabled", async () => {
+  const fake = fakeApi();
+  const probes: Array<{ host: string; port: number }> = [];
+  const p = provider(fake.api, probes, recordingBlobs());
+  const d = { ...deployment(), alwaysOn: true };
+  await p.apply(d, version(1, snapshot("server.js", "v1")));
+  const services = fake.configs[0]!.services as Array<{ autostop: string; min_machines_running: number }>;
+  assert.equal(services[0]!.autostop, "stop");
+  assert.equal(services[0]!.min_machines_running, 0);
+  fake.machines.get(APP)![0]!.state = "stopped";
+  const before = probes.length;
+  await p.resolveEndpoint!(d, version(1, "unused"));
+  assert.equal(probes.length, before + 1);
+  await p.resolveEndpoint!({ ...d, alwaysOn: false }, version(1, "unused"));
+  assert.equal(probes.length, before + 1);
+});


### PR DESCRIPTION
Existing volume-backed Fly deployments use truncated app names, a persistent `/data` volume, and signed release downloads during boot. Switching their next operation directly to the current provider would lose those resource identities.

Add an explicit, validated `FLY_LEGACY_DEPLOYMENT_IDS` inventory that selects the compatible lifecycle for existing deployments. New deployments continue through the current Fly provider. Selection covers publication, Git reconciliation, rollback, reach, archive/restore, logs, deployment profiles, and reaping. Preserve the old release capability and object-store namespace. Document inventory capture, operational invariants, and eventual migration.

The legacy lifecycle also fails closed on app ownership, bounds provider calls, refuses readiness redirects, and waits for Fly's stopped instance before starting an updated machine.

Validation: typecheck, lint, formatting, focused compatibility tests, CLI suite (554), web suite (1,021), and portal/auth/admin suites passed. The full root run had six Python-version failures and one timeout under load; all seven passed on focused rerun with the supported Python version. Independent code and security reviews completed with findings resolved. Live Fly exercises covered create, stopped-machine redeploy, failed rollout recovery, volume-preserving archive/restore, and modern publish/archive. A fresh local Postgres instance passed real web/computer and Firefox Slack response checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791697062&installation_model_id=19911&pr_number=1100&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1100&signature=06f82a48b91b7f0085ab482361654570b2112feb849cdc3bbc29d1d5d36b7b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->