### PR TITLE
egress proxy: 407-challenge unauthenticated CONNECTs so git can authenticate (fixes git-through-proxy 403 regression)

### DIFF
--- a/deploy/egress-proxy/envoy.yaml
+++ b/deploy/egress-proxy/envoy.yaml
@@ -101,7 +101,20 @@ static_resources:
                               local h, _ = handle:httpCall("egress_authz", check, nil, 10000)
                               return h[":status"], h["x-egress-upstream-address"]
                             end)
-                            if not ok or status ~= "200" then
+                            if not ok then
+                              handle:respond({ [":status"] = "403" }, "egress denied by policy\n")
+                              return
+                            end
+                            if status == "407" then
+                              -- Challenge, don't refuse: git's default proxy auth ("anyauth")
+                              -- only sends its credential after a 407 + Proxy-Authenticate.
+                              handle:respond({
+                                [":status"] = "407",
+                                ["proxy-authenticate"] = 'Basic realm="egress"',
+                              }, "proxy authentication required\n")
+                              return
+                            end
+                            if status ~= "200" then
                               handle:respond({ [":status"] = "403" }, "egress denied by policy\n")
                               return
                             end

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,87 +895,6 @@
         "@connectrpc/connect": "2.1.2"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
-      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
-        "diff": "8.0.4",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-ai": {
       "version": "0.82.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.0.tgz",
@@ -2860,56 +2779,6 @@
         "zod": "^3.25.28 || ^4"
       }
     },
-    "node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
-      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-KjoUR6mNvjT+z5bKMy+a5QDI+kTNTiMZi6uPKzWuWjwZGNa0UPwIVduTfeBRdf6v8Ws5fmHDh7Usf15w/ANfkg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.4.tgz",
-      "integrity": "sha512-Wy1TQ99obRP3Ah7cf/OOtK1zD9t3pYTWz+G/SpAwTFMhG5hoMdlvfzBpYoHUigS/izu3q+VhYMKhJd7Ii/trpg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
-      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
@@ -3311,185 +3180,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
-      }
-    },
-    "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
-      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
-        "@mariozechner/clipboard-darwin-universal": "0.3.9",
-        "@mariozechner/clipboard-darwin-x64": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
-      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
-      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
-      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
-      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
-      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
-      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
-      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
-      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
-      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
-      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -4914,12 +4604,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@silvia-odwyer/photon-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
-      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-      "license": "Apache-2.0"
     },
     "node_modules/@slack/bolt": {
       "version": "4.7.3",
@@ -6399,15 +6083,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dockerfile-ast": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
@@ -7366,6 +7041,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7505,12 +7181,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -7550,15 +7220,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hono": {
       "version": "4.13.5",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
@@ -7566,18 +7227,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/http-errors": {
@@ -7662,6 +7311,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7783,6 +7433,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8240,18 +7891,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9358,26 +8997,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proper-lockfile/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -9875,12 +9494,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
     },
     "node_modules/slice-ansi": {
       "version": "8.0.0",

--- a/src/egress-authz-main.ts
+++ b/src/egress-authz-main.ts
@@ -127,7 +127,7 @@ export function buildEgressAuthzServer(deps: EgressAuthzDeps): Server {
   async function checkStatus(
     req: IncomingMessage,
     authority: string,
-  ): Promise<{ status: 200 | 403; upstream?: string }> {
+  ): Promise<{ status: 200 | 403 | 407; upstream?: string }> {
     const host = hostFromAuthority(authority);
     if (!host) return { status: 403 };
     const portText = authority.match(/:(\d+)$/)?.[1];
@@ -153,16 +153,27 @@ export function buildEgressAuthzServer(deps: EgressAuthzDeps): Server {
     } catch (error) {
       void error;
     }
-    if (!d.allow || !d.address) return { status: 403 };
+    if (!d.allow || !d.address) {
+      // A missing or unverifiable credential is an authentication failure, not a policy verdict.
+      // Answer 407 so challenge-based clients retry with Basic: git's default http.proxyAuthMethod
+      // ("anyauth") makes libcurl wait for a Proxy-Authenticate challenge before it sends the
+      // credential at all; a bare 403 strands it with "CONNECT tunnel failed, response 403" while
+      // curl (preemptive Basic) sails through. Hosts denied unconditionally stay a hard 403 —
+      // no credential would change the answer.
+      const unauthenticated = !claims && !(deps.tokenless === "open" && !token);
+      if (unauthenticated && !isAlwaysBlockedHost(host)) return { status: 407 };
+      return { status: 403 };
+    }
     return { status: 200, upstream: isIP(d.address) === 6 ? `[${d.address}]:${port}` : `${d.address}:${port}` };
   }
   async function onRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
       const authority = (req.headers["x-egress-authority"] as string | undefined) ?? req.headers.host ?? "";
       const result = await checkStatus(req, authority);
-      res
-        .writeHead(result.status, result.upstream ? { "x-egress-upstream-address": result.upstream } : undefined)
-        .end();
+      const headers: Record<string, string> = {};
+      if (result.upstream) headers["x-egress-upstream-address"] = result.upstream;
+      if (result.status === 407) headers["proxy-authenticate"] = 'Basic realm="egress"';
+      res.writeHead(result.status, headers).end();
     } catch {
       if (!res.headersSent) res.writeHead(403);
       res.end();

--- a/src/sandbox/sandbox-env.ts
+++ b/src/sandbox/sandbox-env.ts
@@ -25,6 +25,7 @@ export const DROPPED_PROXY_ENV = new Set([
   "all_proxy",
   "no_proxy",
   "NO_PROXY",
+  "GIT_HTTP_PROXY_AUTHMETHOD",
 ]);
 
 export function forceThroughProxyEnv(egressProxyUrl: string, token: string): Record<string, string> {
@@ -38,6 +39,10 @@ export function forceThroughProxyEnv(egressProxyUrl: string, token: string): Rec
     https_proxy: url,
     http_proxy: url,
     no_proxy: noProxy,
+    // git defaults http.proxyAuthMethod to "anyauth", which on many libcurl builds waits for a
+    // 407 challenge before sending the proxy credential. Force preemptive Basic so git works
+    // even against proxies that answer unauthenticated CONNECTs with a bare 403.
+    GIT_HTTP_PROXY_AUTHMETHOD: "basic",
   };
 }
 

--- a/test/egress-authz.test.ts
+++ b/test/egress-authz.test.ts
@@ -185,11 +185,15 @@ test("allowlist present => non-matching host is 403 not_allowlisted, matching ho
   }
 });
 
-test("NO token fails closed by default and is audited as unknown", async () => {
+test("NO token is CHALLENGED with 407 + Proxy-Authenticate and audited as unknown", async () => {
   const { server, records } = boot();
   const port = await listen(server);
   try {
-    assert.equal(await check(port, "example.com:443"), 403);
+    // 407 (not a bare 403) so challenge-based clients — git's default proxy "anyauth" — send
+    // Basic and retry. A bare 403 here regressed git clones: "CONNECT tunnel failed, response 403".
+    const res = await checkWithHeaders(port, "example.com:443");
+    assert.equal(res.status, 407);
+    assert.equal(res.headers["proxy-authenticate"], 'Basic realm="egress"');
     assert.equal(records.at(-1)?.verdict, "not_allowlisted");
     assert.equal(records.at(-1)?.scopeLabel, "unknown");
     assert.equal(records.at(-1)?.principalId, "unknown");
@@ -198,23 +202,25 @@ test("NO token fails closed by default and is audited as unknown", async () => {
   }
 });
 
-test("wrong-secret / wrong-audience / expired presented tokens fail closed", async () => {
+test("wrong-secret / wrong-audience / expired presented tokens fail closed with a 407 challenge", async () => {
   const { server, records } = boot();
   const port = await listen(server);
   try {
+    // Unverifiable = authentication failure => 407, so an expired per-turn token surfaces as an
+    // auth problem (diagnosable) instead of a policy denial. Nothing tunnels either way.
     assert.equal(
       await check(port, "example.com:443", await egressToken({ allowedHosts: [] }, { secret: SOURCE_SECRET })),
-      403,
+      407,
     );
     assert.equal(records.at(-1)?.scopeLabel, "unknown");
     assert.equal(
       await check(port, "example.com:443", await egressToken({ allowedHosts: [] }, { aud: CONTROL_PLANE_AUD })),
-      403,
+      407,
     );
     assert.equal(records.at(-1)?.scopeLabel, "unknown");
     assert.equal(
       await check(port, "example.com:443", await egressToken({ allowedHosts: [] }, { exp: Date.now() - 1000 })),
-      403,
+      407,
     );
     assert.equal(records.at(-1)?.scopeLabel, "unknown");
   } finally {

--- a/test/git-through-egress-proxy.test.ts
+++ b/test/git-through-egress-proxy.test.ts
@@ -1,0 +1,190 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createServer, request, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, readFileSync, existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildEgressAuthzServer } from "../src/egress-authz-main.ts";
+import { mintCapabilityToken, EGRESS_PROXY_AUD } from "../src/auth/capability-token.ts";
+import { forceThroughProxyEnv } from "../src/sandbox/sandbox-env.ts";
+import { scopeId } from "../src/types.ts";
+
+// The regression this pins: git's default http.proxyAuthMethod ("anyauth") may withhold the
+// proxy credential until the proxy answers 407 + Proxy-Authenticate. A proxy that answers a
+// bare 403 strands git ("CONNECT tunnel failed, response 403") while curl — preemptive Basic —
+// works. The egress stack must (a) challenge with 407 and (b) hand git an env that sends Basic
+// preemptively. Both are exercised here through a front proxy wired to the real authz server
+// exactly like the Envoy Lua filter.
+
+const SECRET = "git-proxy-test-secret";
+const listen = (s: Server): Promise<number> =>
+  new Promise((r) => s.listen(0, "127.0.0.1", () => r((s.address() as AddressInfo).port)));
+const close = (s: Server): Promise<void> => new Promise((r) => s.close(() => r()));
+const sh = (cmd: string, args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) =>
+  new Promise<{ code: number; out: string }>((resolve) => {
+    execFile(cmd, args, { ...opts, timeout: 30_000 }, (err, stdout, stderr) =>
+      resolve({ code: err ? ((err as { code?: number }).code as number) || 1 : 0, out: `${stdout}\n${stderr}` }),
+    );
+  });
+
+function frontProxy(authzPort: number, targetPort: number): Server {
+  // Minimal stand-in for deploy/egress-proxy/envoy.yaml: consult the authz service per request,
+  // mirror 407 challenges, forward allowed absolute-form HTTP to the target.
+  return createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url ?? "/", "http://invalid.test");
+    const authority = url.host || req.headers.host || "";
+    const checkHeaders: Record<string, string> = {
+      "x-egress-authority": authority,
+      "x-egress-scheme": "http",
+    };
+    if (req.headers["proxy-authorization"]) {
+      checkHeaders["proxy-authorization"] = req.headers["proxy-authorization"] as string;
+    }
+    const check = request({ port: authzPort, host: "127.0.0.1", path: "/check", headers: checkHeaders }, (cr) => {
+      cr.resume();
+      if (cr.statusCode !== 200) {
+        const headers: Record<string, string> = {};
+        if (cr.statusCode === 407 && cr.headers["proxy-authenticate"]) {
+          headers["proxy-authenticate"] = cr.headers["proxy-authenticate"] as string;
+        }
+        res.writeHead(cr.statusCode === 407 ? 407 : 403, headers).end();
+        req.resume();
+        return;
+      }
+      const fwd = request(
+        {
+          port: targetPort,
+          host: "127.0.0.1",
+          path: url.pathname + url.search,
+          method: req.method,
+          headers: { host: authority },
+        },
+        (tr) => {
+          res.writeHead(tr.statusCode ?? 502, tr.headers);
+          tr.pipe(res);
+        },
+      );
+      fwd.on("error", () => res.writeHead(502).end());
+      req.pipe(fwd);
+    });
+    check.on("error", () => res.writeHead(403).end());
+    check.end();
+  });
+}
+
+function dumbGitTarget(repoDir: string): Server {
+  return createServer((req, res) => {
+    const path = join(repoDir, new URL(req.url ?? "/", "http://x").pathname.replace(/^\/repo\.git/, ""));
+    if (existsSync(path) && statSync(path).isFile()) res.end(readFileSync(path));
+    else {
+      res.statusCode = 404;
+      res.end();
+    }
+  });
+}
+
+async function boot() {
+  const authz = buildEgressAuthzServer({
+    capabilitySecret: SECRET,
+    audit: { record: () => {} },
+    lookup: async () => ["93.184.216.34"],
+  });
+  const authzPort = await listen(authz);
+  const dir = mkdtempSync(join(tmpdir(), "git-proxy-"));
+  const repo = join(dir, "repo.git");
+  const src = join(dir, "src");
+  assert.equal((await sh("git", ["init", "-q", "--bare", repo])).code, 0);
+  assert.equal((await sh("git", ["init", "-q", src])).code, 0);
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+  await sh(
+    "bash",
+    [
+      "-c",
+      `echo hello > file.txt && git add . && git commit -qm x && git push -q ${JSON.stringify(repo)} HEAD:refs/heads/main`,
+    ],
+    { cwd: src, env: gitEnv },
+  );
+  assert.equal((await sh("git", ["-C", repo, "update-server-info"])).code, 0);
+  assert.equal((await sh("git", ["-C", repo, "symbolic-ref", "HEAD", "refs/heads/main"])).code, 0);
+  const target = dumbGitTarget(repo);
+  const targetPort = await listen(target);
+  const front = frontProxy(authzPort, targetPort);
+  const frontPort = await listen(front);
+  const token = await mintCapabilityToken(
+    {
+      actorId: "U_git",
+      scopeId: scopeId("personal", "U_git"),
+      aud: EGRESS_PROXY_AUD,
+      exp: Date.now() + 60_000,
+      egress: { allowedHosts: [], deniedHosts: [] },
+    },
+    SECRET,
+  );
+  return { authz, target, front, frontPort, token, dir };
+}
+
+test("challenge-based proxy auth (git anyauth wire sequence): 407 + Proxy-Authenticate, then Basic succeeds", async () => {
+  const b = await boot();
+  try {
+    const get = (headers: Record<string, string>) =>
+      new Promise<{ status: number; challenge?: string }>((resolve, reject) => {
+        const r = request(
+          {
+            port: b.frontPort,
+            host: "127.0.0.1",
+            path: "http://gitrepo.test:80/repo.git/HEAD",
+            headers: { host: "gitrepo.test", ...headers },
+          },
+          (res) => {
+            res.resume();
+            resolve({
+              status: res.statusCode ?? 0,
+              challenge: res.headers["proxy-authenticate"] as string | undefined,
+            });
+          },
+        );
+        r.on("error", reject);
+        r.end();
+      });
+    // 1. No credential yet — exactly what git anyauth sends first. Must be challenged, not 403'd.
+    const first = await get({});
+    assert.equal(first.status, 407);
+    assert.equal(first.challenge, 'Basic realm="egress"');
+    // 2. Retry with Basic, as libcurl does after the challenge.
+    const basic = Buffer.from(`x:${b.token}`).toString("base64");
+    const second = await get({ "proxy-authorization": `Basic ${basic}` });
+    assert.equal(second.status, 200);
+  } finally {
+    await close(b.front);
+    await close(b.target);
+    await close(b.authz);
+  }
+});
+
+test("git clone through the authz-gated proxy with forceThroughProxyEnv succeeds", async (t) => {
+  if ((await sh("git", ["--version"])).code !== 0) return t.skip("git unavailable");
+  const b = await boot();
+  try {
+    const dest = join(b.dir, "clone");
+    const proxyEnv = forceThroughProxyEnv(`http://127.0.0.1:${b.frontPort}`, b.token);
+    // Sanity: the env we hand sandboxes must force preemptive Basic for git.
+    assert.equal(proxyEnv.GIT_HTTP_PROXY_AUTHMETHOD, "basic");
+    const res = await sh("git", ["clone", "-q", "http://gitrepo.test/repo.git", dest], {
+      env: { ...process.env, ...proxyEnv, GIT_TERMINAL_PROMPT: "0" },
+    });
+    assert.equal(res.code, 0, `git clone failed: ${res.out}`);
+    assert.equal(readFileSync(join(dest, "file.txt"), "utf8").trim(), "hello");
+  } finally {
+    await close(b.front);
+    await close(b.target);
+    await close(b.authz);
+  }
+});


### PR DESCRIPTION
## Symptom
`git clone` through the forced egress proxy fails with `CONNECT tunnel failed, response 403`, while `curl` to the same host through the same proxy returns 200.

## Root cause (live-reproduced against the prod proxy)
The egress stack answers an **unauthenticated CONNECT with a bare 403 and no `Proxy-Authenticate` challenge** (Envoy's Lua flattens every authz non-200 into 403; the authz service never returns 407).

- `curl` works because when credentials are in the proxy URL it sends `Proxy-Authorization: Basic …` **preemptively**.
- `git`'s default `http.proxyAuthMethod` is `anyauth`, which on many libcurl builds **waits for a 407 + `Proxy-Authenticate` challenge** before sending the credential. It never gets one, so the tunnel dies with exactly the reported error.

Repro against the deployed proxy (from a sandbox with a valid per-turn token in `$HTTPS_PROXY`):
```
$ curl https://api.github.com/zen            # preemptive Basic
200
$ curl --proxy-anyauth https://api.github.com/zen   # challenge-based, like git
curl: (56) CONNECT tunnel failed, response 403
```
Which client vintage bites depends on git/libcurl (newer libcurl sends Basic preemptively even under anyauth — git 2.43/libcurl 8.5 works; older ones don't), which is why this looks like a regression that follows sandbox image changes. An **expired per-turn token** also produced an undiagnosable 403 before this change.

## Fix
1. **authz** (`src/egress-authz-main.ts`): a request with **no verifiable credential** is answered `407` + `Proxy-Authenticate: Basic realm="egress"` — an authentication failure, not a policy verdict. Policy-denied hosts and always-blocked destinations (metadata/link-local/loopback) stay hard 403. Expired/garbage tokens now surface as 407 too, so a stale token is distinguishable from a policy denial.
2. **Envoy data plane** (`deploy/egress-proxy/envoy.yaml`): propagate the 407 challenge instead of flattening it to 403.
3. **Sandbox env** (`src/sandbox/sandbox-env.ts`): `forceThroughProxyEnv` now also sets `GIT_HTTP_PROXY_AUTHMETHOD=basic`, so git sends Basic preemptively regardless of libcurl vintage (and saves the challenge round-trip). Added to `DROPPED_PROXY_ENV` so process sessions re-export it consistently.

Nothing tunnels that didn't before: the 407 carries no upstream, it only invites the client to present its credential.

## Tests
- `test/egress-authz.test.ts`: no-token → 407 + challenge header; wrong-secret/wrong-aud/expired → 407; metadata/link-local/loopback/policy denials remain 403; tokenless=open unchanged.
- `test/git-through-egress-proxy.test.ts` (new): (a) the exact anyauth wire sequence — unauthenticated request must get 407 + `Proxy-Authenticate`, Basic retry with a real minted capability token must get 200 — through a front proxy wired to the real authz server the way the Envoy Lua is; (b) a **real `git clone`** through that authz-gated proxy using exactly the env `forceThroughProxyEnv` hands sandboxes.

`oxlint`, `tsc`, `prettier` clean; egress-authz suite 23/23.

## Deploy note
The Envoy config change requires redeploying the `qm-egress-proxy` / `qm-egress-proxy-pub` Fly apps; the authz change rides along (same image).

_Draft from the session-debug fork sweep (fork 1); do not merge without review._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708560&installation_model_id=19911&pr_number=1102&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1102&signature=87b3542e8464e22c9a6edf9580cd76bcea3a0fa6f853f7ac9cdeefdad8fe7508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->