### PR TITLE
web-ui: iOS composer focus no longer scrolls the chat to the top

### DIFF
--- a/plugins/web-ui/package-lock.json
+++ b/plugins/web-ui/package-lock.json
@@ -664,7 +664,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -713,7 +712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1335,7 +1333,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
       "integrity": "sha512-u300euLgCsDDlb8o2Wbz+55eSJga5X2vB58s9XBuFIr2Bi3iI+GMR7t/NYo/O6Vr6obXShXgYjR3SRUJVgo+kQ==",
-      "peer": true,
       "dependencies": {
         "@preact/signals-core": "^1.12.1",
         "class-variance-authority": "^0.7.1",
@@ -2955,7 +2952,6 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
       "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -3193,7 +3189,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3454,7 +3449,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -3835,7 +3829,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/web-ui/src/viewport.ts
+++ b/plugins/web-ui/src/viewport.ts
@@ -20,31 +20,103 @@ export function onPhoneChange(fn: (phone: boolean) => void): () => void {
   return () => listeners.delete(fn);
 }
 
+// How long after a composer focus / keyboard transition we keep re-asserting the wanted state.
+// iOS fires focus-reveal scrolls, visualViewport resizes and pans in device-dependent order,
+// sometimes without any event we can hook — a short rAF settle loop self-heals whatever order
+// they land in.
+const SETTLE_MS = 900;
+const NEAR_BOTTOM_PX = 160;
+const KBD_MIN_PX = 120;
+
 export function trackVisualViewport(): void {
   const vv = window.visualViewport;
   if (!vv) return;
   let wasOpen = false;
+
+  // Chat anchors are captured when the composer is focused — BEFORE the keyboard opens and
+  // Safari's focus-reveal scrolling mangles scroll positions. Capturing at the kbd-open
+  // transition (as before) is too late: by then the browser may already have scrolled
+  // .chat-scroll, so "near bottom" read false and the chat was left wherever Safari dumped it
+  // (often the very top, with the composer pinned at the top of the screen).
+  type Anchor = { el: HTMLElement; pinBottom: boolean; top: number };
+  let anchors: Anchor[] = [];
+  let settleUntil = 0;
+  let settleRaf = 0;
+
+  const captureAnchors = () => {
+    anchors = [...document.querySelectorAll<HTMLElement>(".chat-scroll")].map((el) => ({
+      el,
+      pinBottom: el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX,
+      top: el.scrollTop,
+    }));
+  };
+
+  const restoreAnchors = () => {
+    for (const a of anchors) {
+      if (!a.el.isConnected) continue;
+      if (a.pinBottom) {
+        const bottom = a.el.scrollHeight - a.el.clientHeight;
+        if (a.el.scrollTop < bottom - 1) a.el.scrollTop = a.el.scrollHeight;
+      } else if (Math.abs(a.el.scrollTop - a.top) > 1) {
+        a.el.scrollTop = a.top;
+      }
+    }
+  };
+
   const apply = () => {
     const h = Math.round(vv.height);
     document.documentElement.style.setProperty("--vvh", `${h}px`);
 
-    const open = window.innerHeight - h > 120;
+    const open = window.innerHeight - h > KBD_MIN_PX;
     document.documentElement.classList.toggle("kbd-open", open);
     if (open) {
+      // Undo the browser's focus-reveal scroll of the layout viewport; --vv-top compensates
+      // for pure visual-viewport pans that window.scrollTo cannot touch.
       if (window.scrollY !== 0) window.scrollTo(0, 0);
       document.documentElement.style.setProperty("--vv-top", `${Math.round(vv.offsetTop)}px`);
     } else {
       document.documentElement.style.setProperty("--vv-top", "0px");
     }
-    if (open === wasOpen) return;
-    wasOpen = open;
-    if (!open) return;
-
-    for (const el of document.querySelectorAll<HTMLElement>(".chat-scroll")) {
-      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
-      if (nearBottom) el.scrollTop = el.scrollHeight;
+    if (open !== wasOpen) {
+      wasOpen = open;
+      if (open && !anchors.length) captureAnchors();
+      if (!open) anchors = [];
+      startSettle();
     }
+    if (open && Date.now() < settleUntil) restoreAnchors();
   };
+
+  const raf = (cb: () => void): number =>
+    typeof window.requestAnimationFrame === "function"
+      ? window.requestAnimationFrame(cb)
+      : (window.setTimeout(cb, 16) as unknown as number);
+  const settleTick = () => {
+    apply();
+    if (Date.now() < settleUntil) settleRaf = raf(settleTick);
+    else settleRaf = 0;
+  };
+  const startSettle = () => {
+    settleUntil = Date.now() + SETTLE_MS;
+    if (!settleRaf) settleRaf = raf(settleTick);
+  };
+
+  // The user's own touch outranks our enforcement: stop re-pinning the moment they interact.
+  document.addEventListener(
+    "touchstart",
+    () => {
+      settleUntil = 0;
+    },
+    { passive: true },
+  );
+
+  document.addEventListener("focusin", (e) => {
+    if (!isTouch()) return;
+    const target = e.target as HTMLElement | null;
+    if (!target?.closest(".composer-wrap")) return;
+    captureAnchors();
+    startSettle();
+  });
+
   vv.addEventListener("resize", apply);
   vv.addEventListener("scroll", apply);
   window.addEventListener("scroll", apply, { passive: true });

--- a/plugins/web-ui/test/viewport.test.ts
+++ b/plugins/web-ui/test/viewport.test.ts
@@ -7,9 +7,13 @@ class FakeVisualViewport extends EventTarget {
   offsetTop = 0;
 }
 
-const dom = new JSDOM('<div class="chat-scroll"></div>', { url: "https://example.test/" });
+const dom = new JSDOM(
+  '<div class="chat-scroll"></div><form class="composer-wrap"><textarea class="composer-input"></textarea></form>',
+  { url: "https://example.test/" },
+);
 const vv = new FakeVisualViewport();
 let scrollCalls = 0;
+const rafQueue: Array<() => void> = [];
 Object.defineProperties(dom.window, {
   innerHeight: { value: 659, configurable: true },
   scrollY: { get: () => (vv.offsetTop ? 309 : 0), configurable: true },
@@ -24,38 +28,98 @@ Object.defineProperties(dom.window, {
     },
     configurable: true,
   },
+  requestAnimationFrame: {
+    value: (cb: () => void) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    },
+    configurable: true,
+  },
 });
 Object.assign(globalThis, { document: dom.window.document, window: dom.window });
 
+const flushFrames = (n = 1): void => {
+  for (let i = 0; i < n; i++) {
+    const batch = rafQueue.splice(0);
+    for (const cb of batch) cb();
+  }
+};
+
 const transcript = dom.window.document.querySelector<HTMLElement>(".chat-scroll")!;
 Object.defineProperties(transcript, {
-  scrollHeight: { value: 900 },
-  clientHeight: { value: 500 },
-  scrollTop: { value: 300, writable: true },
+  scrollHeight: { value: 900, configurable: true },
+  clientHeight: { value: 500, configurable: true },
+  scrollTop: { value: 300, writable: true, configurable: true },
 });
+const composerInput = dom.window.document.querySelector<HTMLElement>(".composer-input")!;
 
 const { trackVisualViewport } = await import("../src/viewport.ts");
 trackVisualViewport();
 
-test("an iOS keyboard offset anchors the app to the visual viewport on every viewport event", () => {
+const openKeyboard = (): void => {
   vv.height = 350;
   vv.offsetTop = 309;
   vv.dispatchEvent(new Event("resize"));
+};
+const closeKeyboard = (): void => {
+  vv.height = 659;
+  vv.offsetTop = 0;
+  vv.dispatchEvent(new Event("resize"));
+  flushFrames(80);
+};
+
+test("an iOS keyboard offset anchors the app to the visual viewport on every viewport event", () => {
+  transcript.scrollTop = 300; // 900 - 300 - 500 = 100 < 160 → near bottom
+  openKeyboard();
 
   assert.equal(dom.window.document.documentElement.style.getPropertyValue("--vvh"), "350px");
   assert.equal(dom.window.document.documentElement.style.getPropertyValue("--vv-top"), "309px");
   assert.equal(dom.window.document.documentElement.classList.contains("kbd-open"), true);
-  assert.equal(scrollCalls, 1);
+  assert.ok(scrollCalls >= 1);
   assert.equal(transcript.scrollTop, 900);
 
   vv.offsetTop = 221;
   vv.dispatchEvent(new Event("scroll"));
   assert.equal(dom.window.document.documentElement.style.getPropertyValue("--vv-top"), "221px");
-  assert.equal(scrollCalls, 2);
 
-  vv.height = 659;
-  vv.offsetTop = 0;
-  vv.dispatchEvent(new Event("resize"));
+  closeKeyboard();
   assert.equal(dom.window.document.documentElement.style.getPropertyValue("--vv-top"), "0px");
   assert.equal(dom.window.document.documentElement.classList.contains("kbd-open"), false);
+});
+
+test("focusing the composer captures the chat anchor BEFORE Safari's reveal scroll mangles it", () => {
+  // The regression: user taps the composer while reading near the bottom; Safari scrolls the
+  // chat container (and the window) before the keyboard resize lands. The old code sampled
+  // "near bottom" at the kbd-open transition — too late — and left the chat wherever Safari
+  // dumped it. The anchor must be captured at focusin.
+  transcript.scrollTop = 300; // near bottom at focus time
+  composerInput.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
+  transcript.scrollTop = 0; // Safari's focus-reveal scroll mangles the container pre-resize
+  openKeyboard();
+  flushFrames(3);
+  assert.equal(transcript.scrollTop, 900, "chat re-pinned to bottom from the focus-time anchor");
+  closeKeyboard();
+});
+
+test("a reader far from the bottom gets their scroll position back, not a jump", () => {
+  transcript.scrollTop = 40; // reading history: 900 - 40 - 500 = 360 ≥ 160 → not near bottom
+  composerInput.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
+  transcript.scrollTop = 700; // browser mangles it
+  openKeyboard();
+  flushFrames(3);
+  assert.equal(transcript.scrollTop, 40, "reading position restored after keyboard open");
+  closeKeyboard();
+});
+
+test("the user's own touch ends enforcement", () => {
+  transcript.scrollTop = 300;
+  composerInput.dispatchEvent(new dom.window.Event("focusin", { bubbles: true }));
+  openKeyboard();
+  flushFrames(2);
+  assert.equal(transcript.scrollTop, 900);
+  dom.window.document.dispatchEvent(new dom.window.Event("touchstart"));
+  transcript.scrollTop = 123; // user scrolls somewhere
+  flushFrames(5);
+  assert.equal(transcript.scrollTop, 123, "no re-pin after the user touches the page");
+  closeKeyboard();
 });


### PR DESCRIPTION
## Symptom
On iOS, tapping the composer can scroll the page so the composer sits at the very top of the screen and the chat is scrolled away (screenshot in the session-debug brief).

## Root cause
Two defects in `trackVisualViewport` (plugins/web-ui/src/viewport.ts):

1. **The near-bottom check ran too late.** The restore-to-bottom of `.chat-scroll` only ran at the kbd-open *transition*, sampling `scrollTop` *after* Safari's focus-reveal scrolling had already moved both the window and the chat container. The check usually read false → no restore → the chat stayed wherever Safari dumped it.
2. **Single-shot handling of a multi-event fight.** iOS fires focus-reveal scrolls, `visualViewport` resizes and pans in device-dependent order — sometimes panning the visual viewport without any event we listen to, and `window.scrollTo(0,0)` cannot undo a pure visual-viewport pan. A stale `--vv-top`/`--vvh`/window-scroll combination (layout translated while the viewport isn't panned, or vice versa) renders exactly the reported state: composer strip at the top, blank page below, chat off-screen — and nothing ever self-heals.

## Fix
- Capture the chat anchor **at composer `focusin`** — before the keyboard opens: either *pinned to bottom* (was within 160px) or *the reader's exact scroll position*.
- Run a short **rAF settle loop (~900 ms)** after focus/keyboard transitions that re-asserts the anchor, `window.scrollTo(0,0)`, and fresh `--vvh`/`--vv-top` every frame until iOS stops fighting — covering the event orders that fire nothing we can hook.
- The user's own `touchstart` ends enforcement immediately, so we never fight a real scroll gesture.
- Readers **not** near the bottom now get their position restored (previously they were left wherever Safari's reveal scroll dumped them).

## Tests
`plugins/web-ui/test/viewport.test.ts` (jsdom + fake `visualViewport`, deterministic rAF queue):
- existing anchor-on-every-event test adapted;
- **regression test**: anchor captured at focusin survives Safari mangling `scrollTop` before the resize lands → chat re-pinned to bottom;
- reader far from bottom gets their position back;
- touch cancels enforcement.

Typecheck (app/server/test tsconfigs) and web-ui suite pass: 1023/1023.

## Manual iOS repro notes (no jsdom for real viewport races)
1. iPhone Safari, any chat with enough history to scroll; scroll to the bottom.
2. Tap the composer. Before: page occasionally ends with composer pinned at top / chat scrolled to top (more likely with the keyboard already dismissed-and-retapped quickly, or with autofill bar present). After: chat stays pinned above the keyboard.
3. Scroll up ~2 screens, tap composer: reading position must be preserved (new behavior).
4. While the settle window is active, flick the chat — enforcement must yield instantly.

_Draft from the session-debug fork sweep (fork 3); do not merge without review._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791709334&installation_model_id=19911&pr_number=1103&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1103&signature=5eadef9f3a491e6f703438992a0d2cbf56630d499f9b843dd3f5fc09952d3b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->