### PR TITLE
web-ui: render mid-turn surface posts when they happen (fixes posted-message-never-appears)

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -444,12 +444,14 @@ async function drainWebDeliveries(): Promise<void> {
     const now = Date.now();
     for (const d of pending) {
       const target = d.destination?.target ?? "";
-      const conns = deliveryClients.get(ownerOfWebThread(target) ?? "");
-      if (conns && conns.size) {
+      let notified = false;
+      for (const user of deliveryTargets(target)) {
+        const conns = deliveryClients.get(user);
+        if (!conns?.size) continue;
+        notified = true;
         for (const res of conns) sseEvent(res, "delivery", { threadRef: target });
-      } else if (now - (d.createdAt ?? 0) < WEB_DELIVERY_GIVEUP_MS) {
-        continue;
       }
+      if (!notified && now - (d.createdAt ?? 0) < WEB_DELIVERY_GIVEUP_MS) continue;
       await coreFetch("POST", `/v1/deliveries/${encodeURIComponent(d.id)}/ack`).catch(() => {});
     }
   } catch {
@@ -468,12 +470,34 @@ interface SessionStateFrame {
   [k: string]: unknown;
 }
 
+// threadRef → last-seen participants, fed by the core session-state feed. Delivery records do
+// not name participants, so without this a mid-turn post into a SHARED web thread (a project
+// channel) only ever nudged the thread CREATOR's connections — every other participant's view
+// went stale until a manual reload, and the delivery was acked away after 60s regardless.
+const THREAD_PARTICIPANTS_MAX = 2_000;
+const threadParticipants = new Map<string, string[]>();
+function rememberParticipants(threadRef: string, participants: string[]): void {
+  if (threadParticipants.has(threadRef)) threadParticipants.delete(threadRef);
+  threadParticipants.set(threadRef, participants);
+  if (threadParticipants.size > THREAD_PARTICIPANTS_MAX)
+    threadParticipants.delete(threadParticipants.keys().next().value as string);
+}
+
+function deliveryTargets(threadRef: string): Set<string> {
+  const targets = new Set<string>(threadParticipants.get(threadRef) ?? []);
+  const owner = ownerOfWebThread(threadRef);
+  if (owner) targets.add(owner);
+  return targets;
+}
+
 function forwardSessionState(frame: SessionStateFrame): void {
   const threadRef = typeof frame.threadRef === "string" ? frame.threadRef : "";
   if (!threadRef) return;
-  const targets = new Set<string>(
-    Array.isArray(frame.participants) ? frame.participants.filter((p): p is string => typeof p === "string") : [],
-  );
+  const participants = Array.isArray(frame.participants)
+    ? frame.participants.filter((p): p is string => typeof p === "string")
+    : [];
+  if (participants.length) rememberParticipants(threadRef, participants);
+  const targets = new Set<string>(participants);
   if (targets.size === 0) {
     const owner = ownerOfWebThread(threadRef);
     if (owner) targets.add(owner);

--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -606,7 +606,9 @@ export function createChatSurface(
     const agent = chatState.agent;
     if (!agent || agent.state.isStreaming || !chatState.threadRef || !chatState.normalStreamFn || !chatState.onWork)
       return;
-    void resumeTrackedRun(agent, chatState.threadRef, chatState.normalStreamFn, chatState.onWork);
+    void resumeTrackedRun(agent, chatState.threadRef, chatState.normalStreamFn, chatState.onWork, {
+      refetchWhenSettled: true,
+    });
   }
 
   function syncLocation(): void {
@@ -794,6 +796,7 @@ export function createChatSurface(
     threadRef: string,
     normalStreamFn: Agent["streamFn"],
     onWork: (work: WorkBlock) => void,
+    opts: { refetchWhenSettled?: boolean } = {},
   ): Promise<boolean> {
     let activeRun: Awaited<ReturnType<typeof activeRunForThread>>;
     try {
@@ -803,7 +806,20 @@ export function createChatSurface(
     }
     if (agent === chatState.agent && threadRef === chatState.threadRef)
       ctx.composer.setQueuedRuns(threadRef, activeRun.queued);
-    if (!activeRun.runId || !activeRun.run || runIsTerminal(activeRun.run)) return false;
+    if (!activeRun.runId || !activeRun.run || runIsTerminal(activeRun.run)) {
+      // No live run to attach. A turn may have ENDED while this tab was detached (a locked
+      // phone kills the SSE): its agent_end refetch never ran and its delivery nudges were
+      // dropped or acked while nobody listened — mid-turn posts would stay invisible until a
+      // full reload. Pull the transcript tail now so the view catches up.
+      if (
+        opts.refetchWhenSettled &&
+        agent === chatState.agent &&
+        threadRef === chatState.threadRef &&
+        !agent.state.isStreaming
+      )
+        void refreshTranscriptFromEntries(agent);
+      return false;
+    }
     return resumeRun(agent, threadRef, normalStreamFn, onWork, activeRun.runId, activeRun.run);
   }
 
@@ -2264,6 +2280,9 @@ export function createChatSurface(
         flushSeg();
         const text = ((it.activity.payload as { text?: string } | null)?.text ?? "").trim();
         if (text) parts.push(html`<div class="work-said">${markdown(text)}</div>`);
+      } else if (it.kind === "posted") {
+        flushSeg();
+        parts.push(html`<div class="work-posted">${markdown(it.text)}</div>`);
       } else {
         seg.push(it);
       }
@@ -2331,6 +2350,7 @@ export function createChatSurface(
     const stale = work.stale === true;
     if (item.kind === "thinking") return thinkingRow(item.activity);
     if (item.kind === "text") return messageRow(item.activity);
+    if (item.kind === "posted") return html`<div class="work-posted">${markdown(item.text)}</div>`;
     if (item.kind === "approval") return approvalMarker(item.approval);
     return toolRow(item.row, work, status, stale);
   }

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2035,6 +2035,15 @@ a.chat-row-open {
   line-height: 1.6;
   margin: 10px 0;
 }
+.work-posted {
+  color: var(--foreground);
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 10px 0;
+  padding: 6px 10px;
+  border-left: 2px solid var(--primary);
+  border-radius: 4px;
+}
 .work-fold {
   margin: 2px 0;
 }

--- a/plugins/web-ui/src/timeline.ts
+++ b/plugins/web-ui/src/timeline.ts
@@ -41,6 +41,7 @@ export type TimelineItem =
   | { kind: "thinking"; activity: ToolActivity }
   | { kind: "text"; activity: ToolActivity }
   | { kind: "tool"; row: ToolRowModel }
+  | { kind: "posted"; text: string; row: ToolRowModel }
   | { kind: "approval"; approval: PendingApproval };
 
 function isTerminalWorkStatus(status: WorkBlock["status"]): boolean {
@@ -113,6 +114,19 @@ function orphanCallSignature(row: ToolRowModel): string | null {
   ].join("");
 }
 
+// A successful surface post IS the assistant's message — mid-turn it must read as one, not as a
+// tool chip. The transcript conversion (entriesToMessages) promotes settled posts to real message
+// bubbles, but the LIVE work block renders raw run activity: without this, a mid-turn post shows
+// only its tool row + "[sent]" until the turn ends (and never, if the tab misses the turn's end).
+function postedRowText(row: ToolRowModel): string | null {
+  const call = (row.call?.payload ?? {}) as ToolPayload & { text?: unknown };
+  if (call.action !== "post" || typeof call.text !== "string" || !call.text.trim()) return null;
+  if (!row.result) return null;
+  const result = (row.result.payload ?? {}) as ToolPayload & { ok?: unknown };
+  if (result.isError === true || result.ok === false || result.error || result.blocked) return null;
+  return call.text;
+}
+
 const timelineMemo = new WeakMap<
   WorkBlock,
   {
@@ -172,7 +186,12 @@ function buildTimelineUncached(work: WorkBlock): TimelineItem[] {
       open = null;
     }
   }
-  const collapsed = collapseToolItems(items, work.status);
+  const promoted = items.map((it): TimelineItem => {
+    if (it.kind !== "tool") return it;
+    const text = postedRowText(it.row);
+    return text === null ? it : { kind: "posted", text, row: it.row };
+  });
+  const collapsed = collapseToolItems(promoted, work.status);
   for (const item of collapsed) {
     if (item.kind !== "tool") continue;
     const cmd = (item.row.call?.payload as ToolPayload | undefined)?.command;

--- a/plugins/web-ui/test/timeline.test.ts
+++ b/plugins/web-ui/test/timeline.test.ts
@@ -369,3 +369,47 @@ test("unscreened execution retains its warning and failure status without parsin
     "failed",
   );
 });
+
+test("a successful surface post renders as the message it is, not a tool chip", () => {
+  const work: WorkBlock = {
+    status: "working",
+    activity: [
+      act(1, "tool_call", { tool: "web", action: "post", text: "Here's the summary you asked for.", callId: "c1" }),
+      act(2, "tool_result", { tool: "web", action: "post", ok: true, callId: "c1", result: "[sent]" }),
+    ],
+  };
+  const items = buildTimeline(work);
+  assert.equal(items.length, 1);
+  assert.ok(items[0].kind === "posted", "mid-turn post is promoted to a posted item");
+  assert.equal(items[0].kind === "posted" && items[0].text, "Here's the summary you asked for.");
+});
+
+test("a failed or unresolved post stays a tool row", () => {
+  const failed: WorkBlock = {
+    status: "complete",
+    activity: [
+      act(1, "tool_call", { tool: "web", action: "post", text: "hello", callId: "c1" }),
+      act(2, "tool_result", {
+        tool: "web",
+        action: "post",
+        ok: false,
+        callId: "c1",
+        result: "[not sent] rate limited",
+      }),
+    ],
+  };
+  assert.deepEqual(
+    buildTimeline(failed).map((i) => i.kind),
+    ["tool"],
+    "failed post is visible as a tool row so the failure is inspectable",
+  );
+  const inflight: WorkBlock = {
+    status: "working",
+    activity: [act(1, "tool_call", { tool: "web", action: "post", text: "hello", callId: "c1" })],
+  };
+  assert.deepEqual(
+    buildTimeline(inflight).map((i) => i.kind),
+    ["tool"],
+    "a post without its result yet renders as a running tool row",
+  );
+});


### PR DESCRIPTION
## Symptom
The agent's `post` tool call is visible in the transcript with an `[sent]` result, but the posted message never appears in the web UI (session a46f15dd, seq 51/52, ~11:32 PM PT 9/10, a shared web-project thread, viewed on mobile).

## Root cause — three cooperating gaps
1. **Mid-turn posts render as tool chips, not messages.** `entriesToMessages` promotes settled posts to message bubbles, but the LIVE work block renders raw run activity (`buildTimeline`), which had no notion of a post. During a long web turn the posted text exists only as a chip + `[sent]` until the turn ends.
2. **The turn-end refetch is easy to miss on mobile.** The bubble only materializes via `refreshTranscriptFromEntries` on `agent_end`. A locked/backgrounded phone kills the SSE, so `agent_end` is never observed. On unlock, `resumeIfIdle → resumeTrackedRun` finds the run already terminal and returned `false` **without refetching** — the view stays stale until a full page reload. Delivery nudges can't save it: `onDelivery` drops nudges while `isStreaming`, and the server acks un-notified deliveries away after 60s.
3. **Shared web threads only nudged the creator.** `drainWebDeliveries` resolved targets via `ownerOfWebThread(target)` — the thread creator — so in a web-project (group) thread no other participant's tab ever received a delivery nudge.

## Fix
- **timeline.ts**: a successful post (`action: "post"`, result ok) is promoted to a `posted` timeline item; chat.ts renders it as the message it is (styled `.work-posted`, markdown). Failed/unresolved posts stay inspectable tool rows.
- **chat.ts**: `resumeTrackedRun` (from the idle-resume path only, not thread-open) refetches the transcript tail when there is no live run to attach, so a turn that ended while the tab was detached catches up on next foreground.
- **server/index.ts**: delivery nudges fan out to the thread's **participants**, cached from the core session-state feed (which already carries `participants`), falling back to the creator; a delivery is acked once anyone was notified, or after the existing 60s give-up.

## Tests
- `timeline.test.ts`: successful post → `posted` item carrying the text; failed and still-running posts remain tool rows.
- Full web-ui typecheck (app/server/test) and suite: **1023/1023**.

## Notes for review
- The `posted` style is intentionally subtle (left accent) — at turn end the entry-based conversion replaces the live view with the real bubble.
- The participants cache is bounded (2k threads, insertion-order eviction) and adds no core calls.

_Draft from the session-debug fork sweep (fork 2); do not merge without review._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791709882&installation_model_id=19911&pr_number=1104&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1104&signature=aa6e68de575178e0e22d467d37ae47e5b1d231b629498730b0210ae7b299a9db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->