### PR TITLE
Round Modal exec timeouts up to whole seconds

### DIFF
--- a/src/sandbox/modal-client.ts
+++ b/src/sandbox/modal-client.ts
@@ -139,8 +139,12 @@ export function createSdkModalClient(opts: SdkModalClientOptions): ModalClient {
     sandboxId: sbx.sandboxId,
     async runCommand(command, runOpts): Promise<ModalCommandResult> {
       const timeoutMs = runOpts?.timeoutMs ?? maxCommandMs;
+      // The Modal SDK only accepts exec timeouts in whole seconds; round up so callers
+      // passing arbitrary millisecond deadlines (e.g. snapshot clocks) never trip its
+      // "timeoutMs must be a multiple of 1000ms" rejection.
+      const execTimeoutMs = Math.ceil((timeoutMs + 30_000) / 1000) * 1000;
       try {
-        const p = await sbx.exec(["sh", "-c", command], { mode: "text", timeoutMs: timeoutMs + 30_000 });
+        const p = await sbx.exec(["sh", "-c", command], { mode: "text", timeoutMs: execTimeoutMs });
         const [stdout, stderr, exitCode] = await Promise.all([p.stdout.readText(), p.stderr.readText(), p.wait()]);
         return { stdout, stderr, exitCode };
       } catch (err) {

--- a/test/native-provider-clients.test.ts
+++ b/test/native-provider-clients.test.ts
@@ -6,6 +6,16 @@ import { createSdkE2bClient } from "../src/sandbox/e2b-client.ts";
 const modalCalls: unknown[][] = [];
 const modalSandbox = {
   sandboxId: "sb-native",
+  async exec(cmd: string[], options: { timeoutMs: number }) {
+    modalCalls.push(["exec", cmd, options]);
+    if (options.timeoutMs % 1000 !== 0)
+      throw new Error(`timeoutMs must be a multiple of 1000ms, got ${options.timeoutMs}`);
+    return {
+      stdout: { readText: async () => "ok" },
+      stderr: { readText: async () => "" },
+      wait: async () => 0,
+    };
+  },
   async snapshotDirectory(path: string, options: unknown) {
     modalCalls.push(["snapshot", path, options]);
     return { imageId: "im-native" };
@@ -64,6 +74,26 @@ test("Modal native directory snapshot uses explicit finite retention and restore
   await session.restoreHome!(snapshot.imageId);
   assert.deepEqual(modalCalls[1], ["mount", "/root", { imageId: "im-native" }]);
   assert.equal(client.lifetimeMs, 24 * 3600_000);
+});
+
+test("Modal exec timeouts are rounded up to whole seconds", async () => {
+  const client = createSdkModalClient({
+    tokenId: "id",
+    tokenSecret: "secret",
+    appName: "test",
+    image: "ubuntu",
+  });
+  const session = await client.create({ name: "test" });
+  modalCalls.length = 0;
+  // Arbitrary remaining-deadline values (e.g. snapshot clocks) are not whole seconds;
+  // the SDK rejects timeouts that are not multiples of 1000ms.
+  const r = await session.runCommand("echo hi", { timeoutMs: 144_216 });
+  assert.equal(r.exitCode, 0);
+  const exec = modalCalls.find((c) => c[0] === "exec")!;
+  const { timeoutMs } = exec[2] as { timeoutMs: number };
+  assert.equal(timeoutMs % 1000, 0);
+  assert.ok(timeoutMs >= 144_216 + 30_000);
+  assert.ok(timeoutMs < 144_216 + 31_000);
 });
 
 test("Modal rejects invalid checkpoint retention", () => {


### PR DESCRIPTION
## Problem
The Modal SDK rejects exec timeouts that are not multiples of 1000 ms. The home-snapshot deadline clock (`home-snapshot.ts` `startClock`) passes arbitrary remaining-deadline values (e.g. `174216`), so snapshot rotation fails with `rotate_snapshot_failed: timeoutMs must be a multiple of 1000ms`. This fired 4x on 2026-09-10 (scope `personal:regan@ycombinator.com`) and has recurred across multiple daily sweep windows.

## Fix
Round the final exec timeout up to the next whole second at the single SDK choke point (`modal-client.ts` `wrap.runCommand`), so every caller is covered without touching call sites.

## Tests
- New regression test: the fake Modal SDK `exec` now rejects non-multiples of 1000 ms, exactly like the real SDK; the test passes an arbitrary 144216 ms deadline and asserts the rounded value. Verified it fails on unpatched `main`.
- `test/native-provider-clients.test.ts` + `test/modal-sandbox.test.ts`: 60/60 pass; `tsc`, `eslint`, `oxlint`, `prettier` clean.

Filed by the daily continuous-improvement sweep (draft — do not merge without review).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791727831&installation_model_id=19911&pr_number=1107&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1107&signature=d7b8ee1e36e8aee108ed3993dbf9cd38e15e94d8596ae189ce82a4e8b62b2f30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->