### PR TITLE
Carry the wrapper's redacted diagnostics on a run that ends without a pull request

### DIFF
--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -87,17 +87,41 @@ export type FactoryWorkEffects = Pick<LoopRunnerEffects, "enumerate" | "work" | 
 interface FactoryRun {
   result: FactoryProcessResult;
   config: FactoryConfig;
+  redact: (text: string) => string;
 }
+
+// Only the wrapper's own diagnostics are worth surfacing; build noise and agent chatter are not.
+const DIAGNOSTIC_LINE = /^\[(?:io-coding-agent(?:-js)?|claude-stderr|claude-exit|converge)\]|^error=|FAIL/;
+const NO_PR_TAIL_LINES = 3;
+const NO_PR_LINE_CHARS = 200;
+
+const redactor =
+  (secrets: string[]) =>
+  (text: string): string =>
+    secrets.filter((secret) => secret !== "").reduce((acc, secret) => acc.split(secret).join("***"), text);
 
 const preflightDetail = (result: Extract<PreflightResult, { ok: false }>): string =>
   result.reason === "missing_tools" ? `missing_tools: ${result.missing.join(", ")}` : result.reason;
 
-const noPrVerdict = (): SuccessVerdict => ({
-  outcome: "continue",
-  reason: "no pull request",
-  checks: [],
-  judged: false,
-});
+// A run that ends without a pull request leaves its only explanation in the wrapper's stdout, which
+// otherwise stays inside the sandbox; the redacted diagnostic tail rides on the item's reason.
+const noPrVerdict = (run?: FactoryRun): SuccessVerdict => {
+  const tail = run
+    ? run
+        .redact(run.result.stdout)
+        .split(/\r?\n/)
+        .filter((line) => DIAGNOSTIC_LINE.test(line))
+        .slice(-NO_PR_TAIL_LINES)
+        .map((line) => line.slice(0, NO_PR_LINE_CHARS))
+        .join(" | ")
+    : "";
+  return {
+    outcome: "continue",
+    reason: tail === "" ? "no pull request" : `no pull request — ${tail}`,
+    checks: [],
+    judged: false,
+  };
+};
 
 const prTarget = (artifacts: CapturedArtifact[], config: FactoryConfig): { ref: ForgeRef; branch: string } | null => {
   const pr = artifacts.find((artifact) => artifact.shipAction === "open_pr");
@@ -229,7 +253,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
       if (result.aborted) throw new Error("factory_run_aborted");
 
       for (const key of runs.keys()) if (key.startsWith(itemPrefix)) runs.delete(key);
-      runs.set(runId, { result, config });
+      runs.set(runId, { result, config, redact: redactor([linearApiKey, githubToken, anthropicApiKey]) });
       return { runId };
     },
 
@@ -245,7 +269,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
         const run = runs.get(runId);
         if (!run) return noPrVerdict();
         const target = prTarget(artifacts, run.config);
-        if (!target) return noPrVerdict();
+        if (!target) return noPrVerdict(run);
         const { githubToken } = await loadFactoryContext(deps);
         return await evaluateFactoryForge({
           fetch: deps.fetch,

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -550,6 +550,22 @@ test("work omits IO_FEEDBACK without guidance, honours repoDir, and numbers the 
   assert.equal(runId, "factory:loop-1:item-1:3");
 });
 
+test("a run with no pull request carries the wrapper's redacted diagnostics in its reason", async () => {
+  const stdout = `npm warn noise\n[io-coding-agent] git configured to reach github.com with IO_GITHUB_TOKEN\n[claude-stderr] token ${GITHUB_TOKEN} rejected\n[io-coding-agent-js] FAIL: normal factory runs require a numeric CODING_AGENT_SESSION_URL\n`;
+  const fake = fakeSandbox({ stdout });
+  const effects = createFactoryLoopEffects(deps({ sandbox: fake.sandbox }));
+
+  const runId = await workedRunId(effects);
+  const verdict = await effects.evaluate({ loop: LOOP, item: ITEM, attempt: 1, runId });
+
+  assert.equal(verdict.outcome, "continue");
+  assert.match(verdict.reason, /^no pull request — /);
+  assert.match(verdict.reason, /FAIL: normal factory runs require a numeric CODING_AGENT_SESSION_URL/);
+  assert.match(verdict.reason, /\[claude-stderr\] token \*\*\* rejected/);
+  assert.equal(verdict.reason.includes(GITHUB_TOKEN), false);
+  assert.equal(verdict.reason.includes("npm warn"), false);
+});
+
 test("factorySessionIdFor is a stable positive integer that differs across runs", () => {
   const a = factorySessionIdFor("factory:loop-1:item-1:1");
   assert.equal(a, factorySessionIdFor("factory:loop-1:item-1:1"));


### PR DESCRIPTION
On the first local end-to-end runs the item read only `no pull request` while the wrapper's real reason (a missing session id, then a root check in `claude`) sat in the sandbox at `/root/.agent-proc/<id>/out`. `noPrVerdict` now appends the last three diagnostic lines from the wrapper's stdout (its own `[io-coding-agent*]`, `[claude-stderr]`, `[converge]`, `error=` and `FAIL` lines only), with the Linear, GitHub, and Anthropic secrets masked. A run with no such lines keeps the plain reason, so the existing assertions hold. Pinned by a new effects test. Targets the integration branch, not `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791737507&installation_model_id=19911&pr_number=1108&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1108&signature=631685c94b9b77d4bed67682f29b6ee9f1a049c51afe80e3347905e23566a33a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->