### PR TITLE
Name all three factory credentials on the admin card

### DIFF
--- a/plugins/admin/public/index.html
+++ b/plugins/admin/public/index.html
@@ -5670,7 +5670,10 @@
                 <section class="card sv-customize setting-row hidden" id="card-factory-config">
                   <div class="head">
                     <h2>Software factory</h2>
-                    <p>Credentials are the service credentials factory-linear and factory-github in the keychain.</p>
+                    <p>
+                      Credentials are the service credentials factory-linear, factory-github, and factory-anthropic in
+                      the keychain.
+                    </p>
                   </div>
                   <div class="body">
                     <label for="factory-forge">forge</label>


### PR DESCRIPTION
The Software factory card said the credentials are `factory-linear` and `factory-github`. Since the sandbox model credential landed, the loop also requires `factory-anthropic`, and a first fire without it fails with a slug the card never mentioned. Copy only. Targets the integration branch, not `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791737744&installation_model_id=19911&pr_number=1110&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1110&signature=443b10a8fe76a28c19f83b1eb169f6e4786003c43e2764410a731746747d5997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->