### PR TITLE
Build the local sandbox image for the docker host's architecture

### DIFF
--- a/scripts/local-sandbox-build.sh
+++ b/scripts/local-sandbox-build.sh
@@ -4,7 +4,9 @@ cd "$(dirname "$0")/.."
 
 BASE_TAG="qm-sandbox-base:dev"
 LOCAL_TAG="${LOCAL_SANDBOX_IMAGE:-qm-sandbox-local:latest}"
-PLATFORM="linux/amd64"
+# Default to the docker host's own architecture: an emulated amd64 image on an arm64 host runs
+# node without its JIT, which makes the sandbox test suite crawl and hang on process tests.
+PLATFORM="${LOCAL_SANDBOX_PLATFORM:-linux/$(docker version --format '{{.Server.Arch}}')}"
 
 FINGERPRINT="$(node --input-type=module -e '
 const { computeSandboxImageFingerprint } = await import("./src/sandbox/local-sandbox.ts");
@@ -15,6 +17,7 @@ console.log(fp);
 
 if [[ -n "${FLY_SANDBOX_APP_NAME:-}" ]] && command -v flyctl >/dev/null 2>&1; then
   BASE_REF="registry.fly.io/${FLY_SANDBOX_APP_NAME}:dev"
+  PLATFORM="linux/amd64"
   echo "==> building ${BASE_REF} from fly/Dockerfile on Fly's remote amd64 builder"
   flyctl deploy --build-only --push --remote-only --image-label dev \
     --app "${FLY_SANDBOX_APP_NAME}" -c fly/fly.toml --dockerfile fly/Dockerfile . --yes

--- a/scripts/local-sandbox-build.sh
+++ b/scripts/local-sandbox-build.sh
@@ -4,9 +4,9 @@ cd "$(dirname "$0")/.."
 
 BASE_TAG="qm-sandbox-base:dev"
 LOCAL_TAG="${LOCAL_SANDBOX_IMAGE:-qm-sandbox-local:latest}"
-# Default to the docker host's own architecture: an emulated amd64 image on an arm64 host runs
-# node without its JIT, which makes the sandbox test suite crawl and hang on process tests.
-PLATFORM="${LOCAL_SANDBOX_PLATFORM:-linux/$(docker version --format '{{.Server.Arch}}')}"
+# Match the docker host arch: emulated amd64 on arm64 runs node without its JIT and hangs the sandbox tests.
+HOST_ARCH="$(docker version --format '{{.Server.Arch}}')"
+PLATFORM="${LOCAL_SANDBOX_PLATFORM:-linux/${HOST_ARCH}}"
 
 FINGERPRINT="$(node --input-type=module -e '
 const { computeSandboxImageFingerprint } = await import("./src/sandbox/local-sandbox.ts");


### PR DESCRIPTION
## Why

`scripts/local-sandbox-build.sh` pinned `linux/amd64`. On an arm64 host (OrbStack on Apple silicon) the sandbox image ran under emulation, and the emulator starts every node process with `--no-opt`, so V8 runs without its JIT. Inside the factory sandbox the full `npm run test:all` took hours (1146 tests in 5 hours) and hung on `test/deploy-drain.test.ts` and `test/dev-supervisor-child.test.ts`. The Verify stage never finished.

## What

- Default `PLATFORM` to `linux/<docker server arch>`.
- Keep the Fly remote builder path on `linux/amd64`, because that builder is amd64 only.
- `LOCAL_SANDBOX_PLATFORM` overrides the default.

## Proof

Built on an arm64 host: `docker inspect qm-sandbox-local:latest` reports `arm64`, `node` inside the container starts with a clean command line, and `claude 2.1.210`, `gh 2.93.0`, and `aws-cli 2.34.54` all run. `fly/Dockerfile` already handles `TARGETARCH` for gh and the AWS CLI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791740450&installation_model_id=19911&pr_number=1113&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1113&signature=83c2c4af01356a3abfc8202b2143b374c33b11ed33b207098b4bc8bad2fac4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->