### PR TITLE
QM-35: Post factory run updates to the configured Slack channel

### DIFF
--- a/src/api/routes/admin-resources.ts
+++ b/src/api/routes/admin-resources.ts
@@ -198,7 +198,8 @@ function parseFactoryConfig(body: unknown): { value: FactoryConfig } | { error: 
     const v = raw[key];
     if (v === undefined) continue;
     if (typeof v !== "string") return { error: `factory-config: ${key} must be a string` };
-    value[key] = v;
+    if (v.trim() === "") continue;
+    value[key] = v.trim();
   }
   for (const key of FACTORY_BOOLEANS) {
     const v = raw[key];

--- a/src/loops/factory/credentials.ts
+++ b/src/loops/factory/credentials.ts
@@ -5,9 +5,11 @@ export const FACTORY_LINEAR_SLUG = "factory-linear";
 export const FACTORY_GITHUB_SLUG = "factory-github";
 // The wrapper runs `claude -p` inside the sandbox, so the model key must travel with the other two.
 export const FACTORY_ANTHROPIC_SLUG = "factory-anthropic";
+export const FACTORY_SLACK_SLUG = "factory-slack";
 
 export type FactoryCredentials =
-  { ok: true; linearApiKey: string; githubToken: string; anthropicApiKey: string } | { ok: false; missing: string[] };
+  | { ok: true; linearApiKey: string; githubToken: string; anthropicApiKey: string; slackBotToken?: string }
+  | { ok: false; missing: string[] };
 
 function usableSecret(rec: DecryptedServiceCredential | null): string | null {
   if (!rec || !rec.enabled) return null;
@@ -18,21 +20,36 @@ function usableSecret(rec: DecryptedServiceCredential | null): string | null {
 export async function readFactoryCredentials(
   reader: ServiceCredentialReader,
   orgScopeId: ScopeId,
+  opts: { slack: boolean },
 ): Promise<FactoryCredentials> {
-  const [linearRec, githubRec, anthropicRec] = await Promise.all([
+  const [linearRec, githubRec, anthropicRec, slackRec] = await Promise.all([
     reader.getServiceCredentialSecret(orgScopeId, FACTORY_LINEAR_SLUG),
     reader.getServiceCredentialSecret(orgScopeId, FACTORY_GITHUB_SLUG),
     reader.getServiceCredentialSecret(orgScopeId, FACTORY_ANTHROPIC_SLUG),
+    reader.getServiceCredentialSecret(orgScopeId, FACTORY_SLACK_SLUG),
   ]);
   const linearApiKey = usableSecret(linearRec);
   const githubToken = usableSecret(githubRec);
   const anthropicApiKey = usableSecret(anthropicRec);
-  if (linearApiKey === null || githubToken === null || anthropicApiKey === null) {
+  const slackBotToken = usableSecret(slackRec);
+  if (
+    linearApiKey === null ||
+    githubToken === null ||
+    anthropicApiKey === null ||
+    (opts.slack && slackBotToken === null)
+  ) {
     const missing: string[] = [];
     if (linearApiKey === null) missing.push(FACTORY_LINEAR_SLUG);
     if (githubToken === null) missing.push(FACTORY_GITHUB_SLUG);
     if (anthropicApiKey === null) missing.push(FACTORY_ANTHROPIC_SLUG);
+    if (opts.slack && slackBotToken === null) missing.push(FACTORY_SLACK_SLUG);
     return { ok: false, missing };
   }
-  return { ok: true, linearApiKey, githubToken, anthropicApiKey };
+  return {
+    ok: true,
+    linearApiKey,
+    githubToken,
+    anthropicApiKey,
+    ...(slackBotToken !== null ? { slackBotToken } : {}),
+  };
 }

--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -11,13 +11,19 @@ import { isRunnable, type LoopStore } from "../loop-store.ts";
 import type { CapturedArtifact, LoopRunnerEffects } from "../runner.ts";
 import type { SuccessVerdict } from "../success-evaluation.ts";
 import { createSweeper } from "../../util/sweeper.ts";
-import { swallow } from "../../util/errors.ts";
+import { errMessage, swallow } from "../../util/errors.ts";
 import { shq } from "../../util/shell.ts";
 import { pollProcess } from "../../sandbox/process-poll.ts";
 import { enumerateFactoryCandidates } from "./linear-intake.ts";
 import { readFactoryCredentials } from "./credentials.ts";
 import { preflightFactorySandbox, type PreflightResult } from "./preflight.ts";
-import { renderFactoryEnv, runFactoryProcess, type FactoryProcessResult } from "./process-work.ts";
+import {
+  isFactoryTicketId,
+  renderFactoryEnv,
+  runFactoryProcess,
+  type FactoryProcessResult,
+  type FactorySlackTarget,
+} from "./process-work.ts";
 import { parseFactoryContract } from "./contract.ts";
 import { evaluateFactoryForge } from "./forge-evaluate.ts";
 import type { ForgeRef } from "./ship.ts";
@@ -28,6 +34,9 @@ const DEFAULT_PAUSE_POLL_MS = 30_000;
 const FACTORY_SOURCE_CLONE_DIR = "/workspace/qm-yc";
 const FACTORY_SOURCE_CLONE_URL = "https://github.com/yc-software/qm-yc.git";
 const FACTORY_SOURCE_BOOTSTRAP_TIMEOUT_MS = 300_000;
+
+const SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage";
+const SLACK_POST_TIMEOUT_MS = 10_000;
 
 export const FACTORY_SOURCE_DIR = `${FACTORY_SOURCE_CLONE_DIR}/layer/factory`;
 export const FACTORY_SOURCE_BRANCH = "qm-30-s18477";
@@ -80,6 +89,7 @@ export interface FactoryContext {
   linearApiKey: string;
   githubToken: string;
   anthropicApiKey: string;
+  slackBotToken?: string;
 }
 
 export type FactoryWorkEffects = Pick<LoopRunnerEffects, "enumerate" | "work" | "captureOutputs" | "evaluate">;
@@ -133,16 +143,57 @@ async function bootstrapFactorySource(sandbox: Sandbox, handle: SandboxHandle, g
   if (status.code !== 0) throw new Error(detail(`exit ${status.code}`));
 }
 
+const factorySlackChannel = (config: FactoryConfig): string | undefined => {
+  const channel = config.slackChannel?.trim();
+  return channel ? channel : undefined;
+};
+
+async function openFactorySlackThread(input: {
+  fetch?: typeof globalThis.fetch;
+  botToken: string;
+  channel: string;
+  ticket: string;
+}): Promise<FactorySlackTarget | undefined> {
+  const doFetch = input.fetch ?? globalThis.fetch;
+  try {
+    const res = await doFetch(SLACK_POST_MESSAGE_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.botToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ channel: input.channel, text: `Working on ${input.ticket}` }),
+      signal: AbortSignal.timeout(SLACK_POST_TIMEOUT_MS),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      ok?: boolean;
+      error?: string;
+      ts?: string;
+      channel?: string;
+    } | null;
+    if (body?.ok !== true) throw new Error(body?.error ?? `HTTP ${res.status}`);
+    const threadTs = body.ts?.trim();
+    if (!threadTs) throw new Error("response carried no ts");
+    return { botToken: input.botToken, channelId: body.channel?.trim() || input.channel, threadTs };
+  } catch (e: unknown) {
+    swallow("factory slack thread root", new Error(`slack_post_failed: ${errMessage(e)}`));
+    return undefined;
+  }
+}
+
 export async function loadFactoryContext(deps: FactoryEffectsDeps): Promise<FactoryContext> {
   const config = deps.config.getFactoryConfig();
   if (!config) throw new Error("factory_config_missing");
-  const credentials = await readFactoryCredentials(deps.credentials, deps.orgScopeId);
+  const credentials = await readFactoryCredentials(deps.credentials, deps.orgScopeId, {
+    slack: factorySlackChannel(config) !== undefined,
+  });
   if (!credentials.ok) throw new Error(`factory_credentials_missing: ${credentials.missing.join(", ")}`);
   return {
     config,
     linearApiKey: credentials.linearApiKey,
     githubToken: credentials.githubToken,
     anthropicApiKey: credentials.anthropicApiKey,
+    ...(credentials.slackBotToken !== undefined ? { slackBotToken: credentials.slackBotToken } : {}),
   };
 }
 
@@ -175,7 +226,8 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
     },
 
     async work({ loop, item, guidance }) {
-      const { config, linearApiKey, githubToken, anthropicApiKey } = await loadFactoryContext(deps);
+      if (!isFactoryTicketId(item.sourceKey)) throw new Error("factory_ticket_invalid");
+      const { config, linearApiKey, githubToken, anthropicApiKey, slackBotToken } = await loadFactoryContext(deps);
 
       const preflightHandle = await provisionWorkspace(loop.ownerScopeId);
       let preflight: PreflightResult;
@@ -187,6 +239,17 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
       }
       if (!preflight.ok) throw new Error(`factory_preflight_failed: ${preflightDetail(preflight)}`);
 
+      const channel = factorySlackChannel(config);
+      const slack =
+        channel && slackBotToken
+          ? await openFactorySlackThread({
+              fetch: deps.fetch,
+              botToken: slackBotToken,
+              channel,
+              ticket: item.sourceKey,
+            })
+          : undefined;
+
       const itemPrefix = `factory:${loop.id}:${item.id}:`;
       const runId = `${itemPrefix}${item.attempts + 1}`;
       const env = renderFactoryEnv({
@@ -195,6 +258,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
         linearApiKey,
         githubToken,
         anthropicApiKey,
+        ...(slack ? { slack } : {}),
         factorySessionId: factorySessionIdFor(runId),
         repoDir,
         factorySourceDir: FACTORY_SOURCE_DIR,

--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -10,25 +10,46 @@ export const FACTORY_DRAIN_EMPTY_READS = 2;
 const FACTORY_READ_MAX_BYTES = 65_536;
 const TICKET_RE = /^[A-Z][A-Z0-9]*-\d+$/;
 
+export const isFactoryTicketId = (id: string): boolean => TICKET_RE.test(id);
+
+export interface FactorySlackTarget {
+  botToken: string;
+  channelId: string;
+  threadTs: string;
+}
+
 export interface FactoryEnvInput {
   config: FactoryConfig;
   guidance?: string;
   linearApiKey: string;
   githubToken: string;
   anthropicApiKey: string;
+  slack?: FactorySlackTarget;
   factorySessionId: number;
   repoDir: string;
   factorySourceDir: string;
 }
 
 export function renderFactoryEnv(input: FactoryEnvInput): Record<string, string> {
-  const { config, guidance, linearApiKey, githubToken, anthropicApiKey, factorySessionId, repoDir, factorySourceDir } =
-    input;
+  const {
+    config,
+    guidance,
+    linearApiKey,
+    githubToken,
+    anthropicApiKey,
+    slack,
+    factorySessionId,
+    repoDir,
+    factorySourceDir,
+  } = input;
   return {
     ...(guidance !== undefined ? { IO_FEEDBACK: guidance } : {}),
     IO_LINEAR_API_KEY: linearApiKey,
     IO_GITHUB_TOKEN: githubToken,
     ANTHROPIC_API_KEY: anthropicApiKey,
+    ...(slack?.botToken && slack.channelId && slack.threadTs
+      ? { SLACK_BOT_TOKEN: slack.botToken, SLACK_CHANNEL_ID: slack.channelId, SLACK_THREAD_TS: slack.threadTs }
+      : {}),
     IO_PUBLISH_FORGE: config.forge,
     IO_PUBLISH_PROJECT: config.publishProject,
     IO_PUBLISH_TARGET: config.targetBranch,
@@ -78,7 +99,7 @@ export interface FactoryProcessResult {
 
 export async function runFactoryProcess(input: FactoryProcessInput): Promise<FactoryProcessResult> {
   const { scopeId, repoDir, factorySourceDir, ticketId, env, onChunk, signal } = input;
-  if (!TICKET_RE.test(ticketId)) throw new Error("factory_ticket_invalid");
+  if (!isFactoryTicketId(ticketId)) throw new Error("factory_ticket_invalid");
   const sandbox = input.sandbox;
   if (!supportsProcessSessions(sandbox)) {
     throw new CapabilityUnsupportedError(sandbox.profile.backend, "process sessions");

--- a/test/admin-resources.test.ts
+++ b/test/admin-resources.test.ts
@@ -994,6 +994,25 @@ test("factory-config round-trips through the org scope, replaces wholesale, and 
   }
 });
 
+test("factory-config stores a blank optional string as unset and trims the rest", async () => {
+  const srv = start();
+  try {
+    const blanks = { ...FACTORY_BODY, slackChannel: "   ", repoSetupCmd: "", proofStartCmd: "\t\n" };
+    assert.equal((await putFactory(srv.base, "org:default-org", blanks)).status, 200);
+    assert.deepEqual((await scopeConfig(srv.base, "org:default-org")).factoryConfig, FACTORY_BODY);
+
+    const trimmable = { ...FACTORY_BODY, slackChannel: "  C0123ABC  ", proofBaseUrlCmd: " echo url " };
+    assert.equal((await putFactory(srv.base, "org:default-org", trimmable)).status, 200);
+    assert.deepEqual((await scopeConfig(srv.base, "org:default-org")).factoryConfig, {
+      ...FACTORY_BODY,
+      slackChannel: "C0123ABC",
+      proofBaseUrlCmd: "echo url",
+    });
+  } finally {
+    await srv.close();
+  }
+});
+
 test("factory-config rejects every malformed body by name and leaves the stored record intact", async () => {
   const srv = start();
   try {

--- a/test/loop-factory-credentials.test.ts
+++ b/test/loop-factory-credentials.test.ts
@@ -5,6 +5,7 @@ import {
   FACTORY_ANTHROPIC_SLUG,
   FACTORY_GITHUB_SLUG,
   FACTORY_LINEAR_SLUG,
+  FACTORY_SLACK_SLUG,
   readFactoryCredentials,
   type FactoryCredentials,
 } from "../src/loops/factory/credentials.ts";
@@ -12,10 +13,12 @@ import {
 const LINEAR_SECRET = "lin_FAKE_SECRET_1";
 const GITHUB_SECRET = "ghp_FAKE_SECRET_2";
 const ANTHROPIC_SECRET = "sk-ant-FAKE_SECRET_3";
+const SLACK_SECRET = "xoxb-FAKE_SECRET_4";
 const SECRET_BY_SLUG: Record<string, string> = {
   [FACTORY_LINEAR_SLUG]: LINEAR_SECRET,
   [FACTORY_GITHUB_SLUG]: GITHUB_SECRET,
   [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_SECRET,
+  [FACTORY_SLACK_SLUG]: SLACK_SECRET,
 };
 const ORG = "org:acme";
 
@@ -54,20 +57,23 @@ test("returns each trimmed secret in its own field whatever the delivery mode", 
     record(FACTORY_LINEAR_SLUG, { secret: `  ${LINEAR_SECRET}\n`, delivery: "env", envKey: "FACTORY_LINEAR_ENV_KEY" }),
     record(FACTORY_GITHUB_SLUG),
     record(FACTORY_ANTHROPIC_SLUG),
+    record(FACTORY_SLACK_SLUG, { secret: `  ${SLACK_SECRET}\n` }),
   ]);
 
-  const result = await readFactoryCredentials(reader, ORG);
+  const result = await readFactoryCredentials(reader, ORG, { slack: true });
 
   assert.deepEqual(result, {
     ok: true,
     linearApiKey: LINEAR_SECRET,
     githubToken: GITHUB_SECRET,
     anthropicApiKey: ANTHROPIC_SECRET,
+    slackBotToken: SLACK_SECRET,
   });
   assert.deepEqual(calls, [
     [ORG, "factory-linear"],
     [ORG, "factory-github"],
     [ORG, "factory-anthropic"],
+    [ORG, "factory-slack"],
   ]);
 });
 
@@ -85,7 +91,7 @@ for (const { label, over } of unusable) {
       const healthy = slugs.filter((slug) => slug !== broken).map((slug) => record(slug));
       const { reader } = fakeReader(over ? [record(broken, over), ...healthy] : healthy);
 
-      const result = await readFactoryCredentials(reader, ORG);
+      const result = await readFactoryCredentials(reader, ORG, { slack: false });
 
       assert.deepEqual(result, { ok: false, missing: [broken] });
       assert.deepEqual(Object.keys(result), ["ok", "missing"]);
@@ -93,18 +99,59 @@ for (const { label, over } of unusable) {
 
     const { reader } = fakeReader(over ? slugs.map((slug) => record(slug, over)) : []);
 
-    assert.deepEqual(await readFactoryCredentials(reader, ORG), {
+    assert.deepEqual(await readFactoryCredentials(reader, ORG, { slack: false }), {
       ok: false,
       missing: slugs,
     });
   });
+
+  test(`${label} slack credential is required only when the caller asks for it`, async () => {
+    const healthy = [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG].map((slug) => record(slug));
+    const { reader } = fakeReader(over ? [...healthy, record(FACTORY_SLACK_SLUG, over)] : healthy);
+
+    const optional = await readFactoryCredentials(reader, ORG, { slack: false });
+
+    assert.equal(optional.ok, true);
+    assert.equal(Object.hasOwn(optional, "slackBotToken"), false, "an unusable slack secret must not be a key");
+
+    const { reader: required } = fakeReader(over ? [...healthy, record(FACTORY_SLACK_SLUG, over)] : healthy);
+
+    assert.deepEqual(await readFactoryCredentials(required, ORG, { slack: true }), {
+      ok: false,
+      missing: [FACTORY_SLACK_SLUG],
+    });
+  });
 }
+
+test("a usable slack credential is returned even when the caller does not require it", async () => {
+  const { reader } = fakeReader(
+    [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG, FACTORY_SLACK_SLUG].map((slug) => record(slug)),
+  );
+
+  assert.deepEqual(await readFactoryCredentials(reader, ORG, { slack: false }), {
+    ok: true,
+    linearApiKey: LINEAR_SECRET,
+    githubToken: GITHUB_SECRET,
+    anthropicApiKey: ANTHROPIC_SECRET,
+    slackBotToken: SLACK_SECRET,
+  });
+});
+
+test("a required slack credential is named last, after every other missing slug", async () => {
+  const { reader } = fakeReader([record(FACTORY_GITHUB_SLUG), record(FACTORY_ANTHROPIC_SLUG)]);
+
+  assert.deepEqual(await readFactoryCredentials(reader, ORG, { slack: true }), {
+    ok: false,
+    missing: [FACTORY_LINEAR_SLUG, FACTORY_SLACK_SLUG],
+  });
+});
 
 test("every credential unusable names every slug and carries no secret material", async () => {
   const { reader } = fakeReader([
     record(FACTORY_LINEAR_SLUG, { enabled: false }),
     record(FACTORY_GITHUB_SLUG, { enabled: false }),
     record(FACTORY_ANTHROPIC_SLUG, { enabled: false }),
+    record(FACTORY_SLACK_SLUG, { enabled: false }),
   ]);
   const levels = ["log", "warn", "error", "info", "debug"] as const;
   const original = levels.map((level) => [level, console[level]] as const);
@@ -116,13 +163,19 @@ test("every credential unusable names every slug and carries no secret material"
         logged.push(args.join(" "));
       };
     }
-    result = await readFactoryCredentials(reader, ORG);
+    result = await readFactoryCredentials(reader, ORG, { slack: true });
   } finally {
     for (const [level, fn] of original) console[level] = fn;
   }
 
-  assert.deepEqual(result, { ok: false, missing: [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG] });
+  assert.deepEqual(result, {
+    ok: false,
+    missing: [FACTORY_LINEAR_SLUG, FACTORY_GITHUB_SLUG, FACTORY_ANTHROPIC_SLUG, FACTORY_SLACK_SLUG],
+  });
   const serialized = JSON.stringify(result);
-  assert.ok(!serialized.includes(LINEAR_SECRET) && !serialized.includes(GITHUB_SECRET), "result carries a secret");
+  assert.ok(
+    !serialized.includes(LINEAR_SECRET) && !serialized.includes(GITHUB_SECRET) && !serialized.includes(SLACK_SECRET),
+    "result carries a secret",
+  );
   assert.deepEqual(logged, []);
 });

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -15,7 +15,12 @@ import {
   factorySessionIdFor,
 } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
-import { FACTORY_ANTHROPIC_SLUG, FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
+import {
+  FACTORY_ANTHROPIC_SLUG,
+  FACTORY_GITHUB_SLUG,
+  FACTORY_LINEAR_SLUG,
+  FACTORY_SLACK_SLUG,
+} from "../src/loops/factory/credentials.ts";
 import { FACTORY_WRAPPER, renderFactoryEnv } from "../src/loops/factory/process-work.ts";
 import { shq } from "../src/util/shell.ts";
 import { LINEAR_GRAPHQL_URL } from "../src/loops/factory/linear-intake.ts";
@@ -36,10 +41,12 @@ const ORG_SCOPE = "org:acme";
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
 const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
+const SLACK_TOKEN = "xoxb-FAKE_SLACK_TOKEN";
 const SECRET_BY_SLUG: Record<string, string> = {
   [FACTORY_LINEAR_SLUG]: LINEAR_KEY,
   [FACTORY_GITHUB_SLUG]: GITHUB_TOKEN,
   [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_KEY,
+  [FACTORY_SLACK_SLUG]: SLACK_TOKEN,
 };
 const REPO_DIR = "/workspace/repo";
 const CLONE_DIR = "/workspace/qm-yc";
@@ -916,4 +923,252 @@ test("an enabled loop is never signalled and the pause poll stops when the proce
     false,
   );
   assert.equal(loops.ids.length, polledAtReturn);
+});
+
+const SLACK_POST_URL = "https://slack.com/api/chat.postMessage";
+const SLACK_CHANNEL = "#factory-runs";
+const SLACK_RESOLVED_CHANNEL = "C0RESOLVED";
+const SLACK_TS = "1730000000.000100";
+const SLACK_CONFIG: FactoryConfig = { ...CONFIG, slackChannel: SLACK_CHANNEL };
+
+const slackCredentials = (over: Partial<DecryptedServiceCredential> | null = {}): ServiceCredentialReader =>
+  fakeCredentials([
+    credentialRecord(FACTORY_LINEAR_SLUG),
+    credentialRecord(FACTORY_GITHUB_SLUG),
+    credentialRecord(FACTORY_ANTHROPIC_SLUG),
+    over === null ? null : credentialRecord(FACTORY_SLACK_SLUG, over),
+  ]);
+
+interface SlackPost {
+  url: string;
+  init: RequestInit | undefined;
+  bootstraps: number;
+  wrapperStarted: boolean;
+}
+
+function slackFetch(
+  sandboxCalls: Call[],
+  responses: (() => Promise<Response> | Response)[],
+): { fetch: typeof globalThis.fetch; posts: SlackPost[] } {
+  const posts: SlackPost[] = [];
+  return {
+    posts,
+    fetch: (url, init) => {
+      posts.push({
+        url: String(url),
+        init,
+        bootstraps: bootstrapStarts(sandboxCalls).length,
+        wrapperStarted: sandboxCalls.some(
+          (call) => call.op === "startProcess" && call.command.includes(FACTORY_WRAPPER),
+        ),
+      });
+      const respond = responses[posts.length - 1];
+      if (!respond) return Promise.reject(new Error(`unscripted fetch #${posts.length}`));
+      return Promise.resolve(respond());
+    },
+  };
+}
+
+async function capturingWarnings<T>(fn: () => Promise<T>): Promise<{ result: T; warnings: string[] }> {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.join(" "));
+  };
+  try {
+    return { result: await fn(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
+const slackRoot =
+  (body: Record<string, unknown>): (() => Response) =>
+  () =>
+    Response.json(body);
+
+test("work posts one Slack thread root after the bootstrap and threads the returned ts into the wrapper env", async () => {
+  const fake = fakeSandbox();
+  const posted = slackFetch(fake.calls, [slackRoot({ ok: true, ts: SLACK_TS, channel: SLACK_RESOLVED_CHANNEL })]);
+  const effects = createFactoryLoopEffects(
+    deps({
+      sandbox: fake.sandbox,
+      config: fakeConfig(SLACK_CONFIG).config,
+      credentials: slackCredentials(),
+      fetch: posted.fetch,
+    }),
+  );
+
+  const runId = await workedRunId(effects);
+
+  assert.equal(posted.posts.length, 1);
+  const post = posted.posts[0]!;
+  assert.equal(post.url, SLACK_POST_URL);
+  assert.equal(post.init?.method, "POST");
+  assert.equal(new Headers(post.init?.headers).get("Authorization"), `Bearer ${SLACK_TOKEN}`);
+  assert.equal(new Headers(post.init?.headers).get("Content-Type"), "application/json; charset=utf-8");
+  assert.deepEqual(JSON.parse(String(post.init?.body)), { channel: SLACK_CHANNEL, text: `Working on ${TICKET}` });
+  assert.ok(post.init?.signal instanceof AbortSignal, "the post was unbounded: it carried no abort signal");
+  assert.equal(post.bootstraps, 1, "the root was posted before the source bootstrap");
+  assert.equal(post.wrapperStarted, false, "the root was posted after the wrapper started");
+
+  const env = wrapperStart(fake.calls).opts?.env;
+  assert.equal(env?.SLACK_BOT_TOKEN, SLACK_TOKEN);
+  assert.equal(env?.SLACK_CHANNEL_ID, SLACK_RESOLVED_CHANNEL);
+  assert.equal(env?.SLACK_THREAD_TS, SLACK_TS);
+  assert.equal(runId, "factory:loop-1:item-1:1");
+});
+
+test("a thread root whose response names no channel keeps the configured one", async () => {
+  const fake = fakeSandbox();
+  const posted = slackFetch(fake.calls, [slackRoot({ ok: true, ts: SLACK_TS })]);
+  const effects = createFactoryLoopEffects(
+    deps({
+      sandbox: fake.sandbox,
+      config: fakeConfig(SLACK_CONFIG).config,
+      credentials: slackCredentials(),
+      fetch: posted.fetch,
+    }),
+  );
+
+  await workedRunId(effects);
+
+  assert.equal(wrapperStart(fake.calls).opts?.env?.SLACK_CHANNEL_ID, SLACK_CHANNEL);
+});
+
+const slackFailures: [string, () => Promise<Response> | Response, string][] = [
+  ["a rejected fetch", () => Promise.reject(new Error("socket hang up")), "socket hang up"],
+  ["a non-OK status", () => new Response("nope", { status: 500 }), "HTTP 500"],
+  ["a body that is not JSON", () => new Response("<html>", { status: 200 }), "HTTP 200"],
+  ["a Slack-level error", () => Response.json({ ok: false, error: "not_in_channel" }), "not_in_channel"],
+  ["a response with no ts", () => Response.json({ ok: true }), "response carried no ts"],
+];
+
+for (const [label, respond, named] of slackFailures) {
+  test(`${label} is swallowed: the run continues with no SLACK_ key and the failure is named`, async () => {
+    const fake = fakeSandbox();
+    const posted = slackFetch(fake.calls, [respond]);
+    const effects = createFactoryLoopEffects(
+      deps({
+        sandbox: fake.sandbox,
+        config: fakeConfig(SLACK_CONFIG).config,
+        credentials: slackCredentials(),
+        fetch: posted.fetch,
+      }),
+    );
+
+    const { result: runId, warnings } = await capturingWarnings(() => workedRunId(effects));
+
+    assert.equal(runId, "factory:loop-1:item-1:1");
+    const env = wrapperStart(fake.calls).opts?.env ?? {};
+    for (const key of Object.keys(env)) assert.equal(key.startsWith("SLACK_"), false, `${key} survived a failure`);
+    assert.equal(warnings.length, 1, warnings.join(" | "));
+    assert.ok(warnings[0]?.startsWith("[swallowed] factory slack thread root: slack_post_failed: "), warnings[0]);
+    assert.ok(warnings[0]?.includes(named), warnings[0]);
+    assert.equal(warnings[0]?.includes(SLACK_TOKEN), false, "the swallow log leaked the bot token");
+
+    assert.deepEqual(await effects.captureOutputs({ loop: LOOP, item: ITEM, runId }), [OPEN_PR_ARTIFACT]);
+  });
+}
+
+test("a blank or unset slack channel posts nothing, requires no credential, and renders today's env", async () => {
+  for (const slackChannel of [undefined, "", "   "]) {
+    const fake = fakeSandbox();
+    const posted = slackFetch(fake.calls, []);
+    const config: FactoryConfig = slackChannel === undefined ? CONFIG : { ...CONFIG, slackChannel };
+    const effects = createFactoryLoopEffects(
+      deps({ sandbox: fake.sandbox, config: fakeConfig(config).config, fetch: posted.fetch }),
+    );
+
+    const runId = await workedRunId(effects);
+
+    assert.equal(posted.posts.length, 0, `channel ${JSON.stringify(slackChannel)} posted`);
+    assert.deepEqual(
+      wrapperStart(fake.calls).opts?.env,
+      renderFactoryEnv({
+        config,
+        linearApiKey: LINEAR_KEY,
+        githubToken: GITHUB_TOKEN,
+        anthropicApiKey: ANTHROPIC_KEY,
+        factorySessionId: factorySessionIdFor(runId),
+        repoDir: REPO_DIR,
+        factorySourceDir: FACTORY_SOURCE_DIR,
+      }),
+    );
+  }
+});
+
+test("a configured channel with no factory-slack credential fails every entry point before any sandbox call", async () => {
+  const fake = fakeSandbox();
+  const posted = slackFetch(fake.calls, []);
+  const base = deps({
+    sandbox: fake.sandbox,
+    config: fakeConfig(SLACK_CONFIG).config,
+    credentials: slackCredentials(null),
+    fetch: posted.fetch,
+  });
+  const effects = createFactoryLoopEffects(base);
+
+  for (const promise of [loadFactoryContext(base), effects.enumerate(LOOP), workedRunId(effects)]) {
+    assert.equal((await rejection(promise)).message, `factory_credentials_missing: ${FACTORY_SLACK_SLUG}`);
+  }
+  assert.deepEqual(fake.calls, []);
+  assert.equal(posted.posts.length, 0);
+});
+
+test("loadFactoryContext carries the slack bot token as a key only when the credential is usable", async () => {
+  const withChannel = await loadFactoryContext(
+    deps({ config: fakeConfig(SLACK_CONFIG).config, credentials: slackCredentials() }),
+  );
+  assert.deepEqual(withChannel, {
+    config: SLACK_CONFIG,
+    linearApiKey: LINEAR_KEY,
+    githubToken: GITHUB_TOKEN,
+    anthropicApiKey: ANTHROPIC_KEY,
+    slackBotToken: SLACK_TOKEN,
+  });
+
+  const withoutCredential = await loadFactoryContext(deps());
+  assert.equal(Object.hasOwn(withoutCredential, "slackBotToken"), false);
+});
+
+test("a preflight or bootstrap failure leaves no orphan thread root", async () => {
+  for (const over of [{ probeMissing: ["gh"] }, { bootstrapExit: 128 }]) {
+    const fake = fakeSandbox(over);
+    const posted = slackFetch(fake.calls, [slackRoot({ ok: true, ts: SLACK_TS })]);
+    const effects = createFactoryLoopEffects(
+      deps({
+        sandbox: fake.sandbox,
+        config: fakeConfig(SLACK_CONFIG).config,
+        credentials: slackCredentials(),
+        fetch: posted.fetch,
+      }),
+    );
+
+    const error = await rejection(effects.work({ loop: LOOP, item: ITEM }));
+
+    assert.ok(error.message.startsWith("factory_"), error.message);
+    assert.equal(posted.posts.length, 0, `${JSON.stringify(over)} posted a root`);
+  }
+});
+
+test("an item whose source key is not a ticket id posts no root and touches no sandbox", async () => {
+  for (const sourceKey of ["<!channel> ship it", "QM-12; rm -rf /", "qm-12", ""]) {
+    const fake = fakeSandbox();
+    const posted = slackFetch(fake.calls, [slackRoot({ ok: true, ts: SLACK_TS })]);
+    const effects = createFactoryLoopEffects(
+      deps({
+        sandbox: fake.sandbox,
+        config: fakeConfig(SLACK_CONFIG).config,
+        credentials: slackCredentials(),
+        fetch: posted.fetch,
+      }),
+    );
+
+    const error = await rejection(effects.work({ loop: LOOP, item: { ...ITEM, sourceKey } }));
+
+    assert.equal(error.message, "factory_ticket_invalid");
+    assert.equal(posted.posts.length, 0, `${JSON.stringify(sourceKey)} reached Slack`);
+    assert.equal(fake.calls.length, 0, `${JSON.stringify(sourceKey)} reached the sandbox`);
+  }
 });

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -81,6 +81,8 @@ const OPTIONAL_KEYS = ["IO_FEEDBACK", "IO_REPO_SETUP_CMD", "IO_PROOF_START_CMD",
 
 const FORBIDDEN_KEYS = ["SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "SLACK_THREAD_TS", "CODING_AGENT_SESSION_URL"];
 
+const SLACK_TARGET = { botToken: "xoxb-secret", channelId: "C0SLACK", threadTs: "1730000000.000100" };
+
 type ReadStep =
   { chunks?: string; cursor: number; status?: ProcessState; delayMs?: number; onServe?: () => void } | { error: Error };
 
@@ -205,7 +207,7 @@ async function rejection(promise: Promise<unknown>): Promise<Error> {
   throw new Error("expected the promise to reject");
 }
 
-test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or session key", () => {
+test("renderFactoryEnv renders no Slack or session key without a slack group, whatever the config channel", () => {
   const env = renderFactoryEnv(ENV_INPUT);
   assert.deepEqual(env, {
     IO_FEEDBACK: "reviewer asked for a smaller diff",
@@ -242,6 +244,43 @@ test("renderFactoryEnv renders exactly the wrapper's tabled keys and no Slack or
   for (const [key, value] of Object.entries(env)) assert.notEqual(value, "C123", `${key} leaks the slack channel`);
   const frozen = Object.freeze({ ...ENV_INPUT, config: Object.freeze({ ...FULL_CONFIG }) });
   assert.deepEqual(renderFactoryEnv(frozen), env);
+});
+
+test("renderFactoryEnv adds the whole Slack triple beside the untouched keys when a slack group is given", () => {
+  const without = renderFactoryEnv(ENV_INPUT);
+  const env = renderFactoryEnv({ ...ENV_INPUT, slack: SLACK_TARGET });
+
+  assert.deepEqual(
+    Object.keys(env).sort(),
+    [...Object.keys(without), "SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID", "SLACK_THREAD_TS"].sort(),
+  );
+  assert.equal(env.SLACK_BOT_TOKEN, SLACK_TARGET.botToken);
+  assert.equal(env.SLACK_CHANNEL_ID, SLACK_TARGET.channelId);
+  assert.equal(env.SLACK_THREAD_TS, SLACK_TARGET.threadTs);
+  for (const [key, value] of Object.entries(without)) assert.equal(env[key], value, `${key} changed`);
+
+  const frozen = Object.freeze({ ...ENV_INPUT, slack: Object.freeze({ ...SLACK_TARGET }) });
+  assert.deepEqual(renderFactoryEnv(frozen), env);
+});
+
+test("renderFactoryEnv drops the whole Slack group when any one member is blank", () => {
+  for (const blank of ["botToken", "channelId", "threadTs"] as const) {
+    const env = renderFactoryEnv({ ...ENV_INPUT, slack: { ...SLACK_TARGET, [blank]: "" } });
+
+    assert.deepEqual(env, renderFactoryEnv(ENV_INPUT), `a blank ${blank} left a partial triple`);
+  }
+});
+
+test("runFactoryProcess keeps a Slack-bearing env out of the command it starts", async () => {
+  const fake = fakeSandbox({ reads: SUCCESS_READS });
+  const env = renderFactoryEnv({ ...ENV_INPUT, slack: SLACK_TARGET });
+
+  await runFactoryProcess(baseInput(fake, { env }));
+
+  const started = fake.calls.startProcess[0];
+  assert.equal(started?.command, `bash ${SOURCE_DIR}/${FACTORY_WRAPPER} ${TICKET}`);
+  assert.equal(started?.command.includes(SLACK_TARGET.botToken), false);
+  assert.equal(started?.opts?.env?.SLACK_BOT_TOKEN, SLACK_TARGET.botToken);
 });
 
 test("renderFactoryEnv omits every optional key whose source is absent", () => {

--- a/test/loop-fire.test.ts
+++ b/test/loop-fire.test.ts
@@ -9,7 +9,12 @@ import { buildShipGrant } from "../src/loops/ship-gate.ts";
 import { createIdempotencyStore } from "../src/idempotency/idempotency-store.ts";
 import { FACTORY_LOOP_SURFACE, type FactoryEffectsDeps } from "../src/loops/factory/effects.ts";
 import { FACTORY_REQUIRED_TOOLS } from "../src/loops/factory/preflight.ts";
-import { FACTORY_ANTHROPIC_SLUG, FACTORY_GITHUB_SLUG, FACTORY_LINEAR_SLUG } from "../src/loops/factory/credentials.ts";
+import {
+  FACTORY_ANTHROPIC_SLUG,
+  FACTORY_GITHUB_SLUG,
+  FACTORY_LINEAR_SLUG,
+  FACTORY_SLACK_SLUG,
+} from "../src/loops/factory/credentials.ts";
 import { FACTORY_WRAPPER } from "../src/loops/factory/process-work.ts";
 import type { FactoryConfig } from "../src/resolution/config-store.ts";
 import type { ServiceCredentialReader } from "../src/credentials/keychain.ts";
@@ -566,10 +571,12 @@ const HEAD_SHA = "1".repeat(40);
 const LINEAR_KEY = "lin_FAKE_KEY";
 const GITHUB_TOKEN = "ghp_FAKE_TOKEN";
 const ANTHROPIC_KEY = "sk-ant-FAKE_KEY";
+const SLACK_TOKEN = "xoxb-FAKE_SLACK_TOKEN";
 const SECRET_BY_SLUG: Record<string, string> = {
   [FACTORY_LINEAR_SLUG]: LINEAR_KEY,
   [FACTORY_GITHUB_SLUG]: GITHUB_TOKEN,
   [FACTORY_ANTHROPIC_SLUG]: ANTHROPIC_KEY,
+  [FACTORY_SLACK_SLUG]: SLACK_TOKEN,
 };
 const WRAPPER_STDOUT = `working\nBRANCH:${FACTORY_BRANCH}\nMR:42\n`;
 const ALREADY_FIXED_STDOUT = "ALREADY_FIXED:true\nALREADY_FIXED_EVIDENCE:fixed by #40\n";
@@ -777,6 +784,7 @@ interface FactoryFake {
   sandbox: FactorySandbox;
   fetch: FactoryFetch;
   instances: () => number;
+  setConfig: (next: FactoryConfig | null) => void;
 }
 
 function factoryFake(
@@ -789,12 +797,15 @@ function factoryFake(
 ): FactoryFake {
   const sandbox = over.sandbox ?? factorySandbox();
   const fetched = over.fetch ?? factoryFetch();
-  const config = over.config === undefined ? FACTORY_CONFIG : over.config;
+  let config = over.config === undefined ? FACTORY_CONFIG : over.config;
   let repoDirReads = 0;
   return {
     sandbox,
     fetch: fetched,
     instances: () => repoDirReads,
+    setConfig: (next) => {
+      config = next;
+    },
     deps: (loops) => ({
       sandbox: sandbox.sandbox,
       config: { getFactoryConfig: () => config },
@@ -995,6 +1006,40 @@ test("factory surface: shipping an open_pr output undrafts the request and advan
   assert.match(sent[1]!.query, /markPullRequestReadyForReview/);
   assert.match(sent[3]!.query, /issueUpdate\(id: "issue-1", input: \{ stateId: "st-review" \}\)/);
   assert.match(sent[5]!.query, /issueAddLabel\(id: "issue-1", labelId: "label-ready"\)/);
+});
+
+test("factory surface: a configured slack channel with no factory-slack credential blocks the ship path", async () => {
+  const fake = factoryFake({ credentials: factoryCredentials([FACTORY_SLACK_SLUG]) });
+  const { s, loop, output, before } = await heldFactoryOutput(fake);
+  fake.setConfig({ ...FACTORY_CONFIG, slackChannel: "#factory-runs" });
+
+  await assert.rejects(
+    s.fire.shipOutput(loop.id, output.id, "josh"),
+    new RegExp(`factory_credentials_missing: ${FACTORY_SLACK_SLUG}`),
+  );
+
+  assert.equal((await s.outputs.get(output.id))?.state, "ready");
+  assert.equal((await s.items.get(output.itemId))?.status, "ready");
+  assert.deepEqual(traffic(fake.fetch.calls.slice(before)), []);
+});
+
+test("factory surface: a configured slack channel with the credential present leaves the ship path unchanged", async () => {
+  const fake = factoryFake();
+  const { s, loop, output, before } = await heldFactoryOutput(fake);
+  fake.setConfig({ ...FACTORY_CONFIG, slackChannel: "#factory-runs" });
+
+  const shipped = await s.fire.shipOutput(loop.id, output.id, "josh");
+
+  assert.equal(shipped?.state, "shipped");
+  assert.equal(shipped?.shipResult?.note, "undraft=true, linear-state=true, linear-label=true");
+  assert.deepEqual(traffic(fake.fetch.calls.slice(before)), [
+    `GET ${GH_REPO}/pulls/42`,
+    `POST ${GH_GRAPHQL}`,
+    `POST ${LINEAR_URL}`,
+    `POST ${LINEAR_URL}`,
+    `POST ${LINEAR_URL}`,
+    `POST ${LINEAR_URL}`,
+  ]);
 });
 
 test("factory surface: re-deciding an already-shipped pull request reports every step unchanged", async () => {


### PR DESCRIPTION
Closes QM-35.

### Changes

**Why this matters:** An operator can point the software factory at a Slack channel in the admin console, but a factory run launched by the QM loop posts nothing there — no phase updates, no completion line. The `slackChannel` setting was validated and stored and then read by nothing, so the only visible sign of a run was the admin console. Operators had no way to follow a run where they already work.

**What changes:**
- A loop-launched factory run now posts a "Working on <ticket>" root message to the configured `slackChannel` and hands the run's wrapper the Slack destination, so the run's phase updates land as threaded replies under that root.
- A new organization service credential, `factory-slack`, holds the bot token. It is optional: it is only required when `slackChannel` is set, and then a missing one fails the run loudly with `factory_credentials_missing: factory-slack` rather than running quietly Slack-less.
- Slack is never allowed to break a run: a failed post, a Slack-level error, or an unreachable Slack leaves the run going with no Slack wiring and a named log line explaining why it went quiet. No root message is posted for a run that dies in preflight or source bootstrap.
- Blank and whitespace-only values in the factory config (including `slackChannel`) are now stored as unset rather than as an empty setting, so a cleared channel truly turns Slack off.

**Acceptance stories:**
- An operator sets `slackChannel` and adds the `factory-slack` credential in the admin console; both persist across a reload and the secret is never echoed back on any admin read.
- An operator clears `slackChannel`; a later run posts nothing at all and still completes, exactly as before this change.
- Quartermaster launches a factory run with a channel configured: previously the run produced zero Slack messages; now it posts one thread root and the run's updates thread under it.
- Quartermaster launches a run with a channel configured but no `factory-slack` credential: the run fails immediately with a named missing-credential error instead of starting and staying silent.
- Slack is down or the bot is not in the channel: the run completes normally and the operator sees the swallowed reason in the run log.

### Test Plan

- `node --experimental-test-module-mocks --test test/loop-factory-*.test.ts test/loop-fire.test.ts test/admin-resources.test.ts`
- `node --experimental-test-module-mocks --test test/config-store-org.test.ts test/loop-factory-wiring.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:all` (three failures, all reproduced on clean `main` in a disposable worktree and unrelated to these files)
- Manual: in a local dev instance, set and clear `slackChannel` on the Software factory card and add the `factory-slack` credential in the keychain, reloading between steps to confirm what persists and that the secret is never shown.

## Proof it works

Every acceptance story passed: the admin setup path was driven in a browser, and the Slack post and wrapper environment were captured over a real socket, including the channel-unset, missing-credential and Slack-down paths.

![story1-a-before-no-slack-channel.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-a-before-no-slack-channel.png)
![story1-b-slack-channel-applied.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-b-slack-channel-applied.png)
![story1-c-slack-channel-persisted.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-c-slack-channel-persisted.png)
![story1-d-credentials-before.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-d-credentials-before.png)
![story1-e-factory-slack-credential-saved.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-e-factory-slack-credential-saved.png)
![story1-f-secret-not-echoed.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-f-secret-not-echoed.png)
![story1-g-slack-channel-cleared.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-g-slack-channel-cleared.png)
![story1-h-factory-config-reset.png](https://github.com/yc-software/qm/raw/assets/qm-35-s18710/story1-h-factory-config-reset.png)

page@2e236746b06cb4ec1b8d48bfac9eb5be.webm — /tmp/claude-recordings

<!-- factory-session:2:18710:ef5ef929bfde4aac4f00417b568c5870 -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791742299&installation_model_id=19911&pr_number=1114&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1114&signature=8e357bd9e33078f8fef0e304a4d5d1e3a501d87906b2a1dbbe2eea98e01e86c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->