### PR TITLE
QM-36: Let every org admin administer the org-scoped loop

### DIFF
--- a/src/api/routes/loops.ts
+++ b/src/api/routes/loops.ts
@@ -13,7 +13,6 @@ import { DEFAULT_CRON_TIMEZONE, userScheduleFromBody, validateUserSchedule } fro
 import type { ScopedConfigStore } from "../../resolution/config-store.ts";
 import { consentRequiredRecipient } from "../../triggers/trigger-store.ts";
 import { errMessage, swallow } from "../../util/errors.ts";
-import type { ServerDeps } from "../deps.ts";
 import { sendJson } from "../http.ts";
 import { isObj, isOrgAdmin, resolveCapabilityDestination } from "./shared.ts";
 import { type ApiCtx, type Route } from "./route.ts";
@@ -37,35 +36,20 @@ interface ActingPrincipal {
   scopeId?: ScopeId;
   capability?: CapabilityClaims;
   liveHuman: boolean;
-  orgAdmin: (scope: ScopeId) => Promise<boolean>;
-}
-
-function withOrgAdmin(deps: ServerDeps, base: Omit<ActingPrincipal, "orgAdmin">): ActingPrincipal {
-  const cache = new Map<ScopeId, Promise<boolean>>();
-  return {
-    ...base,
-    orgAdmin(scope) {
-      const hit = cache.get(scope);
-      if (hit) return hit;
-      const pending = isOrgAdmin(deps, base.actorId, scope);
-      cache.set(scope, pending);
-      return pending;
-    },
-  };
 }
 
 export function actingPrincipal(ctx: ApiCtx): ActingPrincipal | null {
   if (ctx.capability) {
-    return withOrgAdmin(ctx.deps, {
+    return {
       actorId: ctx.capability.actorId,
       scopeId: ctx.capability.scopeId as ScopeId,
       capability: ctx.capability,
       liveHuman: ctx.actor?.p !== undefined || ctx.capability.liveActor === true,
-    });
+    };
   }
-  if (ctx.actor?.p) return withOrgAdmin(ctx.deps, { actorId: ctx.actor.p, liveHuman: true });
+  if (ctx.actor?.p) return { actorId: ctx.actor.p, liveHuman: true };
   const principalId = (ctx.url.searchParams.get("principalId") ?? "").trim();
-  if (principalId) return withOrgAdmin(ctx.deps, { actorId: principalId, liveHuman: false });
+  if (principalId) return { actorId: principalId, liveHuman: false };
   sendJson(ctx.res, 403, { error: "forbidden", message: "loops need an agent capability or a principalId" });
   return null;
 }
@@ -78,7 +62,8 @@ function requireLiveHuman(ctx: ApiCtx, acting: ActingPrincipal): boolean {
 
 async function canAdministerLoop(ctx: ApiCtx, loop: Loop, acting: ActingPrincipal): Promise<boolean> {
   const { app } = ctx;
-  if (parseScopeId(loop.ownerScopeId).kind === "org" && (await acting.orgAdmin(loop.ownerScopeId))) return true;
+  if (parseScopeId(loop.ownerScopeId).kind === "org" && (await isOrgAdmin(ctx.deps, acting.actorId, loop.ownerScopeId)))
+    return true;
   if (await app.membershipControlsScope(loop.ownerScopeId)) {
     return app.managesScope(acting.actorId, loop.ownerScopeId);
   }

--- a/src/api/routes/loops.ts
+++ b/src/api/routes/loops.ts
@@ -1,5 +1,5 @@
 import type { Loop, LoopState } from "../../types.ts";
-import { scopeId, type ScopeId } from "../../types.ts";
+import { parseScopeId, scopeId, type ScopeId } from "../../types.ts";
 import type { CapabilityClaims } from "../../auth/capability-token.ts";
 import type { LoopStore, CreateLoopInput, LoopPatch } from "../../loops/loop-store.ts";
 import { DECISION_LEASE_MS, type LoopItemLedger } from "../../loops/item-ledger.ts";
@@ -13,8 +13,9 @@ import { DEFAULT_CRON_TIMEZONE, userScheduleFromBody, validateUserSchedule } fro
 import type { ScopedConfigStore } from "../../resolution/config-store.ts";
 import { consentRequiredRecipient } from "../../triggers/trigger-store.ts";
 import { errMessage, swallow } from "../../util/errors.ts";
+import type { ServerDeps } from "../deps.ts";
 import { sendJson } from "../http.ts";
-import { isObj, resolveCapabilityDestination } from "./shared.ts";
+import { isObj, isOrgAdmin, resolveCapabilityDestination } from "./shared.ts";
 import { type ApiCtx, type Route } from "./route.ts";
 
 export interface LoopServiceDeps {
@@ -36,20 +37,35 @@ interface ActingPrincipal {
   scopeId?: ScopeId;
   capability?: CapabilityClaims;
   liveHuman: boolean;
+  orgAdmin: (scope: ScopeId) => Promise<boolean>;
+}
+
+function withOrgAdmin(deps: ServerDeps, base: Omit<ActingPrincipal, "orgAdmin">): ActingPrincipal {
+  const cache = new Map<ScopeId, Promise<boolean>>();
+  return {
+    ...base,
+    orgAdmin(scope) {
+      const hit = cache.get(scope);
+      if (hit) return hit;
+      const pending = isOrgAdmin(deps, base.actorId, scope);
+      cache.set(scope, pending);
+      return pending;
+    },
+  };
 }
 
 export function actingPrincipal(ctx: ApiCtx): ActingPrincipal | null {
   if (ctx.capability) {
-    return {
+    return withOrgAdmin(ctx.deps, {
       actorId: ctx.capability.actorId,
       scopeId: ctx.capability.scopeId as ScopeId,
       capability: ctx.capability,
       liveHuman: ctx.actor?.p !== undefined || ctx.capability.liveActor === true,
-    };
+    });
   }
-  if (ctx.actor?.p) return { actorId: ctx.actor.p, liveHuman: true };
+  if (ctx.actor?.p) return withOrgAdmin(ctx.deps, { actorId: ctx.actor.p, liveHuman: true });
   const principalId = (ctx.url.searchParams.get("principalId") ?? "").trim();
-  if (principalId) return { actorId: principalId, liveHuman: false };
+  if (principalId) return withOrgAdmin(ctx.deps, { actorId: principalId, liveHuman: false });
   sendJson(ctx.res, 403, { error: "forbidden", message: "loops need an agent capability or a principalId" });
   return null;
 }
@@ -62,6 +78,7 @@ function requireLiveHuman(ctx: ApiCtx, acting: ActingPrincipal): boolean {
 
 async function canAdministerLoop(ctx: ApiCtx, loop: Loop, acting: ActingPrincipal): Promise<boolean> {
   const { app } = ctx;
+  if (parseScopeId(loop.ownerScopeId).kind === "org" && (await acting.orgAdmin(loop.ownerScopeId))) return true;
   if (await app.membershipControlsScope(loop.ownerScopeId)) {
     return app.managesScope(acting.actorId, loop.ownerScopeId);
   }

--- a/src/api/routes/shared.ts
+++ b/src/api/routes/shared.ts
@@ -1,5 +1,5 @@
 import { orgId as configOrgId, orgScope as configOrgScope } from "../../config.ts";
-import type { Principal } from "../../types.ts";
+import type { Principal, ScopeId } from "../../types.ts";
 import type { AuditEvent } from "../../audit/audit-log.ts";
 import { adminStatusFromGrants } from "../../admin/admin-service.ts";
 import { samePerson } from "../../directory/person.ts";
@@ -41,6 +41,13 @@ export async function authorizeAdmin(
   if (actor && adminStatusFromGrants(grants, actor.id).isAdmin) return actor;
   sendJson(res, 403, { error: "forbidden", message: "admin grant required for this scope" });
   return null;
+}
+
+export async function isOrgAdmin(deps: ServerDeps, principalId: string, scope: ScopeId): Promise<boolean> {
+  if (!deps.admin || !principalId) return false;
+  const scoped = (await deps.admin.listGrants()).filter((g) => g.scopeId === scope);
+  if (!adminStatusFromGrants(scoped, principalId).isAdmin) return false;
+  return activePrincipal(deps, principalId);
 }
 
 export async function activePrincipal(deps: ServerDeps, principalId: string): Promise<boolean> {

--- a/test/loop-item-routes.test.ts
+++ b/test/loop-item-routes.test.ts
@@ -10,7 +10,11 @@ import { createShipGrantStore } from "../src/loops/ship-grant-store.ts";
 import { createCronStore } from "../src/cron/cron-store.ts";
 import { createMemoryConfigStore } from "../src/resolution/config-store.ts";
 import { ensureInboxLoop, INBOX_SYNC_TASK_VERSION, renderInboxSyncTask } from "../src/loops/inbox-loop.ts";
-import type { Cron, Loop, LoopItem } from "../src/types.ts";
+import { scopeId, type Cron, type Loop, type LoopItem } from "../src/types.ts";
+import { orgId } from "../src/config.ts";
+import { createAdminService } from "../src/admin/admin-service.ts";
+import { createAdminGrantStore, createMemoryAdminGrantPersistence } from "../src/admin/admin-grant-store.ts";
+import { ensureFactoryLoop } from "../src/loops/factory/factory-loop.ts";
 import type { LedgerItemView } from "../src/loops/ledger-view.ts";
 import type { SlackUserClient } from "../src/loops/sources/adapter.ts";
 import { sleep } from "../src/util/async.ts";
@@ -102,6 +106,7 @@ async function call(
     capability?: Record<string, unknown> | null;
     actor?: string;
     sessionForThread?: string;
+    deps?: Record<string, unknown>;
   },
 ): Promise<{ status: number; body: unknown }> {
   const url = new URL(`http://x${over.path}`);
@@ -150,6 +155,7 @@ async function call(
             loopSourceTokens: { connectorAccessToken: async () => "tok" },
           }
         : {}),
+      ...over.deps,
     },
     app,
   } as unknown as ApiCtx;
@@ -791,4 +797,152 @@ test("a capability caller's edit is stored as the agent's draft, so its mentions
   });
   assert.equal(sent.status, 200, JSON.stringify(sent.body));
   assert.equal((w.sent.at(-1)!.body as { text: string }).text, "Everyone @\u200bhere please look");
+});
+
+const ORG_SCOPE = scopeId("org", orgId());
+
+const FORBIDDEN = { error: "forbidden", message: "you may not administer this loop" };
+
+function adminDeps(deactivated: readonly string[] = ["admin-dave"]): Record<string, unknown> {
+  return {
+    admin: createAdminService(
+      createAdminGrantStore(createMemoryAdminGrantPersistence(), {
+        seed: [
+          { principalId: "admin-alice", scopeId: ORG_SCOPE, role: "org_admin" },
+          { principalId: "admin-bob", scopeId: ORG_SCOPE, role: "org_admin" },
+          { principalId: "admin-dave", scopeId: ORG_SCOPE, role: "org_admin" },
+        ],
+      }),
+    ),
+    identity: {
+      refresh: async () => {},
+      classify: (id: string) => ({ id, type: deactivated.includes(id) ? "guest" : "internal" }),
+    },
+  };
+}
+
+const BOB_CAP = { ...CAP, actorId: "admin-bob", scopeId: "personal:admin-bob" };
+
+const ITEM_TWO = { ...ITEM, sourceKey: "C1:1.3", slack: { channelId: "C1", ts: "1.3" } };
+
+async function orgLoop(w: World): Promise<Loop> {
+  return ensureFactoryLoop(w.loops.store, { owner: "admin-alice", orgScopeId: ORG_SCOPE });
+}
+
+test("a second org admin works the org loop's ledger items", async () => {
+  const w = world();
+  const loop = await orgLoop(w);
+  const deps = adminDeps();
+
+  const ingested = await call(w, {
+    method: "POST",
+    path: `/v1/loops/${loop.id}/items`,
+    body: { items: [ITEM, ITEM_TWO] },
+    capability: BOB_CAP,
+    deps,
+  });
+  assert.equal(ingested.status, 200, JSON.stringify(ingested.body));
+  assert.deepEqual(ingested.body, { created: 2, updated: 0, skipped: 0 });
+
+  const listed = await call(w, { method: "GET", path: `/v1/loops/${loop.id}/items`, capability: BOB_CAP, deps });
+  assert.equal(listed.status, 200);
+  const body = listed.body as { loop: Loop; items: LedgerItemView[]; counts: Record<string, number> };
+  assert.equal(body.loop.id, loop.id);
+  assert.equal(body.items.length, 2);
+  assert.ok(body.counts);
+  const [first, second] = body.items as [LedgerItemView, LedgerItemView];
+
+  const read = await call(w, {
+    method: "GET",
+    path: `/v1/loops/${loop.id}/items/${first.id}`,
+    capability: BOB_CAP,
+    deps,
+  });
+  assert.equal(read.status, 200);
+  assert.equal((read.body as { item: LedgerItemView }).item.id, first.id);
+
+  const dismissed = await call(w, {
+    method: "POST",
+    path: `/v1/loops/${loop.id}/items/${first.id}/action`,
+    body: { kind: "dismiss" },
+    capability: BOB_CAP,
+    deps,
+  });
+  assert.equal(dismissed.status, 200);
+  assert.ok((dismissed.body as { item: LedgerItemView }).item);
+
+  const followed = await call(w, {
+    method: "POST",
+    path: `/v1/loops/${loop.id}/items/${second.id}/followup`,
+    body: { message: "shorten it" },
+    capability: BOB_CAP,
+    deps,
+  });
+  assert.equal(followed.status, 200);
+  assert.deepEqual(w.followUps, [{ itemId: second.id, message: "shorten it", actorId: "admin-bob" }]);
+
+  const relayedList = await call(w, {
+    method: "GET",
+    path: `/v1/loops/${loop.id}/items?principalId=admin-bob`,
+    capability: PORTAL,
+    deps,
+  });
+  assert.equal(relayedList.status, 200);
+  const relayedIngest = await call(w, {
+    method: "POST",
+    path: `/v1/loops/${loop.id}/items?principalId=admin-bob`,
+    body: { items: [ITEM] },
+    capability: PORTAL,
+    deps,
+  });
+  assert.equal(relayedIngest.status, 403);
+  assert.equal((relayedIngest.body as { message: string }).message, "ledger items are ingested by the agent");
+});
+
+test("the org loop's ledger stays shut to non-admins and to admins of nothing else", async () => {
+  const w = world();
+  const loop = await orgLoop(w);
+  const deps = adminDeps();
+  const seeded = await call(w, {
+    method: "POST",
+    path: `/v1/loops/${loop.id}/items`,
+    body: { items: [ITEM] },
+    capability: BOB_CAP,
+    deps,
+  });
+  assert.equal(seeded.status, 200);
+  const [item] = await w.loops.items.byLoop(loop.id);
+  const personal = await ensureInboxLoop(w.loops.store, "josh");
+
+  const rows = (loopId: string, itemId: string) =>
+    [
+      ["POST", `/v1/loops/${loopId}/items`, { items: [ITEM] }],
+      ["GET", `/v1/loops/${loopId}/items`, undefined],
+      ["GET", `/v1/loops/${loopId}/items/${itemId}`, undefined],
+      ["POST", `/v1/loops/${loopId}/items/${itemId}/action`, { kind: "dismiss" }],
+      ["POST", `/v1/loops/${loopId}/items/${itemId}/followup`, { message: "hi" }],
+    ] as const;
+
+  for (const actor of ["carol", "admin-dave"]) {
+    for (const [method, path, body] of rows(loop.id, item!.id)) {
+      const out = await call(w, {
+        method,
+        path,
+        body,
+        capability: { ...CAP, actorId: actor, scopeId: `personal:${actor}` },
+        deps,
+      });
+      assert.deepEqual(out.body, FORBIDDEN, `${actor} ${method} ${path}`);
+      assert.equal(out.status, 403);
+    }
+  }
+  for (const [method, path, body] of rows(personal.id, item!.id)) {
+    const out = await call(w, { method, path, body, capability: BOB_CAP, deps });
+    assert.deepEqual(out.body, FORBIDDEN, `admin-bob ${method} ${path}`);
+    assert.equal(out.status, 403);
+  }
+
+  const inbox = await call(w, { method: "GET", path: "/v1/loops/inbox", capability: BOB_CAP, deps });
+  assert.equal(inbox.status, 200);
+  assert.equal((inbox.body as { loop: Loop | null }).loop, null);
 });

--- a/test/loop-routes.test.ts
+++ b/test/loop-routes.test.ts
@@ -847,36 +847,6 @@ test("a second org admin reads and lists the org-scoped factory loop", async () 
   assert.deepEqual(denied.body, FORBIDDEN);
 });
 
-test("listing org loops asks the grant store once for the whole request", async () => {
-  const deps = services();
-  for (let i = 0; i < 25; i += 1) {
-    await deps.store.create({
-      owner: "admin-alice",
-      createdBy: "admin-alice",
-      ownerScopeId: ORG_SCOPE,
-      name: `Org loop ${i}`,
-      playbook: "p",
-      successCondition: "c",
-    });
-  }
-  const service = createAdminService();
-  let grantReads = 0;
-  const admin = {
-    ...service,
-    listGrants: () => {
-      grantReads += 1;
-      return service.listGrants();
-    },
-  };
-  const listed = await call(deps, "GET", "/v1/loops", undefined, {
-    actor: "admin-bob",
-    mode: "source",
-    deps: { admin, identity: identityStub() },
-  });
-  assert.equal((listed.body as { loops: Loop[] }).loops.length, 25);
-  assert.ok(grantReads <= 2, `listGrants ran ${grantReads} times`);
-});
-
 test("a second org admin drives every org loop mutation as themselves", async () => {
   const deps = services();
   const shipped: string[] = [];

--- a/test/loop-routes.test.ts
+++ b/test/loop-routes.test.ts
@@ -10,14 +10,20 @@ import { createCronStore } from "../src/cron/cron-store.ts";
 import { createMemoryConfigStore } from "../src/resolution/config-store.ts";
 import { findRoute } from "../src/api/routes/route.ts";
 import type { ApiCtx, Route } from "../src/api/routes/route.ts";
-import { scopeId, type Loop, type ShipGrant } from "../src/types.ts";
+import { scopeId, type Loop, type LoopOutput, type ScopeId, type ShipGrant } from "../src/types.ts";
+import { orgId } from "../src/config.ts";
+import { createAdminService, type AdminGrant, type AdminService } from "../src/admin/admin-service.ts";
+import { createAdminGrantStore, createMemoryAdminGrantPersistence } from "../src/admin/admin-grant-store.ts";
+import { ensureFactoryLoop } from "../src/loops/factory/factory-loop.ts";
+import { createCanManageScope } from "../src/resolution/scope-membership.ts";
 
 function fakeRes() {
-  const out = { status: 0, body: undefined as unknown };
+  const out = { status: 0, body: undefined as unknown, writes: 0 };
   return {
     res: {
       writeHead(status: number) {
         out.status = status;
+        out.writes += 1;
         return this;
       },
       end(data?: string) {
@@ -39,15 +45,23 @@ function services(): LoopServiceDeps {
   };
 }
 
+interface CallOptions {
+  actor?: string;
+  mode?: "capability" | "source";
+  liveActor?: boolean;
+  scope?: ScopeId;
+  deps?: Record<string, unknown>;
+  app?: Record<string, unknown>;
+}
+
 async function call(
   deps: LoopServiceDeps,
   method: string,
   path: string,
   body?: unknown,
-  actor = "josh",
-  mode: "capability" | "source" = "capability",
-  liveActor = true,
-): Promise<{ status: number; body: unknown }> {
+  opts: CallOptions = {},
+): Promise<{ status: number; body: unknown; writes: number }> {
+  const { actor = "josh", mode = "capability", liveActor = true } = opts;
   const found = findRoute(loopRoutes as ReadonlyArray<Route<ApiCtx>>, method, path);
   assert.ok(found, `no route for ${method} ${path}`);
   const { res, out } = fakeRes();
@@ -62,7 +76,7 @@ async function call(
       mode === "capability"
         ? {
             actorId: actor,
-            scopeId: scopeId("personal", actor),
+            scopeId: opts.scope ?? scopeId("personal", actor),
             ...(liveActor ? { liveActor: true } : {}),
             destinations: [{ key: "alerts", label: "Alerts", type: "slack", target: "C-alerts" }],
           }
@@ -71,8 +85,9 @@ async function call(
       membershipControlsScope: async () => false,
       managesScope: async () => false,
       samePerson: async (a: string, b: string) => a === b,
+      ...opts.app,
     },
-    deps: { loops: deps },
+    deps: { loops: deps, ...opts.deps },
   } as unknown as ApiCtx;
   await found.route.handle(ctx);
   return out;
@@ -129,9 +144,7 @@ test("create and patch configure a validated escalation destination", async () =
     "PATCH",
     `/v1/loops/${loop.id}`,
     { destinationKey: "alerts" },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(denied.status, 403);
   assert.equal((denied.body as { error: string }).error, "human_required");
@@ -231,9 +244,7 @@ test("only a live human can introduce an auto ship gate", async () => {
     "POST",
     "/v1/loops",
     { ...CREATE, shipActions: [{ action: "open_pr", gate: "auto" }] },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(deniedCreate.status, 403);
   assert.equal((deniedCreate.body as { error: string }).error, "human_required");
@@ -242,8 +253,7 @@ test("only a live human can introduce an auto ship gate", async () => {
     "POST",
     "/v1/loops",
     { ...CREATE, shipActions: [{ action: "open_pr", gate: "auto" }] },
-    "josh",
-    "source",
+    { actor: "josh", mode: "source" },
   );
   assert.equal(signedCreate.status, 403);
   assert.equal((signedCreate.body as { error: string }).error, "human_required");
@@ -255,9 +265,7 @@ test("only a live human can introduce an auto ship gate", async () => {
     "PATCH",
     `/v1/loops/${id}`,
     { shipActions: [{ action: "open_pr", gate: "auto" }] },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(deniedPatch.status, 403);
   assert.equal((deniedPatch.body as { error: string }).error, "human_required");
@@ -270,9 +278,7 @@ test("only a live human can introduce an auto ship gate", async () => {
         "PATCH",
         `/v1/loops/${id}`,
         { shipActions: [{ action: "open_pr", gate: "auto" }] },
-        "josh",
-        "capability",
-        false,
+        { actor: "josh", mode: "capability", liveActor: false },
       )
     ).status,
     200,
@@ -284,9 +290,7 @@ test("only a live human can introduce an auto ship gate", async () => {
         "PATCH",
         `/v1/loops/${id}`,
         { shipActions: [{ action: "open_pr", gate: "hold" }] },
-        "josh",
-        "capability",
-        false,
+        { actor: "josh", mode: "capability", liveActor: false },
       )
     ).status,
     200,
@@ -308,10 +312,10 @@ test("only the owner may read, patch, or delete a personal loop", async () => {
   const created = await call(deps, "POST", "/v1/loops", CREATE);
   const id = (created.body as { loop: { id: string } }).loop.id;
   assert.equal((await call(deps, "GET", `/v1/loops/${id}`)).status, 200);
-  assert.equal((await call(deps, "GET", `/v1/loops/${id}`, undefined, "mallory")).status, 403);
-  assert.equal((await call(deps, "PATCH", `/v1/loops/${id}`, { name: "stolen" }, "mallory")).status, 403);
-  assert.equal((await call(deps, "DELETE", `/v1/loops/${id}`, undefined, "mallory")).status, 403);
-  const list = await call(deps, "GET", "/v1/loops", undefined, "mallory");
+  assert.equal((await call(deps, "GET", `/v1/loops/${id}`, undefined, { actor: "mallory" })).status, 403);
+  assert.equal((await call(deps, "PATCH", `/v1/loops/${id}`, { name: "stolen" }, { actor: "mallory" })).status, 403);
+  assert.equal((await call(deps, "DELETE", `/v1/loops/${id}`, undefined, { actor: "mallory" })).status, 403);
+  const list = await call(deps, "GET", "/v1/loops", undefined, { actor: "mallory" });
   assert.deepEqual((list.body as { loops: unknown[] }).loops, []);
 });
 
@@ -329,8 +333,20 @@ test("only a live human can clear quarantine and the clearance is audited", asyn
   const deps = services();
   const created = await call(deps, "POST", "/v1/loops", CREATE);
   const id = (created.body as { loop: Loop }).loop.id;
-  await call(deps, "PATCH", `/v1/loops/${id}`, { state: "quarantined" }, "josh", "capability", false);
-  const denied = await call(deps, "PATCH", `/v1/loops/${id}`, { state: "enabled" }, "josh", "capability", false);
+  await call(
+    deps,
+    "PATCH",
+    `/v1/loops/${id}`,
+    { state: "quarantined" },
+    { actor: "josh", mode: "capability", liveActor: false },
+  );
+  const denied = await call(
+    deps,
+    "PATCH",
+    `/v1/loops/${id}`,
+    { state: "enabled" },
+    { actor: "josh", mode: "capability", liveActor: false },
+  );
   assert.equal(denied.status, 403);
   assert.equal((denied.body as { error: string }).error, "human_required");
   assert.equal((await deps.store.get(id))?.state, "quarantined");
@@ -340,7 +356,13 @@ test("only a live human can clear quarantine and the clearance is audited", asyn
   assert.equal(typeof loop.quarantineClearedAt, "number");
 
   await call(deps, "PATCH", `/v1/loops/${id}`, { state: "paused" });
-  const agentEnabled = await call(deps, "PATCH", `/v1/loops/${id}`, { state: "enabled" }, "josh", "capability", false);
+  const agentEnabled = await call(
+    deps,
+    "PATCH",
+    `/v1/loops/${id}`,
+    { state: "enabled" },
+    { actor: "josh", mode: "capability", liveActor: false },
+  );
   assert.equal(agentEnabled.status, 200);
 });
 
@@ -394,25 +416,27 @@ test("decisions and grants require verified live-human evidence", async () => {
     "POST",
     `/v1/loops/${id}/grants`,
     { shipAction: "open_pr" },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   const decide = await call(
     deps,
     "POST",
     `/v1/loops/${id}/outputs/o1/decide`,
     { decision: "shipped" },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(grant.status, 403);
   assert.equal((grant.body as { error: string }).error, "human_required");
   assert.equal(decide.status, 403);
   assert.equal((decide.body as { error: string }).error, "human_required");
   assert.equal((await call(deps, "POST", `/v1/loops/${id}/grants`, { shipAction: "open_pr" })).status, 200);
-  const signedGrant = await call(deps, "POST", `/v1/loops/${id}/grants`, { shipAction: "open_pr" }, "josh", "source");
+  const signedGrant = await call(
+    deps,
+    "POST",
+    `/v1/loops/${id}/grants`,
+    { shipAction: "open_pr" },
+    { actor: "josh", mode: "source" },
+  );
   assert.equal(signedGrant.status, 403);
   assert.equal((signedGrant.body as { error: string }).error, "human_required");
   const signedDecision = await call(
@@ -420,8 +444,7 @@ test("decisions and grants require verified live-human evidence", async () => {
     "POST",
     `/v1/loops/${id}/outputs/o1/decide`,
     { decision: "ship" },
-    "josh",
-    "source",
+    { actor: "josh", mode: "source" },
   );
   assert.equal(signedDecision.status, 403);
   assert.equal((signedDecision.body as { error: string }).error, "human_required");
@@ -454,14 +477,10 @@ test("ship grants become stale after policy edits and can be revoked by a live h
     grant: ShipGrant;
   };
 
-  const denied = await call(
-    deps,
-    "DELETE",
-    `/v1/loops/${loop.id}/grants/${currentGrant.grant.id}`,
-    undefined,
-    "josh",
-    "source",
-  );
+  const denied = await call(deps, "DELETE", `/v1/loops/${loop.id}/grants/${currentGrant.grant.id}`, undefined, {
+    actor: "josh",
+    mode: "source",
+  });
   assert.equal(denied.status, 403);
   assert.equal((denied.body as { error: string }).error, "human_required");
   const revoked = await call(deps, "DELETE", `/v1/loops/${loop.id}/grants/${currentGrant.grant.id}`);
@@ -493,9 +512,7 @@ test("autopilot requires a live human to enable every gate and grant", async () 
     "POST",
     `/v1/loops/${loop.id}/autopilot`,
     { enabled: true },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(denied.status, 403);
   assert.equal((denied.body as { error: string }).error, "human_required");
@@ -525,9 +542,7 @@ test("an agent can disable autopilot and revoke every active grant", async () =>
     "POST",
     `/v1/loops/${loop.id}/autopilot`,
     { enabled: false },
-    "josh",
-    "capability",
-    false,
+    { actor: "josh", mode: "capability", liveActor: false },
   );
   assert.equal(disabled.status, 200);
   const body = disabled.body as { loop: Loop; grants: ShipGrant[] };
@@ -539,9 +554,7 @@ test("an agent can disable autopilot and revoke every active grant", async () =>
     "POST",
     `/v1/loops/${loop.id}/autopilot`,
     { enabled: false },
-    "mallory",
-    "capability",
-    false,
+    { actor: "mallory", mode: "capability", liveActor: false },
   );
   assert.equal(stranger.status, 403);
 });
@@ -664,13 +677,16 @@ test("deciding an output reports an active item decision lease", async () => {
 
 test("the portal's source-authed path acts as the signed principalId", async () => {
   const deps = services();
-  const created = await call(deps, "POST", "/v1/loops", CREATE, "josh", "source");
+  const created = await call(deps, "POST", "/v1/loops", CREATE, { actor: "josh", mode: "source" });
   assert.equal(created.status, 200);
   const id = (created.body as { loop: { id: string; owner: string } }).loop.id;
   assert.equal((created.body as { loop: { owner: string } }).loop.owner, "josh");
-  assert.equal((await call(deps, "GET", `/v1/loops/${id}`, undefined, "josh", "source")).status, 200);
-  assert.equal((await call(deps, "GET", `/v1/loops/${id}`, undefined, "mallory", "source")).status, 403);
-  const bare = await call(deps, "GET", "/v1/loops", undefined, "", "capability");
+  assert.equal((await call(deps, "GET", `/v1/loops/${id}`, undefined, { actor: "josh", mode: "source" })).status, 200);
+  assert.equal(
+    (await call(deps, "GET", `/v1/loops/${id}`, undefined, { actor: "mallory", mode: "source" })).status,
+    403,
+  );
+  const bare = await call(deps, "GET", "/v1/loops", undefined, { actor: "", mode: "capability" });
   assert.ok(bare.status === 200 || bare.status === 403);
 });
 
@@ -722,10 +738,318 @@ test("only a live human can re-enable an archived loop", async () => {
   const loop = (created.body as { loop: Loop }).loop;
   const archived = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "archived" });
   assert.equal(archived.status, 200);
-  const denied = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "enabled" }, "josh", "capability", false);
+  const denied = await call(
+    deps,
+    "PATCH",
+    `/v1/loops/${loop.id}`,
+    { state: "enabled" },
+    { actor: "josh", mode: "capability", liveActor: false },
+  );
   assert.equal(denied.status, 403);
   assert.equal((denied.body as { error: string }).error, "human_required");
   const revived = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "enabled" });
   assert.equal(revived.status, 200);
   assert.equal((revived.body as { loop: Loop }).loop.state, "enabled");
+});
+
+const ORG_SCOPE = scopeId("org", orgId());
+
+const FORBIDDEN = { error: "forbidden", message: "you may not administer this loop" };
+
+function identityStub(deactivated: readonly string[] = []) {
+  return {
+    refresh: async () => {},
+    classify: (id: string) => ({ id, type: deactivated.includes(id) ? "guest" : "internal" }),
+  };
+}
+
+function adminServiceWith(grants: AdminGrant[]): AdminService {
+  return createAdminService(createAdminGrantStore(createMemoryAdminGrantPersistence(), { seed: grants }));
+}
+
+const orgGrant = (principalId: string, scope: ScopeId = ORG_SCOPE): AdminGrant => ({
+  principalId,
+  scopeId: scope,
+  role: "org_admin",
+});
+
+function factoryLoop(deps: LoopServiceDeps): Promise<Loop> {
+  return ensureFactoryLoop(deps.store, { owner: "admin-alice", orgScopeId: ORG_SCOPE });
+}
+
+function fireStub(shipped: string[]): LoopServiceDeps["fire"] {
+  const output = (loopId: string, id: string, state: LoopOutput["state"]): LoopOutput => ({
+    id,
+    loopId,
+    itemId: "i1",
+    attemptId: "a1",
+    shipAction: "open_pr",
+    title: "t",
+    state,
+    capturedBy: "agent",
+    createdAt: 0,
+    updatedAt: 0,
+  });
+  return {
+    fire: async () => ({ status: "ok" as const }),
+    shipOutput: async (loopId, outputId, actorId) => {
+      shipped.push(`${outputId}:${actorId}`);
+      return output(loopId, outputId, "shipped");
+    },
+    returnOutput: async (loopId, outputId) => output(loopId, outputId, "returned"),
+    sweepStale: async () => {},
+    followUp: async () => null,
+    itemAction: async () => ({ ok: true }),
+  };
+}
+
+test("a second org admin reads and lists the org-scoped factory loop", async () => {
+  const deps = services();
+  const loop = await factoryLoop(deps);
+  const admin = { admin: createAdminService(), identity: identityStub() };
+
+  const relayed = await call(deps, "GET", `/v1/loops/${loop.id}`, undefined, {
+    actor: "admin-bob",
+    mode: "source",
+    deps: admin,
+  });
+  assert.equal(relayed.status, 200);
+  const read = relayed.body as { loop: Loop; items: unknown[]; outputs: unknown[]; grants: unknown[]; vitals: unknown };
+  assert.equal(read.loop.owner, "admin-alice");
+  assert.deepEqual([read.items, read.outputs, read.grants], [[], [], []]);
+  assert.ok(read.vitals);
+
+  const relayedList = await call(deps, "GET", "/v1/loops", undefined, {
+    actor: "admin-bob",
+    mode: "source",
+    deps: admin,
+  });
+  assert.deepEqual(
+    (relayedList.body as { loops: Loop[] }).loops.map((l) => l.id),
+    [loop.id],
+  );
+
+  const live = await call(deps, "GET", `/v1/loops/${loop.id}`, undefined, { actor: "admin-bob", deps: admin });
+  assert.equal(live.status, 200);
+  const liveList = await call(deps, "GET", "/v1/loops", undefined, { actor: "admin-bob", deps: admin });
+  assert.deepEqual(
+    (liveList.body as { loops: Loop[] }).loops.map((l) => l.id),
+    [loop.id],
+  );
+
+  const denied = await call(deps, "GET", `/v1/loops/${loop.id}`, undefined, {
+    actor: "carol",
+    mode: "source",
+    deps: admin,
+  });
+  assert.equal(denied.status, 403);
+  assert.equal(denied.writes, 1);
+  assert.deepEqual(denied.body, FORBIDDEN);
+});
+
+test("listing org loops asks the grant store once for the whole request", async () => {
+  const deps = services();
+  for (let i = 0; i < 25; i += 1) {
+    await deps.store.create({
+      owner: "admin-alice",
+      createdBy: "admin-alice",
+      ownerScopeId: ORG_SCOPE,
+      name: `Org loop ${i}`,
+      playbook: "p",
+      successCondition: "c",
+    });
+  }
+  const service = createAdminService();
+  let grantReads = 0;
+  const admin = {
+    ...service,
+    listGrants: () => {
+      grantReads += 1;
+      return service.listGrants();
+    },
+  };
+  const listed = await call(deps, "GET", "/v1/loops", undefined, {
+    actor: "admin-bob",
+    mode: "source",
+    deps: { admin, identity: identityStub() },
+  });
+  assert.equal((listed.body as { loops: Loop[] }).loops.length, 25);
+  assert.ok(grantReads <= 2, `listGrants ran ${grantReads} times`);
+});
+
+test("a second org admin drives every org loop mutation as themselves", async () => {
+  const deps = services();
+  const shipped: string[] = [];
+  deps.fire = fireStub(shipped);
+  const loop = await factoryLoop(deps);
+  const admin = { admin: createAdminService(), identity: identityStub() };
+  const bob = { actor: "admin-bob", deps: admin };
+  const relay = { actor: "admin-bob", mode: "source" as const, deps: admin };
+
+  await deps.store.setState(loop.id, "quarantined");
+  const autopilotQuarantined = await call(deps, "POST", `/v1/loops/${loop.id}/autopilot`, { enabled: true }, bob);
+  assert.equal(autopilotQuarantined.status, 409);
+  const relayedClear = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "enabled" }, relay);
+  assert.equal(relayedClear.status, 403);
+  assert.equal((relayedClear.body as { error: string }).error, "human_required");
+  const cleared = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "enabled" }, bob);
+  assert.equal(cleared.status, 200);
+  const clearedLoop = (cleared.body as { loop: Loop }).loop;
+  assert.equal(clearedLoop.quarantineClearedBy, "admin-bob");
+  assert.equal(typeof clearedLoop.quarantineClearedAt, "number");
+
+  assert.equal((await call(deps, "POST", `/v1/loops/${loop.id}/fire`, undefined, bob)).status, 200);
+  assert.equal((await call(deps, "PATCH", `/v1/loops/${loop.id}`, { state: "paused" }, bob)).status, 200);
+  const edited = await call(deps, "PATCH", `/v1/loops/${loop.id}`, { playbook: "work the queue" }, bob);
+  assert.equal(edited.status, 200);
+  const history = (edited.body as { loop: Loop }).loop.playbookHistory;
+  assert.equal(history[history.length - 1]?.by, "admin-bob");
+
+  const shipDecision = await call(deps, "POST", `/v1/loops/${loop.id}/outputs/o1/decide`, { decision: "ship" }, bob);
+  assert.equal(shipDecision.status, 200);
+  assert.deepEqual(shipped, ["o1:admin-bob"]);
+  const noteless = await call(deps, "POST", `/v1/loops/${loop.id}/outputs/o1/decide`, { decision: "return" }, bob);
+  assert.equal(noteless.status, 400);
+  assert.equal((noteless.body as { error: string }).error, "bad_request");
+
+  const granted = await call(deps, "POST", `/v1/loops/${loop.id}/grants`, { shipAction: "open_pr" }, bob);
+  assert.equal(granted.status, 200);
+  const grant = (granted.body as { grant: ShipGrant }).grant;
+  assert.equal(grant.actorId, "admin-bob");
+  const undeclared = await call(deps, "POST", `/v1/loops/${loop.id}/grants`, { shipAction: "deploy" }, bob);
+  assert.equal(undeclared.status, 400);
+  assert.equal((undeclared.body as { error: string }).error, "bad_request");
+
+  assert.equal((await call(deps, "POST", `/v1/loops/${loop.id}/autopilot`, { enabled: true }, bob)).status, 200);
+  const off = await call(deps, "POST", `/v1/loops/${loop.id}/autopilot`, { enabled: false }, bob);
+  assert.equal(off.status, 200);
+  const offBody = off.body as { loop: Loop; grants: ShipGrant[] };
+  assert.ok(offBody.loop.shipActions.every((policy) => policy.gate === "hold"));
+  assert.ok(offBody.grants.every((g) => g.revokedBy === "admin-bob" && g.revokedAt !== undefined));
+
+  const regranted = await call(deps, "POST", `/v1/loops/${loop.id}/grants`, { shipAction: "open_pr" }, bob);
+  const liveGrant = (regranted.body as { grant: ShipGrant }).grant;
+  const revoked = await call(deps, "DELETE", `/v1/loops/${loop.id}/grants/${liveGrant.id}`, undefined, bob);
+  assert.equal(revoked.status, 200);
+  assert.equal((revoked.body as { grant: ShipGrant }).grant.revokedBy, "admin-bob");
+
+  for (const [path, body] of [
+    [`/v1/loops/${loop.id}/outputs/o1/decide`, { decision: "ship" }],
+    [`/v1/loops/${loop.id}/grants`, { shipAction: "open_pr" }],
+    [`/v1/loops/${loop.id}/autopilot`, { enabled: true }],
+  ] as const) {
+    const refused = await call(deps, "POST", path, body, relay);
+    assert.equal(refused.status, 403);
+    assert.equal((refused.body as { error: string }).error, "human_required");
+  }
+
+  const still = await deps.store.get(loop.id);
+  assert.equal(still?.owner, "admin-alice");
+  assert.equal(still?.runAs, undefined);
+  assert.equal((await call(deps, "DELETE", `/v1/loops/${loop.id}`, undefined, bob)).status, 200);
+  assert.equal(await deps.store.get(loop.id), null);
+});
+
+test("a non-admin member and a deactivated admin may not administer the org loop", async () => {
+  const deps = services();
+  deps.fire = fireStub([]);
+  const loop = await factoryLoop(deps);
+  const admin = {
+    admin: adminServiceWith([orgGrant("admin-bob"), orgGrant("admin-dave"), orgGrant("admin-erin", "org:other-org")]),
+    identity: identityStub(["admin-dave"]),
+  };
+  const routes = [
+    ["GET", `/v1/loops/${loop.id}`, undefined],
+    ["PATCH", `/v1/loops/${loop.id}`, { name: "stolen" }],
+    ["POST", `/v1/loops/${loop.id}/fire`, undefined],
+    ["POST", `/v1/loops/${loop.id}/outputs/o1/decide`, { decision: "ship" }],
+    ["POST", `/v1/loops/${loop.id}/grants`, { shipAction: "open_pr" }],
+    ["POST", `/v1/loops/${loop.id}/autopilot`, { enabled: true }],
+    ["DELETE", `/v1/loops/${loop.id}`, undefined],
+  ] as const;
+  for (const actor of ["carol", "admin-dave", "admin-erin"]) {
+    for (const [method, path, body] of routes) {
+      const out = await call(deps, method, path, body, { actor, deps: admin });
+      assert.deepEqual(out.body, FORBIDDEN, `${actor} ${method} ${path}`);
+      assert.equal(out.status, 403);
+    }
+    const listed = await call(deps, "GET", "/v1/loops", undefined, { actor, deps: admin });
+    assert.deepEqual(listed.body, { loops: [] });
+  }
+  assert.equal(
+    (await call(deps, "GET", `/v1/loops/${loop.id}`, undefined, { actor: "admin-bob", deps: admin })).status,
+    200,
+  );
+
+  const unwired = await call(deps, "GET", `/v1/loops/${loop.id}`, undefined, { actor: "admin-bob" });
+  assert.equal(unwired.status, 403);
+  assert.deepEqual(unwired.body, FORBIDDEN);
+  assert.deepEqual((await call(deps, "GET", "/v1/loops", undefined, { actor: "admin-bob" })).body, { loops: [] });
+});
+
+test("org admin authority does not widen personal, group or channel loops", async () => {
+  const deps = services();
+  const orgLoop = await factoryLoop(deps);
+  const { loop: personal } = await deps.store.create({
+    owner: "josh",
+    createdBy: "josh",
+    ownerScopeId: scopeId("personal", "josh"),
+    name: "Josh triage",
+    playbook: "p",
+    successCondition: "c",
+  });
+  const { loop: group } = await deps.store.create({
+    owner: "josh",
+    createdBy: "josh",
+    ownerScopeId: "group:g1",
+    name: "Group triage",
+    playbook: "p",
+    successCondition: "c",
+  });
+  const { loop: channel } = await deps.store.create({
+    owner: "josh",
+    createdBy: "josh",
+    ownerScopeId: "channel:c1",
+    name: "Channel triage",
+    playbook: "p",
+    successCondition: "c",
+    runAs: "scopeShared",
+  });
+  const admin = { admin: createAdminService(), identity: identityStub() };
+
+  const strangerLoop = await call(deps, "GET", `/v1/loops/${personal.id}`, undefined, {
+    actor: "admin-bob",
+    deps: admin,
+  });
+  assert.equal(strangerLoop.status, 403);
+  const bobList = await call(deps, "GET", "/v1/loops", undefined, { actor: "admin-bob", deps: admin });
+  assert.deepEqual(
+    (bobList.body as { loops: Loop[] }).loops.map((l) => l.id),
+    [orgLoop.id],
+  );
+  assert.equal((await call(deps, "GET", `/v1/loops/${personal.id}`, undefined, { actor: "josh" })).status, 200);
+
+  const groupApp = {
+    membershipControlsScope: async (scope: ScopeId) => scope === "group:g1",
+    managesScope: async (_actor: string, scope: ScopeId) => scope === "group:g1",
+  };
+  const viaMembership = await call(deps, "GET", `/v1/loops/${group.id}`, undefined, {
+    actor: "carol",
+    app: groupApp,
+    deps: admin,
+  });
+  assert.equal(viaMembership.status, 200);
+  const viaScopeShared = await call(deps, "GET", `/v1/loops/${channel.id}`, undefined, {
+    actor: "carol",
+    scope: "channel:c1",
+    deps: admin,
+  });
+  assert.equal(viaScopeShared.status, 200);
+  assert.equal(await createCanManageScope({})("admin-bob", ORG_SCOPE), false);
+
+  const bobOnly = { admin: adminServiceWith([orgGrant("admin-bob")]), identity: identityStub() };
+  const owner = await call(deps, "GET", `/v1/loops/${orgLoop.id}`, undefined, { actor: "admin-alice", deps: bobOnly });
+  assert.equal(owner.status, 200);
+  const ownerList = await call(deps, "GET", "/v1/loops", undefined, { actor: "admin-alice", deps: bobOnly });
+  assert.ok((ownerList.body as { loops: Loop[] }).loops.some((l) => l.id === orgLoop.id));
 });


### PR DESCRIPTION
Closes QM-36.

### Changes

**Why this matters:** The org-scoped "Software factory" loop is created by whichever org admin first applies the factory config, and until now only that one person could administer it. Every other org admin got a 403 on the loop's detail, fire, pause, decide, grant and autopilot endpoints, and the loop never appeared in their loops list at all. Administration of an org-wide resource was pinned to a single human, so if that admin was away or lost access nobody else could run or unblock the factory.

**What changes:**
- Any current org admin can now read, list and administer a loop whose owner scope is the org scope, including `GET /v1/loops`, `GET/PATCH/DELETE /v1/loops/:id`, fire, output decisions, grants, autopilot and the loop's ledger items.
- Ownership is unchanged: the loop keeps its original owner, and actions are attributed to the admin who performed them.
- Nothing else widens — personal, group, channel and capability-scoped loops behave exactly as before, and a member without an org admin grant (or an admin whose grant or account has been removed) is still refused.
- The live-human requirement on sensitive actions is untouched: relayed requests without a live human still get `human_required` on decide, grant creation and enabling autopilot.

**Acceptance stories:**
- A second org admin opens the Loops page and now sees and opens the "Software factory" loop, where before the list was empty and the detail page bounced back.
- A second org admin fires the loop, pauses and resumes it, clears quarantine, toggles autopilot and edits the playbook, and each action is recorded under their own name while the loop's owner stays the original admin.
- An org member with no admin grant still gets an empty loops list and a "you may not administer this loop" refusal, as does an admin whose grant was just revoked.
- An org admin still cannot reach another person's personal loop.
- An API caller on a deployment with no admin service wired sees exactly today's behavior, since the new check simply answers no.

### Test Plan

- `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --experimental-test-module-mocks --test test/loop-routes.test.ts`
- `NODE_ENV=test ALLOW_UNSIGNED_TEST_IDENTITY=1 node --experimental-test-module-mocks --test test/loop-item-routes.test.ts`
- `node --experimental-test-module-mocks --test test/loop-routes.test.ts test/loop-item-routes.test.ts test/loop-factory-loop.test.ts test/admin-grants.test.ts test/admin-resources.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/api/routes/loops.ts src/api/routes/shared.ts test/loop-routes.test.ts test/loop-item-routes.test.ts`
- Manual: on a local dev stack, applied the factory config as the first admin, then signed in as a second org admin and drove the Loops page (open, fire, pause, resume, clear quarantine, autopilot off/on, back link); reproduced the empty list and 403 first with the fix reverted, and confirmed a revoked grant immediately restores the refusal.

## Proof it works

On the same live stack, the second org admin went from an empty Loops list and a 403 detail page to seeing, opening and driving the factory loop, while a non-admin stayed refused.

![story0-before-loops-list-empty.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story0-before-loops-list-empty.png)
![story0-before-loop-detail-denied.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story0-before-loop-detail-denied.png)
![story1-loops-list-second-admin.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story1-loops-list-second-admin.png)
![story1-loop-detail-second-admin.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story1-loop-detail-second-admin.png)
![story2a-clear-quarantine.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2a-clear-quarantine.png)
![story2b-paused.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2b-paused.png)
![story2c-resumed.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2c-resumed.png)
![story2d-autopilot-off.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2d-autopilot-off.png)
![story2e-autopilot-on.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2e-autopilot-on.png)
![story2f-playbook-edit.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2f-playbook-edit.png)
![story2g-fire-now.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2g-fire-now.png)
![story2h-back-to-list.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story2h-back-to-list.png)
![story3-review-sections.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story3-review-sections.png)
![story4-nonadmin-loops-list-empty.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story4-nonadmin-loops-list-empty.png)
![story4-nonadmin-loop-detail-denied.png](https://github.com/yc-software/qm/raw/assets/qm-36-s18720/story4-nonadmin-loop-detail-denied.png)

Session recordings, not embeddable here:
page@962d80c2a90f3bf22b520f880cd9f420.webm — .io-agent-qm-36/video/
page@cbac5f4176f618c3135b91a0377817f5.webm — .io-agent-qm-36/video/
page@32ee1b4fa4443c2e3b8d442ca22519a3.webm — .io-agent-qm-36/video/

<!-- factory-session:2:18720:c05d5d14c3717a516d9afa30d8d017ff -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791745077&installation_model_id=19911&pr_number=1118&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1118&signature=778339a9334b72037e02d159b949c628db083cbed0de6d1a582e52029a9dd1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->