### PR TITLE
fix: unify composer status font sizes

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2545,6 +2545,7 @@ a.chat-row-open {
   background: none;
   color: inherit;
   font: inherit;
+  font-size: var(--composer-font-size, inherit);
   text-align: left;
   cursor: pointer;
 }
@@ -2676,7 +2677,7 @@ a.chat-row-open {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  font-size: 15px;
+  font-size: var(--composer-font-size, 15px);
   line-height: 1.4;
   cursor: pointer;
   border-radius: 6px;
@@ -2847,6 +2848,7 @@ a.chat-row-open {
 }
 
 .composer-wrap {
+  --composer-font-size: 15px;
   --composer-pad-block: 12px;
   --composer-pad-inline: 12px;
   --composer-pad-end: var(--composer-pad-inline);
@@ -2875,7 +2877,7 @@ a.chat-row-open {
   background: transparent;
   color: var(--foreground);
   font: inherit;
-  font-size: 15px;
+  font-size: var(--composer-font-size);
   line-height: 1.5;
   padding: 3px 4px 8px;
   box-sizing: border-box;
@@ -9563,6 +9565,7 @@ h3.ambient-field-label {
   }
 
   .composer-wrap {
+    --composer-font-size: 16px;
     width: calc(100% - 16px);
     margin: 0 auto calc(8px + env(safe-area-inset-bottom));
     --composer-pad-block: 8px;
@@ -9572,7 +9575,6 @@ h3.ambient-field-label {
     border-radius: 22px;
   }
   .composer-input {
-    font-size: 16px;
     line-height: 1.4;
     min-height: 40px;
     max-height: 32vh;
@@ -9739,7 +9741,7 @@ h3.ambient-field-label {
     min-height: 36px;
     padding: 4px 6px;
     border-radius: 10px;
-    font-size: 13px;
+    font-size: var(--composer-font-size, 13px);
   }
   :root {
     --meta-lane: 34px;

--- a/plugins/web-ui/test/pinned-composer-polish.test.ts
+++ b/plugins/web-ui/test/pinned-composer-polish.test.ts
@@ -25,3 +25,14 @@ test("editable background activity is rendered inside the composer surface", () 
     /\.composer-wrap > \.bg-activity \{[^}]*background: color-mix\(in srgb, var\(--secondary\) 40%, var\(--background\)\);/,
   );
 });
+
+test("composer status rows share the responsive input font size", () => {
+  const sizes = [...css.matchAll(/--composer-font-size: (\d+)px/g)].map((match) => Number(match[1]));
+  assert.deepEqual(sizes, [15, 16]);
+  for (const selector of [".live-work-line", ".bg-activity-strip", ".composer-input"]) {
+    const blocks = css.matchAll(new RegExp(`${selector.replaceAll(".", "\\.")} \\{([^}]+)\\}`, "g"));
+    const declarations = [...blocks].flatMap((match) => [...match[1].matchAll(/font-size: ([^;]+);/g)]);
+    assert.ok(declarations.length > 0, selector);
+    for (const declaration of declarations) assert.match(declaration[1], /^var\(--composer-font-size[,)]/);
+  }
+});


### PR DESCRIPTION
Use one responsive font size for the composer input, live activity, and background-job summary while preserving standalone activity styling.

- 15px desktop; 16px mobile.
- Six focused regression tests, web UI typecheck, ESLint, and formatting passed.
- Real frontend with synthetic session data: six font-size checks and 106 layout checks passed across desktop, tablet, and phone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791745122&installation_model_id=19911&pr_number=1119&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1119&signature=559f1f6809f53b4749d3bc46c2c50d32c47a6d4b606ba8cca7843768df8b7f61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->