### PR TITLE
Install lsof and procps in the sandbox base image

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       bash coreutils findutils grep sed gawk \
-      git curl wget jq unzip \
+      git curl wget jq unzip lsof procps \
       nftables \
       python3 python3-venv python3-pip \
       ca-certificates gnupg \


### PR DESCRIPTION
## Why

`scripts/dev/lib/proc.ts` finds a port's holder with `lsof -ti tcp:<port>`. The sandbox base image had no `lsof`, so inside a factory sandbox `test/dev-supervisor-child.test.ts` failed two port-ownership tests, never killed its TERM-ignoring squatter child, and hung `npm run test:all` for the rest of the run. Reproduced in a native arm64 sandbox container: both concurrent copies of the suite sat on that file for over ten minutes.

## What

Add `lsof` and `procps` to the apt install in `fly/Dockerfile`. `procps` supplies `ps`, which the image also lacked.

## Proof

Before: `command -v lsof` prints nothing in the container, and the file's tests 3 and 5 fail with `web exited during startup` and `holders.includes(child.proc.pid)` false. After the rebuild, the same file passes 5 of 5 in a fresh container from the new image. A fresh loop attempt is running on it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791748159&installation_model_id=19911&pr_number=1121&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1121&signature=43f37fde42fa5c61871fbd947e3fbbe1bb5dcec618c5cf5c58b09261ebd591e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->