### PR TITLE
chart: run pods as a configurable service account

### DIFF
--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -36,3 +36,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{- end -}}
+
+{{- define "qm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "qm.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -108,7 +108,6 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- /* One entry per name: values override the wired defaults, and a duplicate name breaks helm upgrade. */}}
           {{- $env := mergeOverwrite (deepCopy $wired) (deepCopy ($root.Values.env | default dict)) $componentEnv }}
           {{- if $env }}
           env:

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "qm.serviceAccountName" $root }}
       containers:
         - name: {{ $name }}
           image: "{{ $root.Values.image.repository }}{{ $root.Values.image.separator | default "/" }}{{ $svc.image }}:{{ $svc.tag | default $root.Values.image.tag | default $root.Chart.AppVersion }}"
@@ -93,31 +94,25 @@ spec:
           {{- $_ := set $wired "ADMIN_BASE_PATH" "/admin" }}
           {{- $_ := set $wired "ADMIN_ENABLED" (ternary "1" "0" (index $root.Values.services "admin").enabled) }}
           {{- end }}
-          {{- if or $wired $root.Values.env $svc.env }}
+          {{- $componentEnv := deepCopy ($svc.env | default dict) }}
+          {{- $component := "" }}
+          {{- if eq $name "portal" }}{{- $component = "auth" }}{{- end }}
+          {{- if eq $name "web-ui" }}{{- $component = "admin" }}{{- end }}
+          {{- if and $component (index $root.Values.services $component).enabled }}
+          {{- range $k, $v := (index $root.Values.services $component).env }}
+          {{- if ne $k "PORT" }}
+          {{- if and (hasKey $componentEnv $k) (ne (toString (index $componentEnv $k)) (toString $v)) }}
+          {{- fail (printf "Conflicting %s settings in %s and %s" $k $name $component) }}
+          {{- end }}
+          {{- $_ := set $componentEnv $k $v }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- /* One entry per name: values override the wired defaults, and a duplicate name breaks helm upgrade. */}}
+          {{- $env := mergeOverwrite (deepCopy $wired) (deepCopy ($root.Values.env | default dict)) $componentEnv }}
+          {{- if $env }}
           env:
-            {{- range $k, $v := $wired }}
-            - name: {{ $k }}
-              value: {{ $v | quote }}
-            {{- end }}
-            {{- range $k, $v := $root.Values.env }}
-            - name: {{ $k }}
-              value: {{ $v | quote }}
-            {{- end }}
-            {{- $componentEnv := deepCopy ($svc.env | default dict) }}
-            {{- $component := "" }}
-            {{- if eq $name "portal" }}{{- $component = "auth" }}{{- end }}
-            {{- if eq $name "web-ui" }}{{- $component = "admin" }}{{- end }}
-            {{- if and $component (index $root.Values.services $component).enabled }}
-            {{- range $k, $v := (index $root.Values.services $component).env }}
-            {{- if ne $k "PORT" }}
-            {{- if and (hasKey $componentEnv $k) (ne (toString (index $componentEnv $k)) (toString $v)) }}
-            {{- fail (printf "Conflicting %s settings in %s and %s" $k $name $component) }}
-            {{- end }}
-            {{- $_ := set $componentEnv $k $v }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- range $k, $v := $componentEnv }}
+            {{- range $k, $v := $env }}
             - name: {{ $k }}
               value: {{ $v | quote }}
             {{- end }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "qm.serviceAccountName" . }}
+  labels:
+    {{- include "qm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,9 +6,6 @@ image:
 
 imagePullSecrets: []
 
-# Service account the deployments run as. Leave create false to use the namespace default;
-# set create true (and optionally annotations) to bind a cloud identity such as EKS Pod Identity
-# or IRSA to the qm pods.
 serviceAccount:
   create: false
   name: ""

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,6 +6,14 @@ image:
 
 imagePullSecrets: []
 
+# Service account the deployments run as. Leave create false to use the namespace default;
+# set create true (and optionally annotations) to bind a cloud identity such as EKS Pod Identity
+# or IRSA to the qm pods.
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
## Description

The current chart doesn't have a way to define a service account - would like one so I can attach a pod identity to that SA for S3 access  without giving access to the default role (for QM's distributed storage).

Currently am running QM with this setup, and tested E2E on my side.

Also folded in a small fix: web-ui rendered `ADMIN_BASE_PATH` twice with default values, which broke `helm upgrade`. Env is now merged into one dict before rendering, so each name appears once.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/yc-software/codesmith/qm/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791749859&installation_model_id=19911&pr_number=1122&repository=yc-software%2Fqm&return_to=https%3A%2F%2Fgithub.com%2Fyc-software%2Fqm%2Fpull%2F1122&signature=128a01c40496fad33c744f583ab6e93104063d50202bac3d8103512127561416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

