### PR TITLE
Rename projects from the Projects page

### DIFF
--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -105,6 +105,12 @@ export const contextsState = {
   titleValue: "",
   titleBusy: false,
   titleError: "",
+  // Bumped whenever the title-edit session is torn down or a new one begins (reset,
+  // navigating to a different scope, opening a fresh edit). A commit in flight captures
+  // this generation plus the project id it's editing, so a late response from an old
+  // session can never overwrite a newer or different one (including A -> B -> A again).
+  titleEditGen: 0,
+  titleEditProjectId: null as string | null,
 };
 
 let contextsLoading = false;
@@ -167,6 +173,8 @@ export function resetContextsState(): void {
   contextsState.titleValue = "";
   contextsState.titleBusy = false;
   contextsState.titleError = "";
+  contextsState.titleEditProjectId = null;
+  contextsState.titleEditGen++;
   cancelMemberSearchTimer();
   contextsNotice = "";
   memberSearchSeq++;
@@ -192,6 +200,21 @@ export async function renderContexts(): Promise<void> {
     contextsNotice = errMessage(e, "Failed to load contexts.");
   }
   contextsLoading = false;
+  // Cheap ownership recheck: a refresh can find the signed-in user is no longer the
+  // project's owner (e.g. ownership changed elsewhere) while its title editor was open.
+  // Hide/cancel that dual state on the client; the PATCH's own server-side ownership
+  // check is unchanged and would have refused the write regardless.
+  if (contextsState.titleEditing && contextsState.selected) {
+    const editing = contextsState.list.find((c) => c.scopeId === contextsState.selected);
+    if (!editing?.project || editing.project.ownerId !== appState.me?.user) {
+      contextsState.titleEditing = false;
+      contextsState.titleValue = "";
+      contextsState.titleBusy = false;
+      contextsState.titleError = "";
+      contextsState.titleEditProjectId = null;
+      contextsState.titleEditGen++;
+    }
+  }
   if (
     contextsState.selected &&
     contextsState.list.some((c) => c.scopeId === contextsState.selected) &&
@@ -524,7 +547,10 @@ function isProjectOwner(context: CoreContext): boolean {
 }
 
 function projectTitleBlock(context: CoreContext, project: CoreProject, title: string): TemplateResult {
-  if (contextsState.titleEditing) return projectTitleEditor(project);
+  // Owner check gates the editor too (not just the idle pencil): if a refresh finds
+  // ownership no longer held while editing was open, fall back to the plain idle view
+  // instead of showing a dual state a non-owner can't actually save.
+  if (contextsState.titleEditing && isProjectOwner(context)) return projectTitleEditor(project);
   return html`
     <span class="project-title-text" dir="auto">${title}</span>
     ${
@@ -532,6 +558,7 @@ function projectTitleBlock(context: CoreContext, project: CoreProject, title: st
         ? html`<button
             class="project-icon-button project-title-edit"
             type="button"
+            data-focus-key="project-title"
             aria-label="Rename project"
             ${tip("Rename project")}
             @click=${() => beginProjectTitleRename(project)}
@@ -575,6 +602,7 @@ function projectTitleEditor(project: CoreProject): TemplateResult {
       <button
         class="project-icon-button project-title-save"
         type="submit"
+        data-focus-key="project-title"
         aria-label="Save project name"
         ${tip("Save")}
         ?disabled=${contextsState.titleBusy}
@@ -584,6 +612,7 @@ function projectTitleEditor(project: CoreProject): TemplateResult {
       <button
         class="project-icon-button project-title-cancel"
         type="button"
+        data-focus-key="project-title"
         aria-label="Cancel renaming project"
         ${tip("Cancel")}
         ?disabled=${contextsState.titleBusy}
@@ -599,6 +628,8 @@ function beginProjectTitleRename(project: CoreProject): void {
   contextsState.titleEditing = true;
   contextsState.titleValue = project.name;
   contextsState.titleError = "";
+  contextsState.titleEditProjectId = project.id;
+  contextsState.titleEditGen++;
   drawContexts();
   requestAnimationFrame(() => {
     const input = appState.mainEl?.querySelector<HTMLInputElement>(".project-title-input");
@@ -612,6 +643,7 @@ function cancelProjectTitleRename(): void {
   contextsState.titleEditing = false;
   contextsState.titleValue = "";
   contextsState.titleError = "";
+  contextsState.titleEditProjectId = null;
   drawContexts();
 }
 
@@ -627,21 +659,47 @@ async function commitProjectTitleRename(project: CoreProject): Promise<void> {
     cancelProjectTitleRename();
     return;
   }
+  // Capture the reset generation, the title-edit generation, and which project this
+  // request belongs to. A slow save that resolves after the user has navigated away
+  // (which bumps titleEditGen and clears titleEditProjectId) or reopened editing on the
+  // same project again (which also bumps titleEditGen) must not touch state that now
+  // belongs to a different session — whether that's a different project's draft/error or
+  // a fresh draft reopened on this same project (A -> B -> A again).
   const resetSeq = contextsResetSeq;
+  const editGen = contextsState.titleEditGen;
+  const projectId = project.id;
   contextsState.titleBusy = true;
   contextsState.titleError = "";
   drawContexts();
   const ok = await renameProject(project, next);
-  if (resetSeq !== contextsResetSeq) return;
+  const stale =
+    resetSeq !== contextsResetSeq ||
+    editGen !== contextsState.titleEditGen ||
+    contextsState.titleEditProjectId !== projectId;
+  if (stale) return;
   contextsState.titleBusy = false;
   if (ok) {
     contextsState.titleEditing = false;
     contextsState.titleValue = "";
     contextsState.titleError = "";
+    contextsState.titleEditProjectId = null;
   } else {
     contextsState.titleError = "Couldn't rename this project. Try again.";
   }
   drawContexts();
+  // The busy-disabled inputs above break the generic replaceChildrenPreservingFocus key
+  // match (a disabled element can't hold focus, so the pre-await render already dropped
+  // focus to <body>), so explicitly restore it here for the two real-request outcomes.
+  // Only do this if focus is still sitting on <body> — if the user deliberately focused
+  // something else on the page while the save was in flight, leave it alone; a slow save
+  // must never steal focus back from wherever the user has since moved on to.
+  if (document.activeElement === document.body) {
+    requestAnimationFrame(() => {
+      if (document.activeElement !== document.body) return;
+      const el = appState.mainEl?.querySelector<HTMLElement>(ok ? ".project-title-edit" : ".project-title-input");
+      el?.focus();
+    });
+  }
 }
 
 function memberLabel(context: CoreContext, principalId: string): string {
@@ -1565,6 +1623,8 @@ function selectContext(scopeId: string | null): void {
   contextsState.titleValue = "";
   contextsState.titleBusy = false;
   contextsState.titleError = "";
+  contextsState.titleEditProjectId = null;
+  contextsState.titleEditGen++;
   contextsState.selected = scopeId;
   contextsState.resources = null;
   contextsState.resourcesScope = null;

--- a/plugins/web-ui/src/contexts.ts
+++ b/plugins/web-ui/src/contexts.ts
@@ -2,10 +2,12 @@ import { html, nothing, render, type TemplateResult } from "lit";
 import {
   ArrowLeft,
   Boxes,
+  Check,
   Folder,
   FolderPlus,
   Hash,
   Lock,
+  Pencil,
   Plus,
   Search,
   User,
@@ -99,6 +101,10 @@ export const contextsState = {
   slackValue: "",
   slackBusy: false,
   slackError: "",
+  titleEditing: false,
+  titleValue: "",
+  titleBusy: false,
+  titleError: "",
 };
 
 let contextsLoading = false;
@@ -157,6 +163,10 @@ export function resetContextsState(): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  contextsState.titleEditing = false;
+  contextsState.titleValue = "";
+  contextsState.titleBusy = false;
+  contextsState.titleError = "";
   cancelMemberSearchTimer();
   contextsNotice = "";
   memberSearchSeq++;
@@ -427,13 +437,18 @@ function detailTpl(c: CoreContext): TemplateResult {
       <div class="context-detail-head">
         <span class="context-glyph large">${icon(glyph, 22)}</span>
         <div class="context-detail-titles">
-          <h1 class="pane-title">
-            ${title}
+          <h1 class="pane-title project-detail-title">
+            ${c.project ? projectTitleBlock(c, c.project, title) : html`<span dir="auto">${title}</span>`}
             ${c.isPrivate ? html`<span class="context-lock" ${tip("Private channel")}>${icon(Lock, 14)}</span>` : nothing}
           </h1>
           <div class="context-sub">
             ${c.project ? sub : `${sub} The agent's files and memory here are separate from your other contexts.`}
           </div>
+          ${
+            c.project && contextsState.titleEditing && contextsState.titleError
+              ? html`<div class="project-member-status error" aria-live="polite">${contextsState.titleError}</div>`
+              : nothing
+          }
         </div>
         <div class="context-detail-actions">
           ${
@@ -506,6 +521,127 @@ function projectPeople(context: CoreContext): string[] {
 
 function isProjectOwner(context: CoreContext): boolean {
   return context.project?.ownerId === appState.me?.user;
+}
+
+function projectTitleBlock(context: CoreContext, project: CoreProject, title: string): TemplateResult {
+  if (contextsState.titleEditing) return projectTitleEditor(project);
+  return html`
+    <span class="project-title-text" dir="auto">${title}</span>
+    ${
+      isProjectOwner(context)
+        ? html`<button
+            class="project-icon-button project-title-edit"
+            type="button"
+            aria-label="Rename project"
+            ${tip("Rename project")}
+            @click=${() => beginProjectTitleRename(project)}
+          >
+            ${icon(Pencil, 14)}
+          </button>`
+        : nothing
+    }
+  `;
+}
+
+function projectTitleEditor(project: CoreProject): TemplateResult {
+  return html`
+    <form
+      class="project-title-form"
+      @submit=${(e: Event) => {
+        e.preventDefault();
+        void commitProjectTitleRename(project);
+      }}
+    >
+      <input
+        class="project-title-input"
+        type="text"
+        data-focus-key="project-title"
+        aria-label="Project name"
+        maxlength="200"
+        autocomplete="off"
+        .value=${contextsState.titleValue}
+        ?disabled=${contextsState.titleBusy}
+        @input=${(e: Event) => {
+          contextsState.titleValue = (e.target as HTMLInputElement).value;
+        }}
+        @keydown=${(e: KeyboardEvent) => {
+          if (e.isComposing || e.keyCode === 229) return;
+          if (e.key === "Escape") {
+            e.preventDefault();
+            cancelProjectTitleRename();
+          }
+        }}
+      />
+      <button
+        class="project-icon-button project-title-save"
+        type="submit"
+        aria-label="Save project name"
+        ${tip("Save")}
+        ?disabled=${contextsState.titleBusy}
+      >
+        ${icon(Check, 15)}
+      </button>
+      <button
+        class="project-icon-button project-title-cancel"
+        type="button"
+        aria-label="Cancel renaming project"
+        ${tip("Cancel")}
+        ?disabled=${contextsState.titleBusy}
+        @click=${() => cancelProjectTitleRename()}
+      >
+        ${icon(X, 15)}
+      </button>
+    </form>
+  `;
+}
+
+function beginProjectTitleRename(project: CoreProject): void {
+  contextsState.titleEditing = true;
+  contextsState.titleValue = project.name;
+  contextsState.titleError = "";
+  drawContexts();
+  requestAnimationFrame(() => {
+    const input = appState.mainEl?.querySelector<HTMLInputElement>(".project-title-input");
+    if (!input) return;
+    input.focus();
+    input.select();
+  });
+}
+
+function cancelProjectTitleRename(): void {
+  contextsState.titleEditing = false;
+  contextsState.titleValue = "";
+  contextsState.titleError = "";
+  drawContexts();
+}
+
+async function commitProjectTitleRename(project: CoreProject): Promise<void> {
+  if (!contextsState.titleEditing || contextsState.titleBusy) return;
+  const next = contextsState.titleValue.trim();
+  if (!next) {
+    contextsState.titleError = "Project name can't be empty.";
+    drawContexts();
+    return;
+  }
+  if (next === project.name) {
+    cancelProjectTitleRename();
+    return;
+  }
+  const resetSeq = contextsResetSeq;
+  contextsState.titleBusy = true;
+  contextsState.titleError = "";
+  drawContexts();
+  const ok = await renameProject(project, next);
+  if (resetSeq !== contextsResetSeq) return;
+  contextsState.titleBusy = false;
+  if (ok) {
+    contextsState.titleEditing = false;
+    contextsState.titleValue = "";
+    contextsState.titleError = "";
+  } else {
+    contextsState.titleError = "Couldn't rename this project. Try again.";
+  }
+  drawContexts();
 }
 
 function memberLabel(context: CoreContext, principalId: string): string {
@@ -1425,6 +1561,10 @@ function selectContext(scopeId: string | null): void {
   contextsState.slackValue = "";
   contextsState.slackBusy = false;
   contextsState.slackError = "";
+  contextsState.titleEditing = false;
+  contextsState.titleValue = "";
+  contextsState.titleBusy = false;
+  contextsState.titleError = "";
   contextsState.selected = scopeId;
   contextsState.resources = null;
   contextsState.resourcesScope = null;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5304,12 +5304,19 @@ a.chat-row-open {
   width: 26px;
   height: 26px;
   flex: 0 0 26px;
+}
+.project-detail-title .project-title-edit {
   opacity: 0;
   transition: opacity 0.12s ease;
 }
-.project-detail-title:hover .project-icon-button,
-.project-detail-title .project-icon-button:focus-visible {
+.project-detail-title:hover .project-title-edit,
+.project-detail-title .project-title-edit:focus-visible {
   opacity: 1;
+}
+@media (hover: none) {
+  .project-detail-title .project-title-edit {
+    opacity: 1;
+  }
 }
 .project-title-form {
   display: inline-flex;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5293,6 +5293,47 @@ a.chat-row-open {
   flex: 1;
   min-width: 0;
 }
+.project-detail-title {
+  min-width: 0;
+}
+.project-detail-title .project-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.project-detail-title .project-icon-button {
+  width: 26px;
+  height: 26px;
+  flex: 0 0 26px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.project-detail-title:hover .project-icon-button,
+.project-detail-title .project-icon-button:focus-visible {
+  opacity: 1;
+}
+.project-title-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.project-title-input {
+  box-sizing: border-box;
+  min-width: 0;
+  width: min(360px, 60vw);
+  padding: 4px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 20px;
+  font-weight: 600;
+}
+.project-title-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--foreground) 30%, transparent);
+}
 .context-sub {
   margin-top: 4px;
   max-width: 640px;

--- a/plugins/web-ui/test/project-title-rename-review-fixes.test.ts
+++ b/plugins/web-ui/test/project-title-rename-review-fixes.test.ts
@@ -1,0 +1,426 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+import { createServer, type ViteDevServer } from "vite";
+
+// Shared harness: same JSDOM + vite.ssrLoadModule pattern as
+// test/project-interactions.test.ts and test/project-title-rename.test.ts, loading the
+// real contexts.ts module so these are real-DOM regression tests, not source matching.
+async function setupHarness(): Promise<{
+  vite: ViteDevServer;
+  appState: { me: unknown; currentView: string; mainEl: HTMLElement | null; viewRenderSeq: number };
+  contextsState: {
+    selected: string | null;
+    list: unknown[];
+    titleEditing: boolean;
+    titleValue: string;
+    titleBusy: boolean;
+    titleError: string;
+  };
+  renderContexts: () => Promise<void>;
+}> {
+  const dom = new JSDOM(
+    '<!doctype html><button id="outside">Outside focus target</button><div id="app"></div><main id="main"></main>',
+    {
+      url: "http://localhost/web-ui/?view=contexts",
+    },
+  );
+  Object.defineProperty(dom.window, "matchMedia", {
+    value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+  });
+  Object.defineProperty(dom.window.HTMLDialogElement.prototype, "showModal", {
+    value(this: HTMLDialogElement) {
+      this.open = true;
+    },
+  });
+  const globals = {
+    window: dom.window,
+    document: dom.window.document,
+    location: dom.window.location,
+    history: dom.window.history,
+    localStorage: dom.window.localStorage,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLInputElement: dom.window.HTMLInputElement,
+    HTMLDialogElement: dom.window.HTMLDialogElement,
+    customElements: dom.window.customElements,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MouseEvent: dom.window.MouseEvent,
+    SubmitEvent: dom.window.SubmitEvent,
+    InputEvent: dom.window.InputEvent,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: clearTimeout,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+  };
+  for (const [key, value] of Object.entries(globals))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+
+  const vite = await createServer({ server: { middlewareMode: true, hmr: false }, appType: "custom" });
+  const { appState } = await vite.ssrLoadModule("/src/shell-state.ts");
+  const { contextsState, renderContexts } = await vite.ssrLoadModule("/src/contexts.ts");
+  appState.me = { user: "owner", org: "acme" };
+  appState.currentView = "contexts";
+  appState.mainEl = document.querySelector("#main");
+  return { vite, appState, contextsState, renderContexts };
+}
+
+function makeProject(id: string, name: string, ownerId: string) {
+  return {
+    id,
+    name,
+    ownerId,
+    memberIds: [ownerId],
+    scopeId: `project:${id}`,
+    members: [{ principalId: ownerId, displayName: ownerId === "owner" ? "Owner" : ownerId }],
+  };
+}
+
+function contextFor(project: ReturnType<typeof makeProject>) {
+  return {
+    scopeId: project.scopeId,
+    kind: "personal" as const,
+    name: null,
+    sessionCount: 0,
+    lastActivityAt: null,
+    project,
+  };
+}
+
+function clickRowFor(name: string): void {
+  const row = [...document.querySelectorAll<HTMLButtonElement>(".context-row")].find((el) =>
+    el.textContent?.includes(name),
+  );
+  if (!row) throw new Error(`no .context-row for ${name}`);
+  row.click();
+}
+
+function submitTitleForm(): void {
+  document
+    .querySelector<HTMLFormElement>(".project-title-form")!
+    .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+}
+
+function setTitleInput(value: string): void {
+  const input = document.querySelector<HTMLInputElement>(".project-title-input")!;
+  input.value = value;
+  input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+}
+
+// Opening the editor focuses+selects the input via requestAnimationFrame (see
+// beginProjectTitleRename), which our test globals resolve on a real macrotask, not
+// synchronously. Wait for it so the "currently focused element" driving the
+// preserve-focus behavior under test is actually the input, matching real usage.
+async function clickPencil(): Promise<void> {
+  document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// A real commit chains several awaits (fetch -> webFetch -> api -> renameProject ->
+// commitProjectTitleRename), and its own focus fallback is itself queued one
+// requestAnimationFrame after that. Give the event loop several microtask+macrotask
+// rounds to fully drain both before asserting on the settled DOM/focus state.
+async function settle(rounds = 5): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+test("stale rename completions never clobber a different project's draft, or a fresh reopened draft on the same project (A -> B, A -> B -> A)", async () => {
+  const { vite, contextsState, renderContexts } = await setupHarness();
+  try {
+    const projectA = makeProject("a", "Project A", "owner");
+    const projectB = makeProject("b", "Project B", "owner");
+    const contexts = [contextFor(projectA), contextFor(projectB)];
+
+    let heldA: { resolve: (r: Response) => void }[] = [];
+    globalThis.fetch = async (input, init) => {
+      const path = String(input);
+      if (path === "/api/contexts") return Response.json({ contexts });
+      if (path === "/api/sessions") return Response.json({ sessions: [] });
+      if (path.startsWith("/api/scope-resources"))
+        return Response.json({ files: [], webhooks: [], crons: [], deployments: [], skills: [], manageable: true });
+      if (path === "/api/projects/a" && init?.method === "PATCH") {
+        return new Promise<Response>((resolve) => heldA.push({ resolve }));
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+    };
+
+    contextsState.selected = null;
+    await renderContexts();
+
+    // Open A, start a save, and leave it hanging (simulates a slow network).
+    clickRowFor("Project A");
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    setTitleInput("A renamed while B is untouched");
+    submitTitleForm();
+    await Promise.resolve();
+    assert.equal(heldA.length, 1, "A's save should be in flight");
+
+    // Navigate away to B before A responds, and start a fresh, different draft there.
+    document.querySelector<HTMLButtonElement>(".context-back")!.click();
+    clickRowFor("Project B");
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    setTitleInput("B's own draft");
+
+    // A's slow save now resolves successfully. It must not touch B's open draft.
+    heldA[0]!.resolve(Response.json({ project: { ...projectA, name: "A renamed while B is untouched" } }));
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.deepEqual(
+      {
+        stillEditingB: contextsState.titleEditing,
+        bDraftIntact: contextsState.titleValue,
+        noErrorLeakedUnderB: contextsState.titleError,
+        bInputStillShowsDraft: document.querySelector<HTMLInputElement>(".project-title-input")?.value,
+      },
+      {
+        stillEditingB: true,
+        bDraftIntact: "B's own draft",
+        noErrorLeakedUnderB: "",
+        bInputStillShowsDraft: "B's own draft",
+      },
+      "A's late success must not close B's editor, touch B's draft, or leave an error under B",
+    );
+    // The rename itself is still real and must have landed in the shared list, just not
+    // in the ephemeral per-editor UI fields that now belong to B's session.
+    const updatedA = (contextsState.list as Array<{ scopeId: string; project?: { name: string } }>).find(
+      (c) => c.scopeId === "project:a",
+    );
+    assert.equal(updatedA?.project?.name, "A renamed while B is untouched");
+
+    // Now: A -> B -> A again, with a brand new draft, and prove a second stale
+    // response (from a request left over from a still-earlier attempt) can't land either.
+    // A's display name in the grid is now whatever the first rename above landed it at.
+    heldA = [];
+    document.querySelector<HTMLButtonElement>(".context-back")!.click();
+    clickRowFor("A renamed while B is untouched");
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    setTitleInput("first retry on A");
+    submitTitleForm();
+    await Promise.resolve();
+    const firstRetryRequest = heldA[0]!;
+    heldA = [];
+
+    // Leave, come back, and open a completely fresh edit on A before that request answers.
+    // The grid still shows the pre-"first retry" name here because that request is the
+    // one being held open below — it hasn't resolved (and so hasn't updated the list) yet.
+    document.querySelector<HTMLButtonElement>(".context-back")!.click();
+    clickRowFor("A renamed while B is untouched");
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    setTitleInput("second, newer draft on A");
+
+    firstRetryRequest.resolve(Response.json({ project: { ...projectA, name: "first retry on A" } }));
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.deepEqual(
+      {
+        stillEditingNewSession: contextsState.titleEditing,
+        newDraftIntact: contextsState.titleValue,
+        noErrorFromOldRequest: contextsState.titleError,
+      },
+      { stillEditingNewSession: true, newDraftIntact: "second, newer draft on A", noErrorFromOldRequest: "" },
+      "a stale response from an earlier A edit session must not touch a freshly reopened A edit session (A -> B -> A)",
+    );
+  } finally {
+    await vite.close();
+  }
+});
+
+test("focus is restored predictably after every exit path, and a slow save never steals focus back from elsewhere on the page", async () => {
+  const { vite, contextsState, renderContexts } = await setupHarness();
+  try {
+    const project = makeProject("focus", "Focus Test Project", "owner");
+    const contexts = [contextFor(project)];
+    let held: { resolve: (r: Response) => void }[] = [];
+    let shouldFail = false;
+    globalThis.fetch = async (input, init) => {
+      const path = String(input);
+      if (path === "/api/contexts") return Response.json({ contexts });
+      if (path === "/api/sessions") return Response.json({ sessions: [] });
+      if (path.startsWith("/api/scope-resources"))
+        return Response.json({ files: [], webhooks: [], crons: [], deployments: [], skills: [], manageable: true });
+      if (path === "/api/projects/focus" && init?.method === "PATCH") {
+        return new Promise<Response>((resolve) => held.push({ resolve }));
+      }
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+    };
+
+    contextsState.selected = "project:focus";
+    await renderContexts();
+
+    const classOf = (): string | undefined => (document.activeElement as HTMLElement | null)?.className;
+
+    // Escape -> pencil.
+    await clickPencil();
+    document
+      .querySelector<HTMLInputElement>(".project-title-input")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    assert.match(classOf() ?? "", /project-title-edit/, "Escape should return focus to the pencil");
+
+    // Cancel button click -> pencil.
+    await clickPencil();
+    document.querySelector<HTMLButtonElement>(".project-title-cancel")!.click();
+    await Promise.resolve();
+    assert.match(classOf() ?? "", /project-title-edit/, "clicking Cancel should return focus to the pencil");
+
+    // Blank submit -> stays editing, focus stays in the input (not the vanished pencil).
+    await clickPencil();
+    setTitleInput("   ");
+    submitTitleForm();
+    await Promise.resolve();
+    assert.equal(contextsState.titleEditing, true, "blank submit stays in edit mode");
+    assert.match(classOf() ?? "", /project-title-input/, "blank submit should keep focus in the input to fix the typo");
+
+    // Unchanged name -> exits, focus -> pencil.
+    setTitleInput(project.name);
+    submitTitleForm();
+    await Promise.resolve();
+    assert.equal(contextsState.titleEditing, false, "unchanged submit exits editing");
+    assert.match(classOf() ?? "", /project-title-edit/, "unchanged submit should return focus to the pencil");
+
+    // Real (slow) successful save -> after the async round trip, focus -> pencil.
+    await clickPencil();
+    setTitleInput("Focus Test Project renamed");
+    submitTitleForm();
+    await Promise.resolve();
+    assert.equal(document.activeElement, document.body, "the busy-disabled inputs drop focus to <body> mid-flight");
+    held[0]!.resolve(Response.json({ project: { ...project, name: "Focus Test Project renamed" } }));
+    held = [];
+    await settle();
+    assert.match(classOf() ?? "", /project-title-edit/, "a real successful save should restore focus to the pencil");
+
+    // Real (slow) failed save -> focus -> input, draft preserved.
+    await clickPencil();
+    setTitleInput("this one will fail");
+    submitTitleForm();
+    await Promise.resolve();
+    shouldFail = true;
+    held[0]!.resolve(
+      shouldFail ? new Response(JSON.stringify({ message: "nope" }), { status: 409 }) : Response.json({}),
+    );
+    held = [];
+    await settle();
+    assert.equal(contextsState.titleEditing, true, "a failed save stays in edit mode");
+    assert.match(classOf() ?? "", /project-title-input/, "a real failed save should restore focus to the input");
+
+    // Back out of that failed attempt before starting the next scenario.
+    document.querySelector<HTMLButtonElement>(".project-title-cancel")!.click();
+    await Promise.resolve();
+
+    // A slow save must never steal focus from somewhere else the user has since moved to.
+    await clickPencil();
+    setTitleInput("should not steal focus");
+    submitTitleForm();
+    await Promise.resolve();
+    const outside = document.querySelector<HTMLButtonElement>("#outside")!;
+    outside.focus();
+    assert.equal(document.activeElement, outside);
+    held[0]!.resolve(Response.json({ project: { ...project, name: "should not steal focus" } }));
+    await settle();
+    assert.equal(
+      document.activeElement,
+      outside,
+      "a slow save resolving after the user focused something else must not steal focus back",
+    );
+  } finally {
+    await vite.close();
+  }
+});
+
+test("a cheap ownership recheck on refresh hides/cancels an open title editor once the signed-in user is no longer the owner", async () => {
+  const { vite, contextsState, renderContexts } = await setupHarness();
+  try {
+    const project = makeProject("owned-then-not", "Transfer Test", "owner");
+    let ownerId = "owner";
+    globalThis.fetch = async (input, init) => {
+      const path = String(input);
+      if (path === "/api/contexts")
+        return Response.json({
+          contexts: [contextFor({ ...project, ownerId })],
+        });
+      if (path === "/api/sessions") return Response.json({ sessions: [] });
+      if (path.startsWith("/api/scope-resources"))
+        return Response.json({ files: [], webhooks: [], crons: [], deployments: [], skills: [], manageable: true });
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+    };
+
+    contextsState.selected = "project:owned-then-not";
+    await renderContexts();
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    setTitleInput("mid-edit when ownership changes");
+    assert.equal(contextsState.titleEditing, true);
+    assert.ok(document.querySelector(".project-title-input"), "editor is open before the ownership change");
+
+    // Ownership changes elsewhere; the next refresh (e.g. window focus) picks it up.
+    ownerId = "someone-else";
+    await renderContexts();
+
+    assert.deepEqual(
+      {
+        stillEditing: contextsState.titleEditing,
+        draftCleared: contextsState.titleValue,
+        noPencilForNonOwner: document.querySelector(".project-title-edit") === null,
+        noInputLeftOpen: document.querySelector(".project-title-input") === null,
+      },
+      { stillEditing: false, draftCleared: "", noPencilForNonOwner: true, noInputLeftOpen: true },
+      "losing ownership while the editor is open should hide/cancel it on the next refresh",
+    );
+  } finally {
+    await vite.close();
+  }
+});
+
+test("only the idle pencil carries the hover-revealed opacity class; Save/Cancel are always visible while editing", async () => {
+  // shell.css scopes the opacity-0-until-hover/focus rule (and its `@media (hover: none)`
+  // touch fallback) to `.project-detail-title .project-title-edit` specifically — not the
+  // broader `.project-detail-title .project-icon-button`, which would also match the Save
+  // and Cancel buttons rendered inside the same `.project-detail-title` and make them fade
+  // out whenever the mouse isn't literally over the title (including while the input has
+  // focus, since focus-visible only lights up the one focused button). This is a real-DOM
+  // structural check for that scoping; actual CSS media-query cascade evaluation isn't
+  // available in this JSDOM/vite unit-test harness — a real-browser touch/no-hover render
+  // was attempted but this sandbox has no way to force `(hover: none)` (no CDP
+  // Emulation.setEmulatedMedia, and no way to create a `hasTouch` browser context), so this
+  // is the closest automated regression coverage available for that selector scoping.
+  const { vite, contextsState, renderContexts } = await setupHarness();
+  try {
+    const project = makeProject("scope", "CSS Scope Test", "owner");
+    const contexts = [contextFor(project)];
+    globalThis.fetch = async (input, init) => {
+      const path = String(input);
+      if (path === "/api/contexts") return Response.json({ contexts });
+      if (path === "/api/sessions") return Response.json({ sessions: [] });
+      if (path.startsWith("/api/scope-resources"))
+        return Response.json({ files: [], webhooks: [], crons: [], deployments: [], skills: [], manageable: true });
+      throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+    };
+
+    contextsState.selected = "project:scope";
+    await renderContexts();
+    const pencil = document.querySelector<HTMLButtonElement>(".project-title-edit")!;
+    assert.equal(pencil.classList.contains("project-title-edit"), true);
+
+    await clickPencil();
+    const save = document.querySelector<HTMLButtonElement>(".project-title-save")!;
+    const cancel = document.querySelector<HTMLButtonElement>(".project-title-cancel")!;
+    assert.deepEqual(
+      {
+        saveCarriesEditClass: save.classList.contains("project-title-edit"),
+        cancelCarriesEditClass: cancel.classList.contains("project-title-edit"),
+        bothStillIconButtons:
+          save.classList.contains("project-icon-button") && cancel.classList.contains("project-icon-button"),
+      },
+      { saveCarriesEditClass: false, cancelCarriesEditClass: false, bothStillIconButtons: true },
+      "Save/Cancel must not carry the opacity-hiding class, only the sizing one",
+    );
+  } finally {
+    await vite.close();
+  }
+});

--- a/plugins/web-ui/test/project-title-rename.test.ts
+++ b/plugins/web-ui/test/project-title-rename.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { JSDOM } from "jsdom";
+import { createServer } from "vite";
+
+test("owner-only inline project title rename: affordance, save/cancel/blank/unchanged/error/busy, and sidebar propagation", async () => {
+  const dom = new JSDOM('<!doctype html><div id="app"></div><main id="main"></main>', {
+    url: "http://localhost/web-ui/?view=contexts",
+  });
+  Object.defineProperty(dom.window, "matchMedia", {
+    value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+  });
+  Object.defineProperty(dom.window.HTMLDialogElement.prototype, "showModal", {
+    value(this: HTMLDialogElement) {
+      this.open = true;
+    },
+  });
+  const globals = {
+    window: dom.window,
+    document: dom.window.document,
+    location: dom.window.location,
+    history: dom.window.history,
+    localStorage: dom.window.localStorage,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    HTMLInputElement: dom.window.HTMLInputElement,
+    HTMLDialogElement: dom.window.HTMLDialogElement,
+    customElements: dom.window.customElements,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MouseEvent: dom.window.MouseEvent,
+    SubmitEvent: dom.window.SubmitEvent,
+    InputEvent: dom.window.InputEvent,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: clearTimeout,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+  };
+  for (const [key, value] of Object.entries(globals))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+
+  const owner = { scopeId: "project:owned", kind: "personal", name: null, sessionCount: 0, lastActivityAt: null };
+  const ownedProject = {
+    id: "project-owned",
+    name: "Launch planning",
+    ownerId: "owner",
+    memberIds: ["owner"],
+    scopeId: "project:owned",
+    members: [{ principalId: "owner", displayName: "Owner" }],
+  };
+  const ownedContext = { ...owner, project: ownedProject };
+  const other = { scopeId: "project:other", kind: "personal", name: null, sessionCount: 0, lastActivityAt: null };
+  const otherProject = {
+    id: "project-other",
+    name: "Someone else's project",
+    ownerId: "not-me",
+    memberIds: ["owner", "not-me"],
+    scopeId: "project:other",
+    members: [
+      { principalId: "not-me", displayName: "Not Me" },
+      { principalId: "owner", displayName: "Owner" },
+    ],
+  };
+  const otherContext = { ...other, project: otherProject };
+
+  let patchCalls = 0;
+  let lastPatchBody: { name?: string } | null = null;
+  // Toggle between throwing (simulated failure) and succeeding, and let a single
+  // in-flight request be held open on demand to inspect the busy-disabled UI.
+  let patchShouldFail = false;
+  let holdPatch: { resolve: () => void } | null = null;
+
+  globalThis.fetch = async (input, init) => {
+    const path = String(input);
+    if (path === "/api/contexts") return Response.json({ contexts: [ownedContext, otherContext] });
+    if (path === "/api/sessions") return Response.json({ sessions: [] });
+    if (path === "/api/projects/project-owned" && init?.method === "PATCH") {
+      patchCalls++;
+      lastPatchBody = JSON.parse(String(init.body));
+      if (holdPatch) {
+        await new Promise<void>((resolve) => {
+          holdPatch = { resolve };
+        });
+      }
+      if (patchShouldFail) return new Response(JSON.stringify({ message: "name already in use" }), { status: 409 });
+      const updated = { ...ownedProject, name: lastPatchBody!.name };
+      return Response.json({ project: updated });
+    }
+    throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${path}`);
+  };
+
+  const vite = await createServer({ server: { middlewareMode: true, hmr: false }, appType: "custom" });
+  try {
+    const { appState } = await vite.ssrLoadModule("/src/shell-state.ts");
+    const { contextsState, renderContexts, resetContextsState } = await vite.ssrLoadModule("/src/contexts.ts");
+    appState.me = { user: "owner", org: "acme" };
+    appState.currentView = "contexts";
+    appState.mainEl = document.querySelector("#main");
+    resetContextsState();
+    contextsState.selected = "project:other";
+
+    await renderContexts();
+
+    // Non-owner: no rename affordance is rendered at all.
+    const noEditButtonForNonOwner = document.querySelector(".project-title-edit") === null;
+    assert.ok(document.querySelector(".pane-title")?.textContent?.includes(otherProject.name));
+
+    contextsState.selected = "project:owned";
+    await renderContexts();
+
+    // Owner: the idle title shows a subtle pencil affordance next to the plain name.
+    const titleText = document.querySelector(".project-title-text")?.textContent;
+    const editButton = document.querySelector<HTMLButtonElement>(".project-title-edit");
+    const hasEditButtonForOwner = editButton !== null;
+
+    editButton!.click();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Editing state: a focused, prefilled input plus explicit save/cancel controls.
+    const input = document.querySelector<HTMLInputElement>(".project-title-input")!;
+    const inputPrefilled = input.value === ownedProject.name;
+    const inputFocused = document.activeElement === input;
+    const hasSaveButton = document.querySelector(".project-title-save") !== null;
+    const hasCancelButton = document.querySelector(".project-title-cancel") !== null;
+
+    // Escape cancels without calling the API.
+    input.value = "changed but escaped";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    const cancelledBackToIdle = document.querySelector(".project-title-input") === null;
+    const noCallsAfterEscape = patchCalls === 0;
+
+    // Re-open, submit blank -> validation error, no API call, stays editing.
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    await Promise.resolve();
+    const blankInput = document.querySelector<HTMLInputElement>(".project-title-input")!;
+    blankInput.value = "   ";
+    blankInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    document
+      .querySelector<HTMLFormElement>(".project-title-form")!
+      .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    const blankShowsError = document.body.textContent?.includes("can't be empty") === true;
+    const staysEditingAfterBlank = document.querySelector(".project-title-input") !== null;
+    const noCallOnBlank = patchCalls === 0;
+
+    // Unchanged name -> exits editing quietly without an API call.
+    const unchangedInput = document.querySelector<HTMLInputElement>(".project-title-input")!;
+    unchangedInput.value = ownedProject.name;
+    unchangedInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    document
+      .querySelector<HTMLFormElement>(".project-title-form")!
+      .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    const exitsOnUnchanged = document.querySelector(".project-title-input") === null;
+    const noCallOnUnchanged = patchCalls === 0;
+
+    // Real rename attempt that fails server-side: draft is preserved, error is shown,
+    // and the busy guard disables the controls while the request is in flight.
+    document.querySelector<HTMLButtonElement>(".project-title-edit")!.click();
+    await Promise.resolve();
+    patchShouldFail = true;
+    let release!: () => void;
+    holdPatch = null;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const path = String(input);
+      if (path === "/api/projects/project-owned" && init?.method === "PATCH") {
+        patchCalls++;
+        lastPatchBody = JSON.parse(String(init.body));
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return new Response(JSON.stringify({ message: "name already in use" }), { status: 409 });
+      }
+      return originalFetch(input, init);
+    };
+    const failInput = document.querySelector<HTMLInputElement>(".project-title-input")!;
+    failInput.value = "Renamed launch planning";
+    failInput.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    document
+      .querySelector<HTMLFormElement>(".project-title-form")!
+      .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    const busyDisablesInput = document.querySelector<HTMLInputElement>(".project-title-input")!.disabled === true;
+    const busyDisablesSave = document.querySelector<HTMLButtonElement>(".project-title-save")!.disabled === true;
+    release();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const staysEditingAfterFailure = document.querySelector(".project-title-input") !== null;
+    const draftPreservedAfterFailure =
+      document.querySelector<HTMLInputElement>(".project-title-input")!.value === "Renamed launch planning";
+    const errorShownAfterFailure = document.body.textContent?.includes("Couldn't rename this project") === true;
+    globalThis.fetch = originalFetch;
+
+    // Retry succeeds: title updates in the header and propagates to the shared
+    // contexts list the sidebar reads from, and editing closes.
+    patchShouldFail = false;
+    document
+      .querySelector<HTMLFormElement>(".project-title-form")!
+      .dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const successClosesEditing = document.querySelector(".project-title-input") === null;
+    const headerShowsNewName = document.querySelector(".project-title-text")?.textContent === "Renamed launch planning";
+    const propagatedToSharedList = contextsState.list.find((c: { scopeId: string }) => c.scopeId === "project:owned")
+      ?.project?.name;
+
+    assert.deepEqual(
+      {
+        noEditButtonForNonOwner,
+        hasEditButtonForOwner,
+        titleText,
+        inputPrefilled,
+        inputFocused,
+        hasSaveButton,
+        hasCancelButton,
+        cancelledBackToIdle,
+        noCallsAfterEscape,
+        blankShowsError,
+        staysEditingAfterBlank,
+        noCallOnBlank,
+        exitsOnUnchanged,
+        noCallOnUnchanged,
+        busyDisablesInput,
+        busyDisablesSave,
+        staysEditingAfterFailure,
+        draftPreservedAfterFailure,
+        errorShownAfterFailure,
+        successClosesEditing,
+        headerShowsNewName,
+        propagatedToSharedList,
+      },
+      {
+        noEditButtonForNonOwner: true,
+        hasEditButtonForOwner: true,
+        titleText: "Launch planning",
+        inputPrefilled: true,
+        inputFocused: true,
+        hasSaveButton: true,
+        hasCancelButton: true,
+        cancelledBackToIdle: true,
+        noCallsAfterEscape: true,
+        blankShowsError: true,
+        staysEditingAfterBlank: true,
+        noCallOnBlank: true,
+        exitsOnUnchanged: true,
+        noCallOnUnchanged: true,
+        busyDisablesInput: true,
+        busyDisablesSave: true,
+        staysEditingAfterFailure: true,
+        draftPreservedAfterFailure: true,
+        errorShownAfterFailure: true,
+        successClosesEditing: true,
+        headerShowsNewName: true,
+        propagatedToSharedList: "Renamed launch planning",
+      },
+    );
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
## Summary

Adds an owner-only inline rename affordance to the project title on the Projects detail page.

Fixes #321, reported by @ianTPE.

- Reuses the existing `renameProject` action (existing `PATCH /v1/projects/:id`, existing owner-checked authorization) — no new backend, no new capability.
- Small inline editor next to the project title, subtle pencil affordance for the owner only, matching the existing Slack-channel-linker editor pattern.
- Keyboard: Enter saves, Escape cancels. Blank names show a validation error and stay in edit mode; unchanged names exit quietly. A busy guard disables the controls during a save, and a failed save preserves the typed draft with an error instead of discarding it silently.
- Navigation-race safe: a slow save can't clobber a different project's draft/error after navigating away, or a freshly reopened draft on the same project.
- Focus is restored predictably after every exit path (including on a real async save/failure), and never stolen from elsewhere on the page.
- Visible on touch as well as desktop hover/focus.

## Verification

- 1026 web-ui tests pass
- Typecheck, ESLint, oxlint, and Prettier all clean
- Independently reviewed before this PR was opened

## Demo

Rendered locally against synthetic fixture data (no production data), verified via automated real-DOM tests plus manual screenshots taken outside this repo.