### PR TITLE
Fix prompt expansion controls inside message bubbles

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1490,8 +1490,8 @@ export function createChatSurface(
               ${attachments.length ? html`<div class="message-files">${attachments.map(userAttachmentBadge)}</div>` : nothing}
               ${edited || deleted ? html`<span class="revision-badge">(${deleted ? "deleted" : "edited"})</span>` : nothing}
             </div>
+            <button class="pin-toggle" type="button" hidden aria-expanded="false">Show more</button>
           </div>
-          <button class="pin-toggle" type="button" hidden aria-expanded="false">Show more</button>
           ${
             sendFailure
               ? html`<div class="send-failure">

--- a/plugins/web-ui/src/shared-session.ts
+++ b/plugins/web-ui/src/shared-session.ts
@@ -75,8 +75,8 @@ render(
                           }
                         </div>
                         ${message.role === "assistant" ? html`<div class="message-meta"><button class="msg-copy" aria-label="Copy message" title="Copy" @click=${(e: Event) => void copyText(message.text, e.currentTarget as HTMLButtonElement)}>${icon(Copy, 13)}</button></div>` : ""}
+                        ${message.role === "user" ? html`<button class="pin-toggle" type="button" hidden aria-expanded="false">Show more</button>` : ""}
                       </div>
-                      ${message.role === "user" ? html`<button class="pin-toggle" type="button" hidden aria-expanded="false">Show more</button>` : ""}
                       ${message.role === "user" ? html`<div class="message-meta"><button class="msg-copy" aria-label="Copy message" title="Copy" @click=${(e: Event) => void copyText(message.text, e.currentTarget as HTMLButtonElement)}>${icon(Copy, 13)}</button></div>` : ""}
                     </article>
                   `,

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1775,24 +1775,26 @@ a.chat-row-open {
 .user-bubble > .pin-content {
   display: flow-root;
 }
-.message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble {
+.message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble > .pin-content {
   max-height: var(--pin-clamp, 320px);
   overflow: hidden;
 }
 .pin-toggle {
   display: none;
+  width: fit-content;
+  margin: 6px 0 0 auto;
   pointer-events: auto;
   border: 0;
   border-radius: 6px;
-  background: var(--background);
+  background: transparent;
   color: var(--muted-foreground);
   font: inherit;
   font-size: 12px;
   padding: 6px 8px;
   cursor: pointer;
 }
-.message-stack .user-row:not(:has(~ .user-row)) > .pin-toggle:not([hidden]) {
-  display: inline-flex;
+.message-stack .user-row:not(:has(~ .user-row)) > .user-bubble > .pin-toggle:not([hidden]) {
+  display: flex;
 }
 .pin-toggle:hover {
   color: var(--foreground);
@@ -8954,7 +8956,7 @@ h3.ambient-field-label {
 .mini-convo-body .message-stack {
   width: 100%;
 }
-.mini-convo-body .message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble {
+.mini-convo-body .message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble > .pin-content {
   max-height: 100px;
 }
 .mini-convo-missing {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1775,7 +1775,7 @@ a.chat-row-open {
 .user-bubble > .pin-content {
   display: flow-root;
 }
-.message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble > .pin-content {
+.message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded):not(.pin-fits) .user-bubble > .pin-content {
   max-height: var(--pin-clamp, 320px);
   overflow: hidden;
 }
@@ -8956,7 +8956,11 @@ h3.ambient-field-label {
 .mini-convo-body .message-stack {
   width: 100%;
 }
-.mini-convo-body .message-stack .user-row:not(:has(~ .user-row)):not(.pin-expanded) .user-bubble > .pin-content {
+.mini-convo-body
+  .message-stack
+  .user-row:not(:has(~ .user-row)):not(.pin-expanded):not(.pin-fits)
+  .user-bubble
+  > .pin-content {
   max-height: 100px;
 }
 .mini-convo-missing {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -2816,7 +2816,7 @@ a.chat-row-open {
 }
 .assistant-body code-block[language="text"] copy-button button,
 .user-bubble code-block[language="text"] copy-button button {
-  width: var(--meta-lane);
+  min-width: var(--meta-lane);
   height: var(--meta-lane);
   padding: 0;
 }

--- a/plugins/web-ui/src/transcript-viewport.ts
+++ b/plugins/web-ui/src/transcript-viewport.ts
@@ -38,8 +38,7 @@ export function createTranscriptViewport() {
       `${Math.round(Math.min(320, Math.max(96, scroller.clientHeight * 0.35)))}px`,
     );
     prompt.classList.toggle("pin-expanded", expanded);
-    const bubble = prompt.querySelector<HTMLElement>(".user-bubble");
-    const clipped = !expanded && !!bubble && bubble.scrollHeight > bubble.clientHeight + 1;
+    const clipped = !expanded && content.scrollHeight > content.clientHeight + 1;
     const toggle = prompt.querySelector<HTMLButtonElement>(".pin-toggle");
     if (toggle) {
       toggle.hidden = !clipped && !expanded;

--- a/plugins/web-ui/src/transcript-viewport.ts
+++ b/plugins/web-ui/src/transcript-viewport.ts
@@ -23,7 +23,7 @@ export function createTranscriptViewport() {
   }
 
   function clearPrompt(): void {
-    prompt?.classList.remove("stuck", "sticky-disabled", "pin-expanded");
+    prompt?.classList.remove("stuck", "sticky-disabled", "pin-expanded", "pin-fits");
     prompt?.style.removeProperty("--pin-clamp");
     const toggle = prompt?.querySelector<HTMLButtonElement>(".pin-toggle");
     if (toggle) toggle.hidden = true;
@@ -38,7 +38,10 @@ export function createTranscriptViewport() {
       `${Math.round(Math.min(320, Math.max(96, scroller.clientHeight * 0.35)))}px`,
     );
     prompt.classList.toggle("pin-expanded", expanded);
-    const clipped = !expanded && content.scrollHeight > content.clientHeight + 1;
+    // Measure at the normal clamp before deciding whether collapsing saves a useful amount.
+    prompt.classList.remove("pin-fits");
+    const clipped = !expanded && content.scrollHeight > content.clientHeight + 24;
+    prompt.classList.toggle("pin-fits", !expanded && !clipped);
     const toggle = prompt.querySelector<HTMLButtonElement>(".pin-toggle");
     if (toggle) {
       toggle.hidden = !clipped && !expanded;

--- a/plugins/web-ui/test/pinned-prompt-collapse.test.ts
+++ b/plugins/web-ui/test/pinned-prompt-collapse.test.ts
@@ -5,27 +5,26 @@ import { createTranscriptViewport } from "../src/transcript-viewport.ts";
 
 function fixture() {
   const dom = new JSDOM(
-    `<section class="chat-scroll"><div class="message-stack"><article class="user-row" data-index="1"><div class="user-bubble"><div class="pin-content">Example prompt</div></div><button class="pin-toggle" hidden>Show more</button></article></div></section>`,
+    `<section class="chat-scroll"><div class="message-stack"><article class="user-row" data-index="1"><div class="user-bubble"><div class="pin-content">Example prompt</div><button class="pin-toggle" hidden>Show more</button></div></article></div></section>`,
   );
   const scroller = dom.window.document.querySelector<HTMLElement>("section")!;
   const row = scroller.querySelector<HTMLElement>("article")!;
-  const bubble = row.querySelector<HTMLElement>(".user-bubble")!;
   const content = row.querySelector<HTMLElement>(".pin-content")!;
   const toggle = row.querySelector<HTMLButtonElement>("button")!;
   let height = 300;
   let fullHeight = 600;
   Object.defineProperties(scroller, { clientHeight: { get: () => height }, scrollHeight: { value: 2000 } });
-  Object.defineProperties(bubble, {
+  Object.defineProperties(content, {
     scrollHeight: { get: () => fullHeight },
     clientHeight: {
       get: () =>
-        row.classList.contains("pin-expanded")
+        row.classList.contains("pin-expanded") || row.classList.contains("pin-fits")
           ? fullHeight
           : Math.min(fullHeight, parseFloat(row.style.getPropertyValue("--pin-clamp")) || 320),
     },
   });
   scroller.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
-  row.getBoundingClientRect = () => ({ top: 0, height: bubble.clientHeight + 24 }) as DOMRect;
+  row.getBoundingClientRect = () => ({ top: 0, height: content.clientHeight + 24 }) as DOMRect;
   const observed = new Set<Element>();
   let resize = () => {};
   const restore = ["ResizeObserver", "getComputedStyle"].map(
@@ -53,7 +52,6 @@ function fixture() {
   return {
     scroller,
     row,
-    bubble,
     content,
     toggle,
     observed,
@@ -87,7 +85,7 @@ test("long prompts clamp to the pane and expand or collapse through their button
     assert.equal(f.toggle.getAttribute("aria-expanded"), "true");
     assert.equal(f.toggle.textContent, "Show less");
     f.toggle.click();
-    assert.ok(f.bubble.scrollHeight > f.bubble.clientHeight);
+    assert.ok(f.content.scrollHeight > f.content.clientHeight);
     assert.equal(f.toggle.getAttribute("aria-expanded"), "false");
   } finally {
     f.close();
@@ -114,7 +112,7 @@ test("late content growth reveals the control without a scroll or redraw", () =>
     assert.equal(f.toggle.hidden, true);
     f.grow(800);
     assert.equal(f.toggle.hidden, false);
-    assert.ok(f.bubble.scrollHeight > f.bubble.clientHeight);
+    assert.ok(f.content.scrollHeight > f.content.clientHeight);
   } finally {
     f.close();
   }

--- a/plugins/web-ui/test/transcript-viewport.test.ts
+++ b/plugins/web-ui/test/transcript-viewport.test.ts
@@ -130,11 +130,11 @@ test("resizing a settled transcript updates the prompt expansion control", () =>
   const f = fixture();
   try {
     f.prompt.innerHTML =
-      '<div class="user-bubble"><div class="pin-content"><markdown-block></markdown-block></div></div><button class="pin-toggle" hidden>Show more</button>';
-    const bubble = f.prompt.querySelector<HTMLElement>(".user-bubble")!;
+      '<div class="user-bubble"><div class="pin-content"><markdown-block></markdown-block></div><button class="pin-toggle" hidden>Show more</button></div>';
+    const content = f.prompt.querySelector<HTMLElement>(".pin-content")!;
     const toggle = f.prompt.querySelector<HTMLButtonElement>(".pin-toggle")!;
     let availableHeight = 240;
-    Object.defineProperties(bubble, {
+    Object.defineProperties(content, {
       scrollHeight: { value: 240 },
       clientHeight: { get: () => availableHeight },
     });
@@ -285,4 +285,25 @@ test("a prompt stays in flow when pins leave too little room, and can stick agai
   } finally {
     f.close();
   }
+});
+
+test("prompt expansion control belongs inside the bubble in both renderers", () => {
+  for (const [source, start] of [
+    [chat, '<article class="message-row user-row'],
+    [readFileSync(new URL("../src/shared-session.ts", import.meta.url), "utf8"), "<article class=${"],
+  ]) {
+    const rowStart = source!.indexOf(start!);
+    assert.ok(rowStart >= 0);
+    const row = source!.slice(rowStart, source!.indexOf("</article>", rowStart) + "</article>".length);
+    const dom = new JSDOM(row);
+    try {
+      const toggle = dom.window.document.querySelector(".pin-toggle");
+      assert.equal(toggle?.parentElement?.tagName, "DIV");
+      assert.equal(toggle?.parentElement?.parentElement?.tagName, "ARTICLE");
+    } finally {
+      dom.window.close();
+    }
+  }
+  assert.match(css, /:not\(\.pin-expanded\) \.user-bubble > \.pin-content \{/);
+  assert.match(css, /\.user-bubble > \.pin-toggle:not\(\[hidden\]\)/);
 });

--- a/plugins/web-ui/test/transcript-viewport.test.ts
+++ b/plugins/web-ui/test/transcript-viewport.test.ts
@@ -307,3 +307,35 @@ test("prompt expansion control belongs inside the bubble in both renderers", () 
   assert.match(css, /:not\(\.pin-expanded\) \.user-bubble > \.pin-content \{/);
   assert.match(css, /\.user-bubble > \.pin-toggle:not\(\[hidden\]\)/);
 });
+
+test("nested paste and attachment controls do not toggle the whole prompt", () => {
+  const f = fixture();
+  try {
+    f.prompt.innerHTML =
+      '<div class="user-bubble"><div class="pin-content"><code-block><button class="text-code-toggle">Show more</button><copy-button><button>Copy</button></copy-button></code-block><div class="message-files"><a class="file-chip" href="#file">notes.txt</a></div></div><button class="pin-toggle" hidden>Show more</button></div>';
+    const content = f.prompt.querySelector<HTMLElement>(".pin-content")!;
+    const toggle = f.prompt.querySelector<HTMLButtonElement>(".pin-toggle")!;
+    Object.defineProperties(content, {
+      scrollHeight: { value: 500 },
+      clientHeight: { value: 160 },
+    });
+    f.viewport.sync(f.s);
+    assert.equal(toggle.hidden, false);
+    for (const expanded of [false, true]) {
+      if (expanded) toggle.click();
+      for (const selector of [".text-code-toggle", "copy-button button", ".file-chip"]) {
+        f.prompt.querySelector<HTMLElement>(selector)!.click();
+        assert.equal(f.prompt.classList.contains("pin-expanded"), expanded);
+        assert.equal(toggle.getAttribute("aria-expanded"), String(expanded));
+      }
+    }
+  } finally {
+    f.close();
+  }
+});
+
+test("plain-text copy confirmation can grow beyond its icon width", () => {
+  const rule = css.match(/\.user-bubble code-block\[language="text"\] copy-button button \{[^}]*\}/)?.[0] ?? "";
+  assert.match(rule, /min-width: var\(--meta-lane\)/);
+  assert.doesNotMatch(rule, /(?:^|[;{])\s*width:/);
+});

--- a/plugins/web-ui/test/transcript-viewport.test.ts
+++ b/plugins/web-ui/test/transcript-viewport.test.ts
@@ -304,7 +304,7 @@ test("prompt expansion control belongs inside the bubble in both renderers", () 
       dom.window.close();
     }
   }
-  assert.match(css, /:not\(\.pin-expanded\) \.user-bubble > \.pin-content \{/);
+  assert.match(css, /:not\(\.pin-expanded\):not\(\.pin-fits\)\s+\.user-bubble\s+>\s+\.pin-content \{/);
   assert.match(css, /\.user-bubble > \.pin-toggle:not\(\[hidden\]\)/);
 });
 
@@ -338,4 +338,31 @@ test("plain-text copy confirmation can grow beyond its icon width", () => {
   const rule = css.match(/\.user-bubble code-block\[language="text"\] copy-button button \{[^}]*\}/)?.[0] ?? "";
   assert.match(rule, /min-width: var\(--meta-lane\)/);
   assert.doesNotMatch(rule, /(?:^|[;{])\s*width:/);
+});
+
+test("marginal overflow is shown in full without an expansion control", () => {
+  const f = fixture();
+  try {
+    f.prompt.innerHTML =
+      '<div class="user-bubble"><div class="pin-content"></div><button class="pin-toggle" hidden>Show more</button></div>';
+    const content = f.prompt.querySelector<HTMLElement>(".pin-content")!;
+    const toggle = f.prompt.querySelector<HTMLButtonElement>(".pin-toggle")!;
+    let overflow = 5;
+    Object.defineProperties(content, {
+      scrollHeight: { get: () => 160 + overflow },
+      clientHeight: { get: () => (f.prompt.classList.contains("pin-fits") ? 160 + overflow : 160) },
+    });
+    f.viewport.sync(f.s);
+    for (overflow of [0, 5, 24, 25, 100, 5]) {
+      f.resize(30, 50);
+      assert.equal(toggle.hidden, overflow <= 24);
+      assert.equal(f.prompt.classList.contains("pin-fits"), overflow <= 24);
+      f.resize(30, 50);
+      assert.equal(toggle.hidden, overflow <= 24, "stable on repeated measurements");
+    }
+    f.viewport.dispose();
+    assert.equal(f.prompt.classList.contains("pin-fits"), false);
+  } finally {
+    f.close();
+  }
 });

--- a/plugins/web-ui/test/user-message-cap.test.ts
+++ b/plugins/web-ui/test/user-message-cap.test.ts
@@ -6,12 +6,12 @@ const css = readFileSync(new URL("../src/shell.css", import.meta.url), "utf8");
 const chat = readFileSync(new URL("../src/chat.ts", import.meta.url), "utf8");
 const shared = readFileSync(new URL("../src/shared-session.ts", import.meta.url), "utf8");
 
-const pinned = String.raw`\.message-stack \.user-row:not\(:has\(~ \.user-row\)\):not\(\.pin-expanded\) \.user-bubble`;
+const pinned = String.raw`\.message-stack\s+\.user-row:not\(:has\(~ \.user-row\)\):not\(\.pin-expanded\):not\(\.pin-fits\)\s+\.user-bubble\s+>\s+\.pin-content`;
 
 test("only the collapsed pinned prompt is capped and overflow clips instead of nesting scrollbars", () => {
   const bubble =
     css.match(
-      /\.message-stack \.user-row:not\(:has\(~ \.user-row\)\):not\(\.pin-expanded\) \.user-bubble \{[^}]*\}/,
+      /\.message-stack\s+\.user-row:not\(:has\(~ \.user-row\)\):not\(\.pin-expanded\):not\(\.pin-fits\)\s+\.user-bubble\s+>\s+\.pin-content \{[^}]*\}/,
     )?.[0] ?? "";
   assert.match(bubble, /max-height: var\(--pin-clamp, 320px\);/);
   assert.match(bubble, /overflow: hidden;/);
@@ -24,7 +24,7 @@ test("the scroller is the size container the cap measures, except the content-si
   assert.match(css, /\n\.chat-scroll \{[^}]*container-type: size;/);
   const mini = css.match(/\n\.mini-convo-body \.chat-scroll \{[^}]*\}/)?.[0] ?? "";
   assert.match(mini, /container-type: normal;/);
-  assert.match(css, new RegExp(String.raw`\n\.mini-convo-body ${pinned} \{[^}]*max-height: 100px;`));
+  assert.match(css, new RegExp(String.raw`\n\.mini-convo-body\s+${pinned} \{[^}]*max-height: 100px;`));
   assert.match(css, /\n\.readonly-chat \.custom-chat-shell \{[^}]*flex-direction: column;/);
   assert.match(css, /\n\.readonly-chat \.chat-scroll \{[^}]*flex: 1;/);
   assert.doesNotMatch(chat, /--chat-viewport/);


### PR DESCRIPTION
## Summary
- Keep Show more / Show less inside the message bubble, below the clamped content.
- Show marginal overflow (up to 24px) in full without an expansion control.
- Let pasted-code copy confirmation fit without crowding its neighboring control.

## Testing
- 1,047 web UI tests; typecheck, ESLint, Oxlint, Prettier, knip, and production build pass locally.
- Chromium: 19 viewport sizes, light/dark themes, files and pasted code, cutoff boundaries, and live resizing.
- Physical iOS/Safari not tested.
