### PR TITLE
Fix bottom-following when streamed replies finish

### DIFF
--- a/plugins/web-ui/src/chat.ts
+++ b/plugins/web-ui/src/chat.ts
@@ -1294,9 +1294,13 @@ export function createChatSurface(
       chatState.host,
     );
     decorateStreamingTail();
-    requestAnimationFrame(() => decorateTextCodeBlocks(chatState.host));
-    ctx.composer.resizeComposer();
-    scrollTranscript(opts.forceScroll);
+    const host = chatState.host;
+    requestAnimationFrame(() => {
+      if (chatState.host !== host || chatState.agent !== agent || !host.isConnected) return;
+      decorateTextCodeBlocks(host);
+      ctx.composer.resizeComposer();
+      scrollTranscript(opts.forceScroll);
+    });
     postCurrentPaneState();
   }
 

--- a/plugins/web-ui/test/layout-thrash.test.ts
+++ b/plugins/web-ui/test/layout-thrash.test.ts
@@ -55,3 +55,19 @@ test("both pagination paths adjust their anchor without smooth scrolling", () =>
   );
   assert.equal(anchors?.length, 2);
 });
+
+test("chat layout waits for markdown custom elements before measuring the transcript", () => {
+  const fn = chat.match(/function drawActiveChat\([\s\S]*?\n {2}\}/)?.[0] ?? "";
+  const deferred = fn.match(/requestAnimationFrame\(\(\) => \{[\s\S]*?\n {4}\}\);/)?.[0] ?? "";
+  assert.match(deferred, /decorateTextCodeBlocks\(host\)/);
+  assert.match(deferred, /ctx\.composer\.resizeComposer\(\)/);
+  assert.match(deferred, /scrollTranscript\(opts\.forceScroll\)/);
+  assert.doesNotMatch(fn.replace(deferred, ""), /resizeComposer\(|scrollTranscript\(/);
+});
+
+test("deferred chat layout cannot scroll a replacement or detached session", () => {
+  const fn = chat.match(/function drawActiveChat\([\s\S]*?\n {2}\}/)?.[0] ?? "";
+  const guard = fn.indexOf("if (chatState.host !== host || chatState.agent !== agent || !host.isConnected) return;");
+  const measure = fn.indexOf("ctx.composer.resizeComposer()");
+  assert.ok(guard >= 0 && guard < measure);
+});


### PR DESCRIPTION
## Change

Wait for markdown rendering before measuring the transcript, so finishing a streamed response does not accidentally disable bottom-following. Scrolling upward still opts out; returning to the bottom resumes following. Ignore deferred layout for replaced or detached sessions.

## Verification

- 52 affected tests pass, including new layout-order regressions.
- Typechecks, ESLint, Oxlint, Prettier, Knip, and production build pass.
- Desktop/mobile browser checks cover streaming, completion, resuming, scrolling up, and returning to the bottom. Real UI renderer with synthetic messages and mocked APIs; no full backend/model test.

## Demo

The same reply immediately after streaming finishes. Before: 751px from the bottom on desktop and 2644px on mobile. After: 0px on both.

<details>
<summary>Before and after screenshots</summary>

| View | Before | After |
| --- | --- | --- |
| Desktop | ![Before desktop](https://raw.githubusercontent.com/yc-software/qm/6699ddfd49061ac26e8b9a41e4d0e99444f64d7c/before-desktop.png) | ![After desktop](https://raw.githubusercontent.com/yc-software/qm/6699ddfd49061ac26e8b9a41e4d0e99444f64d7c/after-desktop.png) |
| Mobile | ![Before mobile](https://raw.githubusercontent.com/yc-software/qm/6699ddfd49061ac26e8b9a41e4d0e99444f64d7c/before-mobile.png) | ![After mobile](https://raw.githubusercontent.com/yc-software/qm/6699ddfd49061ac26e8b9a41e4d0e99444f64d7c/after-mobile.png) |

</details>
