### PR TITLE
Retry transient read failures while polling the factory wrapper

### DIFF
--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -10,7 +10,7 @@ export const FACTORY_STDOUT_CAP_BYTES = 4 * 1024 * 1024;
 export const FACTORY_TERM_GRACE_MS = 30_000;
 export const FACTORY_DRAIN_EMPTY_READS = 2;
 export const FACTORY_READ_RETRIES = 6;
-export const FACTORY_READ_RETRY_MS = 2_000;
+const FACTORY_READ_RETRY_MS = 2_000;
 const FACTORY_READ_MAX_BYTES = 65_536;
 const TICKET_RE = /^[A-Z][A-Z0-9]*-\d+$/;
 

--- a/src/loops/factory/process-work.ts
+++ b/src/loops/factory/process-work.ts
@@ -1,12 +1,16 @@
 import { CapabilityUnsupportedError, supportsProcessSessions, type Sandbox } from "../../sandbox/sandbox.ts";
 import type { FactoryConfig } from "../../resolution/config-store.ts";
 import type { ScopeId } from "../../types.ts";
+import { processIsGone } from "../../sandbox/process-poll.ts";
+import { sleep } from "../../util/async.ts";
 
 export const FACTORY_WRAPPER = ".claude/io-coding-agent-js.sh";
 export const FACTORY_READ_WAIT_MS = 5_000;
 export const FACTORY_STDOUT_CAP_BYTES = 4 * 1024 * 1024;
 export const FACTORY_TERM_GRACE_MS = 30_000;
 export const FACTORY_DRAIN_EMPTY_READS = 2;
+export const FACTORY_READ_RETRIES = 6;
+export const FACTORY_READ_RETRY_MS = 2_000;
 const FACTORY_READ_MAX_BYTES = 65_536;
 const TICKET_RE = /^[A-Z][A-Z0-9]*-\d+$/;
 
@@ -86,6 +90,7 @@ export interface FactoryProcessInput {
   onChunk?: (chunk: string) => void;
   signal?: AbortSignal;
   readWaitMs?: number;
+  readRetryMs?: number;
   termGraceMs?: number;
 }
 
@@ -106,6 +111,7 @@ export async function runFactoryProcess(input: FactoryProcessInput): Promise<Fac
   }
 
   const waitMs = input.readWaitMs ?? FACTORY_READ_WAIT_MS;
+  const retryMs = input.readRetryMs ?? FACTORY_READ_RETRY_MS;
   const grace = input.termGraceMs ?? FACTORY_TERM_GRACE_MS;
   const handle = await sandbox.provision([{ scopeId, mode: "rw", mountPath: "" }]);
   try {
@@ -127,12 +133,22 @@ export async function runFactoryProcess(input: FactoryProcessInput): Promise<Fac
       let killSent = false;
       let killAt = 0;
       let emptyExitedReads = 0;
+      let readFailures = 0;
       for (;;) {
-        const read = await sandbox.readProcess(handle, processId, {
-          sinceCursor: cursor,
-          maxBytes: FACTORY_READ_MAX_BYTES,
-          waitMs,
-        });
+        let read;
+        try {
+          read = await sandbox.readProcess(handle, processId, {
+            sinceCursor: cursor,
+            maxBytes: FACTORY_READ_MAX_BYTES,
+            waitMs,
+          });
+        } catch (e) {
+          // A saturated sandbox can push one poll past the exec timeout; one slow read must not end a multi-hour run.
+          if (processIsGone(e) || ++readFailures > FACTORY_READ_RETRIES) throw e;
+          await sleep(retryMs);
+          continue;
+        }
+        readFailures = 0;
         cursor = read.cursor;
         if (read.chunks !== "") {
           stdout += read.chunks;

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -467,6 +467,18 @@ test("a transient read failure is retried and the run completes with no signal",
   assert.equal(result.stdout, SUCCESS_STDOUT);
   assert.equal(result.exitCode, 3);
   assert.equal(fake.calls.readProcess.length, SUCCESS_READS.length + 1);
+  assert.equal(fake.calls.readProcess[2]!.opts?.sinceCursor, 9);
+  assert.deepEqual(fake.calls.signalProcess, []);
+});
+
+test("a successful read resets the failure count, so two separate streaks under the budget both survive", async () => {
+  const flaky = new Error("The operation was aborted due to timeout");
+  const streak = (): ReadStep[] => Array.from({ length: FACTORY_READ_RETRIES }, () => ({ error: flaky }));
+  const fake = fakeSandbox({
+    reads: [...streak(), SUCCESS_READS[0]!, ...streak(), ...SUCCESS_READS.slice(1)],
+  });
+  const result = await runFactoryProcess(baseInput(fake, { readRetryMs: 0 }));
+  assert.equal(result.stdout, SUCCESS_STDOUT);
   assert.deepEqual(fake.calls.signalProcess, []);
 });
 
@@ -598,12 +610,16 @@ test("no path logs to the console or puts a credential in an error", async () =>
     () => runFactoryProcess(baseInput(fakeSandbox({}), { env, ticketId: "QM-12; rm -rf /" })),
     () => runFactoryProcess(baseInput(fakeSandbox({ processSessions: false }), { env })),
     () => runFactoryProcess(baseInput(fakeSandbox({ startError: new Error("boom-start") }), { env })),
-    () => runFactoryProcess(baseInput(fakeSandbox({ reads: [{ error: new Error("boom-read") }] }), { env })),
     () =>
       runFactoryProcess(
-        baseInput(fakeSandbox({ reads: [{ error: new Error("boom-read") }], signalError: new Error("boom-signal") }), {
-          env,
-        }),
+        baseInput(fakeSandbox({ reads: persistentReadFailure(new Error("boom-read")) }), { env, readRetryMs: 0 }),
+      ),
+    () =>
+      runFactoryProcess(
+        baseInput(
+          fakeSandbox({ reads: persistentReadFailure(new Error("boom-read")), signalError: new Error("boom-signal") }),
+          { env, readRetryMs: 0 },
+        ),
       ),
   ];
   const logged: unknown[][] = [];

--- a/test/loop-factory-process-work.test.ts
+++ b/test/loop-factory-process-work.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   FACTORY_DRAIN_EMPTY_READS,
+  FACTORY_READ_RETRIES,
   FACTORY_READ_WAIT_MS,
   FACTORY_STDOUT_CAP_BYTES,
   FACTORY_TERM_GRACE_MS,
@@ -197,6 +198,9 @@ const SUCCESS_READS: ReadStep[] = [
 ];
 
 const SUCCESS_STDOUT = "line one\nBRANCH:qm-12-s99\nMR:41\n";
+
+const persistentReadFailure = (error: Error): ReadStep[] =>
+  Array.from({ length: FACTORY_READ_RETRIES + 1 }, () => ({ error }));
 
 async function rejection(promise: Promise<unknown>): Promise<Error> {
   try {
@@ -436,31 +440,48 @@ test("a sandbox failure propagates after teardown, with no partial result", asyn
   assert.deepEqual(started.calls.signalProcess, []);
 
   const readBoom = new Error("boom-read");
-  const read = fakeSandbox({ reads: [{ chunks: "line one\n", cursor: 9 }, { error: readBoom }] });
-  assert.equal(await rejection(runFactoryProcess(baseInput(read))), readBoom);
+  const read = fakeSandbox({ reads: [{ chunks: "line one\n", cursor: 9 }, ...persistentReadFailure(readBoom)] });
+  assert.equal(await rejection(runFactoryProcess(baseInput(read, { readRetryMs: 0 }))), readBoom);
   assert.deepEqual(read.calls.teardown, [{ handle: HANDLE, opts: { keepWarm: true } }]);
 });
 
-test("a read that throws terminates the wrapper once, before the unchanged teardown", async () => {
+test("a read that keeps throwing terminates the wrapper once after the retry budget, before the unchanged teardown", async () => {
   const readBoom = new Error("boom-read");
-  const fake = fakeSandbox({ reads: [{ chunks: "line one\n", cursor: 9 }, { error: readBoom }] });
-  assert.equal(await rejection(runFactoryProcess(baseInput(fake))), readBoom);
+  const fake = fakeSandbox({ reads: [{ chunks: "line one\n", cursor: 9 }, ...persistentReadFailure(readBoom)] });
+  assert.equal(await rejection(runFactoryProcess(baseInput(fake, { readRetryMs: 0 }))), readBoom);
   assert.deepEqual(fake.calls.signalProcess, [{ handle: HANDLE, processId: "p-7", signal: "TERM" }]);
   assert.deepEqual(fake.calls.teardown, [{ handle: HANDLE, opts: { keepWarm: true } }]);
   assert.deepEqual(fake.calls.order, [
     "provision",
     "startProcess",
-    "readProcess",
-    "readProcess",
+    ...Array.from({ length: FACTORY_READ_RETRIES + 2 }, () => "readProcess"),
     "signalProcess",
     "teardown",
   ]);
 });
 
+test("a transient read failure is retried and the run completes with no signal", async () => {
+  const timeout = new Error("The operation was aborted due to timeout");
+  const fake = fakeSandbox({ reads: [SUCCESS_READS[0]!, { error: timeout }, ...SUCCESS_READS.slice(1)] });
+  const result = await runFactoryProcess(baseInput(fake, { readRetryMs: 0 }));
+  assert.equal(result.stdout, SUCCESS_STDOUT);
+  assert.equal(result.exitCode, 3);
+  assert.equal(fake.calls.readProcess.length, SUCCESS_READS.length + 1);
+  assert.deepEqual(fake.calls.signalProcess, []);
+});
+
+test("a vanished process session is not retried", async () => {
+  const gone = new Error("no such process session: p-7");
+  const fake = fakeSandbox({ reads: [{ chunks: "line one\n", cursor: 9 }, { error: gone }] });
+  assert.equal(await rejection(runFactoryProcess(baseInput(fake, { readRetryMs: 0 }))), gone);
+  assert.equal(fake.calls.readProcess.length, 2);
+  assert.deepEqual(fake.calls.signalProcess, [{ handle: HANDLE, processId: "p-7", signal: "TERM" }]);
+});
+
 test("a cleanup signal that itself rejects never masks the error that triggered it", async () => {
   const readBoom = new Error("boom-read");
-  const fake = fakeSandbox({ reads: [{ error: readBoom }], signalError: new Error("boom-signal") });
-  assert.equal(await rejection(runFactoryProcess(baseInput(fake))), readBoom);
+  const fake = fakeSandbox({ reads: persistentReadFailure(readBoom), signalError: new Error("boom-signal") });
+  assert.equal(await rejection(runFactoryProcess(baseInput(fake, { readRetryMs: 0 }))), readBoom);
   assert.deepEqual(fake.calls.signalProcess, [{ handle: HANDLE, processId: "p-7", signal: "TERM" }]);
   assert.deepEqual(fake.calls.teardown, [{ handle: HANDLE, opts: { keepWarm: true } }]);
 });
@@ -488,8 +509,8 @@ test("a failing teardown is swallowed on both the success and the failure path",
   assert.equal(ok.calls.teardown.length, 1);
 
   const boom = new Error("boom-read");
-  const bad = fakeSandbox({ reads: [{ error: boom }], teardownError });
-  assert.equal(await rejection(runFactoryProcess(baseInput(bad))), boom);
+  const bad = fakeSandbox({ reads: persistentReadFailure(boom), teardownError });
+  assert.equal(await rejection(runFactoryProcess(baseInput(bad, { readRetryMs: 0 }))), boom);
   assert.equal(bad.calls.teardown.length, 1);
 });
 


### PR DESCRIPTION
## Why

`runFactoryProcess` polls the wrapper through `sandbox.readProcess`, which the exec-based process session implements as one `run` call with a `waitMs + 20s` timeout. On the local backend that is an `AbortSignal.timeout` on a single HTTP call. During QM-1 attempt 7 the container was saturated by the full test suite in the second Review pass, one poll exceeded the timeout, the error propagated out of the work stage, the loop parked the item with `The operation was aborted due to timeout`, and sent TERM to a wrapper that had already passed Verify and Review after 3 hours 48 minutes.

## What

- Retry up to `FACTORY_READ_RETRIES` (6) consecutive read failures with a `FACTORY_READ_RETRY_MS` (2 s) pause. A success resets the count.
- A vanished process session (`no such process session`) is still fatal on the first read, through the existing `processIsGone` predicate.
- `readRetryMs` joins `readWaitMs` and `termGraceMs` as a test-time override.

## Tests

- New: a transient failure is retried and the run completes with no signal.
- New: a vanished process session is not retried.
- Updated: the three tests that relied on a single throwing read now script a persistent failure of `FACTORY_READ_RETRIES + 1` throws with `readRetryMs: 0`, and pin the same TERM-once and teardown-once behavior.
- Mutation check: with `FACTORY_READ_RETRIES = 0` the transient-failure test fails; reverted.

`node --test` on the process-work and effects files: 77 pass. `tsc`, eslint, prettier green.