### PR TITLE
Fix stuck file-drop overlay during streaming

### DIFF
--- a/plugins/web-ui/src/composer.ts
+++ b/plugins/web-ui/src/composer.ts
@@ -1,5 +1,6 @@
 import { getRuntimeConfig, loadRuntimeConfig, saveRuntimeConfig, subscribeRuntimeConfig } from "./runtime-config-store";
 import type { Agent, AgentMessage } from "@earendil-works/pi-agent-core";
+import { createFileDragState } from "./file-drag";
 import type { Attachment } from "@earendil-works/pi-web-ui";
 import { FolderDropError, folderToZipFile, isFolderReadError, splitDropItems, type DropEntryLike } from "./folder-drop";
 import { html, nothing, type TemplateResult } from "lit";
@@ -263,7 +264,10 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
     );
   }
 
-  let dragDepth = 0;
+  const fileDrag = createFileDragState((dragging) => {
+    composerState.dragging = dragging;
+    ctx.chat.drawActiveChat();
+  });
   let skillsLoading = false;
   let slashActiveIndex = 0;
   let fastModeCharging = false;
@@ -1726,11 +1730,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   function onDragEnter(e: DragEvent): void {
     if (!dragHasFiles(e)) return;
     e.preventDefault();
-    dragDepth += 1;
-    if (!composerState.dragging) {
-      composerState.dragging = true;
-      ctx.chat.drawActiveChat();
-    }
+    fileDrag.enter(e);
   }
 
   function onDragOver(e: DragEvent): void {
@@ -1740,20 +1740,13 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   }
 
   function onDragLeave(e: DragEvent): void {
-    if (!dragHasFiles(e)) return;
-    e.preventDefault();
-    dragDepth = Math.max(0, dragDepth - 1);
-    if (dragDepth === 0 && composerState.dragging) {
-      composerState.dragging = false;
-      ctx.chat.drawActiveChat();
-    }
+    fileDrag.leave(e);
   }
 
   async function onDrop(e: DragEvent, agent: Agent): Promise<void> {
     if (!dragHasFiles(e)) return;
     e.preventDefault();
-    dragDepth = 0;
-    composerState.dragging = false;
+    fileDrag.reset();
     const { files, folders } = splitDropItems(Array.from(e.dataTransfer?.items ?? []));
     if (!files.length && !folders.length) files.push(...Array.from(e.dataTransfer?.files ?? []));
     ctx.chat.drawActiveChat(agent);
@@ -1870,6 +1863,7 @@ export function createComposerSurface(ctx: ConvCtx): ComposerSurface {
   function dispose(): void {
     unsubscribeRuntime?.();
     ++runtimeRequest;
+    fileDrag.dispose();
     autosizeObserver?.disconnect();
     autosizeObserver = null;
     autosizedTa = null;

--- a/plugins/web-ui/src/file-drag.ts
+++ b/plugins/web-ui/src/file-drag.ts
@@ -1,0 +1,36 @@
+/** Track the current target, not balanced enter/leave counts: rendering can detach a target. */
+export function createFileDragState(onChange: (dragging: boolean) => void) {
+  let target: EventTarget | null = null;
+
+  function eventTarget(event: Event): EventTarget | null {
+    return event.composedPath()[0] ?? event.target;
+  }
+
+  function clear(): boolean {
+    if (!target) return false;
+    target.removeEventListener("dragleave", leave);
+    target = null;
+    return true;
+  }
+
+  function reset(): void {
+    if (clear()) onChange(false);
+  }
+
+  function leave(event: Event): void {
+    // The new target's dragenter precedes the old target's dragleave.
+    if (eventTarget(event) === target) reset();
+  }
+
+  function enter(event: DragEvent): void {
+    const next = eventTarget(event);
+    if (!next || next === target) return;
+    const wasDragging = clear();
+    target = next;
+    // A detached descendant's leave cannot bubble to the pane, but still reaches this listener.
+    target.addEventListener("dragleave", leave);
+    if (!wasDragging) onChange(true);
+  }
+
+  return { enter, leave, reset, dispose: clear };
+}

--- a/plugins/web-ui/test/file-drag.test.ts
+++ b/plugins/web-ui/test/file-drag.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { createFileDragState } from "../src/file-drag.ts";
+
+function fixture() {
+  const dom = new JSDOM(
+    '<main><section id="a"><p><span>Streaming reply</span></p></section><section id="b"></section></main>',
+  );
+  const doc = dom.window.document;
+  const a = doc.querySelector<HTMLElement>("#a")!;
+  const b = doc.querySelector<HTMLElement>("#b")!;
+  const text = doc.querySelector<HTMLElement>("span")!;
+  const changes: boolean[] = [];
+  const drag = createFileDragState((value) => changes.push(value));
+  a.addEventListener("dragenter", (event) => drag.enter(event as unknown as DragEvent));
+  a.addEventListener("dragleave", drag.leave);
+  a.addEventListener("drop", drag.reset);
+  function dispatch(target: EventTarget, type: string) {
+    target.dispatchEvent(new dom.window.Event(type, { bubbles: true, composed: true }));
+  }
+  return { dom, doc, a, b, text, changes, drag, dispatch };
+}
+
+test("a streamed-away target can end the drag without bubbling to the pane", () => {
+  const { text, a, dispatch, changes } = fixture();
+  let paneLeaves = 0;
+  a.addEventListener("dragleave", () => paneLeaves++);
+  dispatch(text, "dragenter");
+  text.remove();
+  dispatch(text, "dragleave");
+  assert.equal(paneLeaves, 0);
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("replacement target enter followed by detached old leave does not hide the overlay", () => {
+  const { text, doc, a, dispatch, changes } = fixture();
+  dispatch(text, "dragenter");
+  text.remove();
+  const replacement = doc.createElement("span");
+  a.append(replacement);
+  dispatch(replacement, "dragenter");
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true]);
+  dispatch(replacement, "dragleave");
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("nested target transitions and repeated enters do not accumulate drag depth", () => {
+  const { text, a, dispatch, changes } = fixture();
+  dispatch(a, "dragenter");
+  dispatch(text, "dragenter");
+  dispatch(a, "dragleave");
+  dispatch(text, "dragenter");
+  assert.deepEqual(changes, [true]);
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("leaving a replaced target and dropping in another pane clears each pane independently", () => {
+  const { text, a, b, dispatch, changes } = fixture();
+  const otherChanges: boolean[] = [];
+  const other = createFileDragState((value) => otherChanges.push(value));
+  b.addEventListener("dragenter", (event) => other.enter(event as unknown as DragEvent));
+  b.addEventListener("drop", other.reset);
+  dispatch(text, "dragenter");
+  text.remove();
+  dispatch(a, "dragenter");
+  dispatch(text, "dragleave");
+  dispatch(b, "dragenter");
+  dispatch(a, "dragleave");
+  dispatch(b, "drop");
+  assert.deepEqual(changes, [true, false]);
+  assert.deepEqual(otherChanges, [true, false]);
+});
+
+test("drop resets tracking and a subsequent drag can start", () => {
+  const { text, dispatch, changes } = fixture();
+  dispatch(text, "dragenter");
+  dispatch(text, "drop");
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true, false]);
+  dispatch(text, "dragenter");
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true, false, true, false]);
+});
+
+test("dispose removes the retained target listener without redrawing a destroyed pane", () => {
+  const { text, dispatch, drag, changes } = fixture();
+  dispatch(text, "dragenter");
+  drag.dispose();
+  text.remove();
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true]);
+});
+
+test("shadow-root descendants remain tracked when removed from their connected host", () => {
+  const { doc, a, dispatch, changes } = fixture();
+  const host = doc.createElement("div");
+  a.append(host);
+  const shadow = host.attachShadow({ mode: "open" });
+  const text = doc.createElement("span");
+  shadow.append(text);
+  dispatch(text, "dragenter");
+  text.remove();
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true, false]);
+});
+
+test("a target removed during the initial overlay draw still delivers its leave", () => {
+  const { text, dispatch } = fixture();
+  const changes: boolean[] = [];
+  const drag = createFileDragState((value) => {
+    changes.push(value);
+    if (value) text.remove();
+  });
+  text.addEventListener("dragenter", (event) => drag.enter(event as unknown as DragEvent));
+  dispatch(text, "dragenter");
+  dispatch(text, "dragleave");
+  assert.deepEqual(changes, [true, false]);
+});


### PR DESCRIPTION
## Summary
Fix the file-drop overlay getting stuck when streaming replaces the element under a drag. Track the current target and listen for its exit directly, including after it leaves the DOM, instead of counting bubbled events.

## Verification
- 1,057 web UI tests pass, including 8 new drag-state regressions.
- Typechecks, changed-file ESLint/oxlint, knip, formatting, and production build pass.
- Native cross-window drags in Linux Chromium: streaming followed by cancellation, leaving the window, or dropping in another pane all clear the overlay. The same cases stuck before the fix. Real UI components with mocked backend/stream updates.
