### PR TITLE
Derive the wrapper session id from the item, not the attempt

### DIFF
--- a/src/loops/factory/effects.ts
+++ b/src/loops/factory/effects.ts
@@ -53,11 +53,12 @@ const FACTORY_SOURCE_BOOTSTRAP_SCRIPT = [
 
 export const FACTORY_LOOP_SURFACE = "factory";
 
-// The wrapper's ownership marker and session branch need a positive integer that is stable for one run
-// and distinct across runs; a loop has no ECS session, so the run id is hashed into one.
-export function factorySessionIdFor(runId: string): number {
+// The wrapper's ownership marker and session branch need a positive integer that is stable across an
+// item's attempts, so a re-run revises the same branch and PR, and distinct across items; a loop has no
+// ECS session, so the item key is hashed into one.
+export function factorySessionIdFor(itemKey: string): number {
   let hash = 0x811c9dc5;
-  for (const ch of runId) {
+  for (const ch of itemKey) {
     hash ^= ch.charCodeAt(0);
     hash = Math.imul(hash, 0x01000193) >>> 0;
   }
@@ -274,7 +275,8 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
             })
           : undefined;
 
-      const itemPrefix = `factory:${loop.id}:${item.id}:`;
+      const itemKey = `factory:${loop.id}:${item.id}`;
+      const itemPrefix = `${itemKey}:`;
       const runId = `${itemPrefix}${item.attempts + 1}`;
       const env = renderFactoryEnv({
         config,
@@ -283,7 +285,7 @@ export function createFactoryLoopEffects(deps: FactoryEffectsDeps): FactoryWorkE
         githubToken,
         anthropicApiKey,
         ...(slack ? { slack } : {}),
-        factorySessionId: factorySessionIdFor(runId),
+        factorySessionId: factorySessionIdFor(itemKey),
         repoDir,
         factorySourceDir: FACTORY_SOURCE_DIR,
       });

--- a/test/loop-factory-effects.test.ts
+++ b/test/loop-factory-effects.test.ts
@@ -534,7 +534,7 @@ test("work preflights on a warm-released handle, then runs the wrapper with the 
       linearApiKey: LINEAR_KEY,
       githubToken: GITHUB_TOKEN,
       anthropicApiKey: ANTHROPIC_KEY,
-      factorySessionId: factorySessionIdFor("factory:loop-1:item-1:1"),
+      factorySessionId: factorySessionIdFor("factory:loop-1:item-1"),
       repoDir: REPO_DIR,
       factorySourceDir: FACTORY_SOURCE_DIR,
     }),
@@ -573,12 +573,25 @@ test("a run with no pull request carries the wrapper's redacted diagnostics in i
   assert.equal(verdict.reason.includes("npm warn"), false);
 });
 
-test("factorySessionIdFor is a stable positive integer that differs across runs", () => {
-  const a = factorySessionIdFor("factory:loop-1:item-1:1");
-  assert.equal(a, factorySessionIdFor("factory:loop-1:item-1:1"));
+test("factorySessionIdFor is a stable positive integer per item and differs across items and loops", () => {
+  const a = factorySessionIdFor("factory:loop-1:item-1");
+  assert.equal(a, factorySessionIdFor("factory:loop-1:item-1"));
   assert.ok(Number.isInteger(a) && a > 0 && a <= 2_000_000_000);
-  assert.notEqual(a, factorySessionIdFor("factory:loop-1:item-1:2"));
-  assert.notEqual(a, factorySessionIdFor("factory:loop-1:item-2:1"));
+  assert.notEqual(a, factorySessionIdFor("factory:loop-1:item-2"));
+  assert.notEqual(a, factorySessionIdFor("factory:loop-2:item-1"));
+});
+
+test("a second attempt of the same item launches the wrapper with the same session id", async () => {
+  const first = fakeSandbox();
+  await createFactoryLoopEffects(deps({ sandbox: first.sandbox })).work({ loop: LOOP, item: ITEM });
+  const second = fakeSandbox();
+  await createFactoryLoopEffects(deps({ sandbox: second.sandbox })).work({
+    loop: LOOP,
+    item: { ...ITEM, attempts: 1 },
+  });
+  const sessionOf = (calls: Call[]) => wrapperStart(calls).opts?.env?.IO_FACTORY_SESSION_ID;
+  assert.ok(sessionOf(first.calls));
+  assert.equal(sessionOf(second.calls), sessionOf(first.calls));
 });
 
 test("work bootstraps the factory control plane on the preflight handle before the wrapper, once per call", async () => {
@@ -1106,7 +1119,7 @@ test("a blank or unset slack channel posts nothing, requires no credential, and 
         linearApiKey: LINEAR_KEY,
         githubToken: GITHUB_TOKEN,
         anthropicApiKey: ANTHROPIC_KEY,
-        factorySessionId: factorySessionIdFor(runId),
+        factorySessionId: factorySessionIdFor(runId.replace(/:\d+$/, "")),
         repoDir: REPO_DIR,
         factorySourceDir: FACTORY_SOURCE_DIR,
       }),


### PR DESCRIPTION
## Why

`factorySessionIdFor` hashed the run id, which carries the attempt number, so every attempt of one loop item launched the wrapper with a different session id and therefore a different session branch. A feedback re-run keeps the previous attempt's worktree (Setup logs `clean-base abort skipped`), so attempt 8 of QM-1 sat on branch `qm-1-s939116131` from attempt 7 while Ship expected the branch for the new id. The MR-create journal check compared the two and Ship failed with `session_mr_identity_missing` after Verify, Review, and Proof had all passed.

## What

- Hash `factory:<loopId>:<itemId>` instead of `factory:<loopId>:<itemId>:<attempt>`. Every attempt of one item shares one session id, one branch, and one PR identity, the same way a ycinternal coding session spans its re-runs.
- The run id itself is unchanged and still distinct per attempt.

## Tests

- `factorySessionIdFor` is stable per item and differs across items and loops.
- New: a second attempt of the same item launches the wrapper with the same `IO_FACTORY_SESSION_ID`.
- Mutation check: with the call site back on the run id, the new test fails; reverted.

`node --test` on the effects, process-work, and fire files: 128 pass. `tsc`, eslint, prettier green.