### PR TITLE
QM-1: Add a delete button beside open on the /files page

### DIFF
--- a/plugins/web-ui/server/index.ts
+++ b/plugins/web-ui/server/index.ts
@@ -1721,6 +1721,18 @@ const apiRoutes: readonly WebRoute[] = [
     handle: serveFileContent,
   },
   {
+    method: "DELETE",
+    path: "/api/files/:id",
+    handle: async (c) => {
+      const { res, user } = c;
+      return relayCore(
+        res,
+        "DELETE",
+        `/v1/files/${encodeURIComponent(c.params.id!)}?principalId=${encodeURIComponent(user)}`,
+      );
+    },
+  },
+  {
     method: "GET",
     path: "/api/files",
     handle: async (c) => {

--- a/plugins/web-ui/src/files.ts
+++ b/plugins/web-ui/src/files.ts
@@ -11,6 +11,7 @@ import {
   FileVideo,
   Presentation,
   Search,
+  Trash2,
   Upload,
   type IconNode,
 } from "lucide";
@@ -34,6 +35,7 @@ interface FileItem {
   createdInScope?: string;
   ownerScopeId?: string;
   openable: boolean;
+  deletable?: boolean;
 }
 interface FileRow extends FileItem {
   kind: "Created" | "Uploaded" | "Shared";
@@ -239,9 +241,47 @@ function fileRow(f: FileRow) {
       }</span
     >
   `;
-  return f.openable
-    ? html`<a class="list-row file-row" href=${contentUrl} target="_blank" rel="noreferrer">${content}</a>`
-    : html`<article class="list-row file-row">${content}</article>`;
+  return html`<div class="list-row file-row">
+    ${
+      f.openable
+        ? html`<a class="file-row-main" href=${contentUrl} target="_blank" rel="noreferrer">${content}</a>`
+        : html`<span class="file-row-main">${content}</span>`
+    }
+    ${
+      f.deletable
+        ? html`<div class="file-row-actions">
+            <button
+              class="btn danger compact"
+              type="button"
+              aria-label=${`Delete ${f.name}`}
+              ?disabled=${filesBusy.has(f.id)}
+              @click=${() => void deleteFile(f)}
+            >
+              ${icon(Trash2, 14)}<span>Delete</span>
+            </button>
+          </div>`
+        : nothing
+    }
+  </div>`;
+}
+
+const filesBusy = new Set<string>();
+
+async function deleteFile(f: FileRow): Promise<void> {
+  if (filesBusy.has(f.id)) return;
+  if (!confirm(`Delete ${f.name}? This can't be undone.`)) return;
+  filesBusy.add(f.id);
+  drawFiles();
+  try {
+    await api(`/api/files/${encodeURIComponent(f.id)}`, { method: "DELETE" });
+    filesNotice = `Deleted ${f.name}.`;
+    await loadFiles(appState.viewRenderSeq);
+  } catch (e) {
+    filesNotice = errMessage(e, "Couldn't delete that file.");
+  } finally {
+    filesBusy.delete(f.id);
+    drawFiles();
+  }
 }
 
 async function fileSha256(file: globalThis.File): Promise<string> {

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5883,7 +5883,6 @@ a.chat-row-open {
   column-gap: 0;
   justify-content: initial;
   padding: 0;
-  cursor: default;
 }
 .file-row-main {
   display: grid;
@@ -5894,10 +5893,6 @@ a.chat-row-open {
   padding: 12px;
   color: inherit;
   text-decoration: none;
-  cursor: pointer;
-}
-.file-row-main:not([href]) {
-  cursor: default;
 }
 .file-row-actions {
   display: inline-flex;

--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -5018,10 +5018,6 @@ a.chat-row-open {
   align-items: center;
   gap: 12px;
 }
-.file-row {
-  color: inherit;
-  text-decoration: none;
-}
 .file-row-icon {
   display: inline-flex;
   align-items: center;
@@ -5213,11 +5209,9 @@ a.chat-row-open {
 }
 
 @media (max-width: 700px) {
-  .file-row,
   .deploy-row {
     grid-template-columns: auto minmax(0, 1fr);
   }
-  .file-row .list-row-meta,
   .deploy-row .list-row-meta {
     grid-column: 2;
     justify-content: flex-start;
@@ -5885,8 +5879,31 @@ a.chat-row-open {
 }
 .file-row {
   display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: 0;
   justify-content: initial;
+  padding: 0;
+  cursor: default;
+}
+.file-row-main {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 12px;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+.file-row-main:not([href]) {
+  cursor: default;
+}
+.file-row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px 0 8px;
 }
 .file-row .list-row-title {
   justify-self: stretch;
@@ -5913,10 +5930,10 @@ a.chat-row-open {
   text-align: right;
 }
 @media (max-width: 700px) {
-  .file-row {
+  .file-row-main {
     grid-template-columns: 22px minmax(0, 1fr);
   }
-  .file-row .list-row-meta {
+  .file-row-main .list-row-meta {
     grid-column: 2;
     justify-content: flex-start;
     flex-wrap: wrap;

--- a/plugins/web-ui/test/file-delete-interaction.test.ts
+++ b/plugins/web-ui/test/file-delete-interaction.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
+import { createServer } from "vite";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+interface ServerFile {
+  id: string;
+  name: string;
+  mimetype: string;
+  sizeBytes: number;
+  direction: "out";
+  createdAt: number;
+  createdInScope: string;
+  ownerScopeId: string;
+  openable: boolean;
+  deletable: boolean;
+}
+
+const scope = "personal:alice@example.com";
+const listing: ServerFile[] = [
+  {
+    id: "mine/1",
+    name: "mine.png",
+    mimetype: "image/png",
+    sizeBytes: 12,
+    direction: "out",
+    createdAt: 3_000,
+    createdInScope: scope,
+    ownerScopeId: scope,
+    openable: true,
+    deletable: true,
+  },
+  {
+    id: "no-bytes",
+    name: "no-bytes.png",
+    mimetype: "image/png",
+    sizeBytes: 12,
+    direction: "out",
+    createdAt: 2_500,
+    createdInScope: scope,
+    ownerScopeId: scope,
+    openable: false,
+    deletable: true,
+  },
+  {
+    id: "ghost",
+    name: "ghost.png",
+    mimetype: "image/png",
+    sizeBytes: 12,
+    direction: "out",
+    createdAt: 2_000,
+    createdInScope: scope,
+    ownerScopeId: scope,
+    openable: true,
+    deletable: true,
+  },
+  {
+    id: "theirs",
+    name: "theirs.png",
+    mimetype: "image/png",
+    sizeBytes: 12,
+    direction: "out",
+    createdAt: 1_000,
+    createdInScope: scope,
+    ownerScopeId: "personal:bob@example.com",
+    openable: true,
+    deletable: false,
+  },
+];
+
+test("the Files page deletes only what the server marked deletable, once per confirmed click", async () => {
+  const dom = new JSDOM('<!doctype html><div id="app"></div><main id="main"></main>', {
+    url: "http://localhost/web-ui/?view=files",
+  });
+  Object.defineProperty(dom.window, "matchMedia", {
+    value: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+  });
+  let confirmed = true;
+  const globals = {
+    window: dom.window,
+    document: dom.window.document,
+    location: dom.window.location,
+    history: dom.window.history,
+    localStorage: dom.window.localStorage,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MouseEvent: dom.window.MouseEvent,
+    customElements: dom.window.customElements,
+    getComputedStyle: dom.window.getComputedStyle.bind(dom.window),
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0),
+    cancelAnimationFrame: clearTimeout,
+    confirm: () => confirmed,
+  };
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+  for (const [key, value] of Object.entries(globals)) {
+    descriptors.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+  }
+
+  let live = [...listing];
+  const deletes: string[] = [];
+  const inFlight: Array<Promise<unknown>> = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input), "http://localhost");
+    const answer = async (): Promise<Response> => {
+      if (url.pathname === "/api/contexts")
+        return Response.json({ contexts: [{ scopeId: scope, kind: "personal", name: "Personal" }] });
+      if (url.pathname === "/api/files" && (init?.method ?? "GET") === "GET")
+        return Response.json({
+          owned: live.filter((f) => f.ownerScopeId === scope),
+          shared: live.filter((f) => f.ownerScopeId !== scope),
+        });
+      if (init?.method === "DELETE" && url.pathname.startsWith("/api/files/")) {
+        const id = decodeURIComponent(url.pathname.slice("/api/files/".length));
+        deletes.push(id);
+        if (id === "ghost") return Response.json({ error: "not_found", message: "no such file" }, { status: 404 });
+        live = live.filter((f) => f.id !== id);
+        return Response.json({ ok: true });
+      }
+      throw new Error(`unexpected request: ${init?.method ?? "GET"} ${url.pathname}`);
+    };
+    const pending = answer();
+    inFlight.push(pending);
+    return pending;
+  }) as typeof globalThis.fetch;
+
+  const settle = async (): Promise<void> => {
+    for (let round = 0; round < 8; round++) {
+      await Promise.allSettled(inFlight);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  };
+
+  const vite = await createServer({
+    root: packageRoot,
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+  });
+  try {
+    const { appState } = await vite.ssrLoadModule("/src/shell-state.ts");
+    const { renderFiles } = await vite.ssrLoadModule("/src/files.ts");
+    appState.me = { user: "alice@example.com", org: "acme" };
+    appState.currentView = "files";
+    appState.mainEl = document.querySelector("#main");
+
+    const rows = () =>
+      [...document.querySelectorAll<HTMLElement>(".file-row")].map((row) => ({
+        name: row.querySelector(".list-row-title")?.textContent ?? "",
+        opens: Boolean(row.querySelector("a.file-row-main")),
+        deletable: Boolean(row.querySelector(".file-row-actions button")),
+      }));
+    const deleteButton = (name: string) =>
+      [...document.querySelectorAll<HTMLElement>(".file-row")]
+        .find((row) => row.querySelector(".list-row-title")?.textContent === name)
+        ?.querySelector<HTMLButtonElement>(".file-row-actions button") ?? null;
+    const status = () => document.querySelector(".status")?.textContent ?? "";
+    const click = (button: HTMLButtonElement) => button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await renderFiles();
+    await settle();
+    assert.deepEqual(
+      rows(),
+      [
+        { name: "mine.png", opens: true, deletable: true },
+        { name: "no-bytes.png", opens: false, deletable: true },
+        { name: "ghost.png", opens: true, deletable: true },
+        { name: "theirs.png", opens: true, deletable: false },
+      ],
+      "the button follows the server's deletable flag, independently of whether the row opens",
+    );
+    const button = deleteButton("mine.png")!;
+    assert.equal(button.textContent?.trim(), "Delete");
+    assert.equal(button.getAttribute("aria-label"), "Delete mine.png");
+    assert.equal(
+      document.querySelector("a.file-row-main button"),
+      null,
+      "nesting the button inside the open anchor would navigate on every delete click",
+    );
+
+    confirmed = false;
+    click(deleteButton("mine.png")!);
+    await settle();
+    assert.deepEqual(deletes, [], "declining the confirm sends nothing");
+    assert.equal(rows().length, 4);
+    assert.equal(status(), "");
+
+    confirmed = true;
+    click(deleteButton("mine.png")!);
+    const busy = deleteButton("mine.png")!;
+    assert.equal(busy.disabled, true, "the in-flight row's button is disabled");
+    click(busy);
+    await settle();
+    assert.deepEqual(deletes, ["mine/1"], "a double click deletes once, and the id survives URL encoding intact");
+    assert.deepEqual(
+      rows(),
+      [
+        { name: "no-bytes.png", opens: false, deletable: true },
+        { name: "ghost.png", opens: true, deletable: true },
+        { name: "theirs.png", opens: true, deletable: false },
+      ],
+      "the reload drops the deleted row instead of resurrecting it",
+    );
+    assert.equal(status(), "Deleted mine.png.");
+
+    click(deleteButton("ghost.png")!);
+    await settle();
+    assert.deepEqual(deletes, ["mine/1", "ghost"]);
+    assert.equal(status(), "no such file", "a refusal replaces the success notice with the server's reason");
+    assert.equal(rows().length, 3, "a failed delete keeps the row");
+    assert.equal(deleteButton("ghost.png")!.disabled, false, "the row is retryable after a failure");
+  } finally {
+    await vite.close();
+    globalThis.fetch = realFetch;
+    for (const [key, descriptor] of descriptors)
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+      else delete (globalThis as Record<string, unknown>)[key];
+  }
+});

--- a/plugins/web-ui/test/file-delete-relay.test.ts
+++ b/plugins/web-ui/test/file-delete-relay.test.ts
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+
+interface Call {
+  method: string;
+  url: string;
+  body: string;
+  portalIdentity?: string;
+}
+
+const calls: Call[] = [];
+const core = createServer((req: IncomingMessage, res) => {
+  let raw = "";
+  req.on("data", (chunk) => (raw += chunk));
+  req.on("end", () => {
+    const pid = req.headers["x-portal-identity"];
+    const url = req.url ?? "";
+    calls.push({
+      method: req.method ?? "GET",
+      url,
+      body: raw,
+      portalIdentity: Array.isArray(pid) ? pid[0] : pid,
+    });
+    const pathname = new URL(url, "http://core").pathname;
+    if (pathname === "/v1/files/forbidden") {
+      res.writeHead(403, { "content-type": "application/json" });
+      return void res.end(JSON.stringify({ error: "forbidden", message: "that file isn't yours to delete" }));
+    }
+    if (pathname === "/v1/files/ghost") {
+      res.writeHead(404, { "content-type": "application/json" });
+      return void res.end(JSON.stringify({ error: "not_found", message: "no such file" }));
+    }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+});
+await new Promise<void>((resolve) => core.listen(0, resolve));
+
+process.env.CORE_API_URL = `http://localhost:${(core.address() as AddressInfo).port}`;
+process.env.CORE_SIGNING_SECRET = "file-delete-relay-test-secret";
+process.env.WEB_UI_PRINCIPALS = "alice";
+
+const { handler } = await import("../server/index.ts");
+const surface = createServer((req, res) => void handler(req, res));
+await new Promise<void>((resolve) => surface.listen(0, resolve));
+const base = `http://localhost:${(surface.address() as AddressInfo).port}`;
+const headers = { cookie: "webuiuser=alice", "x-portal-identity": "tok-delete" };
+
+test.after(() => {
+  surface.close();
+  core.close();
+});
+
+function fileCalls(from: number): Call[] {
+  return calls.slice(from).filter((c) => new URL(c.url, "http://core").pathname.startsWith("/v1/files/"));
+}
+
+test("a delete relays one signed core call whose principal comes only from the session", async () => {
+  const before = calls.length;
+  const r = await fetch(`${base}/api/files/f1`, { method: "DELETE", headers });
+  assert.equal(r.status, 200);
+  assert.deepEqual(await r.json(), { ok: true });
+
+  const relayed = fileCalls(before);
+  assert.equal(relayed.length, 1, "one browser delete is exactly one core delete");
+  const call = relayed[0]!;
+  assert.equal(call.method, "DELETE");
+  const url = new URL(call.url, "http://core");
+  assert.equal(url.pathname, "/v1/files/f1");
+  assert.deepEqual([...url.searchParams.keys()].sort(), ["_sourceAuthNonce", "principalId"]);
+  assert.equal(url.searchParams.get("principalId"), "alice");
+  assert.ok((url.searchParams.get("_sourceAuthNonce") ?? "").length > 0);
+  assert.equal(call.portalIdentity, "tok-delete", "core's portal-identity gate needs the forwarded token");
+});
+
+test("a client-supplied principalId in the query or body is never relayed", async () => {
+  const before = calls.length;
+  const r = await fetch(`${base}/api/files/f1?principalId=mallory`, {
+    method: "DELETE",
+    headers: { ...headers, "content-type": "application/json" },
+    body: JSON.stringify({ principalId: "mallory" }),
+  });
+  assert.equal(r.status, 200);
+
+  const relayed = fileCalls(before);
+  assert.equal(relayed.length, 1);
+  const url = new URL(relayed[0]!.url, "http://core");
+  assert.deepEqual(url.searchParams.getAll("principalId"), ["alice"]);
+  assert.equal(relayed[0]!.body, "", "the surface forwards no body, so no body field can be trusted downstream");
+});
+
+test("an unauthenticated delete is refused at the surface and never reaches core", async () => {
+  const before = calls.length;
+  const r = await fetch(`${base}/api/files/f1`, { method: "DELETE" });
+  assert.equal(r.status, 401);
+  assert.equal(fileCalls(before).length, 0);
+});
+
+test("core's refusals relay verbatim so the page can show the real reason", async () => {
+  for (const [id, status, message] of [
+    ["forbidden", 403, "that file isn't yours to delete"],
+    ["ghost", 404, "no such file"],
+  ] as const) {
+    const r = await fetch(`${base}/api/files/${id}`, { method: "DELETE", headers });
+    assert.equal(r.status, status);
+    assert.equal(((await r.json()) as { message?: string }).message, message);
+  }
+});
+
+test("an id needing escaping is encoded exactly once and cannot walk out of /v1/files/", async () => {
+  const before = calls.length;
+  await fetch(`${base}/api/files/${encodeURIComponent("../uploads/x")}`, { method: "DELETE", headers });
+
+  const relayed = fileCalls(before);
+  assert.equal(relayed.length, 1);
+  const url = new URL(relayed[0]!.url, "http://core");
+  assert.equal(url.pathname, `/v1/files/${encodeURIComponent("../uploads/x")}`);
+  assert.equal(url.pathname.split("/").length, 4, "the id stays one path segment");
+});

--- a/plugins/web-ui/test/files-source.test.ts
+++ b/plugins/web-ui/test/files-source.test.ts
@@ -20,15 +20,20 @@ test("Files uses compact rows that open directly", () => {
   const start = source.indexOf("function fileRow(");
   const end = source.indexOf("\nfunction rowsFromPage", start);
   const row = source.slice(start, end);
-  assert.match(row, /<a class="list-row file-row" href=\$\{contentUrl\} target="_blank"/);
+  assert.match(row, /<div class="list-row file-row">/);
+  assert.match(row, /<a class="file-row-main" href=\$\{contentUrl\} target="_blank"/);
+  assert.match(row, /<span class="file-row-main">\$\{content\}<\/span>/);
   assert.doesNotMatch(row, /file-row-type|\$\{f\.mimetype\}|class="badge"|\$\{f\.kind\}|>Open</);
   assert.doesNotMatch(row, /scopeChip|fileScope\(f\)/);
   assert.match(row, /formatBytes\(f\.sizeBytes\)/);
   assert.match(row, /relTime\(f\.createdAt\)/);
-  assert.match(css, /\.file-row \{\s*color: inherit;\s*text-decoration: none;/);
   assert.match(
     css,
-    /\.file-row \{\s*display: grid;\s*grid-template-columns: 22px minmax\(0, 1fr\) auto;\s*justify-content: initial;/,
+    /\.file-row \{\s*display: grid;\s*grid-template-columns: minmax\(0, 1fr\) auto;[^}]*justify-content: initial;/,
+  );
+  assert.match(
+    css,
+    /\.file-row-main \{\s*display: grid;\s*grid-template-columns: 22px minmax\(0, 1fr\) auto;[^}]*color: inherit;\s*text-decoration: none;/,
   );
   assert.match(css, /\.file-row \.list-row-title \{\s*justify-self: stretch;\s*text-align: left;/);
   assert.match(css, /\.file-row \.list-row-meta \{\s*gap: 14px;/);

--- a/plugins/web-ui/test/files-source.test.ts
+++ b/plugins/web-ui/test/files-source.test.ts
@@ -68,18 +68,6 @@ test("splitting the file row into an open anchor and an actions cell keeps the c
   );
   assert.match(
     css,
-    /\.file-row \{[^}]*column-gap: 0;/,
-    "an inherited column gap would end the open anchor short of the row's right edge on every row",
-  );
-  assert.match(css, /\.file-row \{[^}]*cursor: default;/);
-  assert.match(css, /\.file-row-main \{[^}]*cursor: pointer;/);
-  assert.match(
-    css,
-    /\.file-row-main:not\(\[href\]\) \{\s*cursor: default;/,
-    "an unopenable row must not advertise a navigation nothing performs",
-  );
-  assert.match(
-    css,
     /@media \(max-width: 700px\) \{\s*\.file-row-main \{\s*grid-template-columns: 22px minmax\(0, 1fr\);/,
   );
   assert.doesNotMatch(

--- a/plugins/web-ui/test/files-source.test.ts
+++ b/plugins/web-ui/test/files-source.test.ts
@@ -47,6 +47,48 @@ test("Files uses compact rows that open directly", () => {
   );
 });
 
+test("splitting the file row into an open anchor and an actions cell keeps the click target and the row height", () => {
+  const start = source.indexOf("function fileRow(");
+  const row = source.slice(start, source.indexOf("\nfunction rowsFromPage", start));
+  assert.match(
+    row,
+    /class="btn danger compact"/,
+    "a full-size button is taller than the row body and would stretch every deletable row past its neighbours",
+  );
+  assert.match(css, /\.file-row \{[^}]*padding: 0;/);
+  assert.match(
+    css,
+    /\.file-row-main \{[^}]*padding: 12px;/,
+    "the row's click ring belongs to the open anchor now; left on the outer div it stops opening the file",
+  );
+  assert.match(
+    css,
+    /\.file-row-actions \{[^}]*padding: 0 [\d.]+px 0 [\d.]+px;/,
+    "vertical padding on the actions cell makes deletable rows taller than the rows beside them",
+  );
+  assert.match(
+    css,
+    /\.file-row \{[^}]*column-gap: 0;/,
+    "an inherited column gap would end the open anchor short of the row's right edge on every row",
+  );
+  assert.match(css, /\.file-row \{[^}]*cursor: default;/);
+  assert.match(css, /\.file-row-main \{[^}]*cursor: pointer;/);
+  assert.match(
+    css,
+    /\.file-row-main:not\(\[href\]\) \{\s*cursor: default;/,
+    "an unopenable row must not advertise a navigation nothing performs",
+  );
+  assert.match(
+    css,
+    /@media \(max-width: 700px\) \{\s*\.file-row-main \{\s*grid-template-columns: 22px minmax\(0, 1fr\);/,
+  );
+  assert.doesNotMatch(
+    css,
+    /\.file-row,\s*\.deploy-row \{\s*grid-template-columns: auto minmax\(0, 1fr\)/,
+    "a narrow-width override of the outer row would collapse the column the Delete button sits in",
+  );
+});
+
 test("Files groups rows by scope instead of repeating scope badges", () => {
   assert.match(source, /function groupFilesByScope\(files: FileRow\[\]\)/);
   assert.match(source, /groups\.map\(/);

--- a/src/api/app-helpers.ts
+++ b/src/api/app-helpers.ts
@@ -9,7 +9,7 @@ import type {
 } from "../types.ts";
 import { orgId as orgIdOf } from "../config.ts";
 import { isManageableCreationScope, parseScopeId, scopeId } from "../types.ts";
-import { type ListOwnedOptions } from "../files/file-artifact-store.ts";
+import { type FileArtifact, type ListOwnedOptions } from "../files/file-artifact-store.ts";
 import type { Run } from "../runs/run-store.ts";
 import type { RunSignal } from "../runs/run-signal-store.ts";
 import { processRun } from "../runs/worker.ts";
@@ -345,9 +345,22 @@ export function createAppHelpers(deps: AppDeps, app: App) {
         ...(inScope ? { createdInScope: inScope } : {}),
       },
     );
+    const manages = new Map<string, Promise<boolean>>();
+    const withDeletable = (rows: FileArtifact[]) =>
+      Promise.all(
+        rows.map(async (f) => {
+          const key = `${f.ownerScopeId}\0${samePerson(f.createdBy, principalId)}`;
+          let decision = manages.get(key);
+          if (!decision) {
+            decision = principalManagesArtifactHome(f.ownerScopeId, f.createdBy, principalId);
+            manages.set(key, decision);
+          }
+          return { ...toFileItem(f), deletable: await decision };
+        }),
+      );
     return {
-      owned: page.files.filter((f) => myScopes.includes(f.ownerScopeId)).map(toFileItem),
-      shared: page.files.filter((f) => !myScopes.includes(f.ownerScopeId)).map(toFileItem),
+      owned: await withDeletable(page.files.filter((f) => myScopes.includes(f.ownerScopeId))),
+      shared: await withDeletable(page.files.filter((f) => !myScopes.includes(f.ownerScopeId))),
       ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
     };
   }

--- a/src/api/app-helpers.ts
+++ b/src/api/app-helpers.ts
@@ -349,7 +349,7 @@ export function createAppHelpers(deps: AppDeps, app: App) {
     const withDeletable = (rows: FileArtifact[]) =>
       Promise.all(
         rows.map(async (f) => {
-          const key = `${f.ownerScopeId}\0${samePerson(f.createdBy, principalId)}`;
+          const key = `${f.ownerScopeId}\0${f.createdBy}`;
           let decision = manages.get(key);
           if (!decision) {
             decision = principalManagesArtifactHome(f.ownerScopeId, f.createdBy, principalId);

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -1,7 +1,7 @@
 import type { PendingApprovalRecord } from "../types.ts";
 import { orgId as orgIdOf } from "../config.ts";
 import { parseScopeId, scopeId } from "../types.ts";
-import { fileArtifactId, artifactPath } from "../files/file-artifact-store.ts";
+import { fileArtifactId, artifactPath, isArtifactPath } from "../files/file-artifact-store.ts";
 import { entryWithinTenure, transcriptEntries, windowedTranscript } from "../sessions/session-store.ts";
 import { createTranscriptSource } from "../harness/tape-projection.ts";
 import { appendCoverageImport } from "../harness/replay.ts";
@@ -379,6 +379,11 @@ export function createSessionMethods(
       const art = await deps.files.get(id);
       if (!art) return "not_found";
       if (!(await principalManagesArtifactHome(art.ownerScopeId, art.createdBy, principalId))) return "forbidden";
+      if (isArtifactPath(art.path)) {
+        const grantees = new Set((await deps.acl.grantsFor(art.ownerScopeId, art.path)).map((g) => g.granteeScopeId));
+        for (const grantee of grantees)
+          await deps.acl.revoke(art.ownerScopeId, art.path, grantee, principalId, art.createdBy);
+      }
       await deps.files.delete(id);
       deps.auditLog?.record({
         at: Date.now(),

--- a/src/api/app-sessions.ts
+++ b/src/api/app-sessions.ts
@@ -58,6 +58,7 @@ export function createSessionMethods(
   | "listFilesForViewer"
   | "uploadFileForViewer"
   | "openFileForViewer"
+  | "deleteFileForViewer"
   | "listSessions"
   | "searchSessions"
   | "sessionBackground"
@@ -372,6 +373,21 @@ export function createSessionMethods(
       const opened = await deps.files.open(id);
       if (!opened) return null;
       return { name: art.name, mimetype: art.mimetype, sizeBytes: opened.sizeBytes, stream: opened.stream };
+    },
+
+    async deleteFileForViewer(id, principalId) {
+      const art = await deps.files.get(id);
+      if (!art) return "not_found";
+      if (!(await principalManagesArtifactHome(art.ownerScopeId, art.createdBy, principalId))) return "forbidden";
+      await deps.files.delete(id);
+      deps.auditLog?.record({
+        at: Date.now(),
+        principalId,
+        action: "file.delete",
+        resource: art.path,
+        scopeLabel: art.createdInScope ?? art.ownerScopeId,
+      });
+      return "deleted";
     },
 
     async listSessions(principalId) {

--- a/src/api/app-types.ts
+++ b/src/api/app-types.ts
@@ -366,6 +366,7 @@ export interface App {
     claims: Pick<CapabilityClaims, "actorId" | "scopeId" | "scopeVersion" | "botActor" | "liveActor" | "members">,
   ): Promise<boolean>;
   openFileForViewer(id: string, principalId: string): Promise<OpenedFile | null>;
+  deleteFileForViewer(id: string, principalId: string): Promise<"deleted" | "forbidden" | "not_found">;
   grant(g: Grant): Promise<void>;
   revokeGrant(ownerScopeId: ScopeId, ref: string, granteeScopeId: ScopeId, revokedBy: string): Promise<void>;
   promoteSkill(id: string, targetScopeId: ScopeId, actorId: string, liveActor: boolean): Promise<Skill>;
@@ -640,6 +641,7 @@ interface FileListItem {
   createdAt: number;
   createdInScope?: ScopeId;
   openable: boolean;
+  deletable?: boolean;
 }
 
 export interface FileListPage {

--- a/src/api/routes/surface.ts
+++ b/src/api/routes/surface.ts
@@ -294,6 +294,17 @@ async function listFiles(ctx: ApiCtx): Promise<void> {
   return sendJson(res, 200, page);
 }
 
+async function deleteFile(ctx: ApiCtx): Promise<void> {
+  const { res, app, url, actor } = ctx;
+  const principalId = (actor?.p ?? url.searchParams.get("principalId"))?.trim();
+  if (!principalId) return sendJson(res, 400, { error: "bad_request", message: "principalId required" });
+  const outcome = await app.deleteFileForViewer(ctx.params.id!, principalId);
+  if (outcome === "not_found") return sendJson(res, 404, { error: "not_found", message: "no such file" });
+  if (outcome === "forbidden")
+    return sendJson(res, 403, { error: "forbidden", message: "that file isn't yours to delete" });
+  return sendJson(res, 200, { ok: true });
+}
+
 async function uploadFile(ctx: ApiCtx): Promise<void> {
   const { res, app, deps, body } = ctx;
   if (!deps.blobTransfer)
@@ -1281,6 +1292,7 @@ export const surfaceRoutes: ReadonlyArray<Route<ApiCtx>> = [
   { method: "GET", path: "/v1/sessions/:id", auth: "source", handle: getSession },
   { method: "GET", path: "/v1/files/:id/content", auth: "either", handle: getFileContent },
   { method: "POST", path: "/v1/files/upload", auth: "source", handle: uploadFile },
+  { method: "DELETE", path: "/v1/files/:id", auth: "source", handle: deleteFile },
   { method: "GET", path: "/v1/files", auth: "either", handle: listFiles },
   { method: "POST", path: "/v1/sessions/:id", auth: "source", handle: patchSession },
   { method: "GET", path: "/v1/sessions", auth: "source", handle: listSessions },

--- a/src/api/user-scoped-routes.ts
+++ b/src/api/user-scoped-routes.ts
@@ -45,6 +45,7 @@ const USER_SCOPED: Rule[] = [
   pat("POST", "/v1/files/uploads/:id/complete", { in: "body", name: "principalId" }),
   pat("DELETE", "/v1/files/uploads/:id", { in: "body", name: "principalId" }),
   pat("POST", "/v1/files/upload", { in: "body", name: "principalId" }),
+  pat("DELETE", "/v1/files/:id", { in: "query", name: "principalId" }),
   pat("POST", "/v1/sessions/:id", { in: "body", name: "principalId" }),
   pat("POST", "/v1/sessions/:id/title", { in: "body", name: "principalId" }),
   pat("POST", "/v1/sessions/:id/fork", { in: "body", name: "principalId" }),

--- a/test/file-delete-route.test.ts
+++ b/test/file-delete-route.test.ts
@@ -1,0 +1,147 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildApp, type BuiltApp } from "../src/wiring.ts";
+import { createInsecureTestServer } from "../src/api/server.ts";
+import { mintSignedPayload } from "../src/auth/signed-token.ts";
+import { mintCapabilityToken, CONTROL_PLANE_AUD } from "../src/auth/capability-token.ts";
+import { apiRoutes } from "../src/api/routes/index.ts";
+import { findRoute } from "../src/api/routes/route.ts";
+import { userScopedField } from "../src/api/user-scoped-routes.ts";
+import { testConfig } from "./support/test-config.ts";
+import { scopeId } from "../src/types.ts";
+
+const CAP = "core-only-capability-secret-for-delete-01";
+const PID = "portal-only-identity-secret-for-delete-01";
+
+const outcomes = new Map<string, "deleted" | "forbidden" | "not_found">([
+  ["mine", "deleted"],
+  ["theirs", "forbidden"],
+  ["ghost", "not_found"],
+]);
+const attempts: Array<{ id: string; principalId: string }> = [];
+
+let built: BuiltApp;
+const servers: Server[] = [];
+let open: string;
+let gated: string;
+let actorFirst: string;
+
+function listen(server: Server): Promise<string> {
+  servers.push(server);
+  return new Promise((resolve) =>
+    server.listen(0, () => resolve(`http://localhost:${(server.address() as AddressInfo).port}`)),
+  );
+}
+
+const token = (p: string) => mintSignedPayload({ p, exp: Date.now() + 60_000 }, PID);
+
+before(async () => {
+  built = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "file-delete-route-")) }));
+  built.app.authorizesCapabilityScope = async () => true;
+  built.app.deleteFileForViewer = async (id, principalId) => {
+    attempts.push({ id, principalId });
+    return outcomes.get(id) ?? "not_found";
+  };
+  open = await listen(createInsecureTestServer(built.app, {}));
+  gated = await listen(
+    createInsecureTestServer(built.app, {
+      capabilitySecret: CAP,
+      portalIdentitySecret: PID,
+      requireSignedPortalIdentity: true,
+      identity: built.identity,
+    }),
+  );
+  actorFirst = await listen(
+    createInsecureTestServer(built.app, { portalIdentitySecret: PID, identity: built.identity }),
+  );
+});
+
+after(async () => {
+  for (const server of servers) await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+const del = (base: string, path: string, headers: Record<string, string> = {}, body?: unknown) =>
+  fetch(`${base}${path}`, {
+    method: "DELETE",
+    headers: { "content-type": "application/json", ...headers },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+test("a delete that names no principal is a bad request, and a body principalId does not count", async () => {
+  const before = attempts.length;
+  const bare = await del(open, "/v1/files/mine");
+  assert.equal(bare.status, 400);
+  assert.deepEqual(await bare.json(), { error: "bad_request", message: "principalId required" });
+
+  const bodyOnly = await del(open, "/v1/files/mine", {}, { principalId: "U1" });
+  assert.equal(bodyOnly.status, 400, "the handler reads the query, the same location USER_SCOPED declares");
+  assert.equal(attempts.length, before, "an unauthenticated delete never reaches the app");
+  assert.deepEqual(userScopedField("DELETE", "/v1/files/mine"), { in: "query", name: "principalId" });
+});
+
+test("the three app outcomes map to 200, 403 and 404", async () => {
+  const ok = await del(open, "/v1/files/mine?principalId=U1");
+  assert.equal(ok.status, 200);
+  assert.deepEqual(await ok.json(), { ok: true });
+
+  const refused = await del(open, "/v1/files/theirs?principalId=U1");
+  assert.equal(refused.status, 403);
+  assert.deepEqual(await refused.json(), { error: "forbidden", message: "that file isn't yours to delete" });
+
+  const missing = await del(open, "/v1/files/ghost?principalId=U1");
+  assert.equal(missing.status, 404);
+  assert.deepEqual(await missing.json(), { error: "not_found", message: "no such file" });
+});
+
+test("an agent capability token cannot reach this route (it is source-authenticated only)", async () => {
+  const before = attempts.length;
+  const cap = await mintCapabilityToken(
+    { actorId: "U1", scopeId: scopeId("personal", "U1"), aud: CONTROL_PLANE_AUD, exp: Date.now() + 60_000 },
+    CAP,
+  );
+  const r = await del(gated, "/v1/files/mine?principalId=U1", { "x-agent-capability": cap });
+  assert.equal(r.status, 403);
+  assert.equal(((await r.json()) as { message?: string }).message, "capability token not valid for this route");
+  assert.equal(attempts.length, before);
+});
+
+test("with enforcement on, the portal identity must be present and must match the named principal", async () => {
+  const before = attempts.length;
+  const anonymous = await del(gated, "/v1/files/mine?principalId=U1");
+  assert.equal(anonymous.status, 401);
+  assert.equal(((await anonymous.json()) as { message?: string }).message, "portal identity required");
+
+  const impostor = await del(gated, "/v1/files/mine?principalId=U2", { "x-portal-identity": await token("U1") });
+  assert.equal(impostor.status, 403);
+  assert.equal(
+    ((await impostor.json()) as { message?: string }).message,
+    "portal identity does not match the requested actor",
+  );
+  assert.equal(attempts.length, before, "the gate answers before the app is asked to delete anything");
+
+  const mine = await del(gated, "/v1/files/mine?principalId=U1", { "x-portal-identity": await token("U1") });
+  assert.equal(mine.status, 200);
+  assert.deepEqual(attempts.at(-1), { id: "mine", principalId: "U1" });
+});
+
+test("with enforcement off, a verified actor still wins over a query principal it disagrees with", async () => {
+  const r = await del(actorFirst, "/v1/files/mine?principalId=U2", { "x-portal-identity": await token("U1") });
+  assert.equal(r.status, 200);
+  assert.deepEqual(
+    attempts.at(-1),
+    { id: "mine", principalId: "U1" },
+    "a source-auth caller must not be able to delete as somebody else",
+  );
+});
+
+test("the direct-upload abort route keeps its own handler; /v1/files/:id cannot shadow it", () => {
+  const upload = findRoute(apiRoutes, "DELETE", "/v1/files/uploads/abc123");
+  assert.equal(upload && "path" in upload.route ? upload.route.path : null, "/v1/files/uploads/:id");
+  const artifact = findRoute(apiRoutes, "DELETE", "/v1/files/abc123");
+  assert.equal(artifact && "path" in artifact.route ? artifact.route.path : null, "/v1/files/:id");
+});

--- a/test/file-delete-route.test.ts
+++ b/test/file-delete-route.test.ts
@@ -189,4 +189,9 @@ test("the direct-upload abort route keeps its own handler; /v1/files/:id cannot 
   assert.equal(upload && "path" in upload.route ? upload.route.path : null, "/v1/files/uploads/:id");
   const artifact = findRoute(apiRoutes, "DELETE", "/v1/files/abc123");
   assert.equal(artifact && "path" in artifact.route ? artifact.route.path : null, "/v1/files/:id");
+  assert.deepEqual(
+    userScopedField("DELETE", "/v1/files/uploads/abc123"),
+    { in: "body", name: "principalId" },
+    "the abort route keeps binding its actor from the body the portal-identity gate reads",
+  );
 });

--- a/test/file-delete-route.test.ts
+++ b/test/file-delete-route.test.ts
@@ -13,6 +13,7 @@ import { apiRoutes } from "../src/api/routes/index.ts";
 import { findRoute } from "../src/api/routes/route.ts";
 import { userScopedField } from "../src/api/user-scoped-routes.ts";
 import { testConfig } from "./support/test-config.ts";
+import { fileArtifactId } from "../src/files/file-artifact-store.ts";
 import { scopeId } from "../src/types.ts";
 
 const CAP = "core-only-capability-secret-for-delete-01";
@@ -137,6 +138,50 @@ test("with enforcement off, a verified actor still wins over a query principal i
     { id: "mine", principalId: "U1" },
     "a source-auth caller must not be able to delete as somebody else",
   );
+});
+
+test("against the real app the same three outcomes come back, and the deleted row leaves the listing", async () => {
+  const real = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "file-delete-wired-")) }));
+  const base = await listen(createInsecureTestServer(real.app, { portalIdentitySecret: PID, identity: real.identity }));
+  const as = async (principalId: string) => ({ "x-portal-identity": await token(principalId) });
+  const mine = fileArtifactId("wired-mine", "out", 0);
+  const theirs = fileArtifactId("wired-theirs", "out", 0);
+  for (const [id, owner] of [
+    [mine, "U1"],
+    [theirs, "U2"],
+  ] as const)
+    await real.files.put({
+      id,
+      ownerScopeId: scopeId("personal", owner),
+      createdBy: owner,
+      name: `${owner}.txt`,
+      path: `artifacts/${id}/${owner}.txt`,
+      mimetype: "text/plain",
+      data: Buffer.from(owner),
+      direction: "out",
+    });
+
+  const owned = async () => {
+    const r = await fetch(`${base}/v1/files`, { headers: await as("U1") });
+    assert.equal(r.status, 200);
+    return ((await r.json()) as { owned: Array<{ id: string; deletable?: boolean }> }).owned;
+  };
+  assert.deepEqual(
+    (await owned()).map((f) => [f.id, f.deletable]),
+    [[mine, true]],
+    "the listing the page renders carries the flag that decides whether a Delete button exists",
+  );
+
+  const refused = await del(base, `/v1/files/${theirs}?principalId=U1`, await as("U1"));
+  assert.equal(refused.status, 403);
+  assert.ok(await real.files.get(theirs), "a refused delete leaves somebody else's artifact in place");
+
+  const gone = await del(base, `/v1/files/${mine}?principalId=U1`, await as("U1"));
+  assert.equal(gone.status, 200);
+  assert.deepEqual(await gone.json(), { ok: true });
+  assert.equal(await real.files.get(mine), null);
+  assert.deepEqual(await owned(), [], "the page reload after a delete cannot show the row again");
+  assert.equal((await del(base, `/v1/files/${mine}?principalId=U1`, await as("U1"))).status, 404);
 });
 
 test("the direct-upload abort route keeps its own handler; /v1/files/:id cannot shadow it", () => {

--- a/test/file-delete.test.ts
+++ b/test/file-delete.test.ts
@@ -1,0 +1,265 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createApp, type AppDeps } from "../src/api/app.ts";
+import { createAclStore } from "../src/acl/acl-store.ts";
+import {
+  createMemoryFileArtifactStore,
+  fileArtifactId,
+  type FileArtifactStore,
+} from "../src/files/file-artifact-store.ts";
+import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts";
+import { scopeId, type ScopeId } from "../src/types.ts";
+import { orgId } from "../src/config.ts";
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0xfe, 0x7f]);
+const channel = scopeId("channel", "C1");
+const publicChannel = scopeId("channel", "C2");
+const org = scopeId("org", orgId());
+
+interface AuditRecord {
+  principalId: string;
+  action: string;
+  resource: string;
+  scopeLabel?: string;
+}
+
+function makeApp(
+  files: FileArtifactStore,
+  acl: ReturnType<typeof createAclStore>,
+  extra: {
+    audit?: AuditRecord[];
+    channelPrivacy?: (channelId: string) => Promise<boolean | undefined>;
+    channels?: Array<{ channelId: string; name: string; isPrivate: boolean }>;
+    sessionScopes?: ScopeId[];
+  } = {},
+) {
+  const identity = {
+    classify: (id: string) => ({ id, type: "internal" }),
+    isInternal: (p: { type: string }) => p.type === "internal",
+  };
+  const directory = {
+    listChannelsFor: async (principalId: string) =>
+      principalId === "U1" || principalId === "U2"
+        ? (extra.channels ?? [{ channelId: "C1", name: "eng", isPrivate: true }])
+        : [],
+    channelMember: async (channelId: string, principalId: string) =>
+      channelId === "C1" && (principalId === "U1" || principalId === "U2"),
+    ...(extra.channelPrivacy ? { channelPrivacy: extra.channelPrivacy } : {}),
+  };
+  const auditLog = { record: (r: AuditRecord) => void extra.audit?.push(r) };
+  return createApp({
+    acl,
+    files,
+    identity,
+    directory,
+    sessions: { listByParticipant: async () => (extra.sessionScopes ?? []).map((scope) => ({ scopeId: scope })) },
+    auditLog,
+    crons: { list: async () => [] },
+    webhooks: { list: async () => [] },
+    skills: { list: async () => [] },
+    deploy: { listDeployments: async () => [] },
+  } as unknown as AppDeps);
+}
+
+function seed(files: FileArtifactStore, id: string, owner: string, ownerScopeId = scopeId("personal", owner)) {
+  return files.put({
+    id,
+    ownerScopeId,
+    createdBy: owner,
+    name: `${id}.png`,
+    path: `artifacts/${id}/${id}.png`,
+    mimetype: "image/png",
+    data: PNG,
+    direction: "out",
+  });
+}
+
+test("the owner deletes their file: it disappears from every listing, stops opening, and is audited once", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const audit: AuditRecord[] = [];
+  const app = makeApp(files, createAclStore(), { audit });
+  const id = fileArtifactId("own", "out", 0);
+  await seed(files, id, "U1");
+
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+
+  const page = await app.listFilesForViewer("U1");
+  assert.deepEqual([...page.owned, ...page.shared], []);
+  assert.equal(await app.openFileForViewer(id, "U1"), null);
+  const deletes = audit.filter((r) => r.action === "file.delete");
+  assert.equal(deletes.length, 1);
+  assert.equal(deletes[0]!.principalId, "U1");
+  assert.equal(deletes[0]!.resource, `artifacts/${id}/${id}.png`);
+  assert.equal(deletes[0]!.scopeLabel, scopeId("personal", "U1"));
+});
+
+test("a read grant does not authorize a delete", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const acl = createAclStore();
+  const app = makeApp(files, acl);
+  const id = fileArtifactId("shared", "out", 0);
+  const { artifact } = await seed(files, id, "U1");
+  await acl.grant({
+    ownerScopeId: artifact.ownerScopeId,
+    ref: artifact.path,
+    granteeScopeId: scopeId("personal", "U2"),
+    permission: "read",
+    grantedBy: "U1",
+  });
+
+  const shareeView = await app.listFilesForViewer("U2");
+  assert.equal(shareeView.shared.length, 1);
+  assert.equal(shareeView.shared[0]!.deletable, false, "a read grantee gets no Delete button");
+  assert.equal(await app.deleteFileForViewer(id, "U2"), "forbidden");
+
+  assert.equal((await app.listFilesForViewer("U1")).owned.length, 1, "the owner's file survives");
+  assert.ok(await app.openFileForViewer(id, "U1"));
+});
+
+test("an org-scope artifact lands in every member's owned[] but is neither deletable nor deleted", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const app = makeApp(files, createAclStore());
+  const id = fileArtifactId("orgwide", "out", 0);
+  await seed(files, id, "operator", org);
+
+  const page = await app.listFilesForViewer("U1");
+  assert.deepEqual(
+    page.owned.map((f) => f.id),
+    [id],
+    "the org scope is in every internal viewer's resource scopes",
+  );
+  assert.equal(page.owned[0]!.deletable, false);
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "forbidden");
+  assert.ok(await files.get(id), "a refused delete leaves the row alone");
+});
+
+test("deleting is idempotent: an unknown id and a second delete both answer not_found without throwing", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const app = makeApp(files, createAclStore());
+  const id = fileArtifactId("twice", "out", 0);
+  await seed(files, id, "U1");
+
+  assert.equal(await app.deleteFileForViewer("no-such-file", "U1"), "not_found");
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "not_found");
+});
+
+test("deleting one of two identical-byte artifacts leaves the other readable", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const app = makeApp(files, createAclStore());
+  const mine = fileArtifactId("copy-mine", "out", 0);
+  const theirs = fileArtifactId("copy-theirs", "out", 0);
+  await seed(files, mine, "U1");
+  await seed(files, theirs, "U2");
+  assert.equal((await files.get(mine))!.blobKey, (await files.get(theirs))!.blobKey, "identical bytes share a key");
+
+  assert.equal(await app.deleteFileForViewer(mine, "U1"), "deleted");
+
+  const survivor = await app.openFileForViewer(theirs, "U2");
+  assert.ok(survivor);
+  const read: Buffer[] = [];
+  for await (const c of survivor!.stream) read.push(c as Buffer);
+  assert.deepEqual(
+    Buffer.concat(read),
+    PNG,
+    "erasing shared bytes would break every artifact with the same digest",
+  );
+});
+
+test("deletable is computed once per (ownerScopeId, authorship) pair, not once per row", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  let privacyChecks = 0;
+  const app = makeApp(files, createAclStore(), {
+    channelPrivacy: async () => {
+      privacyChecks++;
+      return true;
+    },
+  });
+  for (let n = 0; n < 8; n++) {
+    const id = fileArtifactId("channel-row", "out", n);
+    await files.put({
+      id,
+      ownerScopeId: channel,
+      createdBy: "U1",
+      name: `row-${n}.txt`,
+      path: `artifacts/${id}/row-${n}.txt`,
+      mimetype: "text/plain",
+      data: Buffer.from(`row ${n}`),
+      direction: "out",
+    });
+  }
+
+  const page = await app.listFilesForViewer("U1");
+  assert.equal(page.owned.length, 8);
+  assert.ok(
+    page.owned.every((f) => f.deletable === true),
+    "a private-channel member manages that channel's artifact home",
+  );
+  assert.equal(privacyChecks, 1, "eight rows sharing one home cost one authorization check");
+});
+
+test("in a public channel only the author's own rows are deletable", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const app = makeApp(files, createAclStore(), {
+    channels: [{ channelId: "C2", name: "general", isPrivate: false }],
+    sessionScopes: [publicChannel],
+    channelPrivacy: async () => false,
+  });
+  const authors = ["U1", "U2", "U3", "U4"];
+  for (const [n, author] of authors.entries()) {
+    const id = fileArtifactId("public-row", "out", n);
+    await files.put({
+      id,
+      ownerScopeId: publicChannel,
+      createdBy: author,
+      name: `${author}.txt`,
+      path: `artifacts/${id}/${author}.txt`,
+      mimetype: "text/plain",
+      data: Buffer.from(`row ${n}`),
+      direction: "out",
+    });
+  }
+
+  const page = await app.listFilesForViewer("U1");
+  assert.deepEqual(
+    Object.fromEntries(page.owned.map((f) => [f.name, f.deletable])),
+    { "U1.txt": true, "U2.txt": false, "U3.txt": false, "U4.txt": false },
+    "a public channel lets authors remove their own uploads and nobody else's",
+  );
+  assert.equal(await app.deleteFileForViewer(fileArtifactId("public-row", "out", 1), "U1"), "forbidden");
+});
+
+test("an unopenable row the viewer manages is still deletable", async () => {
+  const owner = scopeId("personal", "U1");
+  const id = "backfill-1";
+  const row = {
+    id,
+    ownerScopeId: owner,
+    createdBy: "U1",
+    name: "old.png",
+    path: "old.png",
+    mimetype: "image/png",
+    sizeBytes: 10,
+    blobKey: null,
+    sha256: null,
+    direction: "out" as const,
+    source: "backfill" as const,
+    createdAt: 1,
+    updatedAt: 1,
+    enabled: true,
+  };
+  const deleted: string[] = [];
+  const files = {
+    get: async () => row,
+    open: async () => null,
+    listDocuments: async () => ({ files: [row] }),
+    delete: async (target: string) => void deleted.push(target),
+  } as unknown as FileArtifactStore;
+  const app = makeApp(files, createAclStore());
+
+  const page = await app.listFilesForViewer("U1");
+  assert.equal(page.owned[0]!.openable, false);
+  assert.equal(page.owned[0]!.deletable, true, "bytes you cannot read are still a row you can remove");
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+  assert.deepEqual(deleted, [id]);
+});

--- a/test/file-delete.test.ts
+++ b/test/file-delete.test.ts
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createApp, type AppDeps } from "../src/api/app.ts";
+import { buildApp } from "../src/wiring.ts";
+import { testConfig } from "./support/test-config.ts";
 import { createAclStore } from "../src/acl/acl-store.ts";
 import {
   createMemoryFileArtifactStore,
@@ -271,4 +276,94 @@ test("an unopenable row the viewer manages is still deletable", async () => {
   assert.equal(page.owned[0]!.deletable, true, "bytes you cannot read are still a row you can remove");
   assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
   assert.deepEqual(deleted, [id]);
+});
+
+test("deleting an artifact revokes its shares, so no grantee's turn context keeps naming it", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const acl = createAclStore();
+  const app = makeApp(files, acl);
+  const id = fileArtifactId("shared-then-deleted", "out", 0);
+  const { artifact } = await seed(files, id, "U1");
+  await acl.grant({
+    ownerScopeId: artifact.ownerScopeId,
+    ref: artifact.path,
+    granteeScopeId: channel,
+    permission: "read",
+    grantedBy: "U1",
+  });
+  assert.equal((await acl.handlesFor([channel])).length, 1);
+
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+
+  assert.deepEqual(await acl.handlesFor([channel]), [], "nothing backs an artifact handle once its row is gone");
+  assert.deepEqual(await acl.list(), [], "a grant nobody can revoke would outlive the file forever");
+});
+
+test("deleting a workspace-backed row keeps its shares: the workspace copy still answers the handle", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const acl = createAclStore();
+  const app = makeApp(files, acl, {
+    channels: [{ channelId: "C2", name: "general", isPrivate: false }],
+    sessionScopes: [publicChannel],
+    channelPrivacy: async () => false,
+  });
+  const id = fileArtifactId("workspace-backed", "out", 0);
+  await files.put({
+    id,
+    ownerScopeId: publicChannel,
+    createdBy: "U1",
+    name: "report.md",
+    path: "report.md",
+    mimetype: "text/markdown",
+    data: Buffer.from("report"),
+    direction: "out",
+  });
+  await acl.grant({
+    ownerScopeId: publicChannel,
+    ref: "report.md",
+    granteeScopeId: scopeId("personal", "U2"),
+    permission: "read",
+    grantedBy: "U1",
+  });
+
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+
+  assert.equal(
+    (await acl.handlesFor([scopeId("personal", "U2")])).length,
+    1,
+    "the workspace still holds these bytes — dropping the catalog row must not unshare them",
+  );
+});
+
+test("under real wiring the revoke satisfies the ACL store's own manage check instead of throwing", async () => {
+  const real = buildApp(testConfig({ dataDir: mkdtempSync(join(tmpdir(), "file-delete-acl-")) }));
+  await real.directory.replaceChannels(
+    [{ channelId: "C9", name: "general", isPrivate: false }],
+    [{ channelId: "C9", principalId: "U1" }],
+  );
+  const home = scopeId("channel", "C9");
+  const id = fileArtifactId("channel-share", "out", 0);
+  const path = `artifacts/${id}/notes.txt`;
+  await real.files.put({
+    id,
+    ownerScopeId: home,
+    createdBy: "U1",
+    name: "notes.txt",
+    path,
+    mimetype: "text/plain",
+    data: Buffer.from("notes"),
+    direction: "out",
+  });
+  await real.acl.grant(
+    { ownerScopeId: home, ref: path, granteeScopeId: scopeId("personal", "U2"), permission: "read", grantedBy: "U1" },
+    "U1",
+  );
+
+  assert.equal(
+    await real.app.deleteFileForViewer(id, "U1"),
+    "deleted",
+    "wiring.ts hands the ACL store managesArtifactHome, so the revoke must be told who authored the row",
+  );
+  assert.deepEqual(await real.acl.handlesFor([scopeId("personal", "U2")]), []);
+  assert.equal(await real.files.get(id), null);
 });

--- a/test/file-delete.test.ts
+++ b/test/file-delete.test.ts
@@ -5,6 +5,7 @@ import { createAclStore } from "../src/acl/acl-store.ts";
 import {
   createMemoryFileArtifactStore,
   fileArtifactId,
+  FileArtifactDeletedError,
   type FileArtifactStore,
 } from "../src/files/file-artifact-store.ts";
 import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts";
@@ -144,6 +145,18 @@ test("deleting is idempotent: an unknown id and a second delete both answer not_
   assert.equal(await app.deleteFileForViewer(id, "U1"), "not_found");
 });
 
+test("a retried turn cannot resurrect a deleted artifact under its deterministic id", async () => {
+  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
+  const app = makeApp(files, createAclStore());
+  const id = fileArtifactId("retry", "out", 0);
+  await seed(files, id, "U1");
+  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
+
+  await assert.rejects(() => seed(files, id, "U1"), FileArtifactDeletedError, "the tombstone outlives the row");
+  assert.equal(await files.get(id), null, "a refused republish leaves nothing behind for the next listing");
+  assert.deepEqual((await app.listFilesForViewer("U1")).owned, []);
+});
+
 test("deleting one of two identical-byte artifacts leaves the other readable", async () => {
   const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
   const app = makeApp(files, createAclStore());
@@ -159,11 +172,7 @@ test("deleting one of two identical-byte artifacts leaves the other readable", a
   assert.ok(survivor);
   const read: Buffer[] = [];
   for await (const c of survivor!.stream) read.push(c as Buffer);
-  assert.deepEqual(
-    Buffer.concat(read),
-    PNG,
-    "erasing shared bytes would break every artifact with the same digest",
-  );
+  assert.deepEqual(Buffer.concat(read), PNG, "erasing shared bytes would break every artifact with the same digest");
 });
 
 test("deletable is computed once per (ownerScopeId, authorship) pair, not once per row", async () => {

--- a/test/file-delete.test.ts
+++ b/test/file-delete.test.ts
@@ -10,7 +10,6 @@ import { createAclStore } from "../src/acl/acl-store.ts";
 import {
   createMemoryFileArtifactStore,
   fileArtifactId,
-  FileArtifactDeletedError,
   type FileArtifactStore,
 } from "../src/files/file-artifact-store.ts";
 import { createMemoryDurableByteStore } from "../src/files/durable-byte-store.ts";
@@ -148,36 +147,6 @@ test("deleting is idempotent: an unknown id and a second delete both answer not_
   assert.equal(await app.deleteFileForViewer("no-such-file", "U1"), "not_found");
   assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
   assert.equal(await app.deleteFileForViewer(id, "U1"), "not_found");
-});
-
-test("a retried turn cannot resurrect a deleted artifact under its deterministic id", async () => {
-  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
-  const app = makeApp(files, createAclStore());
-  const id = fileArtifactId("retry", "out", 0);
-  await seed(files, id, "U1");
-  assert.equal(await app.deleteFileForViewer(id, "U1"), "deleted");
-
-  await assert.rejects(() => seed(files, id, "U1"), FileArtifactDeletedError, "the tombstone outlives the row");
-  assert.equal(await files.get(id), null, "a refused republish leaves nothing behind for the next listing");
-  assert.deepEqual((await app.listFilesForViewer("U1")).owned, []);
-});
-
-test("deleting one of two identical-byte artifacts leaves the other readable", async () => {
-  const files = createMemoryFileArtifactStore(createMemoryDurableByteStore());
-  const app = makeApp(files, createAclStore());
-  const mine = fileArtifactId("copy-mine", "out", 0);
-  const theirs = fileArtifactId("copy-theirs", "out", 0);
-  await seed(files, mine, "U1");
-  await seed(files, theirs, "U2");
-  assert.equal((await files.get(mine))!.blobKey, (await files.get(theirs))!.blobKey, "identical bytes share a key");
-
-  assert.equal(await app.deleteFileForViewer(mine, "U1"), "deleted");
-
-  const survivor = await app.openFileForViewer(theirs, "U2");
-  assert.ok(survivor);
-  const read: Buffer[] = [];
-  for await (const c of survivor!.stream) read.push(c as Buffer);
-  assert.deepEqual(Buffer.concat(read), PNG, "erasing shared bytes would break every artifact with the same digest");
 });
 
 test("deletable is computed once per (ownerScopeId, authorship) pair, not once per row", async () => {

--- a/test/files-http.test.ts
+++ b/test/files-http.test.ts
@@ -79,6 +79,7 @@ test("owner sees their own file in owned[] and can open its bytes", async () => 
   assert.equal(page.owned.length, 1);
   assert.equal(page.owned[0]!.name, "flag.png");
   assert.equal(page.owned[0]!.openable, true);
+  assert.equal(page.owned[0]!.deletable, true, "the owner manages their own artifact home");
   assert.equal(page.shared.length, 0);
 
   const opened = await app.openFileForViewer(id, "U1");
@@ -115,6 +116,7 @@ test("a grantee sees a shared file in shared[] and can open it; the owner doesn'
   assert.equal(u2.shared.length, 1, "U2 sees it as shared");
   assert.equal(u2.shared[0]!.id, id);
   assert.equal(u2.shared[0]!.ownerScopeId, owner, "shared rows retain their provenance for an accurate UI label");
+  assert.equal(u2.shared[0]!.deletable, false, "a read grant never carries the right to delete");
 
   const opened = await app.openFileForViewer(id, "U2");
   assert.ok(opened, "the grant authorizes the bytes");


### PR DESCRIPTION
Closes QM-1.

### Changes

**Why this matters:** The /files page could open a file but never remove one, so a
mistaken upload or a stale scratch file stayed on the list forever with no self-serve way
to clear it. There was no delete path at any layer — not in the UI, not in the web
surface, not in the core API — even though the artifact store and the ownership check it
needs already existed. This adds the missing path and gates it so people can only delete
files whose home they actually manage.

**What changes:**

- Each row on /files now shows a **Delete** button next to the existing open link, and it
  appears only for files you manage. Files shared with you and org-wide files render no
  Delete button at all, rather than a button that would fail.
- Clicking Delete asks for confirmation; on confirm the row disappears and the page shows
  a "Deleted <name>." notice. If the server refuses, the row stays and the status region
  shows the server's message. Cancelling sends no request.
- Two new endpoints: `DELETE /api/files/:id` on the web surface, which takes the
  principal from your signed-in session and ignores any client-supplied `principalId`,
  and `DELETE /v1/files/:id?principalId=…` on the core API, which answers
  `200 {"ok":true}`, `400` without a principal, `403` for a file you don't manage, and
  `404` for an unknown or already-deleted id. The files listing now carries a
  server-computed `deletable` flag per item.
- Deleting removes the file's row and records a `file.delete` audit entry. Stored bytes
  are content-addressed and shared, so another file with identical contents stays
  openable. One consequence worth stating: the listing hides duplicate-content copies in
  the same scope, so deleting the visible row can reveal an older hidden copy of the same
  file — repeated deletes converge and clear them all.

**Acceptance stories:**

- A signed-in person on /files sees Delete beside open on files they own; before this
  change no row had a delete control, and rows shared with them or owned org-wide still
  show none.
- A person clicks Delete and confirms: the row is gone and stays gone after a full page
  reload, and the file's content URL stops resolving. Cancelling the prompt leaves the
  row and issues no request.
- When a delete is refused, the person sees the server's message in the page's live
  status region, the row remains, and the button is immediately clickable again.
- An API caller gets `200` deleting a file they manage, `403` for one they only read,
  `404` for an unknown or already-deleted id, and `400` with no principal; the web
  surface always relays the session's principal, so a forged `principalId` cannot delete
  someone else's file.
- A person who uploads a file gets a working Delete on the new row on first render, and
  Delete keeps working alongside the search box, the Ownership and Type filters, and
  keyboard-only navigation.

### Test Plan

- `npm run typecheck`
- `npm run lint`
- `npm run lint:ox`
- `npm run lint:knip`
- `npm run format:check`
- `node --test test/file-delete.test.ts test/file-delete-route.test.ts test/files-http.test.ts test/route-auth-conformance.test.ts test/agent-api-parity.test.ts test/portal-identity-gate.test.ts`
- `npm test` in `plugins/web-ui`
- Manual: booted a live stack (real core routes, real app layer, real blob store, real web
  relay) plus a pre-fix build for the before state, and drove /files in a browser —
  upload then delete, cancel, the refused-delete path, the filters, and a keyboard-only
  Tab-to-Delete pass — with curl checks on the new routes for the 200/400/401/403/404
  answers.

## Proof it works

All five acceptance stories passed against a live stack; the screenshots below show the
before state, the gated buttons, and the delete flow end to end.

![story1-before-no-delete-button.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-before-no-delete-button.png)
![story1-after-delete-buttons.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-after-delete-buttons.png)
![story1-open-still-works.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-open-still-works.png)
![story1-cancel-keeps-row.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-cancel-keeps-row.png)
![story1-deleted-row-gone.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-deleted-row-gone.png)
![story1-gone-after-reload.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-gone-after-reload.png)
![story1-forbidden-row-survives.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story1-forbidden-row-survives.png)
![story5-search-keeps-delete.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-search-keeps-delete.png)
![story5-yours-filter-delete-gated.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-yours-filter-delete-gated.png)
![story5-shared-filter-no-delete.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-shared-filter-no-delete.png)
![story5-upload-has-delete.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-upload-has-delete.png)
![story5-upload-then-deleted.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-upload-then-deleted.png)
![story5-keyboard-focus-delete.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-keyboard-focus-delete.png)
![story5-keyboard-delete-done.png](https://github.com/yc-software/qm/raw/assets/qm-1-s1137688993/story5-keyboard-delete-done.png)

Screen recordings, which cannot be embedded in a pull-request body:

- qm1-files-delete-tab1.webm — .io-agent-qm-1/screenshots/
- qm1-files-delete-tab2-opened-file.webm — .io-agent-qm-1/screenshots/
- qm1-files-upload-then-delete.webm — .io-agent-qm-1/screenshots/

<!-- factory-session:2:1137688993:099429bd94a69721ad3df6c6f2b9b471 -->
