### PR TITLE
fix: keep prompt expansion in place

### DIFF
--- a/plugins/web-ui/src/shell.css
+++ b/plugins/web-ui/src/shell.css
@@ -1779,6 +1779,11 @@ a.chat-row-open {
   max-height: var(--pin-clamp, 320px);
   overflow: hidden;
 }
+.message-stack .user-row.pin-expanded .user-bubble > .pin-content {
+  max-height: var(--pin-expanded-max);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
 .pin-toggle {
   display: none;
   width: fit-content;

--- a/plugins/web-ui/src/transcript-viewport.ts
+++ b/plugins/web-ui/src/transcript-viewport.ts
@@ -23,8 +23,10 @@ export function createTranscriptViewport() {
   }
 
   function clearPrompt(): void {
+    if (content) content.scrollTop = 0;
     prompt?.classList.remove("stuck", "sticky-disabled", "pin-expanded", "pin-fits");
     prompt?.style.removeProperty("--pin-clamp");
+    prompt?.style.removeProperty("--pin-expanded-max");
     const toggle = prompt?.querySelector<HTMLButtonElement>(".pin-toggle");
     if (toggle) toggle.hidden = true;
     expanded = false;
@@ -57,6 +59,7 @@ export function createTranscriptViewport() {
     if (!toggle || !prompt?.contains(toggle)) return;
     cancelFollow();
     expanded = !expanded;
+    if (!expanded && content) content.scrollTop = 0;
     syncSticky();
   }
 
@@ -69,6 +72,11 @@ export function createTranscriptViewport() {
     const paddingTop = parseFloat(style.paddingTop) || 0;
     const paddingBottom = parseFloat(style.paddingBottom) || 0;
     const promptMargin = prompt ? parseFloat(getComputedStyle(prompt).marginBottom) || 0 : 0;
+    if (prompt && content) {
+      const chrome = prompt.getBoundingClientRect().height - content.getBoundingClientRect().height;
+      const available = scroller.clientHeight - top - paddingTop - paddingBottom - promptMargin - chrome;
+      prompt.style.setProperty("--pin-expanded-max", `${Math.max(0, Math.floor(available))}px`);
+    }
     const canStick =
       !!prompt &&
       prompt.getBoundingClientRect().height + promptMargin + top + paddingTop + paddingBottom <= scroller.clientHeight;

--- a/plugins/web-ui/test/pinned-prompt-collapse.test.ts
+++ b/plugins/web-ui/test/pinned-prompt-collapse.test.ts
@@ -5,7 +5,7 @@ import { createTranscriptViewport } from "../src/transcript-viewport.ts";
 
 function fixture() {
   const dom = new JSDOM(
-    `<section class="chat-scroll"><div class="message-stack"><article class="user-row" data-index="1"><div class="user-bubble"><div class="pin-content">Example prompt</div><button class="pin-toggle" hidden>Show more</button></div></article></div></section>`,
+    `<section class="chat-scroll"><div class="pinned-strip"></div><div class="message-stack"><article class="user-row" data-index="1"><div class="user-bubble"><div class="pin-content">Example prompt</div><button class="pin-toggle" hidden>Show more</button></div></article></div></section>`,
   );
   const scroller = dom.window.document.querySelector<HTMLElement>("section")!;
   const row = scroller.querySelector<HTMLElement>("article")!;
@@ -13,16 +13,24 @@ function fixture() {
   const toggle = row.querySelector<HTMLButtonElement>("button")!;
   let height = 300;
   let fullHeight = 600;
+  let pinsHeight = 0;
+  scroller.querySelector<HTMLElement>(".pinned-strip")!.getBoundingClientRect = () =>
+    ({ height: pinsHeight }) as DOMRect;
   Object.defineProperties(scroller, { clientHeight: { get: () => height }, scrollHeight: { value: 2000 } });
   Object.defineProperties(content, {
     scrollHeight: { get: () => fullHeight },
     clientHeight: {
-      get: () =>
-        row.classList.contains("pin-expanded") || row.classList.contains("pin-fits")
-          ? fullHeight
-          : Math.min(fullHeight, parseFloat(row.style.getPropertyValue("--pin-clamp")) || 320),
+      get: () => {
+        if (row.classList.contains("pin-expanded")) {
+          const limit = row.style.getPropertyValue("--pin-expanded-max");
+          return Math.min(fullHeight, limit ? parseFloat(limit) : fullHeight);
+        }
+        if (row.classList.contains("pin-fits")) return fullHeight;
+        return Math.min(fullHeight, parseFloat(row.style.getPropertyValue("--pin-clamp")) || 320);
+      },
     },
   });
+  content.getBoundingClientRect = () => ({ height: content.clientHeight }) as DOMRect;
   scroller.getBoundingClientRect = () => ({ top: 0 }) as DOMRect;
   row.getBoundingClientRect = () => ({ top: 0, height: content.clientHeight + 24 }) as DOMRect;
   const observed = new Set<Element>();
@@ -58,6 +66,10 @@ function fixture() {
     viewport,
     resize: (next: number) => {
       height = next;
+      resize();
+    },
+    setPins: (next: number) => {
+      pinsHeight = next;
       resize();
     },
     grow: (next: number) => {
@@ -123,10 +135,12 @@ test("a reused row resets expansion when its message index changes", () => {
   try {
     f.toggle.click();
     assert.equal(f.row.classList.contains("pin-expanded"), true);
+    f.content.scrollTop = 200;
     f.row.dataset.index = "2";
     f.viewport.sync(f.scroller);
     assert.equal(f.row.classList.contains("pin-expanded"), false);
     assert.equal(f.toggle.textContent, "Show more");
+    assert.equal(f.content.scrollTop, 0);
   } finally {
     f.close();
   }
@@ -184,6 +198,69 @@ test("switching to a new scroller resets expansion even when the message index i
     assert.equal(row.classList.contains("pin-expanded"), false);
     assert.equal(row.querySelector(".pin-toggle")!.getAttribute("aria-expanded"), "false");
     assert.equal(f.row.classList.contains("pin-expanded"), false);
+  } finally {
+    f.close();
+  }
+});
+
+test("expanding a scrolled prompt stays sticky with a bounded scrollable body", () => {
+  const f = fixture();
+  try {
+    f.scroller.scrollTop = 500;
+    f.scroller.dispatchEvent(new f.scroller.ownerDocument.defaultView!.Event("scroll"));
+    assert.equal(f.row.classList.contains("stuck"), true);
+    f.toggle.click();
+    assert.equal(f.row.classList.contains("sticky-disabled"), false);
+    assert.equal(f.row.classList.contains("stuck"), true);
+    assert.equal(f.content.clientHeight, 276);
+    assert.ok(f.content.scrollHeight > f.content.clientHeight);
+    assert.equal(f.scroller.scrollTop, 500);
+    f.content.scrollTop = 200;
+    f.toggle.click();
+    assert.equal(f.content.scrollTop, 0);
+    assert.equal(f.row.classList.contains("stuck"), true);
+    assert.equal(f.content.clientHeight, 105);
+    assert.equal(f.scroller.scrollTop, 500);
+  } finally {
+    f.close();
+  }
+});
+
+test("expanded prompts reserve pins and chrome when panes resize or content grows", () => {
+  const f = fixture();
+  try {
+    f.setPins(60);
+    f.scroller.style.paddingTop = "8px";
+    f.scroller.style.paddingBottom = "20px";
+    f.row.style.marginBottom = "12px";
+    f.toggle.click();
+    assert.equal(f.content.clientHeight, 176);
+    assert.equal(f.row.classList.contains("sticky-disabled"), false);
+    f.resize(220);
+    assert.equal(f.content.clientHeight, 96);
+    assert.equal(f.row.classList.contains("sticky-disabled"), false);
+    f.setPins(80);
+    assert.equal(f.content.clientHeight, 76);
+    f.grow(1200);
+    assert.equal(f.content.clientHeight, 76);
+    f.resize(1600);
+    assert.equal(f.content.clientHeight, 1200);
+    f.viewport.dispose();
+    assert.equal(f.row.style.getPropertyValue("--pin-expanded-max"), "");
+  } finally {
+    f.close();
+  }
+});
+
+test("an expanded prompt stays in flow when its chrome alone cannot fit", () => {
+  const f = fixture();
+  try {
+    f.setPins(290);
+    f.toggle.click();
+    assert.equal(f.row.style.getPropertyValue("--pin-expanded-max"), "0px");
+    assert.equal(f.row.classList.contains("sticky-disabled"), true);
+    f.setPins(30);
+    assert.equal(f.row.classList.contains("sticky-disabled"), false);
   } finally {
     f.close();
   }


### PR DESCRIPTION
Keep long prompts pinned when expanded by fitting their scrollable content to the available pane height; collapse restores the preview from the start.

- Regression tests cover expansion, collapse, resizing, pinned notices, and reused messages.
- Verified in the running UI with synthetic data: desktop/mobile, read-only chats, split panes, and incoming output.
- Web UI tests, typechecks, lint, and build passed.
