### PR TITLE
Wait for CI to settle before the forge evaluation judges a PR

### DIFF
--- a/src/loops/factory/forge-evaluate.ts
+++ b/src/loops/factory/forge-evaluate.ts
@@ -1,4 +1,5 @@
 import type { SuccessCheckResult, SuccessVerdict } from "../success-evaluation.ts";
+import { sleep as defaultSleep } from "../../util/async.ts";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_GRAPHQL = "https://api.github.com/graphql";
@@ -8,6 +9,17 @@ const PAGE = `per_page=${PAGE_SIZE}`;
 const GITHUB_MERGEABLE_STATES = new Set(["clean", "unstable", "has_hooks"]);
 const GITHUB_GREEN_CONCLUSIONS = new Set(["success", "skipped", "neutral"]);
 const BUGBOT_LOGIN_PREFIX = "cursor";
+// CI registers and finishes minutes after Ship; judging a pending check would send the item back to work for nothing.
+const CI_SETTLE_MS = 30 * 60_000;
+const CI_POLL_MS = 30_000;
+const GITLAB_PENDING_STATUSES = new Set([
+  "created",
+  "waiting_for_resource",
+  "preparing",
+  "pending",
+  "running",
+  "scheduled",
+]);
 const BUGBOT_NOTE_MARKER = "BUGBOT_REVIEW";
 
 export interface ForgeEvaluateInput {
@@ -18,6 +30,9 @@ export interface ForgeEvaluateInput {
   number: number;
   branch: string;
   bugbotRequired: boolean;
+  ciSettleMs?: number;
+  ciPollMs?: number;
+  sleep?: (ms: number) => Promise<void>;
 }
 
 export const FORGE_CHECKS = ["exact_head", "ci_green_on_head", "ledger_clean", "mergeable", "bugbot_reviewed"] as const;
@@ -103,24 +118,41 @@ export async function evaluateFactoryForge(input: ForgeEvaluateInput): Promise<S
   };
 
   const ciGreenOnHead = async (): Promise<CheckOutcome> => {
-    if (github) {
-      const payload = obj(await forgeGet(input, `/commits/${headSha}/check-runs?${PAGE}`));
-      const runs = arr(payload.check_runs);
-      if (runs.length === 0) return { passed: false, detail: "no check runs" };
-      // A full page may hide runs on the next one, so the check fails closed rather than trusting the visible runs.
-      if (runs.length >= PAGE_SIZE) return { passed: false, detail: "check runs exceed one page" };
-      const offending = runs
-        .map(obj)
-        .find((run) => run.status !== "completed" || !GITHUB_GREEN_CONCLUSIONS.has(str(run.conclusion) ?? ""));
-      if (offending === undefined) return { passed: true };
-      return { passed: false, detail: str(offending.name) ?? "unnamed check run" };
+    const deadline = Date.now() + (input.ciSettleMs ?? CI_SETTLE_MS);
+    const pollMs = input.ciPollMs ?? CI_POLL_MS;
+    const sleep = input.sleep ?? defaultSleep;
+    let mergeRequest = request;
+    for (;;) {
+      const settled = github ? await githubChecks() : gitlabPipeline(mergeRequest);
+      if (settled.outcome !== undefined) return settled.outcome;
+      if (Date.now() >= deadline) return { passed: false, detail: settled.pending };
+      await sleep(pollMs);
+      if (!github) mergeRequest = obj(await forgeGet(input, `/merge_requests/${input.number}`));
     }
-    // GitLab merged-result pipelines run on a temporary merge commit, so the MR's head_pipeline is the
-    // only pointer that survives that sha mismatch.
-    const pipeline = obj(request.head_pipeline);
-    if (Object.keys(pipeline).length === 0) return { passed: false, detail: "no pipeline" };
+  };
+
+  const githubChecks = async (): Promise<{ outcome?: CheckOutcome; pending: string }> => {
+    const payload = obj(await forgeGet(input, `/commits/${headSha}/check-runs?${PAGE}`));
+    const runs = arr(payload.check_runs);
+    if (runs.length === 0) return { pending: "no check runs" };
+    // A full page may hide runs on the next one, so the check fails closed rather than trusting the visible runs.
+    if (runs.length >= PAGE_SIZE)
+      return { outcome: { passed: false, detail: "check runs exceed one page" }, pending: "" };
+    const running = runs.map(obj).find((run) => run.status !== "completed");
+    if (running !== undefined) return { pending: `unsettled: ${str(running.name) ?? "unnamed check run"}` };
+    const offending = runs.map(obj).find((run) => !GITHUB_GREEN_CONCLUSIONS.has(str(run.conclusion) ?? ""));
+    if (offending === undefined) return { outcome: { passed: true }, pending: "" };
+    return { outcome: { passed: false, detail: str(offending.name) ?? "unnamed check run" }, pending: "" };
+  };
+
+  // GitLab merged-result pipelines run on a temporary merge commit, so the MR's head_pipeline is the
+  // only pointer that survives that sha mismatch.
+  const gitlabPipeline = (mergeRequest: Record<string, unknown>): { outcome?: CheckOutcome; pending: string } => {
+    const pipeline = obj(mergeRequest.head_pipeline);
+    if (Object.keys(pipeline).length === 0) return { pending: "no pipeline" };
     const status = str(pipeline.status) ?? "unknown";
-    return status === "success" ? { passed: true } : { passed: false, detail: status };
+    if (GITLAB_PENDING_STATUSES.has(status)) return { pending: `unsettled: ${status}` };
+    return { outcome: status === "success" ? { passed: true } : { passed: false, detail: status }, pending: "" };
   };
 
   const ledgerClean = async (): Promise<CheckOutcome> => {

--- a/src/loops/factory/forge-evaluate.ts
+++ b/src/loops/factory/forge-evaluate.ts
@@ -15,10 +15,12 @@ const CI_POLL_MS = 30_000;
 const GITLAB_PENDING_STATUSES = new Set([
   "created",
   "waiting_for_resource",
+  "waiting_for_callback",
   "preparing",
   "pending",
   "running",
   "scheduled",
+  "canceling",
 ]);
 const BUGBOT_NOTE_MARKER = "BUGBOT_REVIEW";
 
@@ -43,6 +45,8 @@ interface CheckOutcome {
   passed: boolean;
   detail?: string;
 }
+
+type CiReading = CheckOutcome | { pending: string };
 
 const isObj = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
@@ -100,7 +104,9 @@ const unresolvedDetail = (count: number): CheckOutcome =>
 
 export async function evaluateFactoryForge(input: ForgeEvaluateInput): Promise<SuccessVerdict> {
   const github = input.forge === "github";
-  const request = obj(await forgeGet(input, github ? `/pulls/${input.number}` : `/merge_requests/${input.number}`));
+  const requestPath = github ? `/pulls/${input.number}` : `/merge_requests/${input.number}`;
+  // Re-read after every CI poll: mergeability is computed from the same checks, so the pre-wait snapshot is stale.
+  let request = obj(await forgeGet(input, requestPath));
   const headSha = (github ? str(obj(request.head).sha) : str(request.sha)) ?? "";
 
   let discussions: unknown[] | undefined;
@@ -121,38 +127,36 @@ export async function evaluateFactoryForge(input: ForgeEvaluateInput): Promise<S
     const deadline = Date.now() + (input.ciSettleMs ?? CI_SETTLE_MS);
     const pollMs = input.ciPollMs ?? CI_POLL_MS;
     const sleep = input.sleep ?? defaultSleep;
-    let mergeRequest = request;
     for (;;) {
-      const settled = github ? await githubChecks() : gitlabPipeline(mergeRequest);
-      if (settled.outcome !== undefined) return settled.outcome;
-      if (Date.now() >= deadline) return { passed: false, detail: settled.pending };
+      const reading = github ? await githubChecks() : gitlabPipeline();
+      if (!("pending" in reading)) return reading;
+      if (Date.now() >= deadline) return { passed: false, detail: reading.pending };
       await sleep(pollMs);
-      if (!github) mergeRequest = obj(await forgeGet(input, `/merge_requests/${input.number}`));
+      request = obj(await forgeGet(input, requestPath));
     }
   };
 
-  const githubChecks = async (): Promise<{ outcome?: CheckOutcome; pending: string }> => {
+  const githubChecks = async (): Promise<CiReading> => {
     const payload = obj(await forgeGet(input, `/commits/${headSha}/check-runs?${PAGE}`));
-    const runs = arr(payload.check_runs);
+    const runs = arr(payload.check_runs).map(obj);
     if (runs.length === 0) return { pending: "no check runs" };
     // A full page may hide runs on the next one, so the check fails closed rather than trusting the visible runs.
-    if (runs.length >= PAGE_SIZE)
-      return { outcome: { passed: false, detail: "check runs exceed one page" }, pending: "" };
-    const running = runs.map(obj).find((run) => run.status !== "completed");
+    if (runs.length >= PAGE_SIZE) return { passed: false, detail: "check runs exceed one page" };
+    const running = runs.find((run) => run.status !== "completed");
     if (running !== undefined) return { pending: `unsettled: ${str(running.name) ?? "unnamed check run"}` };
-    const offending = runs.map(obj).find((run) => !GITHUB_GREEN_CONCLUSIONS.has(str(run.conclusion) ?? ""));
-    if (offending === undefined) return { outcome: { passed: true }, pending: "" };
-    return { outcome: { passed: false, detail: str(offending.name) ?? "unnamed check run" }, pending: "" };
+    const offending = runs.find((run) => !GITHUB_GREEN_CONCLUSIONS.has(str(run.conclusion) ?? ""));
+    if (offending === undefined) return { passed: true };
+    return { passed: false, detail: str(offending.name) ?? "unnamed check run" };
   };
 
   // GitLab merged-result pipelines run on a temporary merge commit, so the MR's head_pipeline is the
   // only pointer that survives that sha mismatch.
-  const gitlabPipeline = (mergeRequest: Record<string, unknown>): { outcome?: CheckOutcome; pending: string } => {
-    const pipeline = obj(mergeRequest.head_pipeline);
+  const gitlabPipeline = (): CiReading => {
+    const pipeline = obj(request.head_pipeline);
     if (Object.keys(pipeline).length === 0) return { pending: "no pipeline" };
     const status = str(pipeline.status) ?? "unknown";
     if (GITLAB_PENDING_STATUSES.has(status)) return { pending: `unsettled: ${status}` };
-    return { outcome: status === "success" ? { passed: true } : { passed: false, detail: status }, pending: "" };
+    return status === "success" ? { passed: true } : { passed: false, detail: status };
   };
 
   const ledgerClean = async (): Promise<CheckOutcome> => {

--- a/test/loop-factory-forge-evaluate.test.ts
+++ b/test/loop-factory-forge-evaluate.test.ts
@@ -209,7 +209,7 @@ const GITHUB_FAILURES: {
   },
   {
     name: "ci_green_on_head",
-    detail: "slow-suite",
+    detail: "unsettled: slow-suite",
     routes: {
       [GH.checkRuns]: {
         body: {
@@ -267,7 +267,7 @@ test("each failing GitHub check stops the sequence at that check and names it", 
     const label = `${scenario.name} — ${scenario.detail}`;
     const fetched = fakeFetch(githubRoutes(scenario.routes));
 
-    const verdict = await evaluateFactoryForge(githubInput(fetched.fetchImpl));
+    const verdict = await evaluateFactoryForge(githubInput(fetched.fetchImpl, { ciSettleMs: 0 }));
 
     assert.equal(verdict.outcome, "continue", label);
     assert.equal(verdict.reason, `check failed: ${scenario.name} — ${scenario.detail}`, label);
@@ -286,6 +286,64 @@ test("each failing GitHub check stops the sequence at that check and names it", 
     assert.equal(verdict.checks[position - 1]?.detail, scenario.detail, label);
     assert.deepEqual(keysOf(fetched.calls), scenario.reads, label);
   }
+});
+
+test("ci_green_on_head waits for running checks and judges the settled result", async () => {
+  const running = { name: "slow-suite", status: "in_progress", conclusion: null };
+  const finished = { name: "slow-suite", status: "completed", conclusion: "success" };
+  let reads = 0;
+  const base = fakeFetch(githubRoutes());
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    if (String(url).includes("/check-runs")) {
+      reads += 1;
+      const body = { check_runs: reads < 3 ? [running] : [finished] };
+      return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return base.fetchImpl(url, init);
+  }) as typeof fetch;
+  const slept: number[] = [];
+  const sleep = async (ms: number): Promise<void> => {
+    slept.push(ms);
+  };
+
+  const verdict = await evaluateFactoryForge(githubInput(fetchImpl, { ciPollMs: 7, ciSettleMs: 60_000, sleep }));
+
+  assert.equal(verdict.outcome, "met");
+  assert.equal(reads, 3);
+  assert.deepEqual(slept, [7, 7]);
+});
+
+test("a GitLab pipeline still running is re-read until it settles", async () => {
+  let reads = 0;
+  const pending = {
+    sha: HEAD,
+    detailed_merge_status: "mergeable",
+    head_pipeline: { id: 9, sha: HEAD, status: "running" },
+  };
+  const done = {
+    sha: HEAD,
+    detailed_merge_status: "mergeable",
+    head_pipeline: { id: 9, sha: HEAD, status: "success" },
+  };
+  const base = fakeFetch(gitlabRoutes());
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    if (String(url).endsWith("/merge_requests/42")) {
+      reads += 1;
+      const body = reads < 2 ? pending : done;
+      return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return base.fetchImpl(url, init);
+  }) as typeof fetch;
+  const slept: number[] = [];
+  const sleep = async (ms: number): Promise<void> => {
+    slept.push(ms);
+  };
+
+  const verdict = await evaluateFactoryForge(gitlabInput(fetchImpl, { ciPollMs: 3, ciSettleMs: 60_000, sleep }));
+
+  assert.equal(verdict.outcome, "met");
+  assert.equal(reads, 2);
+  assert.deepEqual(slept, [3]);
 });
 
 test("a converged GitLab merge request meets the condition on its own endpoints", async () => {
@@ -326,7 +384,7 @@ test("the merge request's head_pipeline decides ci_green_on_head, whatever sha i
     gitlabRoutes({ [GL.mr]: { body: { sha: HEAD, detailed_merge_status: "mergeable", head_pipeline: null } } }),
   );
   assert.equal(
-    (await evaluateFactoryForge(gitlabInput(absent.fetchImpl))).reason,
+    (await evaluateFactoryForge(gitlabInput(absent.fetchImpl, { ciSettleMs: 0 }))).reason,
     "check failed: ci_green_on_head — no pipeline",
   );
 });

--- a/test/loop-factory-forge-evaluate.test.ts
+++ b/test/loop-factory-forge-evaluate.test.ts
@@ -288,33 +288,67 @@ test("each failing GitHub check stops the sequence at that check and names it", 
   }
 });
 
-test("ci_green_on_head waits for running checks and judges the settled result", async () => {
-  const running = { name: "slow-suite", status: "in_progress", conclusion: null };
-  const finished = { name: "slow-suite", status: "completed", conclusion: "success" };
-  let reads = 0;
-  const base = fakeFetch(githubRoutes());
-  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
-    if (String(url).includes("/check-runs")) {
-      reads += 1;
-      const body = { check_runs: reads < 3 ? [running] : [finished] };
-      return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
-    }
-    return base.fetchImpl(url, init);
-  }) as typeof fetch;
-  const slept: number[] = [];
-  const sleep = async (ms: number): Promise<void> => {
-    slept.push(ms);
-  };
+const jsonResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
 
-  const verdict = await evaluateFactoryForge(githubInput(fetchImpl, { ciPollMs: 7, ciSettleMs: 60_000, sleep }));
+// Serves the scripted bodies in order for the one URL `match` accepts, then repeats the last one; everything else falls through.
+function sequencedFetch(
+  base: typeof fetch,
+  match: (url: string) => boolean,
+  bodies: unknown[],
+): { fetchImpl: typeof fetch; reads: () => number } {
+  let reads = 0;
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    if (!match(String(url))) return base(url, init);
+    reads += 1;
+    return jsonResponse(bodies[Math.min(reads, bodies.length) - 1]);
+  }) as typeof fetch;
+  return { fetchImpl, reads: () => reads };
+}
+
+function recordingSleep(): { sleep: (ms: number) => Promise<void>; slept: number[] } {
+  const slept: number[] = [];
+  return {
+    slept,
+    sleep: async (ms: number): Promise<void> => {
+      slept.push(ms);
+    },
+  };
+}
+
+test("ci_green_on_head waits for running checks and judges the settled result", async () => {
+  const running = { check_runs: [{ name: "slow-suite", status: "in_progress", conclusion: null }] };
+  const finished = { check_runs: [{ name: "slow-suite", status: "completed", conclusion: "success" }] };
+  const checks = sequencedFetch(fakeFetch(githubRoutes()).fetchImpl, (url) => url.includes("/check-runs"), [
+    running,
+    running,
+    finished,
+  ]);
+  const { sleep, slept } = recordingSleep();
+
+  const verdict = await evaluateFactoryForge(githubInput(checks.fetchImpl, { ciPollMs: 7, ciSettleMs: 60_000, sleep }));
 
   assert.equal(verdict.outcome, "met");
-  assert.equal(reads, 3);
+  assert.equal(checks.reads(), 3);
   assert.deepEqual(slept, [7, 7]);
 });
 
+test("mergeable judges the pull request as re-read after the checks settled, not the pre-wait snapshot", async () => {
+  const blocked = { head: { sha: HEAD }, mergeable: false, mergeable_state: "blocked" };
+  const clean = { head: { sha: HEAD }, mergeable: true, mergeable_state: "clean" };
+  const running = { check_runs: [{ name: "gate", status: "in_progress", conclusion: null }] };
+  const finished = { check_runs: [{ name: "gate", status: "completed", conclusion: "success" }] };
+  const pulls = sequencedFetch(fakeFetch(githubRoutes()).fetchImpl, (url) => url === GH.pr.slice(4), [blocked, clean]);
+  const checks = sequencedFetch(pulls.fetchImpl, (url) => url.includes("/check-runs"), [running, finished]);
+  const { sleep } = recordingSleep();
+
+  const verdict = await evaluateFactoryForge(githubInput(checks.fetchImpl, { ciPollMs: 1, ciSettleMs: 60_000, sleep }));
+
+  assert.equal(verdict.outcome, "met");
+  assert.equal(pulls.reads(), 2);
+});
+
 test("a GitLab pipeline still running is re-read until it settles", async () => {
-  let reads = 0;
   const pending = {
     sha: HEAD,
     detailed_merge_status: "mergeable",
@@ -325,24 +359,13 @@ test("a GitLab pipeline still running is re-read until it settles", async () => 
     detailed_merge_status: "mergeable",
     head_pipeline: { id: 9, sha: HEAD, status: "success" },
   };
-  const base = fakeFetch(gitlabRoutes());
-  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
-    if (String(url).endsWith("/merge_requests/42")) {
-      reads += 1;
-      const body = reads < 2 ? pending : done;
-      return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
-    }
-    return base.fetchImpl(url, init);
-  }) as typeof fetch;
-  const slept: number[] = [];
-  const sleep = async (ms: number): Promise<void> => {
-    slept.push(ms);
-  };
+  const mr = sequencedFetch(fakeFetch(gitlabRoutes()).fetchImpl, (url) => url === GL.mr.slice(4), [pending, done]);
+  const { sleep, slept } = recordingSleep();
 
-  const verdict = await evaluateFactoryForge(gitlabInput(fetchImpl, { ciPollMs: 3, ciSettleMs: 60_000, sleep }));
+  const verdict = await evaluateFactoryForge(gitlabInput(mr.fetchImpl, { ciPollMs: 3, ciSettleMs: 60_000, sleep }));
 
   assert.equal(verdict.outcome, "met");
-  assert.equal(reads, 2);
+  assert.equal(mr.reads(), 2);
   assert.deepEqual(slept, [3]);
 });
 


### PR DESCRIPTION
## Why

The loop's evaluate stage runs seconds after Ship. GitHub has registered the check runs by then but not finished them. `ciGreenOnHead` treated any run with `status !== "completed"` as a failure, so the item returned to work with guidance such as `check failed: ci_green_on_head — Core tests (3/5)` for a check that passed minutes later. Each such return costs a full pipeline attempt. Seen on QM-1 attempts 10 and 12: PR #1140 went green within ten minutes both times while a new attempt was already running.

## What

- `ci_green_on_head` polls until every GitHub check run is `completed`, or the GitLab head pipeline leaves its pending states, up to `ciSettleMs` (default 30 minutes) with `ciPollMs` between reads (default 30 seconds). Only then does it judge the conclusions.
- No check runs yet, or no pipeline yet, is treated as pending rather than failed.
- An expired window fails the check with the detail `unsettled: <name>` on GitHub, `unsettled: <status>` on GitLab, or the existing `no check runs` / `no pipeline` detail.
- `ciSettleMs`, `ciPollMs`, and `sleep` are inputs for tests. The GitLab path reuses the first merge request read and re-reads on each poll, so existing read sequences are unchanged.

## Tests

- New: running GitHub checks are re-read until they settle, then judged (`met`, 3 reads, 2 sleeps).
- New: a running GitLab pipeline is re-read until it settles.
- Updated: the failing-check table runs with `ciSettleMs: 0`; the in-progress case now reports `unsettled: slow-suite`; the absent-pipeline case uses a zero window.
- Mutation check: with running checks judged as failures again, two tests fail; reverted.

`node --test` on forge-evaluate, effects, and fire files: 108 pass. `tsc`, eslint, prettier, knip green.