### PR TITLE
Clear sibling group labels before the ship step adds ready-for-review

### DIFF
--- a/src/loops/factory/ship.ts
+++ b/src/loops/factory/ship.ts
@@ -233,11 +233,12 @@ async function addReadyLabel(deps: ShipDeps, issue: LinearIssue): Promise<ShipSt
   const data = await linearGraphql(
     deps,
     "label",
-    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id name parent { id } } } }`,
+    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id parent { id } } } }`,
   );
   let ready: LinearLabel | undefined;
   for (const node of nodes(data.issueLabels)) {
-    ready = linearLabel(node);
+    // The lookup is filtered by name, so only the id and the group come back.
+    ready = linearLabel({ ...obj(node), name: LABEL_READY });
     if (ready !== undefined) break;
   }
   if (ready === undefined) throw new Error(`linear_label_missing: ${LABEL_READY}`);

--- a/src/loops/factory/ship.ts
+++ b/src/loops/factory/ship.ts
@@ -133,12 +133,27 @@ interface LinearWorkflowState {
   type: string;
 }
 
+interface LinearLabel {
+  id: string;
+  name: string;
+  groupId?: string;
+}
+
 interface LinearIssue {
   id: string;
   state: LinearWorkflowState;
-  labels: string[];
+  labels: LinearLabel[];
   teamStates: LinearWorkflowState[];
 }
+
+const linearLabel = (value: unknown): LinearLabel | undefined => {
+  const label = obj(value);
+  const id = str(label.id);
+  const name = str(label.name);
+  if (id === undefined || name === undefined) return undefined;
+  const groupId = str(obj(label.parent).id);
+  return { id, name, ...(groupId === undefined ? {} : { groupId }) };
+};
 
 const workflowState = (value: unknown): LinearWorkflowState => {
   const state = obj(value);
@@ -149,15 +164,15 @@ async function readLinearIssue(deps: ShipDeps, ticket: string): Promise<LinearIs
   const data = await linearGraphql(
     deps,
     "read",
-    `query { issue(id: ${gql(ticket)}) { id state { id name type } labels { nodes { id name } } team { id states { nodes { id name type } } } } }`,
+    `query { issue(id: ${gql(ticket)}) { id state { id name type } labels { nodes { id name parent { id } } } team { id states { nodes { id name type } } } } }`,
   );
   const issue = obj(data.issue);
   return {
     id: str(issue.id) ?? "",
     state: workflowState(issue.state),
     labels: nodes(issue.labels).flatMap((node) => {
-      const name = str(obj(node).name);
-      return name === undefined ? [] : [name];
+      const label = linearLabel(node);
+      return label === undefined ? [] : [label];
     }),
     teamStates: nodes(obj(issue.team).states).map(workflowState),
   };
@@ -214,18 +229,28 @@ async function undraftForgePr(ref: ForgeRef, deps: ShipDeps): Promise<ShipStepRe
 
 async function addReadyLabel(deps: ShipDeps, issue: LinearIssue): Promise<ShipStepResult> {
   const step = "linear-label";
-  if (issue.labels.includes(LABEL_READY)) return { step, changed: false };
+  if (issue.labels.some((label) => label.name === LABEL_READY)) return { step, changed: false };
   const data = await linearGraphql(
     deps,
     "label",
-    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id } } }`,
+    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id parent { id } } } }`,
   );
-  let labelId: string | undefined;
+  let ready: LinearLabel | undefined;
   for (const node of nodes(data.issueLabels)) {
-    labelId = str(obj(node).id);
-    if (labelId !== undefined) break;
+    ready = linearLabel({ ...obj(node), name: LABEL_READY });
+    if (ready !== undefined) break;
   }
-  if (labelId === undefined) throw new Error(`linear_label_missing: ${LABEL_READY}`);
+  if (ready === undefined) throw new Error(`linear_label_missing: ${LABEL_READY}`);
+  const labelId = ready.id;
+  // Linear allows one label per group, and the wrapper leaves its own state label in the same group.
+  for (const sibling of issue.labels) {
+    if (ready.groupId === undefined || sibling.groupId !== ready.groupId) continue;
+    await linearGraphql(
+      deps,
+      "label",
+      `mutation { issueRemoveLabel(id: ${gql(issue.id)}, labelId: ${gql(sibling.id)}) { success } }`,
+    );
+  }
   await linearGraphql(
     deps,
     "label",

--- a/src/loops/factory/ship.ts
+++ b/src/loops/factory/ship.ts
@@ -233,18 +233,17 @@ async function addReadyLabel(deps: ShipDeps, issue: LinearIssue): Promise<ShipSt
   const data = await linearGraphql(
     deps,
     "label",
-    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id parent { id } } } }`,
+    `query { issueLabels(filter: { name: { eq: ${gql(LABEL_READY)} } }) { nodes { id name parent { id } } } }`,
   );
   let ready: LinearLabel | undefined;
   for (const node of nodes(data.issueLabels)) {
-    ready = linearLabel({ ...obj(node), name: LABEL_READY });
+    ready = linearLabel(node);
     if (ready !== undefined) break;
   }
   if (ready === undefined) throw new Error(`linear_label_missing: ${LABEL_READY}`);
-  const labelId = ready.id;
   // Linear allows one label per group, and the wrapper leaves its own state label in the same group.
-  for (const sibling of issue.labels) {
-    if (ready.groupId === undefined || sibling.groupId !== ready.groupId) continue;
+  const siblings = ready.groupId === undefined ? [] : issue.labels.filter((label) => label.groupId === ready.groupId);
+  for (const sibling of siblings) {
     await linearGraphql(
       deps,
       "label",
@@ -254,7 +253,7 @@ async function addReadyLabel(deps: ShipDeps, issue: LinearIssue): Promise<ShipSt
   await linearGraphql(
     deps,
     "label",
-    `mutation { issueAddLabel(id: ${gql(issue.id)}, labelId: ${gql(labelId)}) { success } }`,
+    `mutation { issueAddLabel(id: ${gql(issue.id)}, labelId: ${gql(ready.id)}) { success } }`,
   );
   return { step, changed: true };
 }

--- a/test/loop-factory-ship.test.ts
+++ b/test/loop-factory-ship.test.ts
@@ -225,7 +225,7 @@ test("an ungrouped ready-for-review label removes nothing", async () => {
   const fetched = fakeFetch({
     [`GET ${GH_PULL}`]: { body: { draft: false, state: "open", merged: false } },
     "linear:issue": issueRead({ state: IN_REVIEW, labels: ["bug"], groupLabels: ["converging"] }),
-    "linear:issueLabels": ok({ issueLabels: { nodes: [{ id: "lbl_rfr", name: "ready-for-review", parent: null }] } }),
+    "linear:issueLabels": ok({ issueLabels: { nodes: [{ id: "lbl_rfr", parent: null }] } }),
     "linear:issueAddLabel": LABEL_OK,
   });
 

--- a/test/loop-factory-ship.test.ts
+++ b/test/loop-factory-ship.test.ts
@@ -37,7 +37,14 @@ const parseBody = (rec: Recorded): Record<string, unknown> => JSON.parse(rec.bod
 
 const queryOf = (rec: Recorded): string => String(parseBody(rec).query ?? "");
 
-const LINEAR_OPS = ["issueUpdate", "issueAddLabel", "issueLabels", "commentCreate", "issue("] as const;
+const LINEAR_OPS = [
+  "issueUpdate",
+  "issueRemoveLabel",
+  "issueAddLabel",
+  "issueLabels",
+  "commentCreate",
+  "issue(",
+] as const;
 
 const routeKey = (rec: Recorded): string => {
   if (rec.url === LINEAR_URL) {
@@ -88,9 +95,12 @@ const TEAM_STATES = [
 const AUTO_TRIAGE = { id: "st_triage", name: "Auto-Triage", type: "unstarted" };
 const IN_REVIEW = { id: "st_review", name: "In Review", type: "started" };
 
+const FACTORY_GROUP = { id: "grp_factory" };
+
 const issueRead = (over: {
   state?: { id: string; name: string; type: string };
   labels?: string[];
+  groupLabels?: string[];
   states?: { id: string; name: string; type: string }[];
 }): Route => ({
   body: {
@@ -98,7 +108,12 @@ const issueRead = (over: {
       issue: {
         id: "iss_1",
         state: over.state ?? AUTO_TRIAGE,
-        labels: { nodes: (over.labels ?? []).map((name, index) => ({ id: `lbl_${index}`, name })) },
+        labels: {
+          nodes: [
+            ...(over.labels ?? []).map((name, index) => ({ id: `lbl_${index}`, name, parent: null })),
+            ...(over.groupLabels ?? []).map((name, index) => ({ id: `grp_lbl_${index}`, name, parent: FACTORY_GROUP })),
+          ],
+        },
         team: { id: "team_1", states: { nodes: over.states ?? TEAM_STATES } },
       },
     },
@@ -107,7 +122,8 @@ const issueRead = (over: {
 
 const ok = (payload: Record<string, unknown>): Route => ({ body: { data: payload } });
 
-const LABEL_LOOKUP = ok({ issueLabels: { nodes: [{ id: "lbl_rfr" }] } });
+const LABEL_LOOKUP = ok({ issueLabels: { nodes: [{ id: "lbl_rfr", parent: FACTORY_GROUP }] } });
+const REMOVE_OK = ok({ issueRemoveLabel: { success: true } });
 const STATE_OK = ok({ issueUpdate: { success: true } });
 const LABEL_OK = ok({ issueAddLabel: { success: true } });
 const COMMENT_OK = ok({ commentCreate: { success: true } });
@@ -179,6 +195,28 @@ test("shipping a GitHub draft PR undrafts it, moves the ticket to In Review, and
   assert.equal(linearCalls.length, 4);
   for (const call of linearCalls) assert.equal(call.headers.authorization, LINEAR_KEY);
   assert.equal(linearCalls.filter((call) => /issue\(id: "QM-21"\)/.test(queryOf(call))).length, 1);
+});
+
+test("a sibling factory-state label is removed before ready-for-review is added", async () => {
+  const fetched = fakeFetch({
+    [`GET ${GH_PULL}`]: { body: { draft: false, state: "open", merged: false } },
+    "linear:issue": issueRead({ state: IN_REVIEW, labels: ["bug"], groupLabels: ["converging"] }),
+    "linear:issueLabels": LABEL_LOOKUP,
+    "linear:issueRemoveLabel": REMOVE_OK,
+    "linear:issueAddLabel": LABEL_OK,
+  });
+
+  await shipFactoryPullRequest(github, "QM-1", depsFor(fetched.fetchImpl));
+
+  assert.deepEqual(keysOf(fetched.calls).slice(-3), [
+    "linear:issueLabels",
+    "linear:issueRemoveLabel",
+    "linear:issueAddLabel",
+  ]);
+  assert.match(
+    queryOf(only(fetched.calls, "linear:issueRemoveLabel")),
+    /issueRemoveLabel\(id: "iss_1", labelId: "grp_lbl_0"\)/,
+  );
 });
 
 test("re-shipping a ready GitHub PR already In Review and labelled writes nothing", async () => {

--- a/test/loop-factory-ship.test.ts
+++ b/test/loop-factory-ship.test.ts
@@ -122,7 +122,9 @@ const issueRead = (over: {
 
 const ok = (payload: Record<string, unknown>): Route => ({ body: { data: payload } });
 
-const LABEL_LOOKUP = ok({ issueLabels: { nodes: [{ id: "lbl_rfr", parent: FACTORY_GROUP }] } });
+const LABEL_LOOKUP = ok({
+  issueLabels: { nodes: [{ id: "lbl_rfr", name: "ready-for-review", parent: FACTORY_GROUP }] },
+});
 const REMOVE_OK = ok({ issueRemoveLabel: { success: true } });
 const STATE_OK = ok({ issueUpdate: { success: true } });
 const LABEL_OK = ok({ issueAddLabel: { success: true } });
@@ -206,7 +208,7 @@ test("a sibling factory-state label is removed before ready-for-review is added"
     "linear:issueAddLabel": LABEL_OK,
   });
 
-  await shipFactoryPullRequest(github, "QM-1", depsFor(fetched.fetchImpl));
+  await shipFactoryPullRequest(github, TICKET, depsFor(fetched.fetchImpl));
 
   assert.deepEqual(keysOf(fetched.calls).slice(-3), [
     "linear:issueLabels",
@@ -217,6 +219,19 @@ test("a sibling factory-state label is removed before ready-for-review is added"
     queryOf(only(fetched.calls, "linear:issueRemoveLabel")),
     /issueRemoveLabel\(id: "iss_1", labelId: "grp_lbl_0"\)/,
   );
+});
+
+test("an ungrouped ready-for-review label removes nothing", async () => {
+  const fetched = fakeFetch({
+    [`GET ${GH_PULL}`]: { body: { draft: false, state: "open", merged: false } },
+    "linear:issue": issueRead({ state: IN_REVIEW, labels: ["bug"], groupLabels: ["converging"] }),
+    "linear:issueLabels": ok({ issueLabels: { nodes: [{ id: "lbl_rfr", name: "ready-for-review", parent: null }] } }),
+    "linear:issueAddLabel": LABEL_OK,
+  });
+
+  await shipFactoryPullRequest(github, TICKET, depsFor(fetched.fetchImpl));
+
+  assert.deepEqual(keysOf(fetched.calls).slice(-2), ["linear:issueLabels", "linear:issueAddLabel"]);
 });
 
 test("re-shipping a ready GitHub PR already In Review and labelled writes nothing", async () => {


### PR DESCRIPTION
## Why

Linear allows one label per label group. The factory wrapper leaves its `converging` state label on the ticket, and `ready-for-review` lives in the same "factory states" group. The loop's auto ship for QM-1 (PR #1140) moved the ticket to In Review and then failed on `issueAddLabel`, so the item stayed `ready` with a superseded output and the fire recorded a failure.

## What

- `readLinearIssue` now reads each label's `id`, `name`, and `parent { id }`.
- `addReadyLabel` looks up `ready-for-review` with its group, removes every current label in that group through `issueRemoveLabel`, then adds `ready-for-review`. Labels outside the group are untouched.

## Tests

- New: a ticket carrying `converging` in the group and `bug` outside it gets exactly one `issueRemoveLabel` for the group sibling, then the add, in that order.
- Existing ship, return, and already-fixed tests unchanged in sequence and assertions.
- Mutation check: with the sibling loop skipped, the new test fails; reverted.

`node --test` on ship and effects files: 73 pass. `tsc`, eslint, prettier green.