### PR TITLE
Park a ready item in place when its auto-ship fails

### DIFF
--- a/src/loops/runner.ts
+++ b/src/loops/runner.ts
@@ -108,6 +108,7 @@ export async function runLoopFire(
 
     let autoShippedCount = 0;
     let autoOutputCount = 0;
+    let itemReady = false;
     try {
       const { runId } = await effects.work({
         loop,
@@ -167,6 +168,7 @@ export async function runLoopFire(
         await stores.outputs.supersedeAttempt(item.id, runId);
         continue;
       }
+      itemReady = true;
       const ready = await stores.outputs.promoteAttempt(item.id, runId);
       const autoShipped: string[] = [];
       autoOutputCount = ready.filter(
@@ -191,9 +193,14 @@ export async function runLoopFire(
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       summary.failures.push(`${item.sourceKey}: ${reason}`);
-      if (autoShippedCount > 0) {
-        const partialReason = `partial auto-ship: ${autoShippedCount} of ${autoOutputCount} actions completed before failure — needs human review`;
-        await stores.items.park(item.id, partialReason);
+      // A ready item has released its claim and its outputs are already promoted, so it parks in
+      // place for a person instead of superseding the attempt and requeueing the work.
+      if (itemReady) {
+        const shipReason =
+          autoShippedCount > 0
+            ? `partial auto-ship: ${autoShippedCount} of ${autoOutputCount} actions completed before failure — needs human review`
+            : `auto-ship failed: ${reason} — needs human review`;
+        await stores.items.park(item.id, shipReason);
         summary.parked.push(item.id);
         continue;
       }

--- a/test/loop-runner.test.ts
+++ b/test/loop-runner.test.ts
@@ -165,6 +165,36 @@ test("a partial auto-ship parks for human review without superseding or requeuei
   assert.equal(next.worked, 0);
 });
 
+test("a failed auto-ship with nothing shipped parks the ready output for a person", async () => {
+  const s = stores();
+  const loop = await loopIn(s, { shipActions: [{ action: "open_pr", gate: "auto" }] });
+  const summary = await runLoopFire(
+    loop,
+    s,
+    effects(s, {
+      ship: async ({ output }) => {
+        const claimed = await s.outputs.claimShipping(output.id);
+        await s.outputs.failShipping(claimed!.id, claimed!.claimToken!);
+        throw new Error("label group conflict");
+      },
+    }),
+  );
+  const item = (await s.items.byLoop(loop.id))[0]!;
+  const outputs = await s.outputs.byItem(item.id);
+  assert.deepEqual(
+    outputs.map((output) => output.state),
+    ["ready"],
+  );
+  assert.equal(item.status, "ready");
+  assert.equal(item.parkedReason, "auto-ship failed: label group conflict — needs human review");
+  assert.deepEqual(summary.parked, [item.id]);
+  assert.deepEqual(summary.continued, []);
+  assert.deepEqual(summary.failures, ["SENTRY-1: label group conflict"]);
+  assert.equal((await s.outputs.awaitingReview(loop.id)).length, 1);
+  const next = await runLoopFire(loop, s, effects(s));
+  assert.equal(next.worked, 0);
+});
+
 test("a standing grant graduates its slice and leaves the rest for review", async () => {
   const s = stores();
   const loop = await loopIn(s);


### PR DESCRIPTION
## Why

After `markReady` the item has released its claim token and its outputs are promoted to `ready`. When `effects.ship` then throws before any output ships, the runner's catch path superseded the promoted outputs and parked with the stale claim token. The item sat in `ready` with no output a person could decide on, and the only trace was `consecutiveFailedFires`.

Seen on the local dev loop when the ship step failed on a Linear label group conflict.

## What

- `src/loops/runner.ts`: track `itemReady` after `markReady` succeeds. Any failure after that point parks the item in place without superseding the attempt, the same way the partial auto-ship branch already does. The reason reads `auto-ship failed: <reason> — needs human review`.
- `test/loop-runner.test.ts`: pins that a failed auto-ship with nothing shipped keeps the output `ready`, parks the item with that reason, keeps it out of the next fire, and leaves it in `awaitingReview`.

## Verification

- `node --test test/loop-runner.test.ts test/loop-fire*.test.ts test/loop-factory*.test.ts`: 249 pass.
- Mutation check: with the runner change reverted, the new test fails on `["superseded"]` vs `["ready"]`.
- `npm run typecheck` and `npm run lint` clean.